### PR TITLE
Use private runner credentials for Apple Doctor

### DIFF
--- a/.github/actions/apple-release/Invoke-CapturedPowerShellTool.ps1
+++ b/.github/actions/apple-release/Invoke-CapturedPowerShellTool.ps1
@@ -1,0 +1,21 @@
+param(
+    [Parameter(Mandatory)] [string] $ToolPath,
+    [Parameter(Mandatory)] [string] $ArgumentListBase64
+)
+
+$ErrorActionPreference = 'Stop'
+
+try {
+    $argumentJson = [System.Text.Encoding]::UTF8.GetString(
+        [Convert]::FromBase64String($ArgumentListBase64))
+    $toolArguments = [string[]] @($argumentJson | ConvertFrom-Json -Depth 10)
+    & $ToolPath @toolArguments
+    $succeeded = $?
+    $nativeExitCode = $LASTEXITCODE
+    if ($null -ne $nativeExitCode) { exit [int] $nativeExitCode }
+    if (-not $succeeded) { exit 1 }
+    exit 0
+} catch {
+    [Console]::Error.WriteLine($_.Exception.Message)
+    exit 1
+}

--- a/.github/actions/apple-release/Invoke-PowerForgeAppleRelease.ps1
+++ b/.github/actions/apple-release/Invoke-PowerForgeAppleRelease.ps1
@@ -150,11 +150,30 @@ function Invoke-SecretSafeNativeProcess {
     )
 
     $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
-    $startInfo.FileName = $FilePath
     $startInfo.UseShellExecute = $false
     $startInfo.RedirectStandardOutput = $true
     $startInfo.RedirectStandardError = $true
-    foreach ($argument in $ArgumentList) {
+    $processArguments = $ArgumentList
+    $extension = [System.IO.Path]::GetExtension($FilePath)
+    if ($IsWindows -and $extension -in @('.cmd', '.bat', '.ps1')) {
+        $startInfo.FileName = Join-Path $PSHOME 'pwsh.exe'
+        $argumentJson = $ArgumentList | ConvertTo-Json -Compress -AsArray
+        $argumentBase64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($argumentJson))
+        $processArguments = @(
+            '-NoLogo',
+            '-NoProfile',
+            '-NonInteractive',
+            '-File',
+            (Join-Path $PSScriptRoot 'Invoke-CapturedPowerShellTool.ps1'),
+            '-ToolPath',
+            $FilePath,
+            '-ArgumentListBase64',
+            $argumentBase64
+        )
+    } else {
+        $startInfo.FileName = $FilePath
+    }
+    foreach ($argument in $processArguments) {
         $startInfo.ArgumentList.Add($argument)
     }
 

--- a/.github/actions/apple-release/Invoke-PowerForgeAppleRelease.ps1
+++ b/.github/actions/apple-release/Invoke-PowerForgeAppleRelease.ps1
@@ -298,15 +298,18 @@ Write-ReleaseOutput -Name 'receipt-path' -Value $receiptPath
 $receiptFingerprintBefore = Get-ReleaseFileFingerprint -Path $receiptPath
 
 if ($runnerLocalCredentials) {
-    Add-RunnerLocalCredentialSecret -Value (Join-Path ([string] $env:HOME) '.appstoreconnect')
-    $suppliedCredentialValues = @(
-        $env:APP_STORE_CONNECT_ISSUER_ID,
-        $env:APP_STORE_CONNECT_KEY_ID,
-        $env:APP_STORE_CONNECT_PRIVATE_KEY_PATH
-    ) | Where-Object { -not [string]::IsNullOrWhiteSpace([string] $_) }
     try {
+        Add-RunnerLocalCredentialSecret -Value (Join-Path ([string] $env:HOME) '.appstoreconnect')
+        $suppliedCredentialValues = @(
+            $env:APP_STORE_CONNECT_ISSUER_ID,
+            $env:APP_STORE_CONNECT_KEY_ID,
+            $env:APP_STORE_CONNECT_PRIVATE_KEY_PATH,
+            $config.AppleApps.AppStoreConnectApiKeyPath,
+            $config.AppleApps.AppStoreConnectApiKeyId,
+            $config.AppleApps.AppStoreConnectApiIssuerId
+        ) | Where-Object { -not [string]::IsNullOrWhiteSpace([string] $_) }
         if ($suppliedCredentialValues.Count -gt 0) {
-            throw 'Runner-local App Store Connect credentials must not be combined with action credential inputs.'
+            throw 'Runner-local App Store Connect credentials must not be combined with action inputs or release-config credentials.'
         }
         & (Join-Path $PSScriptRoot 'Resolve-RunnerLocalAppleCredentials.ps1') -Action $action
         $privateKeyContent = [System.IO.File]::ReadAllText($env:APP_STORE_CONNECT_PRIVATE_KEY_PATH)

--- a/.github/actions/apple-release/Invoke-PowerForgeAppleRelease.ps1
+++ b/.github/actions/apple-release/Invoke-PowerForgeAppleRelease.ps1
@@ -1,4 +1,50 @@
 $ErrorActionPreference = 'Stop'
+$script:RunnerLocalCredentialSecrets = [Collections.Generic.List[string]]::new()
+
+function Add-RunnerLocalCredentialSecret {
+    param([AllowEmptyString()] [string] $Value)
+
+    if (-not [string]::IsNullOrWhiteSpace($Value) -and
+        -not $script:RunnerLocalCredentialSecrets.Contains($Value)) {
+        $script:RunnerLocalCredentialSecrets.Add($Value)
+    }
+}
+
+function Protect-RunnerLocalCredentialText {
+    param([AllowNull()] [object] $Value)
+
+    if ($null -eq $Value) { return $null }
+    $text = [string] $Value
+    foreach ($secret in @($script:RunnerLocalCredentialSecrets | Sort-Object Length -Descending)) {
+        $text = $text.Replace($secret, '[redacted]', [StringComparison]::Ordinal)
+    }
+    return $text
+}
+
+function ConvertTo-ProtectedRunnerLocalCredentialValue {
+    param([AllowNull()] [object] $Value)
+
+    if ($null -eq $Value) { return $null }
+    if ($Value -is [string]) { return Protect-RunnerLocalCredentialText $Value }
+    if ($Value -is [Collections.IDictionary]) {
+        $copy = [ordered]@{}
+        foreach ($key in $Value.Keys) {
+            $copy[$key] = ConvertTo-ProtectedRunnerLocalCredentialValue $Value[$key]
+        }
+        return $copy
+    }
+    if ($Value -is [System.Management.Automation.PSCustomObject]) {
+        $copy = [ordered]@{}
+        foreach ($property in $Value.PSObject.Properties) {
+            $copy[$property.Name] = ConvertTo-ProtectedRunnerLocalCredentialValue $property.Value
+        }
+        return $copy
+    }
+    if ($Value -is [Collections.IEnumerable]) {
+        return @($Value | ForEach-Object { ConvertTo-ProtectedRunnerLocalCredentialValue $_ })
+    }
+    return $Value
+}
 
 function Resolve-ReleasePath {
     param(
@@ -97,10 +143,43 @@ function Get-FirstNonEmptyString {
     return $null
 }
 
-function Write-AtomicJsonFile {
+function Invoke-SecretSafeNativeProcess {
+    param(
+        [Parameter(Mandatory)] [string] $FilePath,
+        [Parameter(Mandatory)] [string[]] $ArgumentList
+    )
+
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $FilePath
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    foreach ($argument in $ArgumentList) {
+        $startInfo.ArgumentList.Add($argument)
+    }
+
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    try {
+        if (-not $process.Start()) { throw 'PowerForge could not be started.' }
+        $standardOutputTask = $process.StandardOutput.ReadToEndAsync()
+        $standardErrorTask = $process.StandardError.ReadToEndAsync()
+        $process.WaitForExit()
+        [System.Threading.Tasks.Task]::WaitAll(@($standardOutputTask, $standardErrorTask))
+        return [ordered]@{
+            ExitCode = $process.ExitCode
+            StandardOutput = [string] $standardOutputTask.Result
+            StandardError = [string] $standardErrorTask.Result
+        }
+    } finally {
+        $process.Dispose()
+    }
+}
+
+function Write-AtomicTextFile {
     param(
         [Parameter(Mandatory)] [string] $Path,
-        [Parameter(Mandatory)] [object] $Value
+        [Parameter(Mandatory)] [string] $Value
     )
 
     $directory = Split-Path -Parent $Path
@@ -109,14 +188,41 @@ function Write-AtomicJsonFile {
     }
     $temporaryPath = Join-Path $directory ".$(Split-Path -Leaf $Path).$([Guid]::NewGuid().ToString('N')).tmp"
     try {
-        $json = $Value | ConvertTo-Json -Depth 32
-        [System.IO.File]::WriteAllText($temporaryPath, $json, [System.Text.UTF8Encoding]::new($false))
+        [System.IO.File]::WriteAllText($temporaryPath, $Value, [System.Text.UTF8Encoding]::new($false))
         [System.IO.File]::Move($temporaryPath, $Path, $true)
     } finally {
         if (Test-Path -LiteralPath $temporaryPath -PathType Leaf) {
             Remove-Item -LiteralPath $temporaryPath -Force
         }
     }
+}
+
+function Write-AtomicJsonFile {
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [object] $Value
+    )
+
+    Write-AtomicTextFile -Path $Path -Value ($Value | ConvertTo-Json -Depth 32)
+}
+
+function Protect-RunnerLocalCredentialReceipt {
+    param([Parameter(Mandatory)] [string] $Path)
+
+    if ($script:RunnerLocalCredentialSecrets.Count -eq 0 -or
+        -not (Test-Path -LiteralPath $Path -PathType Leaf)) { return }
+    $raw = [System.IO.File]::ReadAllText($Path)
+    $protectedRaw = Protect-RunnerLocalCredentialText $raw
+    try {
+        $document = $protectedRaw | ConvertFrom-Json -Depth 100
+    } catch {
+        if ($protectedRaw -ne $raw) {
+            Write-AtomicTextFile -Path $Path -Value $protectedRaw
+        }
+        return
+    }
+    $protected = ConvertTo-ProtectedRunnerLocalCredentialValue $document
+    Write-AtomicJsonFile -Path $Path -Value $protected
 }
 
 $allowedActions = @(
@@ -131,6 +237,11 @@ if (-not $action) {
 
 $planOnly = [bool]::Parse($env:INPUT_PLAN_ONLY)
 $confirm = [bool]::Parse($env:INPUT_CONFIRM)
+$runnerLocalCredentials = if ([string]::IsNullOrWhiteSpace($env:INPUT_RUNNER_LOCAL_CREDENTIALS)) {
+    $false
+} else {
+    [bool]::Parse($env:INPUT_RUNNER_LOCAL_CREDENTIALS)
+}
 if ($planOnly -and $confirm) {
     throw 'A plan-only run must not carry mutation confirmation.'
 }
@@ -186,6 +297,73 @@ try {
 Write-ReleaseOutput -Name 'receipt-path' -Value $receiptPath
 $receiptFingerprintBefore = Get-ReleaseFileFingerprint -Path $receiptPath
 
+if ($runnerLocalCredentials) {
+    Add-RunnerLocalCredentialSecret -Value (Join-Path ([string] $env:HOME) '.appstoreconnect')
+    $suppliedCredentialValues = @(
+        $env:APP_STORE_CONNECT_ISSUER_ID,
+        $env:APP_STORE_CONNECT_KEY_ID,
+        $env:APP_STORE_CONNECT_PRIVATE_KEY_PATH
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace([string] $_) }
+    try {
+        if ($suppliedCredentialValues.Count -gt 0) {
+            throw 'Runner-local App Store Connect credentials must not be combined with action credential inputs.'
+        }
+        & (Join-Path $PSScriptRoot 'Resolve-RunnerLocalAppleCredentials.ps1') -Action $action
+        $privateKeyContent = [System.IO.File]::ReadAllText($env:APP_STORE_CONNECT_PRIVATE_KEY_PATH)
+        Add-RunnerLocalCredentialSecret -Value $privateKeyContent
+        $privateKeyBody = [Collections.Generic.List[string]]::new()
+        foreach ($privateKeyLine in ($privateKeyContent -split '\r?\n')) {
+            if ($privateKeyLine -notmatch '^\s*-----' -and $privateKeyLine.Trim().Length -ge 16) {
+                $privateKeyBody.Add($privateKeyLine.Trim())
+                Add-RunnerLocalCredentialSecret -Value $privateKeyLine.Trim()
+            }
+        }
+        Add-RunnerLocalCredentialSecret -Value ($privateKeyBody -join '')
+        Add-RunnerLocalCredentialSecret -Value ([string] $env:APP_STORE_CONNECT_PRIVATE_KEY_PATH)
+        Add-RunnerLocalCredentialSecret -Value ([string] $env:APP_STORE_CONNECT_ISSUER_ID)
+        Add-RunnerLocalCredentialSecret -Value ([string] $env:APP_STORE_CONNECT_KEY_ID)
+    } catch {
+        # Loader failures are intentionally value-free. At this boundary a failed
+        # profile read may have revealed only part of the tuple, so exception text
+        # (including paths and key identifiers) must never enter logs or receipts.
+        $failureMessage = 'Runner-local App Store Connect credential profile is invalid or unavailable.'
+        $failureDiagnostic = [ordered]@{
+            severity = 'error'
+            category = 'credential'
+            code = 'APPLE_RUNNER_LOCAL_CREDENTIALS_INVALID'
+            summary = $failureMessage
+            evidence = $null
+            action = 'Repair the private runner-local App Store Connect profile and retry the read-only Doctor action.'
+            retryable = $false
+        }
+        $relativeReceiptPath = [System.IO.Path]::GetRelativePath($projectRoot, $receiptPath).Replace('\', '/')
+        Write-AtomicJsonFile -Path $receiptPath -Value ([ordered]@{
+            schemaVersion = 3
+            action = $action
+            sourceCommit = [string] $env:INPUT_SOURCE_COMMIT
+            planOnly = $planOnly
+            checkedAt = [DateTimeOffset]::UtcNow
+            planSha256 = $null
+            success = $false
+            errorMessage = $failureMessage
+            receiptPath = $relativeReceiptPath
+            versioning = $null
+            targets = @()
+            cleanup = [ordered]@{}
+            diagnostics = @($failureDiagnostic)
+            nextActions = @($failureDiagnostic.action)
+        })
+        Write-ReleaseOutput -Name 'diagnostics' -Value (@([ordered]@{
+            severity = 'error'
+            category = 'credential'
+            code = 'APPLE_RUNNER_LOCAL_CREDENTIALS_INVALID'
+            action = $failureDiagnostic.action
+            retryable = $false
+        }) | ConvertTo-Json -Compress -AsArray)
+        throw "Runner-local App Store Connect credentials are unavailable. The complete failure receipt is retained at '$receiptPath'."
+    }
+}
+
 $arguments = @('apple-release', $action, '--config', $env:INPUT_CONFIG_PATH, '--summary', '--output', 'json')
 if ($planOnly) { $arguments += '--plan' }
 if ($confirm) { $arguments += '--confirm-apple-action' }
@@ -211,13 +389,16 @@ if (-not [string]::IsNullOrWhiteSpace($env:INPUT_TARGET)) {
     $arguments += @('--target', $env:INPUT_TARGET)
 }
 
-$output = & $env:POWERFORGE_TOOL_PATH @arguments
-$exitCode = $LASTEXITCODE
-$json = $output -join [Environment]::NewLine
+$invocation = Invoke-SecretSafeNativeProcess -FilePath $env:POWERFORGE_TOOL_PATH -ArgumentList $arguments
+$exitCode = [int] $invocation.ExitCode
+$receiptFingerprintAfterInvocation = Get-ReleaseFileFingerprint -Path $receiptPath
+$json = Protect-RunnerLocalCredentialText $invocation.StandardOutput
+$protectedStandardError = Protect-RunnerLocalCredentialText $invocation.StandardError
 $envelope = $null
 if (-not [string]::IsNullOrWhiteSpace($json)) {
     try {
         $envelope = $json | ConvertFrom-Json -Depth 100
+        $envelope = ConvertTo-ProtectedRunnerLocalCredentialValue $envelope
     } catch {
         if ($exitCode -eq 0) { throw }
     }
@@ -237,6 +418,9 @@ if ($exitCode -eq 0 -and -not [string]::IsNullOrWhiteSpace($reportedReceiptPath)
         -Name 'PowerForge reported receipt path'
     Write-ReleaseOutput -Name 'receipt-path' -Value $receiptPath
 }
+if ($runnerLocalCredentials -and $exitCode -eq 0) {
+    Protect-RunnerLocalCredentialReceipt -Path $receiptPath
+}
 
 if ($exitCode -ne 0) {
     # Never echo the complete CLI envelope here. The receipt can contain compact
@@ -251,25 +435,28 @@ if ($exitCode -ne 0) {
             severity = (Get-FirstNonEmptyString @($_.severity, 'error'))
             category = (Get-FirstNonEmptyString @($_.category, 'automation'))
             code = (Get-FirstNonEmptyString @($_.code, 'APPLE_ACTION_FAILED'))
-            summary = (Get-FirstNonEmptyString @($_.summary, "PowerForge Apple action '$action' failed."))
-            evidence = [string] $_.evidence
-            action = (Get-FirstNonEmptyString @($_.action, 'Inspect the retained failure receipt and run logs, correct the reported condition, then retry.'))
+            summary = (Protect-RunnerLocalCredentialText (Get-FirstNonEmptyString @($_.summary, "PowerForge Apple action '$action' failed.")))
+            evidence = (Protect-RunnerLocalCredentialText ([string] $_.evidence))
+            action = (Protect-RunnerLocalCredentialText (Get-FirstNonEmptyString @($_.action, 'Inspect the retained failure receipt and run logs, correct the reported condition, then retry.')))
             retryable = [bool] $_.retryable
         }
     })
-    $failureMessage = Get-FirstNonEmptyString @(
+    $failureMessage = Protect-RunnerLocalCredentialText (Get-FirstNonEmptyString @(
         $result.errorMessage,
-        $envelope.PSObject.Properties['Error'].Value,
+        $envelope['error'],
+        $protectedStandardError,
         "PowerForge Apple action '$action' failed with exit code $exitCode."
-    )
+    ))
     if ($receiptDiagnostics.Count -eq 0) {
         $missingAppStoreCredentials =
             $failureMessage -match 'App Store Connect.*requires.*AppStoreConnectApiKeyPath' -or
             $failureMessage -match 'AppStoreConnectApiKeyPath.*AppStoreConnectApiKeyId.*AppStoreConnectApiIssuerId'
         $failureCategory = if ($missingAppStoreCredentials) { 'credential' } else { 'automation' }
         $failureCode = if ($missingAppStoreCredentials) { 'APPLE_APP_STORE_CONNECT_CREDENTIALS_MISSING' } else { 'APPLE_ACTION_FAILED' }
-        $failureAction = if ($missingAppStoreCredentials) {
-            'Configure app_store_connect_issuer_id, app_store_connect_key_id, and app_store_connect_private_key in the protected Apple environment.'
+        $failureAction = if ($missingAppStoreCredentials -and $runnerLocalCredentials) {
+            'Repair the private runner-local App Store Connect profile and retry the read-only Doctor action.'
+        } elseif ($missingAppStoreCredentials) {
+            'Configure the complete App Store Connect credential tuple for this explicitly authorized action.'
         } else {
             'Inspect the retained failure receipt and run logs, correct the reported preflight condition, then retry.'
         }
@@ -283,9 +470,8 @@ if ($exitCode -ne 0) {
             retryable = $false
         })
     }
-    $receiptFingerprintAfter = Get-ReleaseFileFingerprint -Path $receiptPath
-    $engineWroteCurrentReceipt = $null -ne $receiptFingerprintAfter -and
-        $receiptFingerprintAfter -ne $receiptFingerprintBefore
+    $engineWroteCurrentReceipt = $null -ne $receiptFingerprintAfterInvocation -and
+        $receiptFingerprintAfterInvocation -ne $receiptFingerprintBefore
     # Replace missing or byte-for-byte stale state. Preserve a file changed by this
     # invocation even when stdout was malformed or did not carry diagnostics.
     if (-not $engineWroteCurrentReceipt) {
@@ -306,6 +492,9 @@ if ($exitCode -ne 0) {
             diagnostics = $receiptDiagnostics
             nextActions = @($receiptDiagnostics | ForEach-Object { [string] $_.action } | Select-Object -Unique)
         })
+    }
+    if ($engineWroteCurrentReceipt -and $runnerLocalCredentials) {
+        Protect-RunnerLocalCredentialReceipt -Path $receiptPath
     }
     $safeDiagnostics = @($receiptDiagnostics | ForEach-Object {
         [ordered]@{

--- a/.github/actions/apple-release/Resolve-RunnerLocalAppleCredentials.ps1
+++ b/.github/actions/apple-release/Resolve-RunnerLocalAppleCredentials.ps1
@@ -1,0 +1,185 @@
+param(
+    [Parameter(Mandatory)] [string] $Action
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Assert-PrivateUnixPath {
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [bool] $Directory,
+        [Parameter(Mandatory)] [string] $Description
+    )
+
+    $item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+    if ($null -eq $item) { throw "$Description is missing." }
+    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "$Description must not be a symbolic link or reparse point."
+    }
+    if ($Directory -and -not $item.PSIsContainer) { throw "$Description must be a directory." }
+    if (-not $Directory -and $item.PSIsContainer) { throw "$Description must be a regular file." }
+
+    $stat = @(& /usr/bin/stat -f '%u|%l|%HT' $item.FullName 2>$null)
+    if ($LASTEXITCODE -ne 0 -or $stat.Count -ne 1) { throw "$Description metadata could not be verified." }
+    $statParts = $stat[0].Split('|')
+    $currentUid = [string] (& /usr/bin/id -u)
+    if ($LASTEXITCODE -ne 0 -or $statParts.Count -ne 3 -or $statParts[0] -ne $currentUid) {
+        throw "$Description must be owned by the self-hosted runner user."
+    }
+    $expectedType = if ($Directory) { 'Directory' } else { 'Regular File' }
+    if ($statParts[2] -ne $expectedType) { throw "$Description must be a $($expectedType.ToLowerInvariant())." }
+    if (-not $Directory -and $statParts[1] -ne '1') { throw "$Description must not have hard links." }
+
+    $listing = @(& /bin/ls -lde $item.FullName 2>$null)
+    if ($LASTEXITCODE -ne 0 -or $listing.Count -eq 0) { throw "$Description access controls could not be verified." }
+    $modeToken = ($listing[0] -split '\s+', 2)[0]
+    if ($modeToken.Contains('+')) { throw "$Description must not grant access through a POSIX ACL." }
+
+    $mode = [System.IO.File]::GetUnixFileMode($item.FullName)
+    $shared =
+        [System.IO.UnixFileMode]::GroupRead -bor
+        [System.IO.UnixFileMode]::GroupWrite -bor
+        [System.IO.UnixFileMode]::GroupExecute -bor
+        [System.IO.UnixFileMode]::OtherRead -bor
+        [System.IO.UnixFileMode]::OtherWrite -bor
+        [System.IO.UnixFileMode]::OtherExecute
+    if (($mode -band $shared) -ne 0) {
+        throw "$Description permissions must not grant group or other access."
+    }
+}
+
+function Convert-ProfileValue {
+    param(
+        [Parameter(Mandatory)] [string] $Value,
+        [Parameter(Mandatory)] [string] $Name
+    )
+
+    $text = $Value.Trim()
+    if ($text.Length -ge 2 -and
+        (($text[0] -eq '"' -and $text[$text.Length - 1] -eq '"') -or
+         ($text[0] -eq "'" -and $text[$text.Length - 1] -eq "'"))) {
+        $text = $text.Substring(1, $text.Length - 2)
+    } elseif ($text.StartsWith('"') -or $text.StartsWith("'") -or
+              $text.EndsWith('"') -or $text.EndsWith("'")) {
+        throw "Runner-local credential '$Name' has unmatched quoting."
+    }
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        throw "Runner-local credential '$Name' is empty."
+    }
+    return $text
+}
+
+if ($Action -ine 'Doctor') {
+    throw 'Runner-local App Store Connect credentials are allowed only for the read-only Doctor action.'
+}
+if ($env:RUNNER_ENVIRONMENT -ine 'self-hosted' -or $env:RUNNER_OS -ine 'macOS') {
+    throw 'Runner-local App Store Connect credentials require a self-hosted macOS runner.'
+}
+
+$homePath = [string] $env:HOME
+if ([string]::IsNullOrWhiteSpace($homePath) -or -not [System.IO.Path]::IsPathRooted($homePath)) {
+    throw 'The self-hosted runner HOME directory is unavailable.'
+}
+$homePath = [System.IO.Path]::GetFullPath($homePath)
+$profileRoot = [System.IO.Path]::GetFullPath((Join-Path $homePath '.appstoreconnect'))
+$profilePath = Join-Path $profileRoot 'env'
+Assert-PrivateUnixPath -Path $profileRoot -Directory $true -Description 'Runner-local App Store Connect profile directory'
+Assert-PrivateUnixPath -Path $profilePath -Directory $false -Description 'Runner-local App Store Connect credential profile'
+
+$values = @{}
+foreach ($line in [System.IO.File]::ReadAllLines($profilePath)) {
+    if ($line -match '^\s*(?:#.*)?$') { continue }
+    $match = [regex]::Match(
+        $line,
+        '^\s*(?:export\s+)?(?<name>(?:APP_STORE_CONNECT|ASC)_(?:ISSUER_ID|KEY_ID|PRIVATE_KEY_PATH))\s*=\s*(?<value>.*)\s*$')
+    if (-not $match.Success) {
+        throw 'Runner-local App Store Connect credential profile contains unsupported content.'
+    }
+    $name = $match.Groups['name'].Value
+    if ($values.ContainsKey($name)) { throw "Runner-local credential '$name' is declared more than once." }
+    $values[$name] = Convert-ProfileValue -Value $match.Groups['value'].Value -Name $name
+}
+
+$issuerId = [string] $values['APP_STORE_CONNECT_ISSUER_ID']
+$keyId = [string] $values['APP_STORE_CONNECT_KEY_ID']
+$keyPathSetting = [string] $values['APP_STORE_CONNECT_PRIVATE_KEY_PATH']
+if ($issuerId -notmatch '^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$') {
+    throw 'Runner-local App Store Connect issuer id is missing or invalid.'
+}
+if ($keyId -notmatch '^[A-Z0-9]{10}$') {
+    throw 'Runner-local App Store Connect key id is missing or invalid.'
+}
+
+$aliases = [ordered]@{
+    ASC_ISSUER_ID = 'APP_STORE_CONNECT_ISSUER_ID'
+    ASC_KEY_ID = 'APP_STORE_CONNECT_KEY_ID'
+    ASC_PRIVATE_KEY_PATH = 'APP_STORE_CONNECT_PRIVATE_KEY_PATH'
+}
+foreach ($entry in $aliases.GetEnumerator()) {
+    if (-not $values.ContainsKey($entry.Key)) { continue }
+    $aliasValue = [string] $values[$entry.Key]
+    $canonicalName = [string] $entry.Value
+    $plainReference = '$' + $canonicalName
+    $bracedReference = '${' + $canonicalName + '}'
+    if ($aliasValue -ne $plainReference -and
+        $aliasValue -ne $bracedReference) {
+        throw "Runner-local credential alias '$($entry.Key)' must reference its canonical value."
+    }
+}
+
+if ($keyPathSetting.StartsWith('$HOME/', [StringComparison]::Ordinal)) {
+    $keyPathSetting = Join-Path $homePath $keyPathSetting.Substring(6)
+} elseif ($keyPathSetting.StartsWith('${HOME}/', [StringComparison]::Ordinal)) {
+    $keyPathSetting = Join-Path $homePath $keyPathSetting.Substring(8)
+} elseif ($keyPathSetting.StartsWith('~/', [StringComparison]::Ordinal)) {
+    $keyPathSetting = Join-Path $homePath $keyPathSetting.Substring(2)
+}
+if ($keyPathSetting.Contains('$') -or $keyPathSetting.Contains('`') -or
+    -not [System.IO.Path]::IsPathRooted($keyPathSetting)) {
+    throw 'Runner-local App Store Connect private-key path must be an absolute path or use only the HOME prefix.'
+}
+
+$comparison = [StringComparison]::Ordinal
+$keyPath = [System.IO.Path]::GetFullPath($keyPathSetting)
+$root = $profileRoot.TrimEnd(
+    [System.IO.Path]::DirectorySeparatorChar,
+    [System.IO.Path]::AltDirectorySeparatorChar)
+$prefix = $root + [System.IO.Path]::DirectorySeparatorChar
+if (-not $keyPath.StartsWith($prefix, $comparison) -or
+    [System.IO.Path]::GetExtension($keyPath) -ine '.p8') {
+    throw 'Runner-local App Store Connect private key must be a .p8 file inside the private profile directory.'
+}
+
+$current = $keyPath
+while (-not $current.Equals($root, $comparison)) {
+    Assert-PrivateUnixPath -Path $current -Directory:$($current -ne $keyPath) -Description 'Runner-local App Store Connect private-key path'
+    $parent = [System.IO.Directory]::GetParent($current)?.FullName
+    if ([string]::IsNullOrWhiteSpace($parent)) {
+        throw 'Runner-local App Store Connect private-key path escaped the private profile directory.'
+    }
+    $current = $parent
+}
+$privateKeyText = [System.IO.File]::ReadAllText($keyPath)
+try {
+    if ($privateKeyText -notmatch '(?s)\A-----BEGIN PRIVATE KEY-----\r?\n(?<body>[A-Za-z0-9+/=\r\n]+)\r?\n-----END PRIVATE KEY-----\s*\z') {
+        throw 'The private key must be an unencrypted PKCS#8 PEM document.'
+    }
+    $privateKeyBytes = [Convert]::FromBase64String(($Matches['body'] -replace '\s', ''))
+    $privateKey = [System.Security.Cryptography.ECDsa]::Create()
+    try {
+        $bytesRead = 0
+        $privateKey.ImportPkcs8PrivateKey($privateKeyBytes, [ref] $bytesRead)
+        if ($bytesRead -ne $privateKeyBytes.Length -or $privateKey.KeySize -ne 256) {
+            throw 'The private key must use the Apple P-256 curve.'
+        }
+    } finally {
+        $privateKey.Dispose()
+        [Array]::Clear($privateKeyBytes, 0, $privateKeyBytes.Length)
+    }
+} catch {
+    throw 'Runner-local App Store Connect private key is not a valid unencrypted P-256 PKCS#8 PEM document.'
+}
+
+$env:APP_STORE_CONNECT_ISSUER_ID = $issuerId
+$env:APP_STORE_CONNECT_KEY_ID = $keyId
+$env:APP_STORE_CONNECT_PRIVATE_KEY_PATH = $keyPath

--- a/.github/actions/apple-release/Resolve-RunnerLocalAppleCredentials.ps1
+++ b/.github/actions/apple-release/Resolve-RunnerLocalAppleCredentials.ps1
@@ -169,7 +169,10 @@ try {
     try {
         $bytesRead = 0
         $privateKey.ImportPkcs8PrivateKey($privateKeyBytes, [ref] $bytesRead)
-        if ($bytesRead -ne $privateKeyBytes.Length -or $privateKey.KeySize -ne 256) {
+        $curveOid = [string] $privateKey.ExportParameters($false).Curve.Oid.Value
+        if ($bytesRead -ne $privateKeyBytes.Length -or
+            $privateKey.KeySize -ne 256 -or
+            $curveOid -ne '1.2.840.10045.3.1.7') {
             throw 'The private key must use the Apple P-256 curve.'
         }
     } finally {

--- a/.github/actions/apple-release/action.yml
+++ b/.github/actions/apple-release/action.yml
@@ -41,15 +41,22 @@ inputs:
     description: Pass the explicit Apple mutation confirmation flag.
     required: false
     default: "false"
+  runner-local-credentials:
+    description: Load the fixed private ~/.appstoreconnect profile in-process. Allowed only for Doctor on a self-hosted macOS runner.
+    required: false
+    default: "false"
   issuer-id:
     description: App Store Connect issuer id supplied from a protected secret.
-    required: true
+    required: false
+    default: ""
   key-id:
     description: App Store Connect API key id supplied from a protected secret.
-    required: true
+    required: false
+    default: ""
   private-key:
     description: App Store Connect private key content supplied from a protected secret.
-    required: true
+    required: false
+    default: ""
 
 outputs:
   action:
@@ -148,6 +155,7 @@ runs:
         INPUT_TARGET: ${{ inputs.target }}
         INPUT_PLAN_ONLY: ${{ inputs.plan-only }}
         INPUT_CONFIRM: ${{ inputs.confirm }}
+        INPUT_RUNNER_LOCAL_CREDENTIALS: ${{ inputs.runner-local-credentials }}
         POWERFORGE_TOOL_PATH: ${{ steps.tool.outputs.path }}
         POWERFORGE_VERSION: ${{ steps.tool.outputs.version }}
         APP_STORE_CONNECT_ISSUER_ID: ${{ inputs.issuer-id }}

--- a/.github/workflows/powerforge-apple-monitor.yml
+++ b/.github/workflows/powerforge-apple-monitor.yml
@@ -36,18 +36,6 @@ on:
         required: false
         default: Apple release monitor detected a failure
         type: string
-      environment_name:
-        description: GitHub environment containing Apple monitoring credentials.
-        required: false
-        default: apple-release
-        type: string
-    secrets:
-      caller_app_store_connect_issuer_id:
-        required: false
-      caller_app_store_connect_key_id:
-        required: false
-      caller_app_store_connect_private_key:
-        required: false
 
 concurrency:
   group: powerforge-apple-monitor-${{ github.repository }}
@@ -57,7 +45,6 @@ jobs:
   doctor:
     runs-on: ${{ fromJson(inputs.runner_labels_json) }}
     timeout-minutes: 30
-    environment: ${{ inputs.environment_name }}
     permissions:
       contents: read
       issues: write
@@ -67,9 +54,19 @@ jobs:
         env:
           SOURCE_REF: ${{ inputs.source_ref }}
           POWERFORGE_REF: ${{ inputs.powerforge_ref }}
+          CALLER_SHA: ${{ github.sha }}
+          CALLER_REF: ${{ github.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           foreach ($entry in @{ source_ref = $env:SOURCE_REF; powerforge_ref = $env:POWERFORGE_REF }.GetEnumerator()) {
             if ($entry.Value -notmatch '^[0-9A-Fa-f]{40}$') { throw "$($entry.Key) must be an exact 40-character commit SHA." }
+          }
+          if ([string]::IsNullOrWhiteSpace($env:DEFAULT_BRANCH) -or
+              $env:CALLER_REF -ne "refs/heads/$($env:DEFAULT_BRANCH)") {
+            throw 'Runner-local Apple Doctor may run only from the caller repository default branch.'
+          }
+          if ($env:SOURCE_REF -ine $env:CALLER_SHA) {
+            throw 'Runner-local Apple Doctor source_ref must equal the exact default-branch workflow commit.'
           }
 
       - name: Checkout exact monitored source
@@ -79,6 +76,24 @@ jobs:
           fetch-depth: 1
           path: source
           persist-credentials: false
+
+      - name: Require merged shared monitor source
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          POWERFORGE_REF: ${{ inputs.powerforge_ref }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repository = gh api repos/EvotecIT/PSPublishModule | ConvertFrom-Json -Depth 20
+          if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace([string] $repository.default_branch)) {
+            throw 'Unable to resolve the PSPublishModule default branch.'
+          }
+          $comparison = gh api "repos/EvotecIT/PSPublishModule/compare/$($env:POWERFORGE_REF)...$($repository.default_branch)" |
+            ConvertFrom-Json -Depth 20
+          if ($LASTEXITCODE -ne 0 -or
+              [string] $comparison.merge_base_commit.sha -ine $env:POWERFORGE_REF) {
+            throw 'powerforge_ref must be a commit already merged into the PSPublishModule default branch.'
+          }
 
       - name: Checkout pinned PowerForge monitor
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -107,9 +122,7 @@ jobs:
           tool-manifest-path: ${{ github.workspace }}/source/${{ inputs.tool_manifest_path }}
           tool-path: ${{ steps.build-powerforge.outputs.tool-path }}
           plan-only: "false"
-          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID || secrets.caller_app_store_connect_issuer_id }}
-          key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID || secrets.caller_app_store_connect_key_id }}
-          private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY || secrets.caller_app_store_connect_private_key }}
+          runner-local-credentials: "true"
 
       - name: Retain compact doctor receipt
         if: always() && steps.doctor.outputs.receipt-path != ''

--- a/Docs/PSPublishModule.AppleRelease.md
+++ b/Docs/PSPublishModule.AppleRelease.md
@@ -476,6 +476,9 @@ read-only Doctor action uses only the fixed private profile on the self-hosted M
 never copies that credential tuple into GitHub secrets, inputs, outputs, artifacts, or
 receipts. Runner-local credentials cannot be enabled for Version, Advance, governance,
 screenshots, review submission, release, or any other mutating action.
+Runner-local mode also rejects any `AppStoreConnectApiKeyPath`,
+`AppStoreConnectApiKeyId`, or `AppStoreConnectApiIssuerId` in the tracked release
+configuration so repository content cannot override the validated private profile.
 Release configs and tool manifests must be tracked, unchanged files beneath the exact
 checkout and must not traverse symbolic links or reparse points. Do not add
 repository-wide `secrets: inherit`; that would weaken the environment boundary. When

--- a/Docs/PSPublishModule.AppleRelease.md
+++ b/Docs/PSPublishModule.AppleRelease.md
@@ -449,8 +449,13 @@ The reusable workflow boundary mirrors the human approval boundary:
   the exact source, action, observed Apple state, and App Review readiness evidence still
   produce the reviewed SHA-256. The reviewed hash is also passed into the release engine,
   which recomputes and rejects drift immediately before the first Apple mutation.
-- `powerforge-apple-monitor.yml` runs scheduled `Doctor`, retains the compact receipt,
-  and maintains one marker-owned GitHub incident until errors and warnings are cleared.
+- `powerforge-apple-monitor.yml` runs scheduled `Doctor` on a trusted self-hosted macOS
+  runner, reads its private `~/.appstoreconnect/env` profile only inside that action
+  process, retains the compact receipt, and maintains one marker-owned GitHub incident
+  until errors and warnings are cleared. The profile and referenced `.p8` file must be
+  runner-owned regular files with one link, grant no group, other, or ACL access, and
+  must not contain or traverse symbolic links. The monitor accepts only the exact
+  default-branch commit that invoked it.
 - `powerforge-apple-screenshots.yml` captures from an exact source commit, retains the
   PNG artifact for review, waits at a protected environment, binds the reviewer to
   exact image hashes, and then performs the confirmed screenshot sync.
@@ -465,14 +470,18 @@ The reusable workflow boundary mirrors the human approval boundary:
 
 Callers must pass 40-character commit SHAs for `powerforge_ref` and release
 `source_ref`; the workflows reject branches and tags and verify both checked-out
-commits. The reusable jobs select the caller repository's protected environment and
-resolve its environment-scoped App Store Connect secrets there. Approval callers also
-provide a non-protected planning environment with read-only App Store Connect credentials.
+commits. Mutating reusable jobs select protected environments and require explicitly
+supplied App Store Connect credentials. The monitor is intentionally different: its
+read-only Doctor action uses only the fixed private profile on the self-hosted Mac and
+never copies that credential tuple into GitHub secrets, inputs, outputs, artifacts, or
+receipts. Runner-local credentials cannot be enabled for Version, Advance, governance,
+screenshots, review submission, release, or any other mutating action.
 Release configs and tool manifests must be tracked, unchanged files beneath the exact
 checkout and must not traverse symbolic links or reparse points. Do not add
-repository-wide `secrets: inherit`; that would weaken the environment boundary. The composite
-action writes the private key to a permission-restricted temporary file and removes
-it after every plan or action. Mutating release workflows, including both screenshot
+repository-wide `secrets: inherit`; that would weaken the environment boundary. When
+explicit secret content is supplied, the composite action writes the private key to a
+permission-restricted temporary file and removes it after every plan or action. Mutating
+release workflows, including both screenshot
 approve-and-sync variants, share one repository-scoped concurrency group. Monitoring
 and screenshot capture have dedicated groups so a long capture cannot cancel a release,
 two publication captures cannot overlap, and App Review never observes a partially
@@ -634,8 +643,15 @@ the direct parent, then list their bundle identifiers in the parent
 
 Run `Doctor` on a schedule as well as before a release. The reusable
 `powerforge-apple-monitor.yml` workflow checks out exact 40-character source and
-PowerForge commits, builds that exact shared source, runs Doctor on a trusted Apple
-runner, retains the compact receipt, and maintains one stable GitHub incident. Errors
+PowerForge commits, builds that exact shared source, and runs Doctor on a trusted
+self-hosted macOS runner. The action uses only canonical variables from the runner's
+permission-restricted `~/.appstoreconnect/env`; optional `ASC_*` compatibility entries
+must be exact references to their canonical values. It requires the `.p8` file to remain inside
+that same private directory, validates an unencrypted PKCS#8 PEM shape, and keeps all
+values process-local. It accepts only the exact default-branch commit that invoked the
+workflow and executes only a `powerforge_ref` already merged into PSPublishModule's
+default branch, then retains the compact
+receipt and maintains one stable GitHub incident. Errors
 and warnings open the issue; a clean later run closes only incidents carrying the
 PowerForge monitor ownership marker, never an unrelated same-title issue. This catches upload/build
 state, review, metadata, screenshot, compliance, observability, and TestFlight feedback

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.CapturedTool.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.CapturedTool.cs
@@ -1,0 +1,53 @@
+using System.Text;
+using System.Text.Json;
+
+namespace PowerForge.Tests;
+
+public sealed partial class AppleReleaseWorkflowTests
+{
+    [Fact]
+    public void CapturedPowerShellToolPreservesArgumentsStreamsAndExitCode()
+    {
+        if (!CommandExists("pwsh")) return;
+
+        var root = FindRepoRoot();
+        var sandbox = Path.Combine(root, ".test-temp", $"captured-powershell-tool-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(sandbox);
+            var toolPath = Path.Combine(sandbox, "captured-tool.ps1");
+            File.WriteAllText(
+                toolPath,
+                "param([string] $Value)\n[Console]::Out.Write(\"out:$Value\")\n[Console]::Error.Write(\"error:$Value\")\nexit 7\n");
+            var arguments = Convert.ToBase64String(
+                Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new[] { "value with spaces & symbols" })));
+
+            var result = RunWithEnvironment(
+                "pwsh",
+                sandbox,
+                new Dictionary<string, string?>(),
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-File",
+                Path.Combine(
+                    root,
+                    ".github",
+                    "actions",
+                    "apple-release",
+                    "Invoke-CapturedPowerShellTool.ps1"),
+                "-ToolPath",
+                toolPath,
+                "-ArgumentListBase64",
+                arguments);
+
+            Assert.Equal(7, result.ExitCode);
+            Assert.Equal("out:value with spaces & symbols", result.StandardOutput);
+            Assert.Equal("error:value with spaces & symbols", result.StandardError);
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox)) Directory.Delete(sandbox, recursive: true);
+        }
+    }
+}

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.MonitorFailureReceipt.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.MonitorFailureReceipt.cs
@@ -81,7 +81,7 @@ public sealed partial class AppleReleaseWorkflowTests
             var diagnostic = Assert.Single(rootElement.GetProperty("diagnostics").EnumerateArray());
             Assert.Equal("APPLE_APP_STORE_CONNECT_CREDENTIALS_MISSING", diagnostic.GetProperty("code").GetString());
             Assert.Equal("credential", diagnostic.GetProperty("category").GetString());
-            Assert.Contains("protected Apple environment", diagnostic.GetProperty("action").GetString(), StringComparison.Ordinal);
+            Assert.Contains("complete App Store Connect credential tuple", diagnostic.GetProperty("action").GetString(), StringComparison.Ordinal);
 
             var outputs = File.ReadAllText(outputPath);
             Assert.Contains("receipt-path=", outputs, StringComparison.Ordinal);

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.RunnerLocalCredentials.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.RunnerLocalCredentials.cs
@@ -1,0 +1,391 @@
+using System.Text.Json;
+using System.Security.Cryptography;
+
+namespace PowerForge.Tests;
+
+public sealed partial class AppleReleaseWorkflowTests
+{
+    private const string TestIssuerId = "12345678-1234-1234-1234-123456789abc";
+    private const string TestKeyId = "ABC123DEFG";
+
+    [Fact]
+    public void RunnerLocalDoctorUsesPrivateProfileWithoutSerializingCredentials()
+    {
+        if (OperatingSystem.IsWindows() || !CommandExists("pwsh")) return;
+
+        var root = FindRepoRoot();
+        var sandbox = CreateRunnerLocalSandbox(root, "$HOME/.appstoreconnect/AuthKey_ABC123DEFG.p8");
+        try
+        {
+            var toolPath = CreateSuccessfulCredentialProbe(sandbox);
+            var result = RunRunnerLocalWrapper(root, sandbox, toolPath, "Doctor");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.True(File.Exists(Path.Combine(sandbox, "credential-proof.txt")), result.StandardOutput + result.StandardError);
+            var combined = result.StandardOutput + result.StandardError +
+                           File.ReadAllText(Path.Combine(sandbox, "github-output.txt"));
+            Assert.DoesNotContain(TestIssuerId, combined, StringComparison.Ordinal);
+            Assert.DoesNotContain(TestKeyId, combined, StringComparison.Ordinal);
+            Assert.DoesNotContain("AuthKey_ABC123DEFG.p8", combined, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox)) Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("Release", "self-hosted", "macOS")]
+    [InlineData("Doctor", "github-hosted", "macOS")]
+    [InlineData("Doctor", "self-hosted", "Linux")]
+    public void RunnerLocalCredentialsFailBeforeToolOutsideReadOnlyPrivateMacBoundary(
+        string action,
+        string runnerEnvironment,
+        string runnerOs)
+    {
+        if (OperatingSystem.IsWindows() || !CommandExists("pwsh")) return;
+
+        var root = FindRepoRoot();
+        var sandbox = CreateRunnerLocalSandbox(root, "$HOME/.appstoreconnect/AuthKey_ABC123DEFG.p8");
+        try
+        {
+            var toolPath = CreateSuccessfulCredentialProbe(sandbox);
+            var result = RunRunnerLocalWrapper(root, sandbox, toolPath, action, runnerEnvironment, runnerOs);
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.False(File.Exists(Path.Combine(sandbox, "credential-proof.txt")));
+            AssertRunnerLocalFailureReceipt(sandbox);
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox)) Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RunnerLocalCredentialsRejectActionCredentialMixing()
+    {
+        if (OperatingSystem.IsWindows() || !CommandExists("pwsh")) return;
+
+        var root = FindRepoRoot();
+        var sandbox = CreateRunnerLocalSandbox(root, "$HOME/.appstoreconnect/AuthKey_ABC123DEFG.p8");
+        try
+        {
+            var toolPath = CreateSuccessfulCredentialProbe(sandbox);
+            var result = RunRunnerLocalWrapper(
+                root,
+                sandbox,
+                toolPath,
+                "Doctor",
+                additionalEnvironment: new Dictionary<string, string?>
+                {
+                    ["APP_STORE_CONNECT_KEY_ID"] = TestKeyId
+                });
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.False(File.Exists(Path.Combine(sandbox, "credential-proof.txt")));
+            AssertRunnerLocalFailureReceipt(sandbox);
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox)) Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RunnerLocalDoctorRedactsCredentialMaterialFromFailureHandoffs()
+    {
+        if (OperatingSystem.IsWindows() || !CommandExists("pwsh")) return;
+
+        var root = FindRepoRoot();
+        var sandbox = CreateRunnerLocalSandbox(root, "$HOME/.appstoreconnect/AuthKey_ABC123DEFG.p8");
+        try
+        {
+            var keyPath = Path.Combine(sandbox, "runner-home", ".appstoreconnect", "AuthKey_ABC123DEFG.p8");
+            var privateKeyBodyLine = File.ReadLines(keyPath).First(line => !line.StartsWith("-----", StringComparison.Ordinal));
+            var result = RunRunnerLocalWrapper(root, sandbox, CreateCredentialLeakingTool(sandbox), "Doctor");
+
+            Assert.NotEqual(0, result.ExitCode);
+            var receipt = File.ReadAllText(Path.Combine(sandbox, "build", "powerforge", "apple", "release-receipt.json"));
+            var outputs = File.ReadAllText(Path.Combine(sandbox, "github-output.txt"));
+            var handoff = result.StandardOutput + result.StandardError + receipt + outputs;
+            Assert.DoesNotContain(TestIssuerId, handoff, StringComparison.Ordinal);
+            Assert.DoesNotContain(TestKeyId, handoff, StringComparison.Ordinal);
+            Assert.DoesNotContain(keyPath, handoff, StringComparison.Ordinal);
+            Assert.DoesNotContain(privateKeyBodyLine, handoff, StringComparison.Ordinal);
+            Assert.Contains("[redacted]", receipt, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox)) Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RunnerLocalCredentialsRejectUnsupportedProfileContent()
+    {
+        if (OperatingSystem.IsWindows() || !CommandExists("pwsh")) return;
+
+        var root = FindRepoRoot();
+        var sandbox = CreateRunnerLocalSandbox(root, "$HOME/.appstoreconnect/AuthKey_ABC123DEFG.p8");
+        try
+        {
+            var envPath = Path.Combine(sandbox, "runner-home", ".appstoreconnect", "env");
+            File.AppendAllText(envPath, "echo unsupported\n");
+            var result = RunRunnerLocalWrapper(root, sandbox, CreateSuccessfulCredentialProbe(sandbox), "Doctor");
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.False(File.Exists(Path.Combine(sandbox, "credential-proof.txt")));
+            AssertRunnerLocalFailureReceipt(sandbox);
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox)) Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RunnerLocalCredentialsRejectLiteralAliasCopies()
+    {
+        if (OperatingSystem.IsWindows() || !CommandExists("pwsh")) return;
+
+        var root = FindRepoRoot();
+        var sandbox = CreateRunnerLocalSandbox(root, "$HOME/.appstoreconnect/AuthKey_ABC123DEFG.p8");
+        try
+        {
+            var envPath = Path.Combine(sandbox, "runner-home", ".appstoreconnect", "env");
+            File.WriteAllText(
+                envPath,
+                File.ReadAllText(envPath).Replace(
+                    "export ASC_KEY_ID=\"$APP_STORE_CONNECT_KEY_ID\"",
+                    $"export ASC_KEY_ID=\"{TestKeyId}\"",
+                    StringComparison.Ordinal));
+            var result = RunRunnerLocalWrapper(root, sandbox, CreateSuccessfulCredentialProbe(sandbox), "Doctor");
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.False(File.Exists(Path.Combine(sandbox, "credential-proof.txt")));
+            AssertRunnerLocalFailureReceipt(sandbox);
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox)) Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("outside")]
+    [InlineData("permissive-profile")]
+    [InlineData("linked-key")]
+    [InlineData("hardlinked-key")]
+    [InlineData("fifo-key")]
+    [InlineData("invalid-pem")]
+    [InlineData("public-key-pem")]
+    [InlineData("sec1-key-pem")]
+    public void RunnerLocalCredentialsRejectUnsafeLocalMaterial(string unsafeShape)
+    {
+        if (OperatingSystem.IsWindows() || !CommandExists("pwsh")) return;
+
+        var root = FindRepoRoot();
+        var keySetting = unsafeShape == "outside"
+            ? "$HOME/outside/AuthKey_ABC123DEFG.p8"
+            : "$HOME/.appstoreconnect/AuthKey_ABC123DEFG.p8";
+        var sandbox = CreateRunnerLocalSandbox(root, keySetting);
+        try
+        {
+            var home = Path.Combine(sandbox, "runner-home");
+            if (unsafeShape == "outside")
+            {
+                var outside = Path.Combine(home, "outside");
+                Directory.CreateDirectory(outside);
+                SetUnixMode(outside, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+                var outsideKey = Path.Combine(outside, "AuthKey_ABC123DEFG.p8");
+                File.WriteAllText(outsideKey, "test-key");
+                SetUnixMode(outsideKey, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            }
+            else if (unsafeShape == "permissive-profile")
+            {
+                SetUnixMode(
+                    Path.Combine(home, ".appstoreconnect", "env"),
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead);
+            }
+            else if (unsafeShape == "linked-key")
+            {
+                var key = Path.Combine(home, ".appstoreconnect", "AuthKey_ABC123DEFG.p8");
+                File.Delete(key);
+                File.CreateSymbolicLink(key, Path.Combine(sandbox, "outside-key.p8"));
+                File.WriteAllText(Path.Combine(sandbox, "outside-key.p8"), "test-key");
+            }
+            else if (unsafeShape == "hardlinked-key")
+            {
+                var key = Path.Combine(home, ".appstoreconnect", "AuthKey_ABC123DEFG.p8");
+                var outsideKey = Path.Combine(sandbox, "outside-hardlink-source.p8");
+                File.WriteAllText(outsideKey, File.ReadAllText(key));
+                File.Delete(key);
+                Run("ln", sandbox, outsideKey, key).EnsureSuccess();
+            }
+            else if (unsafeShape == "fifo-key")
+            {
+                var key = Path.Combine(home, ".appstoreconnect", "AuthKey_ABC123DEFG.p8");
+                File.Delete(key);
+                Run("mkfifo", sandbox, key).EnsureSuccess();
+            }
+            else if (unsafeShape == "invalid-pem")
+            {
+                var key = Path.Combine(home, ".appstoreconnect", "AuthKey_ABC123DEFG.p8");
+                File.WriteAllText(key, "-----BEGIN PRIVATE KEY-----\nnot-a-key\n-----END PRIVATE KEY-----\n");
+            }
+            else if (unsafeShape == "public-key-pem")
+            {
+                var key = Path.Combine(home, ".appstoreconnect", "AuthKey_ABC123DEFG.p8");
+                using var publicKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+                File.WriteAllText(key, publicKey.ExportSubjectPublicKeyInfoPem());
+            }
+            else
+            {
+                var key = Path.Combine(home, ".appstoreconnect", "AuthKey_ABC123DEFG.p8");
+                using var sec1Key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+                File.WriteAllText(key, sec1Key.ExportECPrivateKeyPem());
+            }
+
+            var result = RunRunnerLocalWrapper(root, sandbox, CreateSuccessfulCredentialProbe(sandbox), "Doctor");
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.False(File.Exists(Path.Combine(sandbox, "credential-proof.txt")));
+            AssertRunnerLocalFailureReceipt(sandbox);
+            var handoff = result.StandardOutput + result.StandardError +
+                          File.ReadAllText(Path.Combine(sandbox, "build", "powerforge", "apple", "release-receipt.json"));
+            Assert.DoesNotContain("AuthKey_ABC123DEFG.p8", handoff, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox)) Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
+    private static string CreateRunnerLocalSandbox(string root, string keySetting)
+    {
+        var sandbox = Path.Combine(root, ".test-temp", $"runner-local-credentials-{Guid.NewGuid():N}");
+        var profile = Path.Combine(sandbox, "runner-home", ".appstoreconnect");
+        Directory.CreateDirectory(profile);
+        SetUnixMode(profile, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        var keyPath = Path.Combine(profile, "AuthKey_ABC123DEFG.p8");
+        using (var privateKey = ECDsa.Create(ECCurve.NamedCurves.nistP256))
+        {
+            File.WriteAllText(keyPath, privateKey.ExportPkcs8PrivateKeyPem());
+        }
+        SetUnixMode(keyPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        var envPath = Path.Combine(profile, "env");
+        File.WriteAllText(
+            envPath,
+            $"export APP_STORE_CONNECT_ISSUER_ID=\"{TestIssuerId}\"{Environment.NewLine}" +
+            $"export APP_STORE_CONNECT_KEY_ID=\"{TestKeyId}\"{Environment.NewLine}" +
+            $"export APP_STORE_CONNECT_PRIVATE_KEY_PATH=\"{keySetting}\"{Environment.NewLine}" +
+            "export ASC_ISSUER_ID=\"$APP_STORE_CONNECT_ISSUER_ID\"\n" +
+            "export ASC_KEY_ID=\"$APP_STORE_CONNECT_KEY_ID\"\n" +
+            "export ASC_PRIVATE_KEY_PATH=\"$APP_STORE_CONNECT_PRIVATE_KEY_PATH\"\n");
+        SetUnixMode(envPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        File.WriteAllText(
+            Path.Combine(sandbox, "powerforge.release.json"),
+            """{"AppleApps":{"ProjectRoot":".","Automation":{"ReceiptPath":"build/powerforge/apple/release-receipt.json"}}}""");
+        return sandbox;
+    }
+
+    private static ProcessResult RunRunnerLocalWrapper(
+        string root,
+        string sandbox,
+        string toolPath,
+        string action,
+        string runnerEnvironment = "self-hosted",
+        string runnerOs = "macOS",
+        IReadOnlyDictionary<string, string?>? additionalEnvironment = null)
+    {
+        var environment = new Dictionary<string, string?>
+        {
+            ["HOME"] = Path.Combine(sandbox, "runner-home"),
+            ["RUNNER_ENVIRONMENT"] = runnerEnvironment,
+            ["RUNNER_OS"] = runnerOs,
+            ["INPUT_ACTION"] = action,
+            ["INPUT_CONFIG_PATH"] = Path.Combine(sandbox, "powerforge.release.json"),
+            ["INPUT_MARKETING_VERSION"] = string.Empty,
+            ["INPUT_SOURCE_COMMIT"] = new string('a', 40),
+            ["INPUT_EXPECTED_PLAN_SHA256"] = string.Empty,
+            ["INPUT_TARGET"] = string.Empty,
+            ["INPUT_PLAN_ONLY"] = "false",
+            ["INPUT_CONFIRM"] = "false",
+            ["INPUT_RUNNER_LOCAL_CREDENTIALS"] = "true",
+            ["POWERFORGE_TOOL_PATH"] = toolPath,
+            ["POWERFORGE_VERSION"] = "test",
+            ["APP_STORE_CONNECT_ISSUER_ID"] = string.Empty,
+            ["APP_STORE_CONNECT_KEY_ID"] = string.Empty,
+            ["APP_STORE_CONNECT_PRIVATE_KEY_PATH"] = string.Empty,
+            ["GITHUB_OUTPUT"] = Path.Combine(sandbox, "github-output.txt")
+        };
+        if (additionalEnvironment is not null)
+        {
+            foreach (var pair in additionalEnvironment) environment[pair.Key] = pair.Value;
+        }
+        return RunWithEnvironment(
+            "pwsh",
+            sandbox,
+            environment,
+            "-NoProfile",
+            "-File",
+            Path.Combine(root, ".github", "actions", "apple-release", "Invoke-PowerForgeAppleRelease.ps1"));
+    }
+
+    private static string CreateSuccessfulCredentialProbe(string sandbox)
+    {
+        var path = Path.Combine(sandbox, "credential-probe.sh");
+        File.WriteAllText(
+            path,
+            """
+            #!/bin/sh
+            set -eu
+            [ "$APP_STORE_CONNECT_ISSUER_ID" = "12345678-1234-1234-1234-123456789abc" ]
+            [ "$APP_STORE_CONNECT_KEY_ID" = "ABC123DEFG" ]
+            [ "$APP_STORE_CONNECT_PRIVATE_KEY_PATH" = "$HOME/.appstoreconnect/AuthKey_ABC123DEFG.p8" ]
+            [ -r "$APP_STORE_CONNECT_PRIVATE_KEY_PATH" ]
+            printf 'ok\n' > credential-proof.txt
+            mkdir -p build/powerforge/apple
+            printf '%s\n' '{"success":true,"action":"Doctor","targets":[],"diagnostics":[],"nextActions":[]}' > build/powerforge/apple/release-receipt.json
+            printf '%s\n' '{"success":true,"result":{"action":"Doctor","receiptPath":"build/powerforge/apple/release-receipt.json","targets":[],"diagnostics":[],"nextActions":[]}}'
+            """);
+        SetUnixMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        return path;
+    }
+
+    private static string CreateCredentialLeakingTool(string sandbox)
+    {
+        var path = Path.Combine(sandbox, "credential-leaking-tool.sh");
+        File.WriteAllText(
+            path,
+            """
+            #!/bin/sh
+            set -eu
+            key_body=$(sed -n '2p' "$APP_STORE_CONNECT_PRIVATE_KEY_PATH")
+            message="issuer=$APP_STORE_CONNECT_ISSUER_ID key=$APP_STORE_CONNECT_KEY_ID path=$APP_STORE_CONNECT_PRIVATE_KEY_PATH body=$key_body"
+            mkdir -p build/powerforge/apple
+            printf '{"success":false,"action":"Doctor","errorMessage":"%s","targets":[],"diagnostics":[{"severity":"error","category":"credential","code":"APPLE_TEST_LEAK","summary":"%s","evidence":"%s","action":"%s","retryable":false}],"nextActions":[]}\n' "$message" "$message" "$message" "$message" > build/powerforge/apple/release-receipt.json
+            printf '{"success":false,"result":{"action":"Doctor","receiptPath":"build/powerforge/apple/release-receipt.json","errorMessage":"%s","targets":[],"diagnostics":[{"severity":"error","category":"credential","code":"APPLE_TEST_LEAK","summary":"%s","evidence":"%s","action":"%s","retryable":false}],"nextActions":[]}}\n' "$message" "$message" "$message" "$message"
+            printf '%s\n' "$message" >&2
+            exit 1
+            """);
+        SetUnixMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        return path;
+    }
+
+    private static void SetUnixMode(string path, UnixFileMode mode)
+    {
+        if (OperatingSystem.IsWindows()) return;
+        File.SetUnixFileMode(path, mode);
+    }
+
+    private static void AssertRunnerLocalFailureReceipt(string sandbox)
+    {
+        var receiptPath = Path.Combine(sandbox, "build", "powerforge", "apple", "release-receipt.json");
+        Assert.True(File.Exists(receiptPath));
+        using var receipt = JsonDocument.Parse(File.ReadAllText(receiptPath));
+        var diagnostic = Assert.Single(receipt.RootElement.GetProperty("diagnostics").EnumerateArray());
+        Assert.Equal("APPLE_RUNNER_LOCAL_CREDENTIALS_INVALID", diagnostic.GetProperty("code").GetString());
+    }
+}

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.RunnerLocalCredentials.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.RunnerLocalCredentials.cs
@@ -11,7 +11,7 @@ public sealed partial class AppleReleaseWorkflowTests
     [Fact]
     public void RunnerLocalDoctorUsesPrivateProfileWithoutSerializingCredentials()
     {
-        if (OperatingSystem.IsWindows() || !CommandExists("pwsh")) return;
+        if (!OperatingSystem.IsMacOS() || !CommandExists("pwsh")) return;
 
         var root = FindRepoRoot();
         var sandbox = CreateRunnerLocalSandbox(root, "$HOME/.appstoreconnect/AuthKey_ABC123DEFG.p8");
@@ -43,7 +43,7 @@ public sealed partial class AppleReleaseWorkflowTests
         string runnerEnvironment,
         string runnerOs)
     {
-        if (OperatingSystem.IsWindows() || !CommandExists("pwsh")) return;
+        if (!OperatingSystem.IsMacOS() || !CommandExists("pwsh")) return;
 
         var root = FindRepoRoot();
         var sandbox = CreateRunnerLocalSandbox(root, "$HOME/.appstoreconnect/AuthKey_ABC123DEFG.p8");
@@ -65,7 +65,7 @@ public sealed partial class AppleReleaseWorkflowTests
     [Fact]
     public void RunnerLocalCredentialsRejectActionCredentialMixing()
     {
-        if (OperatingSystem.IsWindows() || !CommandExists("pwsh")) return;
+        if (!OperatingSystem.IsMacOS() || !CommandExists("pwsh")) return;
 
         var root = FindRepoRoot();
         var sandbox = CreateRunnerLocalSandbox(root, "$HOME/.appstoreconnect/AuthKey_ABC123DEFG.p8");
@@ -92,10 +92,73 @@ public sealed partial class AppleReleaseWorkflowTests
         }
     }
 
+    [Theory]
+    [InlineData("AppStoreConnectApiKeyPath", ".appstoreconnect/AuthKey_CONFIG.p8")]
+    [InlineData("AppStoreConnectApiKeyId", "CONFIGKEY1")]
+    [InlineData("AppStoreConnectApiIssuerId", "00000000-0000-0000-0000-000000000000")]
+    public void RunnerLocalCredentialsRejectEveryReleaseConfigCredentialField(string name, string value)
+    {
+        if (!OperatingSystem.IsMacOS() || !CommandExists("pwsh")) return;
+
+        var root = FindRepoRoot();
+        var sandbox = CreateRunnerLocalSandbox(root, "$HOME/.appstoreconnect/AuthKey_ABC123DEFG.p8");
+        try
+        {
+            var configPath = Path.Combine(sandbox, "powerforge.release.json");
+            File.WriteAllText(
+                configPath,
+                JsonSerializer.Serialize(new
+                {
+                    AppleApps = new Dictionary<string, object?>
+                    {
+                        ["ProjectRoot"] = ".",
+                        ["Automation"] = new { ReceiptPath = "build/powerforge/apple/release-receipt.json" },
+                        [name] = value
+                    }
+                }));
+
+            var result = RunRunnerLocalWrapper(root, sandbox, CreateSuccessfulCredentialProbe(sandbox), "Doctor");
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.False(File.Exists(Path.Combine(sandbox, "credential-proof.txt")));
+            AssertRunnerLocalFailureReceipt(sandbox);
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox)) Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RunnerLocalCredentialsRetainStructuredFailureWhenHomeIsMissing()
+    {
+        if (!OperatingSystem.IsMacOS() || !CommandExists("pwsh")) return;
+
+        var root = FindRepoRoot();
+        var sandbox = CreateRunnerLocalSandbox(root, "$HOME/.appstoreconnect/AuthKey_ABC123DEFG.p8");
+        try
+        {
+            var result = RunRunnerLocalWrapper(
+                root,
+                sandbox,
+                CreateSuccessfulCredentialProbe(sandbox),
+                "Doctor",
+                additionalEnvironment: new Dictionary<string, string?> { ["HOME"] = string.Empty });
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.False(File.Exists(Path.Combine(sandbox, "credential-proof.txt")));
+            AssertRunnerLocalFailureReceipt(sandbox);
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox)) Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
     [Fact]
     public void RunnerLocalDoctorRedactsCredentialMaterialFromFailureHandoffs()
     {
-        if (OperatingSystem.IsWindows() || !CommandExists("pwsh")) return;
+        if (!OperatingSystem.IsMacOS() || !CommandExists("pwsh")) return;
 
         var root = FindRepoRoot();
         var sandbox = CreateRunnerLocalSandbox(root, "$HOME/.appstoreconnect/AuthKey_ABC123DEFG.p8");
@@ -124,7 +187,7 @@ public sealed partial class AppleReleaseWorkflowTests
     [Fact]
     public void RunnerLocalCredentialsRejectUnsupportedProfileContent()
     {
-        if (OperatingSystem.IsWindows() || !CommandExists("pwsh")) return;
+        if (!OperatingSystem.IsMacOS() || !CommandExists("pwsh")) return;
 
         var root = FindRepoRoot();
         var sandbox = CreateRunnerLocalSandbox(root, "$HOME/.appstoreconnect/AuthKey_ABC123DEFG.p8");
@@ -147,7 +210,7 @@ public sealed partial class AppleReleaseWorkflowTests
     [Fact]
     public void RunnerLocalCredentialsRejectLiteralAliasCopies()
     {
-        if (OperatingSystem.IsWindows() || !CommandExists("pwsh")) return;
+        if (!OperatingSystem.IsMacOS() || !CommandExists("pwsh")) return;
 
         var root = FindRepoRoot();
         var sandbox = CreateRunnerLocalSandbox(root, "$HOME/.appstoreconnect/AuthKey_ABC123DEFG.p8");
@@ -183,7 +246,7 @@ public sealed partial class AppleReleaseWorkflowTests
     [InlineData("sec1-key-pem")]
     public void RunnerLocalCredentialsRejectUnsafeLocalMaterial(string unsafeShape)
     {
-        if (OperatingSystem.IsWindows() || !CommandExists("pwsh")) return;
+        if (!OperatingSystem.IsMacOS() || !CommandExists("pwsh")) return;
 
         var root = FindRepoRoot();
         var keySetting = unsafeShape == "outside"

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.cs
@@ -108,7 +108,7 @@ public sealed partial class AppleReleaseWorkflowTests
         Assert.Contains("IsPathRooted($projectRootSetting)", script, StringComparison.Ordinal);
         Assert.True(
             script.IndexOf("Write-ReleaseOutput -Name 'receipt-path'", StringComparison.Ordinal) <
-            script.IndexOf("& $env:POWERFORGE_TOOL_PATH", StringComparison.Ordinal));
+            script.IndexOf("Invoke-SecretSafeNativeProcess -FilePath $env:POWERFORGE_TOOL_PATH", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -278,9 +278,17 @@ public sealed partial class AppleReleaseWorkflowTests
         var workflow = Read(root, ".github", "workflows", "powerforge-apple-monitor.yml");
         var action = Read(root, ".github", "actions", "apple-release", "action.yml");
         var script = Read(root, ".github", "actions", "apple-release", "Invoke-PowerForgeAppleRelease.ps1");
+        var localCredentialResolver = Read(root, ".github", "actions", "apple-release", "Resolve-RunnerLocalAppleCredentials.ps1");
 
         Assert.Contains("action: Doctor", workflow, StringComparison.Ordinal);
-        Assert.Contains("environment: ${{ inputs.environment_name }}", workflow, StringComparison.Ordinal);
+        Assert.Contains("runner-local-credentials: \"true\"", workflow, StringComparison.Ordinal);
+        Assert.Contains("source_ref must equal the exact default-branch workflow commit", workflow, StringComparison.Ordinal);
+        Assert.Contains("may run only from the caller repository default branch", workflow, StringComparison.Ordinal);
+        Assert.Contains("powerforge_ref must be a commit already merged", workflow, StringComparison.Ordinal);
+        Assert.Contains("merge_base_commit.sha", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("environment:", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("APP_STORE_CONNECT_", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("caller_app_store_connect_", workflow, StringComparison.Ordinal);
         Assert.Contains("Build the exact monitored PowerForge source", workflow, StringComparison.Ordinal);
         Assert.Contains("./powerforge-shared/.github/actions/build-powerforge", workflow, StringComparison.Ordinal);
         Assert.Contains("runtime: ${{ inputs.tool_runtime }}", workflow, StringComparison.Ordinal);
@@ -314,6 +322,15 @@ public sealed partial class AppleReleaseWorkflowTests
         Assert.Contains("diagnostics:", action, StringComparison.Ordinal);
         Assert.Contains("'Status', 'Doctor'", script, StringComparison.Ordinal);
         Assert.Contains("reportedDiagnostics", script, StringComparison.Ordinal);
+        Assert.Contains("APPLE_RUNNER_LOCAL_CREDENTIALS_INVALID", script, StringComparison.Ordinal);
+        Assert.Contains("allowed only for the read-only Doctor action", localCredentialResolver, StringComparison.Ordinal);
+        Assert.Contains("require a self-hosted macOS runner", localCredentialResolver, StringComparison.Ordinal);
+        Assert.Contains("GetUnixFileMode", localCredentialResolver, StringComparison.Ordinal);
+        Assert.Contains("unencrypted P-256 PKCS#8 PEM", localCredentialResolver, StringComparison.Ordinal);
+        Assert.DoesNotContain("GITHUB_OUTPUT", localCredentialResolver, StringComparison.Ordinal);
+        Assert.DoesNotContain("GITHUB_ENV", localCredentialResolver, StringComparison.Ordinal);
+        Assert.DoesNotContain("Write-Host", localCredentialResolver, StringComparison.Ordinal);
+        Assert.DoesNotContain("[pscustomobject]", localCredentialResolver, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("IsNullOrWhiteSpace($env:PRIVATE_KEY)", action, StringComparison.Ordinal);
         Assert.True(
             action.IndexOf("IsNullOrWhiteSpace($env:PRIVATE_KEY)", StringComparison.Ordinal) <
@@ -321,12 +338,11 @@ public sealed partial class AppleReleaseWorkflowTests
     }
 
     [Fact]
-    public void AppleReusableWorkflowsPreferProtectedEnvironmentCredentialsWithCallerFallback()
+    public void MutatingAppleReusableWorkflowsPreferProtectedEnvironmentCredentialsWithCallerFallback()
     {
         var root = FindRepoRoot();
         var workflows = new[]
         {
-            "powerforge-apple-monitor.yml",
             "powerforge-apple-version-pr.yml",
             "powerforge-apple-advance.yml",
             "powerforge-apple-approval.yml",
@@ -581,14 +597,13 @@ public sealed partial class AppleReleaseWorkflowTests
     }
 
     [Fact]
-    public void AppleCallerCredentialFallbacksRemainOptionalAtTheWorkflowCallBoundary()
+    public void MutatingAppleCallerCredentialFallbacksRemainOptionalAtTheWorkflowCallBoundary()
     {
         var root = FindRepoRoot();
         foreach (var workflowName in new[]
                  {
                      "powerforge-apple-screenshots.yml",
                      "powerforge-apple-screenshot-approve.yml",
-                     "powerforge-apple-monitor.yml",
                      "powerforge-apple-version-pr.yml",
                      "powerforge-apple-advance.yml",
                      "powerforge-apple-governance.yml",

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.cs
@@ -109,6 +109,17 @@ public sealed partial class AppleReleaseWorkflowTests
         Assert.True(
             script.IndexOf("Write-ReleaseOutput -Name 'receipt-path'", StringComparison.Ordinal) <
             script.IndexOf("Invoke-SecretSafeNativeProcess -FilePath $env:POWERFORGE_TOOL_PATH", StringComparison.Ordinal));
+        Assert.Contains("$extension -in @('.cmd', '.bat', '.ps1')", script, StringComparison.Ordinal);
+        Assert.Contains("Invoke-CapturedPowerShellTool.ps1", script, StringComparison.Ordinal);
+        var capturedTool = Read(
+            root,
+            ".github",
+            "actions",
+            "apple-release",
+            "Invoke-CapturedPowerShellTool.ps1");
+        Assert.Contains("& $ToolPath @toolArguments", capturedTool, StringComparison.Ordinal);
+        Assert.Contains("[Console]::Error.WriteLine", capturedTool, StringComparison.Ordinal);
+        Assert.DoesNotContain("Write-Host", capturedTool, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- load App Store Connect credentials directly from the fixed private Mac runner profile for read-only Apple Doctor runs
- keep credentials out of GitHub secrets, workflow inputs, outputs, logs, receipts, and artifacts
- fail closed outside Doctor, self-hosted macOS, the caller default branch, or a shared commit already merged to PSPublishModule main
- reject action-provided and tracked release-config credential tuples so repository content cannot override the private profile
- validate private ownership, permissions, ACLs, links, PKCS#8 material, and the exact Apple P-256 curve
- capture and redact native stdout and stderr before any workflow handoff while preserving executable and Windows script tool paths

Mutation and publication workflows continue to require explicit protected credentials and cannot use this runner-local mode.

## Validation

- 53 focused Apple workflow and runner-local credential tests
- 268 broader Apple release, governance, screenshot, notarization, and workflow tests
- real local profile resolver canary without printing credential values
- captured script argument, stream, and exit-code regression
- PowerShell parsing, YAML contracts, and multi-target PowerForge and PSPublishModule builds