### PR TITLE
Fix binary documentation metadata and direct-import help

### DIFF
--- a/PowerForge.PowerShell/Services/DocumentationEngine.cs
+++ b/PowerForge.PowerShell/Services/DocumentationEngine.cs
@@ -350,6 +350,12 @@ public sealed class DocumentationEngine
         var value = (culture ?? string.Empty).Trim();
         if (string.IsNullOrWhiteSpace(value)) value = "en-US";
 
+        if (string.Equals(value, ".", StringComparison.Ordinal) ||
+            string.Equals(value, "..", StringComparison.Ordinal))
+        {
+            throw new ArgumentException("External help culture must be a single folder name and cannot be '.' or '..'.", nameof(culture));
+        }
+
         // Avoid path traversal and invalid characters; culture should be a folder name like "en-US".
         value = value.Replace(Path.DirectorySeparatorChar, '_').Replace(Path.AltDirectorySeparatorChar, '_');
         foreach (var c in Path.GetInvalidFileNameChars())

--- a/PowerForge.PowerShell/Services/DocumentationEngine.cs
+++ b/PowerForge.PowerShell/Services/DocumentationEngine.cs
@@ -203,6 +203,7 @@ public sealed class DocumentationEngine
             }
 
             var externalHelpFile = string.Empty;
+            IReadOnlyList<string> externalHelpFiles = Array.Empty<string>();
             if (buildDocumentation.GenerateExternalHelp)
             {
                 var culture = NormalizeExternalHelpCulture(buildDocumentation.ExternalHelpCulture);
@@ -216,6 +217,7 @@ public sealed class DocumentationEngine
                 try
                 {
                     externalHelpFile = mamlWriter.WriteExternalHelpFile(extracted, moduleName, externalHelpDir, fileName);
+                    externalHelpFiles = DocumentationExternalHelpAliasWriter.WriteAliases(extracted, externalHelpFile);
                     if (buildDocumentation.IncludeAboutTopics)
                         new AboutTopicWriter().WriteExternalHelpFiles(stagingPath, externalHelpDir, buildDocumentation.AboutTopicsSourcePath);
                     SafeDone(externalHelpStep);
@@ -235,7 +237,8 @@ public sealed class DocumentationEngine
                 exitCode: 0,
                 markdownFiles: CountMarkdownFiles(docsPath),
                 externalHelpFilePath: externalHelpFile,
-                errorMessage: null);
+                errorMessage: null,
+                externalHelpFilePaths: externalHelpFiles);
         }
         catch (Exception ex)
         {
@@ -489,6 +492,7 @@ public sealed class DocumentationEngine
             if (string.IsNullOrWhiteSpace(fileName)) fileName = $"{moduleName}-help.xml";
 
             var externalHelpFile = Path.Combine(externalHelpDir, fileName);
+            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(externalHelpDir);
             if (File.Exists(externalHelpFile))
             {
                 try { File.Delete(externalHelpFile); } catch { /* best effort */ }

--- a/PowerForge.PowerShell/Services/DocumentationEngine.cs
+++ b/PowerForge.PowerShell/Services/DocumentationEngine.cs
@@ -217,7 +217,7 @@ public sealed class DocumentationEngine
                 try
                 {
                     externalHelpFile = mamlWriter.WriteExternalHelpFile(extracted, moduleName, externalHelpDir, fileName);
-                    externalHelpFiles = DocumentationExternalHelpAliasWriter.WriteAliases(extracted, externalHelpFile);
+                    externalHelpFiles = DocumentationExternalHelpAliasWriter.WriteAliases(extracted, externalHelpFile, moduleName);
                     if (buildDocumentation.IncludeAboutTopics)
                         new AboutTopicWriter().WriteExternalHelpFiles(stagingPath, externalHelpDir, buildDocumentation.AboutTopicsSourcePath);
                     SafeDone(externalHelpStep);
@@ -484,6 +484,7 @@ public sealed class DocumentationEngine
 
             var culture = NormalizeExternalHelpCulture(buildDocumentation.ExternalHelpCulture);
             var externalHelpDir = Path.Combine(stagingPath, culture);
+            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(stagingPath, moduleName);
             if (!Directory.Exists(externalHelpDir)) return;
 
             var fileName = string.IsNullOrWhiteSpace(buildDocumentation.ExternalHelpFileName)
@@ -492,7 +493,6 @@ public sealed class DocumentationEngine
             if (string.IsNullOrWhiteSpace(fileName)) fileName = $"{moduleName}-help.xml";
 
             var externalHelpFile = Path.Combine(externalHelpDir, fileName);
-            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(stagingPath);
             if (File.Exists(externalHelpFile))
             {
                 try { File.Delete(externalHelpFile); } catch { /* best effort */ }

--- a/PowerForge.PowerShell/Services/DocumentationEngine.cs
+++ b/PowerForge.PowerShell/Services/DocumentationEngine.cs
@@ -492,7 +492,7 @@ public sealed class DocumentationEngine
             if (string.IsNullOrWhiteSpace(fileName)) fileName = $"{moduleName}-help.xml";
 
             var externalHelpFile = Path.Combine(externalHelpDir, fileName);
-            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(externalHelpDir);
+            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(stagingPath);
             if (File.Exists(externalHelpFile))
             {
                 try { File.Delete(externalHelpFile); } catch { /* best effort */ }

--- a/PowerForge.PowerShell/Services/DocumentationEngine.cs
+++ b/PowerForge.PowerShell/Services/DocumentationEngine.cs
@@ -482,15 +482,15 @@ public sealed class DocumentationEngine
             if (string.IsNullOrWhiteSpace(stagingPath)) return;
             if (string.IsNullOrWhiteSpace(moduleName)) return;
 
-            var culture = NormalizeExternalHelpCulture(buildDocumentation.ExternalHelpCulture);
-            var externalHelpDir = Path.Combine(stagingPath, culture);
-            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(stagingPath, moduleName);
-            if (!Directory.Exists(externalHelpDir)) return;
-
             var fileName = string.IsNullOrWhiteSpace(buildDocumentation.ExternalHelpFileName)
                 ? $"{moduleName}-help.xml"
                 : Path.GetFileName(buildDocumentation.ExternalHelpFileName.Trim());
             if (string.IsNullOrWhiteSpace(fileName)) fileName = $"{moduleName}-help.xml";
+
+            var culture = NormalizeExternalHelpCulture(buildDocumentation.ExternalHelpCulture);
+            var externalHelpDir = Path.Combine(stagingPath, culture);
+            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(stagingPath, moduleName, fileName);
+            if (!Directory.Exists(externalHelpDir)) return;
 
             var externalHelpFile = Path.Combine(externalHelpDir, fileName);
             if (File.Exists(externalHelpFile))

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Management.Automation.Language;
 
 namespace PowerForge;
@@ -375,8 +376,8 @@ internal static class DocumentationExternalHelpAliasWriter
 
             foreach (var value in command.CommandElements
                          .Skip(1)
-                         .OfType<StringConstantExpressionAst>()
-                         .Select(node => node.Value)
+                         .Select(element => GetStaticModuleImportPath(element, scriptDirectory))
+                         .OfType<string>()
                          .Where(value => value.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ||
                                          value.EndsWith(".psm1", StringComparison.OrdinalIgnoreCase)))
             {
@@ -409,6 +410,28 @@ internal static class DocumentationExternalHelpAliasWriter
                     yield return assemblyPath;
             }
         }
+    }
+
+    private static string? GetStaticModuleImportPath(CommandElementAst element, string scriptDirectory)
+    {
+        if (element is StringConstantExpressionAst literal)
+            return literal.Value;
+
+        if (element is not ExpandableStringExpressionAst expandable ||
+            expandable.NestedExpressions.Count == 0 ||
+            expandable.NestedExpressions.Any(expression =>
+                expression is not VariableExpressionAst variable ||
+                !string.Equals(
+                    variable.VariablePath.UserPath,
+                    "PSScriptRoot",
+                    StringComparison.OrdinalIgnoreCase)))
+            return null;
+
+        return Regex.Replace(
+            expandable.Value,
+            @"\$\{?PSScriptRoot\}?",
+            _ => scriptDirectory,
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     }
 
     internal static bool PathTraversesDirectoryReparsePoint(string rootDirectory, string candidateDirectory)

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -106,6 +106,8 @@ internal static class DocumentationExternalHelpAliasWriter
                 continue;
 
             Directory.CreateDirectory(aliasDirectory);
+            if (IsReparsePoint(aliasPath))
+                continue;
             if (!CanWriteGeneratedAlias(aliasPath, moduleName))
                 continue;
             File.WriteAllText(aliasPath, content, new System.Text.UTF8Encoding(false));
@@ -137,6 +139,27 @@ internal static class DocumentationExternalHelpAliasWriter
         var prefix = ReadPrefix(path);
         return prefix.Contains(GetGeneratedAliasMarker(moduleName), StringComparison.Ordinal) ||
                prefix.Contains(LegacyGeneratedAliasMarker, StringComparison.Ordinal);
+    }
+
+    internal static bool IsReparsePoint(string path)
+    {
+        try
+        {
+            return (File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0;
+        }
+        catch (FileNotFoundException)
+        {
+            return false;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return false;
+        }
+        catch
+        {
+            // Fail closed when an existing path cannot be inspected safely.
+            return true;
+        }
     }
 
     private static string ReadPrefix(string path)

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace PowerForge;
 
@@ -10,11 +11,16 @@ namespace PowerForge;
 /// </summary>
 internal static class DocumentationExternalHelpAliasWriter
 {
-    private const string GeneratedAliasMarker = "<!-- PowerForgeGeneratedExternalHelpAlias -->";
+    private const string LegacyGeneratedAliasMarker = "<!-- PowerForgeGeneratedExternalHelpAlias -->";
+    private const string GeneratedAliasMarkerPrefix = "<!-- PowerForgeGeneratedExternalHelpAlias:";
 
-    public static void PruneGeneratedAliases(string rootDirectory)
+    public static void PruneGeneratedAliases(string rootDirectory, string moduleName)
     {
-        if (string.IsNullOrWhiteSpace(rootDirectory) || !Directory.Exists(rootDirectory)) return;
+        if (string.IsNullOrWhiteSpace(rootDirectory) ||
+            string.IsNullOrWhiteSpace(moduleName) ||
+            !Directory.Exists(rootDirectory)) return;
+
+        var marker = GetGeneratedAliasMarker(moduleName);
 
         foreach (var aliasPath in Directory.EnumerateFiles(
                      rootDirectory,
@@ -23,15 +29,7 @@ internal static class DocumentationExternalHelpAliasWriter
         {
             try
             {
-                bool generated;
-                using (var reader = new StreamReader(aliasPath))
-                {
-                    var prefix = new char[512];
-                    var read = reader.Read(prefix, 0, prefix.Length);
-                    generated = new string(prefix, 0, read)
-                        .Contains(GeneratedAliasMarker, StringComparison.Ordinal);
-                }
-                if (generated)
+                if (ReadPrefix(aliasPath).Contains(marker, StringComparison.Ordinal))
                     File.Delete(aliasPath);
             }
             catch
@@ -43,9 +41,11 @@ internal static class DocumentationExternalHelpAliasWriter
 
     public static IReadOnlyList<string> WriteAliases(
         DocumentationExtractionPayload payload,
-        string externalHelpFilePath)
+        string externalHelpFilePath,
+        string moduleName)
     {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
+        if (string.IsNullOrWhiteSpace(moduleName)) throw new ArgumentException("Module name is required.", nameof(moduleName));
         if (string.IsNullOrWhiteSpace(externalHelpFilePath) || !File.Exists(externalHelpFilePath))
             return Array.Empty<string>();
 
@@ -53,7 +53,6 @@ internal static class DocumentationExternalHelpAliasWriter
         var directory = Path.GetDirectoryName(Path.GetFullPath(externalHelpFilePath))!;
         var culture = new DirectoryInfo(directory).Name;
         var stagingRoot = Directory.GetParent(directory)?.FullName ?? directory;
-        var primaryFileName = Path.GetFileName(externalHelpFilePath);
         var assemblyPaths = (payload.Commands ?? new List<DocumentationCommandHelp>())
             .Where(command => command is not null && !string.IsNullOrWhiteSpace(command.AssemblyPath))
             .Select(command => command.AssemblyPath!.Trim().Trim('"'))
@@ -64,11 +63,12 @@ internal static class DocumentationExternalHelpAliasWriter
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase);
 
+        var marker = GetGeneratedAliasMarker(moduleName);
         var content = File.ReadAllText(externalHelpFilePath);
         var declarationEnd = content.IndexOf("?>", StringComparison.Ordinal);
         content = declarationEnd >= 0
-            ? content.Insert(declarationEnd + 2, Environment.NewLine + GeneratedAliasMarker)
-            : GeneratedAliasMarker + Environment.NewLine + content;
+            ? content.Insert(declarationEnd + 2, Environment.NewLine + marker)
+            : marker + Environment.NewLine + content;
 
         foreach (var assemblyPath in assemblyPaths)
         {
@@ -79,16 +79,46 @@ internal static class DocumentationExternalHelpAliasWriter
             var assemblyDirectory = Path.GetDirectoryName(assemblyPath) ?? stagingRoot;
             var aliasDirectory = Path.Combine(assemblyDirectory, culture);
             var aliasPath = Path.Combine(aliasDirectory, aliasName);
-            if (string.Equals(aliasPath, externalHelpFilePath, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(aliasName, primaryFileName, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(aliasPath, externalHelpFilePath, StringComparison.OrdinalIgnoreCase))
                 continue;
 
             Directory.CreateDirectory(aliasDirectory);
+            if (!CanWriteGeneratedAlias(aliasPath, moduleName))
+                continue;
             File.WriteAllText(aliasPath, content, new System.Text.UTF8Encoding(false));
             output.Add(aliasPath);
         }
 
         return output;
+    }
+
+    internal static string GetGeneratedAliasMarker(string moduleName)
+        => GeneratedAliasMarkerPrefix +
+           Convert.ToBase64String(Encoding.UTF8.GetBytes((moduleName ?? string.Empty).ToUpperInvariant())) +
+           " -->";
+
+    internal static bool IsGeneratedAlias(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) return false;
+        var prefix = ReadPrefix(path);
+        return prefix.Contains(GeneratedAliasMarkerPrefix, StringComparison.Ordinal) ||
+               prefix.Contains(LegacyGeneratedAliasMarker, StringComparison.Ordinal);
+    }
+
+    internal static bool CanWriteGeneratedAlias(string path, string moduleName)
+    {
+        if (!File.Exists(path)) return true;
+        var prefix = ReadPrefix(path);
+        return prefix.Contains(GetGeneratedAliasMarker(moduleName), StringComparison.Ordinal) ||
+               prefix.Contains(LegacyGeneratedAliasMarker, StringComparison.Ordinal);
+    }
+
+    private static string ReadPrefix(string path)
+    {
+        using var reader = new StreamReader(path);
+        var prefix = new char[512];
+        var read = reader.Read(prefix, 0, prefix.Length);
+        return new string(prefix, 0, read);
     }
 
     private static bool IsPathWithinRoot(string root, string path)

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -12,14 +12,14 @@ internal static class DocumentationExternalHelpAliasWriter
 {
     private const string GeneratedAliasMarker = "<!-- PowerForgeGeneratedExternalHelpAlias -->";
 
-    public static void PruneGeneratedAliases(string externalHelpDirectory)
+    public static void PruneGeneratedAliases(string rootDirectory)
     {
-        if (string.IsNullOrWhiteSpace(externalHelpDirectory) || !Directory.Exists(externalHelpDirectory)) return;
+        if (string.IsNullOrWhiteSpace(rootDirectory) || !Directory.Exists(rootDirectory)) return;
 
         foreach (var aliasPath in Directory.EnumerateFiles(
-                     externalHelpDirectory,
+                     rootDirectory,
                      "*.dll-Help.xml",
-                     SearchOption.TopDirectoryOnly))
+                     SearchOption.AllDirectories))
         {
             try
             {
@@ -51,28 +51,52 @@ internal static class DocumentationExternalHelpAliasWriter
 
         var output = new List<string> { Path.GetFullPath(externalHelpFilePath) };
         var directory = Path.GetDirectoryName(Path.GetFullPath(externalHelpFilePath))!;
+        var culture = new DirectoryInfo(directory).Name;
+        var stagingRoot = Directory.GetParent(directory)?.FullName ?? directory;
         var primaryFileName = Path.GetFileName(externalHelpFilePath);
-        var aliasNames = (payload.Commands ?? new List<DocumentationCommandHelp>())
+        var assemblyPaths = (payload.Commands ?? new List<DocumentationCommandHelp>())
             .Where(command => command is not null && !string.IsNullOrWhiteSpace(command.AssemblyPath))
-            .Select(command => Path.GetFileName(command.AssemblyPath!.Trim().Trim('"')))
-            .Where(fileName => !string.IsNullOrWhiteSpace(fileName))
-            .Select(fileName => fileName + "-Help.xml")
-            .Where(fileName => !string.Equals(fileName, primaryFileName, StringComparison.OrdinalIgnoreCase))
+            .Select(command => command.AssemblyPath!.Trim().Trim('"'))
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => Path.IsPathRooted(path)
+                ? Path.GetFullPath(path)
+                : Path.GetFullPath(Path.Combine(stagingRoot, path)))
             .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(fileName => fileName, StringComparer.OrdinalIgnoreCase);
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase);
 
-        foreach (var aliasName in aliasNames)
+        var content = File.ReadAllText(externalHelpFilePath);
+        var declarationEnd = content.IndexOf("?>", StringComparison.Ordinal);
+        content = declarationEnd >= 0
+            ? content.Insert(declarationEnd + 2, Environment.NewLine + GeneratedAliasMarker)
+            : GeneratedAliasMarker + Environment.NewLine + content;
+
+        foreach (var assemblyPath in assemblyPaths)
         {
-            var aliasPath = Path.Combine(directory, aliasName);
-            var content = File.ReadAllText(externalHelpFilePath);
-            var declarationEnd = content.IndexOf("?>", StringComparison.Ordinal);
-            content = declarationEnd >= 0
-                ? content.Insert(declarationEnd + 2, Environment.NewLine + GeneratedAliasMarker)
-                : GeneratedAliasMarker + Environment.NewLine + content;
+            if (!IsPathWithinRoot(stagingRoot, assemblyPath))
+                continue;
+
+            var aliasName = Path.GetFileName(assemblyPath) + "-Help.xml";
+            var assemblyDirectory = Path.GetDirectoryName(assemblyPath) ?? stagingRoot;
+            var aliasDirectory = Path.Combine(assemblyDirectory, culture);
+            var aliasPath = Path.Combine(aliasDirectory, aliasName);
+            if (string.Equals(aliasPath, externalHelpFilePath, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(aliasName, primaryFileName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            Directory.CreateDirectory(aliasDirectory);
             File.WriteAllText(aliasPath, content, new System.Text.UTF8Encoding(false));
             output.Add(aliasPath);
         }
 
         return output;
+    }
+
+    private static bool IsPathWithinRoot(string root, string path)
+    {
+        var fullRoot = Path.GetFullPath(root)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var fullPath = Path.GetFullPath(path);
+        return string.Equals(fullRoot, fullPath, StringComparison.OrdinalIgnoreCase) ||
+               fullPath.StartsWith(fullRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -65,6 +65,10 @@ internal static class DocumentationExternalHelpAliasWriter
         var directory = Path.GetDirectoryName(Path.GetFullPath(externalHelpFilePath))!;
         var culture = new DirectoryInfo(directory).Name;
         var stagingRoot = Directory.GetParent(directory)?.FullName ?? directory;
+        var pathComparison = FrameworkCompatibility.GetPathStringComparison(stagingRoot);
+        var pathComparer = pathComparison == StringComparison.Ordinal
+            ? StringComparer.Ordinal
+            : StringComparer.OrdinalIgnoreCase;
         var assemblyPaths = (payload.Commands ?? new List<DocumentationCommandHelp>())
             .Where(command => command is not null && !string.IsNullOrWhiteSpace(command.AssemblyPath))
             .Select(command => command.AssemblyPath!.Trim().Trim('"'))
@@ -72,8 +76,8 @@ internal static class DocumentationExternalHelpAliasWriter
             .Select(path => Path.IsPathRooted(path)
                 ? Path.GetFullPath(path)
                 : Path.GetFullPath(Path.Combine(stagingRoot, path)))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase);
+            .Distinct(pathComparer)
+            .OrderBy(path => path, pathComparer);
 
         var marker = GetGeneratedAliasMarker(moduleName);
         var content = File.ReadAllText(externalHelpFilePath);
@@ -91,7 +95,7 @@ internal static class DocumentationExternalHelpAliasWriter
             var assemblyDirectory = Path.GetDirectoryName(assemblyPath) ?? stagingRoot;
             var aliasDirectory = Path.Combine(assemblyDirectory, culture);
             var aliasPath = Path.Combine(aliasDirectory, aliasName);
-            if (string.Equals(aliasPath, externalHelpFilePath, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(aliasPath, externalHelpFilePath, pathComparison))
                 continue;
 
             Directory.CreateDirectory(aliasDirectory);
@@ -139,24 +143,41 @@ internal static class DocumentationExternalHelpAliasWriter
     private static HashSet<string> GetLegacyPrimaryContent(string rootDirectory, string? primaryFileName)
     {
         var content = new HashSet<string>(StringComparer.Ordinal);
-        if (string.IsNullOrWhiteSpace(primaryFileName)) return content;
+        var fullRoot = Path.GetFullPath(rootDirectory)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var pathComparison = FrameworkCompatibility.GetPathStringComparison(fullRoot);
+        var preferredFileName = Path.GetFileName(primaryFileName ?? string.Empty);
 
         foreach (var path in Directory.EnumerateFiles(
                      rootDirectory,
-                     Path.GetFileName(primaryFileName),
-                     SearchOption.AllDirectories))
+                     "*",
+                     SearchOption.AllDirectories)
+                 .Where(path =>
+                 {
+                     var fileName = Path.GetFileName(path);
+                     return fileName.EndsWith("-Help.xml", StringComparison.OrdinalIgnoreCase) &&
+                            !fileName.EndsWith(".dll-Help.xml", StringComparison.OrdinalIgnoreCase);
+                 })
+                 .OrderByDescending(path => string.Equals(
+                     Path.GetFileName(path), preferredFileName, StringComparison.OrdinalIgnoreCase)))
         {
             var parent = Path.GetDirectoryName(path);
             var candidateRoot = string.IsNullOrWhiteSpace(parent)
                 ? null
                 : Directory.GetParent(parent)?.FullName;
-            if (!string.Equals(
-                    Path.GetFullPath(rootDirectory).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+            if (!string.Equals(fullRoot,
                     candidateRoot?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
-                    StringComparison.OrdinalIgnoreCase))
+                    pathComparison))
                 continue;
 
-            try { content.Add(NormalizeLegacyContent(File.ReadAllText(path))); }
+            try
+            {
+                var text = File.ReadAllText(path);
+                if (text.Contains(GeneratedAliasMarkerPrefix, StringComparison.Ordinal) ||
+                    text.Contains(LegacyGeneratedAliasMarker, StringComparison.Ordinal))
+                    continue;
+                content.Add(NormalizeLegacyContent(text));
+            }
             catch { /* best effort */ }
         }
 
@@ -164,16 +185,22 @@ internal static class DocumentationExternalHelpAliasWriter
     }
 
     private static string[] GetNestedModuleRoots(string rootDirectory)
-        => Directory.EnumerateFiles(rootDirectory, "*.psd1", SearchOption.AllDirectories)
+    {
+        var pathComparison = FrameworkCompatibility.GetPathStringComparison(rootDirectory);
+        var pathComparer = pathComparison == StringComparison.Ordinal
+            ? StringComparer.Ordinal
+            : StringComparer.OrdinalIgnoreCase;
+        return Directory.EnumerateFiles(rootDirectory, "*.psd1", SearchOption.AllDirectories)
             .Select(Path.GetDirectoryName)
             .Where(path => !string.IsNullOrWhiteSpace(path) &&
                            !string.Equals(
                                Path.GetFullPath(path!),
                                Path.GetFullPath(rootDirectory),
-                               StringComparison.OrdinalIgnoreCase))
+                               pathComparison))
             .Select(path => Path.GetFullPath(path!))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Distinct(pathComparer)
             .ToArray();
+    }
 
     private static string NormalizeLegacyContent(string content)
     {
@@ -192,7 +219,8 @@ internal static class DocumentationExternalHelpAliasWriter
         var fullRoot = Path.GetFullPath(root)
             .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         var fullPath = Path.GetFullPath(path);
-        return string.Equals(fullRoot, fullPath, StringComparison.OrdinalIgnoreCase) ||
-               fullPath.StartsWith(fullRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+        var pathComparison = FrameworkCompatibility.GetPathStringComparison(fullRoot);
+        return string.Equals(fullRoot, fullPath, pathComparison) ||
+               fullPath.StartsWith(fullRoot + Path.DirectorySeparatorChar, pathComparison);
     }
 }

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Management.Automation.Language;
 
 namespace PowerForge;
 
@@ -198,6 +199,7 @@ internal static class DocumentationExternalHelpAliasWriter
             : StringComparer.OrdinalIgnoreCase;
         return Directory.EnumerateFiles(rootDirectory, "*", SearchOption.AllDirectories)
             .Where(path => Path.GetFileName(path).EndsWith(".psd1", StringComparison.OrdinalIgnoreCase))
+            .Where(IsModuleManifest)
             .Select(Path.GetDirectoryName)
             .Where(path => !string.IsNullOrWhiteSpace(path) &&
                            !string.Equals(
@@ -208,6 +210,52 @@ internal static class DocumentationExternalHelpAliasWriter
             .Distinct(pathComparer)
             .ToArray();
     }
+
+    private static bool IsModuleManifest(string path)
+    {
+        try
+        {
+            var ast = Parser.ParseFile(path, out _, out var errors);
+            if (errors is { Length: > 0 }) return false;
+            var manifest = ast.Find(
+                node => node is HashtableAst table && !HasHashtableAncestor(table),
+                searchNestedScriptBlocks: false) as HashtableAst;
+            if (manifest is null) return false;
+            var keys = manifest.KeyValuePairs
+                .Select(pair => GetManifestKey(pair.Item1))
+                .Where(key => !string.IsNullOrEmpty(key))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            return keys.Contains("ModuleVersion") && keys.Overlaps(ModuleManifestContentKeys);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool HasHashtableAncestor(Ast ast)
+    {
+        for (var parent = ast.Parent; parent is not null; parent = parent.Parent)
+        {
+            if (parent is HashtableAst) return true;
+        }
+        return false;
+    }
+
+    private static string? GetManifestKey(ExpressionAst key)
+        => key switch
+        {
+            StringConstantExpressionAst text => text.Value,
+            ConstantExpressionAst constant when constant.Value is string value => value,
+            _ => null
+        };
+
+    private static readonly string[] ModuleManifestContentKeys =
+    {
+        "RootModule", "ModuleToProcess", "NestedModules", "RequiredModules",
+        "FunctionsToExport", "CmdletsToExport", "AliasesToExport", "VariablesToExport",
+        "FormatsToProcess", "TypesToProcess", "ScriptsToProcess"
+    };
 
     private static string NormalizeLegacyContent(string content)
     {

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace PowerForge;
+
+/// <summary>
+/// Creates the assembly-named external-help aliases that PowerShell expects when a binary is imported directly.
+/// </summary>
+internal static class DocumentationExternalHelpAliasWriter
+{
+    private const string GeneratedAliasMarker = "<!-- PowerForgeGeneratedExternalHelpAlias -->";
+
+    public static void PruneGeneratedAliases(string externalHelpDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(externalHelpDirectory) || !Directory.Exists(externalHelpDirectory)) return;
+
+        foreach (var aliasPath in Directory.EnumerateFiles(
+                     externalHelpDirectory,
+                     "*.dll-Help.xml",
+                     SearchOption.TopDirectoryOnly))
+        {
+            try
+            {
+                bool generated;
+                using (var reader = new StreamReader(aliasPath))
+                {
+                    var prefix = new char[512];
+                    var read = reader.Read(prefix, 0, prefix.Length);
+                    generated = new string(prefix, 0, read)
+                        .Contains(GeneratedAliasMarker, StringComparison.Ordinal);
+                }
+                if (generated)
+                    File.Delete(aliasPath);
+            }
+            catch
+            {
+                // Best effort only. A locked or independently authored file must not block documentation generation.
+            }
+        }
+    }
+
+    public static IReadOnlyList<string> WriteAliases(
+        DocumentationExtractionPayload payload,
+        string externalHelpFilePath)
+    {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        if (string.IsNullOrWhiteSpace(externalHelpFilePath) || !File.Exists(externalHelpFilePath))
+            return Array.Empty<string>();
+
+        var output = new List<string> { Path.GetFullPath(externalHelpFilePath) };
+        var directory = Path.GetDirectoryName(Path.GetFullPath(externalHelpFilePath))!;
+        var primaryFileName = Path.GetFileName(externalHelpFilePath);
+        var aliasNames = (payload.Commands ?? new List<DocumentationCommandHelp>())
+            .Where(command => command is not null && !string.IsNullOrWhiteSpace(command.AssemblyPath))
+            .Select(command => Path.GetFileName(command.AssemblyPath!.Trim().Trim('"')))
+            .Where(fileName => !string.IsNullOrWhiteSpace(fileName))
+            .Select(fileName => fileName + "-Help.xml")
+            .Where(fileName => !string.Equals(fileName, primaryFileName, StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(fileName => fileName, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var aliasName in aliasNames)
+        {
+            var aliasPath = Path.Combine(directory, aliasName);
+            var content = File.ReadAllText(externalHelpFilePath);
+            var declarationEnd = content.IndexOf("?>", StringComparison.Ordinal);
+            content = declarationEnd >= 0
+                ? content.Insert(declarationEnd + 2, Environment.NewLine + GeneratedAliasMarker)
+                : GeneratedAliasMarker + Environment.NewLine + content;
+            File.WriteAllText(aliasPath, content, new System.Text.UTF8Encoding(false));
+            output.Add(aliasPath);
+        }
+
+        return output;
+    }
+}

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -14,13 +14,18 @@ internal static class DocumentationExternalHelpAliasWriter
     private const string LegacyGeneratedAliasMarker = "<!-- PowerForgeGeneratedExternalHelpAlias -->";
     private const string GeneratedAliasMarkerPrefix = "<!-- PowerForgeGeneratedExternalHelpAlias:";
 
-    public static void PruneGeneratedAliases(string rootDirectory, string moduleName)
+    public static void PruneGeneratedAliases(
+        string rootDirectory,
+        string moduleName,
+        string? primaryFileName = null)
     {
         if (string.IsNullOrWhiteSpace(rootDirectory) ||
             string.IsNullOrWhiteSpace(moduleName) ||
             !Directory.Exists(rootDirectory)) return;
 
         var marker = GetGeneratedAliasMarker(moduleName);
+        var legacyPrimaryContent = GetLegacyPrimaryContent(rootDirectory, primaryFileName);
+        var nestedModuleRoots = GetNestedModuleRoots(rootDirectory);
 
         foreach (var aliasPath in Directory.EnumerateFiles(
                      rootDirectory,
@@ -29,7 +34,14 @@ internal static class DocumentationExternalHelpAliasWriter
         {
             try
             {
-                if (ReadPrefix(aliasPath).Contains(marker, StringComparison.Ordinal))
+                var prefix = ReadPrefix(aliasPath);
+                var ownedByCurrentModule = prefix.Contains(marker, StringComparison.Ordinal);
+                var legacyOwnedByCurrentModule =
+                    legacyPrimaryContent.Count > 0 &&
+                    prefix.Contains(LegacyGeneratedAliasMarker, StringComparison.Ordinal) &&
+                    !nestedModuleRoots.Any(root => IsPathWithinRoot(root, aliasPath)) &&
+                    legacyPrimaryContent.Contains(NormalizeLegacyContent(File.ReadAllText(aliasPath)));
+                if (ownedByCurrentModule || legacyOwnedByCurrentModule)
                     File.Delete(aliasPath);
             }
             catch
@@ -97,6 +109,9 @@ internal static class DocumentationExternalHelpAliasWriter
            Convert.ToBase64String(Encoding.UTF8.GetBytes((moduleName ?? string.Empty).ToUpperInvariant())) +
            " -->";
 
+    internal static string GetLegacyGeneratedAliasMarker()
+        => LegacyGeneratedAliasMarker;
+
     internal static bool IsGeneratedAlias(string path)
     {
         if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) return false;
@@ -119,6 +134,57 @@ internal static class DocumentationExternalHelpAliasWriter
         var prefix = new char[512];
         var read = reader.Read(prefix, 0, prefix.Length);
         return new string(prefix, 0, read);
+    }
+
+    private static HashSet<string> GetLegacyPrimaryContent(string rootDirectory, string? primaryFileName)
+    {
+        var content = new HashSet<string>(StringComparer.Ordinal);
+        if (string.IsNullOrWhiteSpace(primaryFileName)) return content;
+
+        foreach (var path in Directory.EnumerateFiles(
+                     rootDirectory,
+                     Path.GetFileName(primaryFileName),
+                     SearchOption.AllDirectories))
+        {
+            var parent = Path.GetDirectoryName(path);
+            var candidateRoot = string.IsNullOrWhiteSpace(parent)
+                ? null
+                : Directory.GetParent(parent)?.FullName;
+            if (!string.Equals(
+                    Path.GetFullPath(rootDirectory).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                    candidateRoot?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                    StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            try { content.Add(NormalizeLegacyContent(File.ReadAllText(path))); }
+            catch { /* best effort */ }
+        }
+
+        return content;
+    }
+
+    private static string[] GetNestedModuleRoots(string rootDirectory)
+        => Directory.EnumerateFiles(rootDirectory, "*.psd1", SearchOption.AllDirectories)
+            .Select(Path.GetDirectoryName)
+            .Where(path => !string.IsNullOrWhiteSpace(path) &&
+                           !string.Equals(
+                               Path.GetFullPath(path!),
+                               Path.GetFullPath(rootDirectory),
+                               StringComparison.OrdinalIgnoreCase))
+            .Select(path => Path.GetFullPath(path!))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private static string NormalizeLegacyContent(string content)
+    {
+        var normalized = (content ?? string.Empty)
+            .Replace("\r\n", "\n")
+            .Replace("\r", "\n");
+        normalized = normalized
+            .Replace("\n" + LegacyGeneratedAliasMarker, string.Empty)
+            .Replace(LegacyGeneratedAliasMarker + "\n", string.Empty)
+            .Replace(LegacyGeneratedAliasMarker, string.Empty);
+        return normalized.Trim();
     }
 
     private static bool IsPathWithinRoot(string root, string path)

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -98,7 +98,7 @@ internal static class DocumentationExternalHelpAliasWriter
 
             var aliasName = Path.GetFileName(assemblyPath) + "-Help.xml";
             var assemblyDirectory = Path.GetDirectoryName(assemblyPath) ?? stagingRoot;
-            if (ContainsDirectoryReparsePoint(stagingRoot, assemblyDirectory))
+            if (PathTraversesDirectoryReparsePoint(stagingRoot, assemblyDirectory))
                 continue;
             var aliasDirectory = Path.Combine(assemblyDirectory, culture);
             var aliasPath = Path.Combine(aliasDirectory, aliasName);
@@ -213,7 +213,7 @@ internal static class DocumentationExternalHelpAliasWriter
             .ToArray();
     }
 
-    private static bool ContainsDirectoryReparsePoint(string rootDirectory, string candidateDirectory)
+    internal static bool PathTraversesDirectoryReparsePoint(string rootDirectory, string candidateDirectory)
     {
         var fullRoot = Path.GetFullPath(rootDirectory)
             .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
@@ -229,9 +229,17 @@ internal static class DocumentationExternalHelpAliasWriter
                 if ((File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
                     return true;
             }
+            catch (FileNotFoundException)
+            {
+                // A trailing directory may not exist yet. Existing ancestors are still inspected.
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // A trailing directory may not exist yet. Existing ancestors are still inspected.
+            }
             catch
             {
-                // Fail closed when a directory disappears or cannot be inspected.
+                // Fail closed when an existing directory cannot be inspected safely.
                 return true;
             }
 

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -74,7 +74,8 @@ internal static class DocumentationExternalHelpAliasWriter
         var pathComparer = pathComparison == StringComparison.Ordinal
             ? StringComparer.Ordinal
             : StringComparer.OrdinalIgnoreCase;
-        var nestedModuleRoots = GetNestedModuleRoots(stagingRoot);
+        var sameNameNestedModuleRoots = GetNestedModuleRoots(stagingRoot, moduleName);
+        var nestedModuleOwnedAssemblies = GetNestedModuleOwnedAssemblyPaths(stagingRoot);
         var assemblyPaths = (payload.Commands ?? new List<DocumentationCommandHelp>())
             .Where(command => command is not null && !string.IsNullOrWhiteSpace(command.AssemblyPath))
             .Select(command => command.AssemblyPath!.Trim().Trim('"'))
@@ -107,7 +108,8 @@ internal static class DocumentationExternalHelpAliasWriter
             var aliasPath = Path.Combine(aliasDirectory, aliasName);
             if (string.Equals(aliasPath, externalHelpFilePath, pathComparison))
                 continue;
-            if (nestedModuleRoots.Any(root => IsPathWithinRoot(root, aliasPath)))
+            if (sameNameNestedModuleRoots.Any(root => IsPathWithinRoot(root, aliasPath)) ||
+                nestedModuleOwnedAssemblies.Contains(assemblyPath))
                 continue;
 
             Directory.CreateDirectory(aliasDirectory);
@@ -241,6 +243,82 @@ internal static class DocumentationExternalHelpAliasWriter
             .ToArray();
     }
 
+    private static HashSet<string> GetNestedModuleOwnedAssemblyPaths(string rootDirectory)
+    {
+        var fullRoot = Path.GetFullPath(rootDirectory);
+        var pathComparison = FrameworkCompatibility.GetPathStringComparison(fullRoot);
+        var pathComparer = pathComparison == StringComparison.Ordinal
+            ? StringComparer.Ordinal
+            : StringComparer.OrdinalIgnoreCase;
+        var paths = new HashSet<string>(pathComparer);
+
+        foreach (var manifestPath in EnumerateFilesWithoutDirectoryLinks(fullRoot)
+                     .Where(path => Path.GetFileName(path).EndsWith(".psd1", StringComparison.OrdinalIgnoreCase))
+                     .Where(path => !string.Equals(
+                         Path.GetDirectoryName(Path.GetFullPath(path)),
+                         fullRoot,
+                         pathComparison))
+                     .Where(IsModuleManifest))
+        {
+            foreach (var assemblyPath in GetManifestAssemblyPaths(manifestPath, fullRoot))
+                paths.Add(assemblyPath);
+        }
+
+        return paths;
+    }
+
+    private static IEnumerable<string> GetManifestAssemblyPaths(string manifestPath, string rootDirectory)
+    {
+        HashtableAst? manifest;
+        try
+        {
+            var ast = Parser.ParseFile(manifestPath, out _, out var errors);
+            if (errors is { Length: > 0 }) yield break;
+            manifest = ast.Find(
+                node => node is HashtableAst table && !HasHashtableAncestor(table),
+                searchNestedScriptBlocks: false) as HashtableAst;
+        }
+        catch
+        {
+            yield break;
+        }
+
+        if (manifest is null) yield break;
+        var manifestDirectory = Path.GetDirectoryName(Path.GetFullPath(manifestPath));
+        if (string.IsNullOrWhiteSpace(manifestDirectory)) yield break;
+
+        foreach (var pair in manifest.KeyValuePairs)
+        {
+            var key = GetManifestKey(pair.Item1);
+            if (!ManifestAssemblyKeys.Contains(key ?? string.Empty, StringComparer.OrdinalIgnoreCase))
+                continue;
+
+            foreach (var value in pair.Item2.FindAll(
+                         node => node is StringConstantExpressionAst,
+                         searchNestedScriptBlocks: false)
+                     .OfType<StringConstantExpressionAst>()
+                     .Select(node => node.Value)
+                     .Where(value => value.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)))
+            {
+                string candidate;
+                try
+                {
+                    var normalized = value
+                        .Replace('\\', Path.DirectorySeparatorChar)
+                        .Replace('/', Path.DirectorySeparatorChar);
+                    candidate = Path.GetFullPath(Path.Combine(manifestDirectory, normalized));
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (IsPathWithinRoot(rootDirectory, candidate))
+                    yield return candidate;
+            }
+        }
+    }
+
     internal static bool PathTraversesDirectoryReparsePoint(string rootDirectory, string candidateDirectory)
     {
         var fullRoot = Path.GetFullPath(rootDirectory)
@@ -355,6 +433,11 @@ internal static class DocumentationExternalHelpAliasWriter
         "RootModule", "ModuleToProcess", "NestedModules", "RequiredModules",
         "FunctionsToExport", "CmdletsToExport", "AliasesToExport", "VariablesToExport",
         "FormatsToProcess", "TypesToProcess", "ScriptsToProcess"
+    };
+
+    private static readonly string[] ManifestAssemblyKeys =
+    {
+        "RootModule", "ModuleToProcess", "NestedModules"
     };
 
     private static string NormalizeLegacyContent(string content)

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -74,6 +74,7 @@ internal static class DocumentationExternalHelpAliasWriter
         var pathComparer = pathComparison == StringComparison.Ordinal
             ? StringComparer.Ordinal
             : StringComparer.OrdinalIgnoreCase;
+        var nestedModuleRoots = GetNestedModuleRoots(stagingRoot);
         var assemblyPaths = (payload.Commands ?? new List<DocumentationCommandHelp>())
             .Where(command => command is not null && !string.IsNullOrWhiteSpace(command.AssemblyPath))
             .Select(command => command.AssemblyPath!.Trim().Trim('"'))
@@ -103,6 +104,8 @@ internal static class DocumentationExternalHelpAliasWriter
             var aliasDirectory = Path.Combine(assemblyDirectory, culture);
             var aliasPath = Path.Combine(aliasDirectory, aliasName);
             if (string.Equals(aliasPath, externalHelpFilePath, pathComparison))
+                continue;
+            if (nestedModuleRoots.Any(root => IsPathWithinRoot(root, aliasPath)))
                 continue;
 
             Directory.CreateDirectory(aliasDirectory);

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -102,6 +102,8 @@ internal static class DocumentationExternalHelpAliasWriter
             if (PathTraversesDirectoryReparsePoint(stagingRoot, assemblyDirectory))
                 continue;
             var aliasDirectory = Path.Combine(assemblyDirectory, culture);
+            if (PathTraversesDirectoryReparsePoint(stagingRoot, aliasDirectory))
+                continue;
             var aliasPath = Path.Combine(aliasDirectory, aliasName);
             if (string.Equals(aliasPath, externalHelpFilePath, pathComparison))
                 continue;

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -26,7 +26,8 @@ internal static class DocumentationExternalHelpAliasWriter
 
         var marker = GetGeneratedAliasMarker(moduleName);
         var legacyPrimaryContent = GetLegacyPrimaryContent(rootDirectory, primaryFileName);
-        var nestedModuleRoots = GetNestedModuleRoots(rootDirectory, moduleName);
+        var nestedModuleRoots = GetNestedModuleRoots(rootDirectory);
+        var sameNameNestedModuleRoots = GetNestedModuleRoots(rootDirectory, moduleName);
 
         foreach (var aliasPath in EnumerateFilesWithoutDirectoryLinks(rootDirectory)
                  .Where(path => Path.GetFileName(path)
@@ -36,8 +37,9 @@ internal static class DocumentationExternalHelpAliasWriter
             {
                 var prefix = ReadPrefix(aliasPath);
                 var insideNestedModule = nestedModuleRoots.Any(root => IsPathWithinRoot(root, aliasPath));
+                var insideSameNameNestedModule = sameNameNestedModuleRoots.Any(root => IsPathWithinRoot(root, aliasPath));
                 var ownedByCurrentModule =
-                    !insideNestedModule &&
+                    !insideSameNameNestedModule &&
                     prefix.Contains(marker, StringComparison.Ordinal);
                 var legacyOwnedByCurrentModule =
                     legacyPrimaryContent.Count > 0 &&
@@ -187,7 +189,7 @@ internal static class DocumentationExternalHelpAliasWriter
         return content;
     }
 
-    private static string[] GetNestedModuleRoots(string rootDirectory, string moduleName)
+    private static string[] GetNestedModuleRoots(string rootDirectory, string? moduleName = null)
     {
         var pathComparison = FrameworkCompatibility.GetPathStringComparison(rootDirectory);
         var pathComparer = pathComparison == StringComparison.Ordinal
@@ -195,10 +197,10 @@ internal static class DocumentationExternalHelpAliasWriter
             : StringComparer.OrdinalIgnoreCase;
         return EnumerateFilesWithoutDirectoryLinks(rootDirectory)
             .Where(path => Path.GetFileName(path).EndsWith(".psd1", StringComparison.OrdinalIgnoreCase))
-            .Where(path => string.Equals(
-                Path.GetFileNameWithoutExtension(path),
-                moduleName,
-                StringComparison.OrdinalIgnoreCase))
+            .Where(path => moduleName is null || string.Equals(
+                    Path.GetFileNameWithoutExtension(path),
+                    moduleName,
+                    StringComparison.OrdinalIgnoreCase))
             .Where(IsModuleManifest)
             .Select(Path.GetDirectoryName)
             .Where(path => !string.IsNullOrWhiteSpace(path) &&

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -161,7 +161,8 @@ internal static class DocumentationExternalHelpAliasWriter
                  {
                      var fileName = Path.GetFileName(path);
                      return fileName.EndsWith("-Help.xml", StringComparison.OrdinalIgnoreCase) &&
-                            !fileName.EndsWith(".dll-Help.xml", StringComparison.OrdinalIgnoreCase);
+                            (!fileName.EndsWith(".dll-Help.xml", StringComparison.OrdinalIgnoreCase) ||
+                             string.Equals(fileName, preferredFileName, StringComparison.OrdinalIgnoreCase));
                  })
                  .OrderByDescending(path => string.Equals(
                      Path.GetFileName(path), preferredFileName, StringComparison.OrdinalIgnoreCase)))
@@ -195,7 +196,8 @@ internal static class DocumentationExternalHelpAliasWriter
         var pathComparer = pathComparison == StringComparison.Ordinal
             ? StringComparer.Ordinal
             : StringComparer.OrdinalIgnoreCase;
-        return Directory.EnumerateFiles(rootDirectory, "*.psd1", SearchOption.AllDirectories)
+        return Directory.EnumerateFiles(rootDirectory, "*", SearchOption.AllDirectories)
+            .Where(path => Path.GetFileName(path).EndsWith(".psd1", StringComparison.OrdinalIgnoreCase))
             .Select(Path.GetDirectoryName)
             .Where(path => !string.IsNullOrWhiteSpace(path) &&
                            !string.Equals(

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -29,17 +29,22 @@ internal static class DocumentationExternalHelpAliasWriter
 
         foreach (var aliasPath in Directory.EnumerateFiles(
                      rootDirectory,
-                     "*.dll-Help.xml",
-                     SearchOption.AllDirectories))
+                     "*",
+                     SearchOption.AllDirectories)
+                 .Where(path => Path.GetFileName(path)
+                     .EndsWith(".dll-Help.xml", StringComparison.OrdinalIgnoreCase)))
         {
             try
             {
                 var prefix = ReadPrefix(aliasPath);
-                var ownedByCurrentModule = prefix.Contains(marker, StringComparison.Ordinal);
+                var insideNestedModule = nestedModuleRoots.Any(root => IsPathWithinRoot(root, aliasPath));
+                var ownedByCurrentModule =
+                    !insideNestedModule &&
+                    prefix.Contains(marker, StringComparison.Ordinal);
                 var legacyOwnedByCurrentModule =
                     legacyPrimaryContent.Count > 0 &&
                     prefix.Contains(LegacyGeneratedAliasMarker, StringComparison.Ordinal) &&
-                    !nestedModuleRoots.Any(root => IsPathWithinRoot(root, aliasPath)) &&
+                    !insideNestedModule &&
                     legacyPrimaryContent.Contains(NormalizeLegacyContent(File.ReadAllText(aliasPath)));
                 if (ownedByCurrentModule || legacyOwnedByCurrentModule)
                     File.Delete(aliasPath);

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -28,10 +28,7 @@ internal static class DocumentationExternalHelpAliasWriter
         var legacyPrimaryContent = GetLegacyPrimaryContent(rootDirectory, primaryFileName);
         var nestedModuleRoots = GetNestedModuleRoots(rootDirectory);
 
-        foreach (var aliasPath in Directory.EnumerateFiles(
-                     rootDirectory,
-                     "*",
-                     SearchOption.AllDirectories)
+        foreach (var aliasPath in EnumerateFilesWithoutDirectoryLinks(rootDirectory)
                  .Where(path => Path.GetFileName(path)
                      .EndsWith(".dll-Help.xml", StringComparison.OrdinalIgnoreCase)))
         {
@@ -154,10 +151,7 @@ internal static class DocumentationExternalHelpAliasWriter
         var pathComparison = FrameworkCompatibility.GetPathStringComparison(fullRoot);
         var preferredFileName = Path.GetFileName(primaryFileName ?? string.Empty);
 
-        foreach (var path in Directory.EnumerateFiles(
-                     rootDirectory,
-                     "*",
-                     SearchOption.AllDirectories)
+        foreach (var path in EnumerateFilesWithoutDirectoryLinks(rootDirectory)
                  .Where(path =>
                  {
                      var fileName = Path.GetFileName(path);
@@ -197,7 +191,7 @@ internal static class DocumentationExternalHelpAliasWriter
         var pathComparer = pathComparison == StringComparison.Ordinal
             ? StringComparer.Ordinal
             : StringComparer.OrdinalIgnoreCase;
-        return Directory.EnumerateFiles(rootDirectory, "*", SearchOption.AllDirectories)
+        return EnumerateFilesWithoutDirectoryLinks(rootDirectory)
             .Where(path => Path.GetFileName(path).EndsWith(".psd1", StringComparison.OrdinalIgnoreCase))
             .Where(IsModuleManifest)
             .Select(Path.GetDirectoryName)
@@ -209,6 +203,37 @@ internal static class DocumentationExternalHelpAliasWriter
             .Select(path => Path.GetFullPath(path!))
             .Distinct(pathComparer)
             .ToArray();
+    }
+
+    private static IEnumerable<string> EnumerateFilesWithoutDirectoryLinks(string rootDirectory)
+    {
+        var pending = new Stack<string>();
+        pending.Push(Path.GetFullPath(rootDirectory));
+        while (pending.Count > 0)
+        {
+            var directory = pending.Pop();
+            IEnumerable<string> files;
+            try { files = Directory.EnumerateFiles(directory, "*", SearchOption.TopDirectoryOnly).ToArray(); }
+            catch { continue; }
+            foreach (var file in files)
+                yield return file;
+
+            IEnumerable<string> children;
+            try { children = Directory.EnumerateDirectories(directory, "*", SearchOption.TopDirectoryOnly).ToArray(); }
+            catch { continue; }
+            foreach (var child in children)
+            {
+                try
+                {
+                    if ((File.GetAttributes(child) & FileAttributes.ReparsePoint) == 0)
+                        pending.Push(child);
+                }
+                catch
+                {
+                    // Best effort only. Unreadable or changing directories are outside the pruning contract.
+                }
+            }
+        }
     }
 
     private static bool IsModuleManifest(string path)

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -26,7 +26,7 @@ internal static class DocumentationExternalHelpAliasWriter
 
         var marker = GetGeneratedAliasMarker(moduleName);
         var legacyPrimaryContent = GetLegacyPrimaryContent(rootDirectory, primaryFileName);
-        var nestedModuleRoots = GetNestedModuleRoots(rootDirectory);
+        var nestedModuleRoots = GetNestedModuleRoots(rootDirectory, moduleName);
 
         foreach (var aliasPath in EnumerateFilesWithoutDirectoryLinks(rootDirectory)
                  .Where(path => Path.GetFileName(path)
@@ -96,6 +96,8 @@ internal static class DocumentationExternalHelpAliasWriter
 
             var aliasName = Path.GetFileName(assemblyPath) + "-Help.xml";
             var assemblyDirectory = Path.GetDirectoryName(assemblyPath) ?? stagingRoot;
+            if (ContainsDirectoryReparsePoint(stagingRoot, assemblyDirectory))
+                continue;
             var aliasDirectory = Path.Combine(assemblyDirectory, culture);
             var aliasPath = Path.Combine(aliasDirectory, aliasName);
             if (string.Equals(aliasPath, externalHelpFilePath, pathComparison))
@@ -185,7 +187,7 @@ internal static class DocumentationExternalHelpAliasWriter
         return content;
     }
 
-    private static string[] GetNestedModuleRoots(string rootDirectory)
+    private static string[] GetNestedModuleRoots(string rootDirectory, string moduleName)
     {
         var pathComparison = FrameworkCompatibility.GetPathStringComparison(rootDirectory);
         var pathComparer = pathComparison == StringComparison.Ordinal
@@ -193,6 +195,10 @@ internal static class DocumentationExternalHelpAliasWriter
             : StringComparer.OrdinalIgnoreCase;
         return EnumerateFilesWithoutDirectoryLinks(rootDirectory)
             .Where(path => Path.GetFileName(path).EndsWith(".psd1", StringComparison.OrdinalIgnoreCase))
+            .Where(path => string.Equals(
+                Path.GetFileNameWithoutExtension(path),
+                moduleName,
+                StringComparison.OrdinalIgnoreCase))
             .Where(IsModuleManifest)
             .Select(Path.GetDirectoryName)
             .Where(path => !string.IsNullOrWhiteSpace(path) &&
@@ -203,6 +209,37 @@ internal static class DocumentationExternalHelpAliasWriter
             .Select(path => Path.GetFullPath(path!))
             .Distinct(pathComparer)
             .ToArray();
+    }
+
+    private static bool ContainsDirectoryReparsePoint(string rootDirectory, string candidateDirectory)
+    {
+        var fullRoot = Path.GetFullPath(rootDirectory)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var current = Path.GetFullPath(candidateDirectory)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (!IsPathWithinRoot(fullRoot, current)) return true;
+
+        var pathComparison = FrameworkCompatibility.GetPathStringComparison(fullRoot);
+        while (!string.Equals(current, fullRoot, pathComparison))
+        {
+            try
+            {
+                if ((File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
+                    return true;
+            }
+            catch
+            {
+                // Fail closed when a directory disappears or cannot be inspected.
+                return true;
+            }
+
+            var parent = Directory.GetParent(current);
+            if (parent is null) return true;
+            current = parent.FullName
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
+
+        return false;
     }
 
     private static IEnumerable<string> EnumerateFilesWithoutDirectoryLinks(string rootDirectory)

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -142,7 +142,7 @@ internal static class DocumentationExternalHelpAliasWriter
     {
         if (!File.Exists(path)) return true;
         var prefix = ReadPrefix(path);
-        return prefix.Contains(GetGeneratedAliasMarker(moduleName), StringComparison.Ordinal) ||
+        return prefix.Contains(GeneratedAliasMarkerPrefix, StringComparison.Ordinal) ||
                prefix.Contains(LegacyGeneratedAliasMarker, StringComparison.Ordinal);
     }
 

--- a/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
+++ b/PowerForge.PowerShell/Services/DocumentationExternalHelpAliasWriter.cs
@@ -286,6 +286,11 @@ internal static class DocumentationExternalHelpAliasWriter
         if (manifest is null) yield break;
         var manifestDirectory = Path.GetDirectoryName(Path.GetFullPath(manifestPath));
         if (string.IsNullOrWhiteSpace(manifestDirectory)) yield break;
+        var pathComparison = FrameworkCompatibility.GetPathStringComparison(rootDirectory);
+        var pathComparer = pathComparison == StringComparison.Ordinal
+            ? StringComparer.Ordinal
+            : StringComparer.OrdinalIgnoreCase;
+        var scriptModulePaths = new HashSet<string>(pathComparer);
 
         foreach (var pair in manifest.KeyValuePairs)
         {
@@ -298,7 +303,8 @@ internal static class DocumentationExternalHelpAliasWriter
                          searchNestedScriptBlocks: false)
                      .OfType<StringConstantExpressionAst>()
                      .Select(node => node.Value)
-                     .Where(value => value.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)))
+                     .Where(value => value.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ||
+                                     value.EndsWith(".psm1", StringComparison.OrdinalIgnoreCase)))
             {
                 string candidate;
                 try
@@ -313,8 +319,94 @@ internal static class DocumentationExternalHelpAliasWriter
                     continue;
                 }
 
-                if (IsPathWithinRoot(rootDirectory, candidate))
+                if (!IsPathWithinRoot(rootDirectory, candidate))
+                    continue;
+
+                if (value.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
                     yield return candidate;
+                else
+                    scriptModulePaths.Add(candidate);
+            }
+        }
+
+        var visitedScriptModules = new HashSet<string>(pathComparer);
+        foreach (var scriptModulePath in scriptModulePaths)
+        {
+            foreach (var assemblyPath in GetScriptModuleAssemblyPaths(
+                         scriptModulePath,
+                         rootDirectory,
+                         visitedScriptModules))
+                yield return assemblyPath;
+        }
+    }
+
+    private static IEnumerable<string> GetScriptModuleAssemblyPaths(
+        string scriptModulePath,
+        string rootDirectory,
+        HashSet<string> visitedScriptModules)
+    {
+        if (!visitedScriptModules.Add(scriptModulePath) || !File.Exists(scriptModulePath))
+            yield break;
+
+        ScriptBlockAst script;
+        try
+        {
+            script = Parser.ParseFile(scriptModulePath, out _, out var errors);
+            if (errors is { Length: > 0 }) yield break;
+        }
+        catch
+        {
+            yield break;
+        }
+
+        var scriptDirectory = Path.GetDirectoryName(Path.GetFullPath(scriptModulePath));
+        if (string.IsNullOrWhiteSpace(scriptDirectory)) yield break;
+
+        foreach (var command in script.FindAll(
+                     node => node is CommandAst,
+                     searchNestedScriptBlocks: true)
+                 .OfType<CommandAst>())
+        {
+            var commandName = command.GetCommandName();
+            if (string.IsNullOrWhiteSpace(commandName) ||
+                !(string.Equals(commandName, "Import-Module", StringComparison.OrdinalIgnoreCase) ||
+                  commandName.EndsWith("\\Import-Module", StringComparison.OrdinalIgnoreCase)))
+                continue;
+
+            foreach (var value in command.CommandElements
+                         .Skip(1)
+                         .OfType<StringConstantExpressionAst>()
+                         .Select(node => node.Value)
+                         .Where(value => value.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ||
+                                         value.EndsWith(".psm1", StringComparison.OrdinalIgnoreCase)))
+            {
+                string candidate;
+                try
+                {
+                    var normalized = value
+                        .Replace('\\', Path.DirectorySeparatorChar)
+                        .Replace('/', Path.DirectorySeparatorChar);
+                    candidate = Path.GetFullPath(Path.Combine(scriptDirectory, normalized));
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (!IsPathWithinRoot(rootDirectory, candidate))
+                    continue;
+
+                if (value.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                {
+                    yield return candidate;
+                    continue;
+                }
+
+                foreach (var assemblyPath in GetScriptModuleAssemblyPaths(
+                             candidate,
+                             rootDirectory,
+                             visitedScriptModules))
+                    yield return assemblyPath;
             }
         }
     }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Utils.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Utils.cs
@@ -120,7 +120,10 @@ public sealed partial class ModulePipelineRunner
             var stagingRoot = string.IsNullOrWhiteSpace(externalHelpDir)
                 ? string.Empty
                 : Directory.GetParent(externalHelpDir)?.FullName ?? string.Empty;
-            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(projectRoot, plan.ModuleName);
+            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(
+                projectRoot,
+                plan.ModuleName,
+                Path.GetFileName(documentationResult.ExternalHelpFilePath));
 
             foreach (var sourceHelpFile in existingHelpFiles)
             {

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Utils.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Utils.cs
@@ -108,20 +108,29 @@ public sealed partial class ModulePipelineRunner
         if (plan.DocumentationBuild.GenerateExternalHelp &&
             (plan.DocumentationBuild.SyncExternalHelpToProjectRoot ||
              plan.GateMode == ConfigurationGateMode.Documentation) &&
-            !string.IsNullOrWhiteSpace(documentationResult.ExternalHelpFilePath) &&
-            File.Exists(documentationResult.ExternalHelpFilePath))
+            documentationResult.ExternalHelpFilePaths.Count > 0)
         {
-            var externalHelpDir = Path.GetDirectoryName(Path.GetFullPath(documentationResult.ExternalHelpFilePath));
+            var existingHelpFiles = documentationResult.ExternalHelpFilePaths
+                .Where(path => !string.IsNullOrWhiteSpace(path) && File.Exists(path))
+                .Select(Path.GetFullPath)
+                .ToArray();
+            if (existingHelpFiles.Length == 0) return;
+
+            var externalHelpDir = Path.GetDirectoryName(existingHelpFiles[0]);
             var cultureFolder = string.IsNullOrWhiteSpace(externalHelpDir)
                 ? plan.DocumentationBuild.ExternalHelpCulture
                 : new DirectoryInfo(externalHelpDir).Name;
 
             var targetCultureDir = Path.Combine(projectRoot, cultureFolder);
             Directory.CreateDirectory(targetCultureDir);
+            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(targetCultureDir);
 
-            var targetHelpFile = Path.Combine(targetCultureDir, Path.GetFileName(documentationResult.ExternalHelpFilePath));
-            if (!SamePath(documentationResult.ExternalHelpFilePath, targetHelpFile))
-                File.Copy(documentationResult.ExternalHelpFilePath, targetHelpFile, overwrite: true);
+            foreach (var sourceHelpFile in existingHelpFiles)
+            {
+                var targetHelpFile = Path.Combine(targetCultureDir, Path.GetFileName(sourceHelpFile));
+                if (!SamePath(sourceHelpFile, targetHelpFile))
+                    File.Copy(sourceHelpFile, targetHelpFile, overwrite: true);
+            }
         }
 
         _logger.Success($"Updated project documentation at '{targetDocs}'.");

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Utils.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Utils.cs
@@ -120,7 +120,7 @@ public sealed partial class ModulePipelineRunner
             var stagingRoot = string.IsNullOrWhiteSpace(externalHelpDir)
                 ? string.Empty
                 : Directory.GetParent(externalHelpDir)?.FullName ?? string.Empty;
-            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(projectRoot);
+            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(projectRoot, plan.ModuleName);
 
             foreach (var sourceHelpFile in existingHelpFiles)
             {
@@ -131,6 +131,9 @@ public sealed partial class ModulePipelineRunner
                 var targetHelpDirectory = Path.GetDirectoryName(targetHelpFile);
                 if (!string.IsNullOrWhiteSpace(targetHelpDirectory))
                     Directory.CreateDirectory(targetHelpDirectory);
+                if (DocumentationExternalHelpAliasWriter.IsGeneratedAlias(sourceHelpFile) &&
+                    !DocumentationExternalHelpAliasWriter.CanWriteGeneratedAlias(targetHelpFile, plan.ModuleName))
+                    continue;
                 if (!SamePath(sourceHelpFile, targetHelpFile))
                     File.Copy(sourceHelpFile, targetHelpFile, overwrite: true);
             }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Utils.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Utils.cs
@@ -139,6 +139,8 @@ public sealed partial class ModulePipelineRunner
                     continue;
                 if (!string.IsNullOrWhiteSpace(targetHelpDirectory))
                     Directory.CreateDirectory(targetHelpDirectory);
+                if (DocumentationExternalHelpAliasWriter.IsReparsePoint(targetHelpFile))
+                    continue;
                 if (DocumentationExternalHelpAliasWriter.IsGeneratedAlias(sourceHelpFile) &&
                     !DocumentationExternalHelpAliasWriter.CanWriteGeneratedAlias(targetHelpFile, plan.ModuleName))
                     continue;

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Utils.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Utils.cs
@@ -117,17 +117,20 @@ public sealed partial class ModulePipelineRunner
             if (existingHelpFiles.Length == 0) return;
 
             var externalHelpDir = Path.GetDirectoryName(existingHelpFiles[0]);
-            var cultureFolder = string.IsNullOrWhiteSpace(externalHelpDir)
-                ? plan.DocumentationBuild.ExternalHelpCulture
-                : new DirectoryInfo(externalHelpDir).Name;
-
-            var targetCultureDir = Path.Combine(projectRoot, cultureFolder);
-            Directory.CreateDirectory(targetCultureDir);
-            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(targetCultureDir);
+            var stagingRoot = string.IsNullOrWhiteSpace(externalHelpDir)
+                ? string.Empty
+                : Directory.GetParent(externalHelpDir)?.FullName ?? string.Empty;
+            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(projectRoot);
 
             foreach (var sourceHelpFile in existingHelpFiles)
             {
-                var targetHelpFile = Path.Combine(targetCultureDir, Path.GetFileName(sourceHelpFile));
+                var relativeHelpPath = string.IsNullOrWhiteSpace(stagingRoot)
+                    ? Path.GetFileName(sourceHelpFile)
+                    : GetRelativePath(stagingRoot, sourceHelpFile);
+                var targetHelpFile = Path.Combine(projectRoot, relativeHelpPath);
+                var targetHelpDirectory = Path.GetDirectoryName(targetHelpFile);
+                if (!string.IsNullOrWhiteSpace(targetHelpDirectory))
+                    Directory.CreateDirectory(targetHelpDirectory);
                 if (!SamePath(sourceHelpFile, targetHelpFile))
                     File.Copy(sourceHelpFile, targetHelpFile, overwrite: true);
             }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Utils.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Utils.cs
@@ -132,6 +132,11 @@ public sealed partial class ModulePipelineRunner
                     : GetRelativePath(stagingRoot, sourceHelpFile);
                 var targetHelpFile = Path.Combine(projectRoot, relativeHelpPath);
                 var targetHelpDirectory = Path.GetDirectoryName(targetHelpFile);
+                if (!string.IsNullOrWhiteSpace(targetHelpDirectory) &&
+                    DocumentationExternalHelpAliasWriter.PathTraversesDirectoryReparsePoint(
+                        projectRoot,
+                        targetHelpDirectory))
+                    continue;
                 if (!string.IsNullOrWhiteSpace(targetHelpDirectory))
                     Directory.CreateDirectory(targetHelpDirectory);
                 if (DocumentationExternalHelpAliasWriter.IsGeneratedAlias(sourceHelpFile) &&

--- a/PowerForge.Tests/BinaryDocFixtureCollection.cs
+++ b/PowerForge.Tests/BinaryDocFixtureCollection.cs
@@ -1,0 +1,6 @@
+namespace PowerForge.Tests;
+
+[CollectionDefinition("BinaryDocFixture", DisableParallelization = true)]
+public sealed class BinaryDocFixtureCollection
+{
+}

--- a/PowerForge.Tests/DocumentationBinaryFixtureTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryFixtureTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 
 namespace PowerForge.Tests;
 
+[Collection("BinaryDocFixture")]
 public sealed class DocumentationBinaryFixtureTests
 {
     [Fact]
@@ -49,6 +50,14 @@ public sealed class DocumentationBinaryFixtureTests
                 Path.Combine(staleHelpDirectory, "BinaryDocFixture-help.xml"),
                 staleExternalHelp,
                 new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            File.WriteAllText(
+                Path.Combine(staleHelpDirectory, "Removed.Binary.dll-Help.xml"),
+                staleExternalHelp.Replace("?>", "?>\r\n<!-- PowerForgeGeneratedExternalHelpAlias -->", StringComparison.Ordinal),
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            File.WriteAllText(
+                Path.Combine(staleHelpDirectory, "Authored.Binary.dll-Help.xml"),
+                staleExternalHelp,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
 
             var engine = new DocumentationEngine(new PowerShellRunner(), new NullLogger());
             var extracted = engine.ExtractHelpPayload(tempRoot, manifestPath, TimeSpan.FromMinutes(1));
@@ -80,6 +89,8 @@ public sealed class DocumentationBinaryFixtureTests
             var externalHelpPath = Path.Combine(tempRoot, "en-US", "BinaryDocFixture-help.xml");
             Assert.True(File.Exists(markdownPath), $"Expected generated markdown help at '{markdownPath}'.");
             Assert.True(File.Exists(externalHelpPath), $"Expected generated MAML help at '{externalHelpPath}'.");
+            Assert.False(File.Exists(Path.Combine(staleHelpDirectory, "Removed.Binary.dll-Help.xml")));
+            Assert.True(File.Exists(Path.Combine(staleHelpDirectory, "Authored.Binary.dll-Help.xml")));
 
             Assert.Equal(
                 NormalizeText(File.ReadAllText(Path.Combine(expectedRoot, "Get-BinaryDocSample.md"))),

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -53,12 +53,25 @@ public sealed class DocumentationBinaryMetadataContractTests
             Assert.DoesNotContain(command.Parameters, parameter => parameter.Name == "HiddenTransport");
             Assert.All(command.Syntax, syntax => Assert.DoesNotContain("HiddenTransport", syntax.Text, StringComparison.Ordinal));
 
+            var legacyPrimaryDirectory = Path.Combine(root, "en-US");
+            Directory.CreateDirectory(legacyPrimaryDirectory);
+            File.WriteAllText(
+                Path.Combine(legacyPrimaryDirectory, "MetadataFixture-help.xml"),
+                "<legacyHelpItems />");
             var staleAliasDirectory = Path.Combine(root, "Lib", "Removed", "en-US");
             Directory.CreateDirectory(staleAliasDirectory);
             var staleAlias = Path.Combine(staleAliasDirectory, "Removed.dll-Help.xml");
             File.WriteAllText(
                 staleAlias,
-                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("MetadataFixture") + "<helpItems />");
+                DocumentationExternalHelpAliasWriter.GetLegacyGeneratedAliasMarker() + "<legacyHelpItems />");
+            var bundledRoot = Path.Combine(root, "Bundled");
+            var bundledAliasDirectory = Path.Combine(bundledRoot, "Lib", "en-US");
+            Directory.CreateDirectory(bundledAliasDirectory);
+            File.WriteAllText(Path.Combine(bundledRoot, "Bundled.psd1"), "@{ RootModule = '' }");
+            var bundledAlias = Path.Combine(bundledAliasDirectory, "Bundled.dll-Help.xml");
+            File.WriteAllText(
+                bundledAlias,
+                DocumentationExternalHelpAliasWriter.GetLegacyGeneratedAliasMarker() + "<legacyHelpItems />");
 
             var result = engine.Build(
                 "MetadataFixture",
@@ -80,6 +93,7 @@ public sealed class DocumentationBinaryMetadataContractTests
             Assert.True(File.Exists(primary));
             Assert.True(File.Exists(binaryAlias));
             Assert.False(File.Exists(staleAlias));
+            Assert.True(File.Exists(bundledAlias));
             var primaryDocument = System.Xml.Linq.XDocument.Load(primary);
             var aliasDocument = System.Xml.Linq.XDocument.Load(binaryAlias);
             Assert.Equal(primaryDocument.Root!.ToString(), aliasDocument.Root!.ToString());

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -137,9 +137,11 @@ public sealed class DocumentationBinaryMetadataContractTests
             var sameNameAlias = Path.Combine(sameNameModuleRoot, "Lib", "en-US", "Bundled.DLL-Help.xml");
             Directory.CreateDirectory(Path.GetDirectoryName(sameNameAlias)!);
             File.WriteAllText(Path.Combine(sameNameModuleRoot, "OwnerModule.PSD1"), "@{ RootModule = ''; ModuleVersion = '1.0.0' }");
+            var sameNameAssemblyPath = Path.Combine(sameNameModuleRoot, "Lib", "Bundled.DLL");
+            File.WriteAllText(sameNameAssemblyPath, string.Empty);
             File.WriteAllText(
                 sameNameAlias,
-                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule") + "<helpItems />");
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule") + "\n<nestedSameName />");
             var otherNameModuleRoot = Path.Combine(root, "BundledOther");
             var outerAliasUnderOtherModule = Path.Combine(otherNameModuleRoot, "Lib", "en-US", "Outer.DLL-Help.xml");
             Directory.CreateDirectory(Path.GetDirectoryName(outerAliasUnderOtherModule)!);
@@ -148,9 +150,12 @@ public sealed class DocumentationBinaryMetadataContractTests
                 outerAliasUnderOtherModule,
                 DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule") + "<helpItems />");
             var legacyAliasUnderOtherModule = Path.Combine(otherNameModuleRoot, "Lib", "en-US", "Legacy.DLL-Help.xml");
+            var legacyAssemblyPath = Path.Combine(otherNameModuleRoot, "Lib", "Legacy.DLL");
+            File.WriteAllText(legacyAssemblyPath, string.Empty);
+            var legacyAliasContent = DocumentationExternalHelpAliasWriter.GetLegacyGeneratedAliasMarker() + "<nestedLegacy />";
             File.WriteAllText(
                 legacyAliasUnderOtherModule,
-                DocumentationExternalHelpAliasWriter.GetLegacyGeneratedAliasMarker() + "<helpItems />");
+                legacyAliasContent);
             var staleMixedCaseAlias = Path.Combine(root, "Lib", "Removed", "en-US", "Removed.DLL-Help.xml");
             Directory.CreateDirectory(Path.GetDirectoryName(staleMixedCaseAlias)!);
             File.WriteAllText(
@@ -172,7 +177,9 @@ public sealed class DocumentationBinaryMetadataContractTests
                 Commands =
                 [
                     new DocumentationCommandHelp { AssemblyPath = assemblyPath },
-                    new DocumentationCommandHelp { AssemblyPath = authoredAssemblyPath }
+                    new DocumentationCommandHelp { AssemblyPath = authoredAssemblyPath },
+                    new DocumentationCommandHelp { AssemblyPath = sameNameAssemblyPath },
+                    new DocumentationCommandHelp { AssemblyPath = legacyAssemblyPath }
                 ]
             };
             var paths = DocumentationExternalHelpAliasWriter.WriteAliases(payload, primary, "OwnerModule");
@@ -182,6 +189,12 @@ public sealed class DocumentationBinaryMetadataContractTests
             Assert.True(File.Exists(nestedAlias));
             Assert.Equal("<authoredHelpItems />", File.ReadAllText(authoredAlias));
             Assert.DoesNotContain(authoredAlias, paths, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule") + "\n<nestedSameName />",
+                File.ReadAllText(sameNameAlias));
+            Assert.Equal(legacyAliasContent, File.ReadAllText(legacyAliasUnderOtherModule));
+            Assert.DoesNotContain(sameNameAlias, paths, StringComparer.OrdinalIgnoreCase);
+            Assert.DoesNotContain(legacyAliasUnderOtherModule, paths, StringComparer.OrdinalIgnoreCase);
 
             DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(root, "OwnerModule");
 
@@ -189,8 +202,12 @@ public sealed class DocumentationBinaryMetadataContractTests
             Assert.True(File.Exists(authoredAlias));
             Assert.True(File.Exists(otherAlias));
             Assert.True(File.Exists(sameNameAlias));
+            Assert.Equal(
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule") + "\n<nestedSameName />",
+                File.ReadAllText(sameNameAlias));
             Assert.False(File.Exists(outerAliasUnderOtherModule));
             Assert.True(File.Exists(legacyAliasUnderOtherModule));
+            Assert.Equal(legacyAliasContent, File.ReadAllText(legacyAliasUnderOtherModule));
             Assert.False(File.Exists(staleMixedCaseAlias));
             Assert.False(File.Exists(dataAlias));
         }

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -67,7 +67,7 @@ public sealed class DocumentationBinaryMetadataContractTests
             var bundledRoot = Path.Combine(root, "Bundled");
             var bundledAliasDirectory = Path.Combine(bundledRoot, "Lib", "en-US");
             Directory.CreateDirectory(bundledAliasDirectory);
-            File.WriteAllText(Path.Combine(bundledRoot, "Bundled.psd1"), "@{ RootModule = '' }");
+            File.WriteAllText(Path.Combine(bundledRoot, "Bundled.psd1"), "@{ RootModule = ''; ModuleVersion = '1.0.0' }");
             var bundledAlias = Path.Combine(bundledAliasDirectory, "Bundled.dll-Help.xml");
             File.WriteAllText(
                 bundledAlias,
@@ -136,7 +136,7 @@ public sealed class DocumentationBinaryMetadataContractTests
             var sameNameModuleRoot = Path.Combine(root, "BundledOwner");
             var sameNameAlias = Path.Combine(sameNameModuleRoot, "Lib", "en-US", "Bundled.DLL-Help.xml");
             Directory.CreateDirectory(Path.GetDirectoryName(sameNameAlias)!);
-            File.WriteAllText(Path.Combine(sameNameModuleRoot, "OwnerModule.PSD1"), "@{ RootModule = '' }");
+            File.WriteAllText(Path.Combine(sameNameModuleRoot, "OwnerModule.PSD1"), "@{ RootModule = ''; ModuleVersion = '1.0.0' }");
             File.WriteAllText(
                 sameNameAlias,
                 DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule") + "<helpItems />");
@@ -144,6 +144,15 @@ public sealed class DocumentationBinaryMetadataContractTests
             Directory.CreateDirectory(Path.GetDirectoryName(staleMixedCaseAlias)!);
             File.WriteAllText(
                 staleMixedCaseAlias,
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule") + "<helpItems />");
+            var dataRoot = Path.Combine(root, "Data");
+            var dataAlias = Path.Combine(dataRoot, "en-US", "RemovedData.dll-Help.xml");
+            Directory.CreateDirectory(Path.GetDirectoryName(dataAlias)!);
+            File.WriteAllText(
+                Path.Combine(dataRoot, "strings.psd1"),
+                "@{ ModuleVersion = '1.0.0'; Greeting = 'Hello' }");
+            File.WriteAllText(
+                dataAlias,
                 DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule") + "<helpItems />");
 
             var payload = new DocumentationExtractionPayload
@@ -170,6 +179,7 @@ public sealed class DocumentationBinaryMetadataContractTests
             Assert.True(File.Exists(otherAlias));
             Assert.True(File.Exists(sameNameAlias));
             Assert.False(File.Exists(staleMixedCaseAlias));
+            Assert.False(File.Exists(dataAlias));
         }
         finally
         {

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -147,6 +147,10 @@ public sealed class DocumentationBinaryMetadataContractTests
             File.WriteAllText(
                 outerAliasUnderOtherModule,
                 DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule") + "<helpItems />");
+            var legacyAliasUnderOtherModule = Path.Combine(otherNameModuleRoot, "Lib", "en-US", "Legacy.DLL-Help.xml");
+            File.WriteAllText(
+                legacyAliasUnderOtherModule,
+                DocumentationExternalHelpAliasWriter.GetLegacyGeneratedAliasMarker() + "<helpItems />");
             var staleMixedCaseAlias = Path.Combine(root, "Lib", "Removed", "en-US", "Removed.DLL-Help.xml");
             Directory.CreateDirectory(Path.GetDirectoryName(staleMixedCaseAlias)!);
             File.WriteAllText(
@@ -186,6 +190,7 @@ public sealed class DocumentationBinaryMetadataContractTests
             Assert.True(File.Exists(otherAlias));
             Assert.True(File.Exists(sameNameAlias));
             Assert.False(File.Exists(outerAliasUnderOtherModule));
+            Assert.True(File.Exists(legacyAliasUnderOtherModule));
             Assert.False(File.Exists(staleMixedCaseAlias));
             Assert.False(File.Exists(dataAlias));
         }

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -150,7 +150,11 @@ public sealed class DocumentationBinaryMetadataContractTests
             var otherNameModuleRoot = Path.Combine(root, "BundledOther");
             var outerAliasUnderOtherModule = Path.Combine(otherNameModuleRoot, "Lib", "en-US", "Outer.DLL-Help.xml");
             Directory.CreateDirectory(Path.GetDirectoryName(outerAliasUnderOtherModule)!);
-            File.WriteAllText(Path.Combine(otherNameModuleRoot, "OtherModule.psd1"), "@{ RootModule = ''; ModuleVersion = '1.0.0' }");
+            File.WriteAllText(
+                Path.Combine(otherNameModuleRoot, "OtherModule.psd1"),
+                "@{ RootModule = 'Lib/Legacy.DLL'; ModuleVersion = '1.0.0' }");
+            var outerAssemblyPath = Path.Combine(otherNameModuleRoot, "Lib", "Outer.DLL");
+            File.WriteAllText(outerAssemblyPath, string.Empty);
             File.WriteAllText(
                 outerAliasUnderOtherModule,
                 DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule") + "<helpItems />");
@@ -184,7 +188,8 @@ public sealed class DocumentationBinaryMetadataContractTests
                     new DocumentationCommandHelp { AssemblyPath = assemblyPath },
                     new DocumentationCommandHelp { AssemblyPath = authoredAssemblyPath },
                     new DocumentationCommandHelp { AssemblyPath = sameNameAssemblyPath },
-                    new DocumentationCommandHelp { AssemblyPath = legacyAssemblyPath }
+                    new DocumentationCommandHelp { AssemblyPath = legacyAssemblyPath },
+                    new DocumentationCommandHelp { AssemblyPath = outerAssemblyPath }
                 ]
             };
             var paths = DocumentationExternalHelpAliasWriter.WriteAliases(payload, primary, "OwnerModule");
@@ -205,6 +210,11 @@ public sealed class DocumentationBinaryMetadataContractTests
             Assert.Equal(legacyAliasContent, File.ReadAllText(legacyAliasUnderOtherModule));
             Assert.DoesNotContain(sameNameAlias, paths, StringComparer.OrdinalIgnoreCase);
             Assert.DoesNotContain(legacyAliasUnderOtherModule, paths, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains(outerAliasUnderOtherModule, paths, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains(
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule"),
+                File.ReadAllText(outerAliasUnderOtherModule),
+                StringComparison.Ordinal);
 
             DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(root, "OwnerModule");
 

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -140,6 +140,13 @@ public sealed class DocumentationBinaryMetadataContractTests
             File.WriteAllText(
                 sameNameAlias,
                 DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule") + "<helpItems />");
+            var otherNameModuleRoot = Path.Combine(root, "BundledOther");
+            var outerAliasUnderOtherModule = Path.Combine(otherNameModuleRoot, "Lib", "en-US", "Outer.DLL-Help.xml");
+            Directory.CreateDirectory(Path.GetDirectoryName(outerAliasUnderOtherModule)!);
+            File.WriteAllText(Path.Combine(otherNameModuleRoot, "OtherModule.psd1"), "@{ RootModule = ''; ModuleVersion = '1.0.0' }");
+            File.WriteAllText(
+                outerAliasUnderOtherModule,
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule") + "<helpItems />");
             var staleMixedCaseAlias = Path.Combine(root, "Lib", "Removed", "en-US", "Removed.DLL-Help.xml");
             Directory.CreateDirectory(Path.GetDirectoryName(staleMixedCaseAlias)!);
             File.WriteAllText(
@@ -178,6 +185,7 @@ public sealed class DocumentationBinaryMetadataContractTests
             Assert.True(File.Exists(authoredAlias));
             Assert.True(File.Exists(otherAlias));
             Assert.True(File.Exists(sameNameAlias));
+            Assert.False(File.Exists(outerAliasUnderOtherModule));
             Assert.False(File.Exists(staleMixedCaseAlias));
             Assert.False(File.Exists(dataAlias));
         }
@@ -244,6 +252,45 @@ public sealed class DocumentationBinaryMetadataContractTests
             DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(root, "OwnerModule");
 
             Assert.True(File.Exists(outsideAlias));
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+            try { Directory.Delete(outside, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ExternalHelpAliases_DoNotWriteThroughDirectoryLinks()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-binary-alias-write-link-root-" + Guid.NewGuid().ToString("N"));
+        var outside = Path.Combine(Path.GetTempPath(), "pf-binary-alias-write-link-target-" + Guid.NewGuid().ToString("N"));
+        var cultureDirectory = Path.Combine(root, "en-US");
+        Directory.CreateDirectory(cultureDirectory);
+        Directory.CreateDirectory(outside);
+
+        try
+        {
+            var primary = Path.Combine(cultureDirectory, "Owner-help.xml");
+            File.WriteAllText(primary, "<helpItems />");
+            var assemblyPath = Path.Combine(outside, "Foo.dll");
+            File.WriteAllText(assemblyPath, string.Empty);
+            var link = Path.Combine(root, "Linked");
+            try { Directory.CreateSymbolicLink(link, outside); }
+            catch (Exception exception) when (exception is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+            {
+                return;
+            }
+
+            var payload = new DocumentationExtractionPayload
+            {
+                Commands = [new DocumentationCommandHelp { AssemblyPath = Path.Combine(link, "Foo.dll") }]
+            };
+
+            var paths = DocumentationExternalHelpAliasWriter.WriteAliases(payload, primary, "OwnerModule");
+
+            Assert.Single(paths);
+            Assert.False(File.Exists(Path.Combine(outside, "en-US", "Foo.dll-Help.xml")));
         }
         finally
         {

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -322,6 +322,48 @@ public sealed class DocumentationBinaryMetadataContractTests
     }
 
     [Fact]
+    public void ExternalHelpAliases_DoNotWriteThroughCultureDirectoryLinks()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-binary-alias-culture-link-root-" + Guid.NewGuid().ToString("N"));
+        var outside = Path.Combine(Path.GetTempPath(), "pf-binary-alias-culture-link-target-" + Guid.NewGuid().ToString("N"));
+        var primaryDirectory = Path.Combine(root, "en-US");
+        var assemblyDirectory = Path.Combine(root, "Lib");
+        Directory.CreateDirectory(primaryDirectory);
+        Directory.CreateDirectory(assemblyDirectory);
+        Directory.CreateDirectory(outside);
+
+        try
+        {
+            var primary = Path.Combine(primaryDirectory, "Owner-help.xml");
+            File.WriteAllText(primary, "<helpItems />");
+            var assemblyPath = Path.Combine(assemblyDirectory, "Foo.dll");
+            File.WriteAllText(assemblyPath, string.Empty);
+
+            var linkedCulture = Path.Combine(assemblyDirectory, "en-US");
+            try { Directory.CreateSymbolicLink(linkedCulture, outside); }
+            catch (Exception exception) when (exception is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+            {
+                return;
+            }
+
+            var payload = new DocumentationExtractionPayload
+            {
+                Commands = [new DocumentationCommandHelp { AssemblyPath = assemblyPath }]
+            };
+
+            var paths = DocumentationExternalHelpAliasWriter.WriteAliases(payload, primary, "OwnerModule");
+
+            Assert.Single(paths);
+            Assert.False(File.Exists(Path.Combine(outside, "Foo.dll-Help.xml")));
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+            try { Directory.Delete(outside, true); } catch { }
+        }
+    }
+
+    [Fact]
     public void ExternalHelpAliases_DoNotWriteThroughFileLinks()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-binary-alias-write-file-link-root-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -165,6 +165,22 @@ public sealed class DocumentationBinaryMetadataContractTests
             File.WriteAllText(
                 legacyAliasUnderOtherModule,
                 legacyAliasContent);
+            var scriptModuleRoot = Path.Combine(root, "BundledScript");
+            var scriptModuleLibrary = Path.Combine(scriptModuleRoot, "Lib");
+            var scriptOwnedAliasDirectory = Path.Combine(scriptModuleLibrary, "en-US");
+            Directory.CreateDirectory(scriptOwnedAliasDirectory);
+            File.WriteAllText(
+                Path.Combine(scriptModuleRoot, "ScriptModule.psd1"),
+                "@{ RootModule = 'ScriptModule.psm1'; ModuleVersion = '1.0.0' }");
+            File.WriteAllText(
+                Path.Combine(scriptModuleRoot, "ScriptModule.psm1"),
+                "Microsoft.PowerShell.Core\\Import-Module -Name './Lib/ScriptOwned.dll'");
+            var scriptOwnedAssemblyPath = Path.Combine(scriptModuleLibrary, "ScriptOwned.dll");
+            File.WriteAllText(scriptOwnedAssemblyPath, string.Empty);
+            var scriptOwnedAlias = Path.Combine(scriptOwnedAliasDirectory, "ScriptOwned.dll-Help.xml");
+            var scriptOwnedAliasContent =
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("ScriptModule") + "\n<scriptOwned />";
+            File.WriteAllText(scriptOwnedAlias, scriptOwnedAliasContent);
             var staleMixedCaseAlias = Path.Combine(root, "Lib", "Removed", "en-US", "Removed.DLL-Help.xml");
             Directory.CreateDirectory(Path.GetDirectoryName(staleMixedCaseAlias)!);
             File.WriteAllText(
@@ -189,6 +205,7 @@ public sealed class DocumentationBinaryMetadataContractTests
                     new DocumentationCommandHelp { AssemblyPath = authoredAssemblyPath },
                     new DocumentationCommandHelp { AssemblyPath = sameNameAssemblyPath },
                     new DocumentationCommandHelp { AssemblyPath = legacyAssemblyPath },
+                    new DocumentationCommandHelp { AssemblyPath = scriptOwnedAssemblyPath },
                     new DocumentationCommandHelp { AssemblyPath = outerAssemblyPath }
                 ]
             };
@@ -210,6 +227,8 @@ public sealed class DocumentationBinaryMetadataContractTests
             Assert.Equal(legacyAliasContent, File.ReadAllText(legacyAliasUnderOtherModule));
             Assert.DoesNotContain(sameNameAlias, paths, StringComparer.OrdinalIgnoreCase);
             Assert.DoesNotContain(legacyAliasUnderOtherModule, paths, StringComparer.OrdinalIgnoreCase);
+            Assert.DoesNotContain(scriptOwnedAlias, paths, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(scriptOwnedAliasContent, File.ReadAllText(scriptOwnedAlias));
             Assert.Contains(outerAliasUnderOtherModule, paths, StringComparer.OrdinalIgnoreCase);
             Assert.Contains(
                 DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule"),

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -133,6 +133,18 @@ public sealed class DocumentationBinaryMetadataContractTests
             File.WriteAllText(
                 otherAlias,
                 DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OtherModule") + "<helpItems />");
+            var sameNameModuleRoot = Path.Combine(root, "BundledOwner");
+            var sameNameAlias = Path.Combine(sameNameModuleRoot, "Lib", "en-US", "Bundled.DLL-Help.xml");
+            Directory.CreateDirectory(Path.GetDirectoryName(sameNameAlias)!);
+            File.WriteAllText(Path.Combine(sameNameModuleRoot, "OwnerModule.psd1"), "@{ RootModule = '' }");
+            File.WriteAllText(
+                sameNameAlias,
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule") + "<helpItems />");
+            var staleMixedCaseAlias = Path.Combine(root, "Lib", "Removed", "en-US", "Removed.DLL-Help.xml");
+            Directory.CreateDirectory(Path.GetDirectoryName(staleMixedCaseAlias)!);
+            File.WriteAllText(
+                staleMixedCaseAlias,
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule") + "<helpItems />");
 
             var payload = new DocumentationExtractionPayload
             {
@@ -156,6 +168,8 @@ public sealed class DocumentationBinaryMetadataContractTests
             Assert.False(File.Exists(nestedAlias));
             Assert.True(File.Exists(authoredAlias));
             Assert.True(File.Exists(otherAlias));
+            Assert.True(File.Exists(sameNameAlias));
+            Assert.False(File.Exists(staleMixedCaseAlias));
         }
         finally
         {

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -305,6 +305,46 @@ public sealed class DocumentationBinaryMetadataContractTests
     }
 
     [Fact]
+    public void ExternalHelpAliases_DoNotWriteThroughFileLinks()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-binary-alias-write-file-link-root-" + Guid.NewGuid().ToString("N"));
+        var outside = Path.Combine(Path.GetTempPath(), "pf-binary-alias-write-file-link-target-" + Guid.NewGuid().ToString("N") + ".xml");
+        var cultureDirectory = Path.Combine(root, "en-US");
+        Directory.CreateDirectory(cultureDirectory);
+
+        try
+        {
+            var primary = Path.Combine(cultureDirectory, "Owner-help.xml");
+            File.WriteAllText(primary, "<helpItems />");
+            var assemblyPath = Path.Combine(root, "Foo.dll");
+            File.WriteAllText(assemblyPath, string.Empty);
+            const string outsideContent = "<!-- PowerForgeGeneratedExternalHelpAlias --><outside />";
+            File.WriteAllText(outside, outsideContent);
+            var aliasPath = Path.Combine(cultureDirectory, "Foo.dll-Help.xml");
+            try { File.CreateSymbolicLink(aliasPath, outside); }
+            catch (Exception exception) when (exception is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+            {
+                return;
+            }
+
+            var payload = new DocumentationExtractionPayload
+            {
+                Commands = [new DocumentationCommandHelp { AssemblyPath = assemblyPath }]
+            };
+
+            var paths = DocumentationExternalHelpAliasWriter.WriteAliases(payload, primary, "OwnerModule");
+
+            Assert.Single(paths);
+            Assert.Equal(outsideContent, File.ReadAllText(outside));
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+            try { File.Delete(outside); } catch { }
+        }
+    }
+
+    [Fact]
     public void ExternalHelpAliases_UseExplicitDllNamedPrimaryForLegacyOwnership()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-binary-alias-dll-primary-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -174,13 +174,27 @@ public sealed class DocumentationBinaryMetadataContractTests
                 "@{ RootModule = 'ScriptModule.psm1'; ModuleVersion = '1.0.0' }");
             File.WriteAllText(
                 Path.Combine(scriptModuleRoot, "ScriptModule.psm1"),
-                "Microsoft.PowerShell.Core\\Import-Module -Name './Lib/ScriptOwned.dll'");
+                "Microsoft.PowerShell.Core\\Import-Module -Name './Lib/ScriptOwned.dll'" + Environment.NewLine +
+                "Import-Module \"$PSScriptRoot/Lib/ExpandableOwned.dll\"" + Environment.NewLine +
+                "Import-Module \"${PSScriptRoot}\\Lib\\BracedOwned.dll\"");
             var scriptOwnedAssemblyPath = Path.Combine(scriptModuleLibrary, "ScriptOwned.dll");
             File.WriteAllText(scriptOwnedAssemblyPath, string.Empty);
             var scriptOwnedAlias = Path.Combine(scriptOwnedAliasDirectory, "ScriptOwned.dll-Help.xml");
             var scriptOwnedAliasContent =
                 DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("ScriptModule") + "\n<scriptOwned />";
             File.WriteAllText(scriptOwnedAlias, scriptOwnedAliasContent);
+            var expandableOwnedAssemblyPath = Path.Combine(scriptModuleLibrary, "ExpandableOwned.dll");
+            File.WriteAllText(expandableOwnedAssemblyPath, string.Empty);
+            var expandableOwnedAlias = Path.Combine(scriptOwnedAliasDirectory, "ExpandableOwned.dll-Help.xml");
+            var expandableOwnedAliasContent =
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("ScriptModule") + "\n<expandableOwned />";
+            File.WriteAllText(expandableOwnedAlias, expandableOwnedAliasContent);
+            var bracedOwnedAssemblyPath = Path.Combine(scriptModuleLibrary, "BracedOwned.dll");
+            File.WriteAllText(bracedOwnedAssemblyPath, string.Empty);
+            var bracedOwnedAlias = Path.Combine(scriptOwnedAliasDirectory, "BracedOwned.dll-Help.xml");
+            var bracedOwnedAliasContent =
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("ScriptModule") + "\n<bracedOwned />";
+            File.WriteAllText(bracedOwnedAlias, bracedOwnedAliasContent);
             var staleMixedCaseAlias = Path.Combine(root, "Lib", "Removed", "en-US", "Removed.DLL-Help.xml");
             Directory.CreateDirectory(Path.GetDirectoryName(staleMixedCaseAlias)!);
             File.WriteAllText(
@@ -206,6 +220,8 @@ public sealed class DocumentationBinaryMetadataContractTests
                     new DocumentationCommandHelp { AssemblyPath = sameNameAssemblyPath },
                     new DocumentationCommandHelp { AssemblyPath = legacyAssemblyPath },
                     new DocumentationCommandHelp { AssemblyPath = scriptOwnedAssemblyPath },
+                    new DocumentationCommandHelp { AssemblyPath = expandableOwnedAssemblyPath },
+                    new DocumentationCommandHelp { AssemblyPath = bracedOwnedAssemblyPath },
                     new DocumentationCommandHelp { AssemblyPath = outerAssemblyPath }
                 ]
             };
@@ -229,6 +245,10 @@ public sealed class DocumentationBinaryMetadataContractTests
             Assert.DoesNotContain(legacyAliasUnderOtherModule, paths, StringComparer.OrdinalIgnoreCase);
             Assert.DoesNotContain(scriptOwnedAlias, paths, StringComparer.OrdinalIgnoreCase);
             Assert.Equal(scriptOwnedAliasContent, File.ReadAllText(scriptOwnedAlias));
+            Assert.DoesNotContain(expandableOwnedAlias, paths, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(expandableOwnedAliasContent, File.ReadAllText(expandableOwnedAlias));
+            Assert.DoesNotContain(bracedOwnedAlias, paths, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(bracedOwnedAliasContent, File.ReadAllText(bracedOwnedAlias));
             Assert.Contains(outerAliasUnderOtherModule, paths, StringComparer.OrdinalIgnoreCase);
             Assert.Contains(
                 DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule"),

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -221,6 +221,38 @@ public sealed class DocumentationBinaryMetadataContractTests
     }
 
     [Fact]
+    public void ExternalHelpAliases_DoNotTraverseDirectoryLinksWhilePruning()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-binary-alias-link-root-" + Guid.NewGuid().ToString("N"));
+        var outside = Path.Combine(Path.GetTempPath(), "pf-binary-alias-link-target-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        Directory.CreateDirectory(outside);
+
+        try
+        {
+            var outsideAlias = Path.Combine(outside, "Outside.dll-Help.xml");
+            File.WriteAllText(
+                outsideAlias,
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule") + "<helpItems />");
+            var link = Path.Combine(root, "Linked");
+            try { Directory.CreateSymbolicLink(link, outside); }
+            catch (Exception exception) when (exception is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+            {
+                return;
+            }
+
+            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(root, "OwnerModule");
+
+            Assert.True(File.Exists(outsideAlias));
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+            try { Directory.Delete(outside, true); } catch { }
+        }
+    }
+
+    [Fact]
     public void ExternalHelpAliases_UseExplicitDllNamedPrimaryForLegacyOwnership()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-binary-alias-dll-primary-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -136,7 +136,7 @@ public sealed class DocumentationBinaryMetadataContractTests
             var sameNameModuleRoot = Path.Combine(root, "BundledOwner");
             var sameNameAlias = Path.Combine(sameNameModuleRoot, "Lib", "en-US", "Bundled.DLL-Help.xml");
             Directory.CreateDirectory(Path.GetDirectoryName(sameNameAlias)!);
-            File.WriteAllText(Path.Combine(sameNameModuleRoot, "OwnerModule.psd1"), "@{ RootModule = '' }");
+            File.WriteAllText(Path.Combine(sameNameModuleRoot, "OwnerModule.PSD1"), "@{ RootModule = '' }");
             File.WriteAllText(
                 sameNameAlias,
                 DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule") + "<helpItems />");
@@ -202,6 +202,39 @@ public sealed class DocumentationBinaryMetadataContractTests
                 "New-Custom-Name-help.xml");
 
             Assert.True(File.Exists(oldPrimary));
+            Assert.False(File.Exists(staleAlias));
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ExternalHelpAliases_UseExplicitDllNamedPrimaryForLegacyOwnership()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-binary-alias-dll-primary-" + Guid.NewGuid().ToString("N"));
+        var primaryDirectory = Path.Combine(root, "en-US");
+        var aliasDirectory = Path.Combine(root, "Lib", "Removed", "en-US");
+        Directory.CreateDirectory(primaryDirectory);
+        Directory.CreateDirectory(aliasDirectory);
+
+        try
+        {
+            const string content = "<legacyHelpItems />";
+            var primary = Path.Combine(primaryDirectory, "Foo.dll-Help.xml");
+            var staleAlias = Path.Combine(aliasDirectory, "Removed.dll-Help.xml");
+            File.WriteAllText(primary, content);
+            File.WriteAllText(
+                staleAlias,
+                DocumentationExternalHelpAliasWriter.GetLegacyGeneratedAliasMarker() + content);
+
+            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(
+                root,
+                "OwnerModule",
+                "Foo.dll-Help.xml");
+
+            Assert.True(File.Exists(primary));
             Assert.False(File.Exists(staleAlias));
         }
         finally

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -124,6 +124,11 @@ public sealed class DocumentationBinaryMetadataContractTests
             File.WriteAllText(primary, "<helpItems />");
             var assemblyPath = Path.Combine(coreDirectory, "Foo.dll");
             File.WriteAllText(assemblyPath, string.Empty);
+            var renamedAlias = Path.Combine(coreDirectory, "en-US", "Foo.dll-Help.xml");
+            Directory.CreateDirectory(Path.GetDirectoryName(renamedAlias)!);
+            File.WriteAllText(
+                renamedAlias,
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OldModuleName") + "\n<staleHelpItems />");
             var authoredAssemblyPath = Path.Combine(root, "Lib", "Authored", "Authored.dll");
             File.WriteAllText(authoredAssemblyPath, string.Empty);
             var authoredAlias = Path.Combine(authoredDirectory, "Authored.dll-Help.xml");
@@ -187,6 +192,11 @@ public sealed class DocumentationBinaryMetadataContractTests
 
             Assert.Contains(nestedAlias, paths, StringComparer.OrdinalIgnoreCase);
             Assert.True(File.Exists(nestedAlias));
+            Assert.Contains(
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OwnerModule"),
+                File.ReadAllText(nestedAlias),
+                StringComparison.Ordinal);
+            Assert.DoesNotContain("staleHelpItems", File.ReadAllText(nestedAlias), StringComparison.Ordinal);
             Assert.Equal("<authoredHelpItems />", File.ReadAllText(authoredAlias));
             Assert.DoesNotContain(authoredAlias, paths, StringComparer.OrdinalIgnoreCase);
             Assert.Equal(

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -163,6 +163,79 @@ public sealed class DocumentationBinaryMetadataContractTests
         }
     }
 
+    [Fact]
+    public void ExternalHelpAliases_PruneLegacyAliasesAfterPrimaryFileNameChanges()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-binary-alias-rename-" + Guid.NewGuid().ToString("N"));
+        var oldPrimaryDirectory = Path.Combine(root, "en-US");
+        var aliasDirectory = Path.Combine(root, "Lib", "Removed", "en-US");
+        Directory.CreateDirectory(oldPrimaryDirectory);
+        Directory.CreateDirectory(aliasDirectory);
+
+        try
+        {
+            const string oldContent = "<legacyHelpItems />";
+            var oldPrimary = Path.Combine(oldPrimaryDirectory, "Old-Custom-Name-help.xml");
+            var staleAlias = Path.Combine(aliasDirectory, "Removed.dll-Help.xml");
+            File.WriteAllText(oldPrimary, oldContent);
+            File.WriteAllText(
+                staleAlias,
+                DocumentationExternalHelpAliasWriter.GetLegacyGeneratedAliasMarker() + oldContent);
+
+            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(
+                root,
+                "OwnerModule",
+                "New-Custom-Name-help.xml");
+
+            Assert.True(File.Exists(oldPrimary));
+            Assert.False(File.Exists(staleAlias));
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ExternalHelpAliases_DoNotWriteOutsideCaseSensitiveStagingRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-binary-alias-case-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        if (FrameworkCompatibility.GetPathStringComparison(root) != StringComparison.Ordinal)
+        {
+            try { Directory.Delete(root, true); } catch { }
+            return;
+        }
+
+        var stagingRoot = Path.Combine(root, "Module");
+        var siblingRoot = Path.Combine(root, "module");
+        var primaryDirectory = Path.Combine(stagingRoot, "en-US");
+        var siblingBinaryDirectory = Path.Combine(siblingRoot, "Lib");
+        Directory.CreateDirectory(primaryDirectory);
+        Directory.CreateDirectory(siblingBinaryDirectory);
+
+        try
+        {
+            var primary = Path.Combine(primaryDirectory, "Owner-help.xml");
+            var assemblyPath = Path.Combine(siblingBinaryDirectory, "Outside.dll");
+            File.WriteAllText(primary, "<helpItems />");
+            File.WriteAllText(assemblyPath, string.Empty);
+            var payload = new DocumentationExtractionPayload
+            {
+                Commands = [new DocumentationCommandHelp { AssemblyPath = assemblyPath }]
+            };
+
+            var paths = DocumentationExternalHelpAliasWriter.WriteAliases(payload, primary, "Owner");
+
+            Assert.Single(paths);
+            Assert.False(File.Exists(Path.Combine(siblingBinaryDirectory, "en-US", "Outside.dll-Help.xml")));
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+
     private static string BuildFixture(string fixtureRoot)
     {
         var outputDirectory = Path.Combine(Path.GetTempPath(), "pf-binary-metadata-build-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -17,13 +17,16 @@ public sealed class DocumentationBinaryMetadataContractTests
 
         try
         {
+            var binaryDirectory = Path.Combine(root, "Lib", "Core");
+            Directory.CreateDirectory(binaryDirectory);
             foreach (var file in Directory.EnumerateFiles(outputDirectory))
-                File.Copy(file, Path.Combine(root, Path.GetFileName(file)), overwrite: true);
+                File.Copy(file, Path.Combine(binaryDirectory, Path.GetFileName(file)), overwrite: true);
+            File.Delete(Path.Combine(binaryDirectory, "BinaryDocFixture.xml"));
 
             var manifestPath = Path.Combine(root, "MetadataFixture.psd1");
             File.WriteAllText(manifestPath, """
 @{
-    RootModule = 'BinaryDocFixture.dll'
+    RootModule = 'Lib/Core/BinaryDocFixture.dll'
     ModuleVersion = '1.0.0'
     GUID = '12121212-1212-1212-1212-121212121212'
     Author = 'PowerForge.Tests'
@@ -65,7 +68,7 @@ public sealed class DocumentationBinaryMetadataContractTests
 
             Assert.True(result.Succeeded, result.ErrorMessage);
             var primary = Path.Combine(root, "en-US", "MetadataFixture-help.xml");
-            var binaryAlias = Path.Combine(root, "en-US", "BinaryDocFixture.dll-Help.xml");
+            var binaryAlias = Path.Combine(root, "Lib", "Core", "en-US", "BinaryDocFixture.dll-Help.xml");
             Assert.True(File.Exists(primary));
             Assert.True(File.Exists(binaryAlias));
             var primaryDocument = System.Xml.Linq.XDocument.Load(primary);

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -1,0 +1,111 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace PowerForge.Tests;
+
+[Collection("BinaryDocFixture")]
+public sealed class DocumentationBinaryMetadataContractTests
+{
+    [Fact]
+    public void DocumentationEngine_NormalizesBinaryMetadataAndWritesDirectImportHelpAlias()
+    {
+        var fixtureRoot = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "PowerForge.Tests", "Fixtures", "BinaryDocFixture"));
+        var outputDirectory = BuildFixture(fixtureRoot);
+        var root = Path.Combine(Path.GetTempPath(), "pf-binary-metadata-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            foreach (var file in Directory.EnumerateFiles(outputDirectory))
+                File.Copy(file, Path.Combine(root, Path.GetFileName(file)), overwrite: true);
+
+            var manifestPath = Path.Combine(root, "MetadataFixture.psd1");
+            File.WriteAllText(manifestPath, """
+@{
+    RootModule = 'BinaryDocFixture.dll'
+    ModuleVersion = '1.0.0'
+    GUID = '12121212-1212-1212-1212-121212121212'
+    Author = 'PowerForge.Tests'
+    Description = 'Binary documentation metadata contract.'
+    FunctionsToExport = @()
+    CmdletsToExport = @('Get-BinaryDocMetadataContract')
+    AliasesToExport = @()
+    VariablesToExport = @()
+}
+""", new UTF8Encoding(false));
+
+            var engine = new DocumentationEngine(new PowerShellRunner(), new NullLogger());
+            var payload = engine.ExtractHelpPayload(root, manifestPath, TimeSpan.FromMinutes(1));
+            new XmlDocCommentEnricher(new NullLogger()).Enrich(payload);
+            var command = Assert.Single(payload.Commands);
+            var nullable = Assert.Single(command.Parameters, parameter => parameter.Name == "NullableMode");
+            var nullableMatrix = Assert.Single(command.Parameters, parameter => parameter.Name == "NullableModeMatrix");
+            var inherited = Assert.Single(command.Parameters, parameter => parameter.Name == "InheritedLabel");
+
+            Assert.Equal("BinaryDocMode", nullable.Type);
+            Assert.Equal("BinaryDocMode[,]", nullableMatrix.Type);
+            Assert.Equal(new[] { "Advanced", "Basic" }, nullable.PossibleValues.OrderBy(value => value));
+            Assert.Equal("Inherited label documented in a separate declaring assembly.", inherited.Description);
+            Assert.DoesNotContain(command.Parameters, parameter => parameter.Name == "HiddenTransport");
+            Assert.All(command.Syntax, syntax => Assert.DoesNotContain("HiddenTransport", syntax.Text, StringComparison.Ordinal));
+
+            var result = engine.Build(
+                "MetadataFixture",
+                root,
+                manifestPath,
+                new DocumentationConfiguration { Path = "Docs", PathReadme = "Docs/Readme.md" },
+                new BuildDocumentationConfiguration
+                {
+                    Enable = true,
+                    GenerateExternalHelp = true,
+                    IncludeAboutTopics = false,
+                    GenerateFallbackExamples = false
+                });
+
+            Assert.True(result.Succeeded, result.ErrorMessage);
+            var primary = Path.Combine(root, "en-US", "MetadataFixture-help.xml");
+            var binaryAlias = Path.Combine(root, "en-US", "BinaryDocFixture.dll-Help.xml");
+            Assert.True(File.Exists(primary));
+            Assert.True(File.Exists(binaryAlias));
+            var primaryDocument = System.Xml.Linq.XDocument.Load(primary);
+            var aliasDocument = System.Xml.Linq.XDocument.Load(binaryAlias);
+            Assert.Equal(primaryDocument.Root!.ToString(), aliasDocument.Root!.ToString());
+            Assert.Contains("PowerForgeGeneratedExternalHelpAlias", File.ReadAllText(binaryAlias), StringComparison.Ordinal);
+            Assert.Contains(binaryAlias, result.ExternalHelpFilePaths, StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+            try { Directory.Delete(outputDirectory, true); } catch { }
+        }
+    }
+
+    private static string BuildFixture(string fixtureRoot)
+    {
+        var outputDirectory = Path.Combine(Path.GetTempPath(), "pf-binary-metadata-build-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDirectory);
+        var start = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = fixtureRoot,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        start.ArgumentList.Add("build");
+        start.ArgumentList.Add("BinaryDocFixture.csproj");
+        start.ArgumentList.Add("-c");
+        start.ArgumentList.Add("Release");
+        start.ArgumentList.Add("-o");
+        start.ArgumentList.Add(outputDirectory);
+        start.ArgumentList.Add("--nologo");
+
+        using var process = Process.Start(start) ?? throw new InvalidOperationException("Failed to start fixture build.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, stdout + Environment.NewLine + stderr);
+        return outputDirectory;
+    }
+}

--- a/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryMetadataContractTests.cs
@@ -53,6 +53,13 @@ public sealed class DocumentationBinaryMetadataContractTests
             Assert.DoesNotContain(command.Parameters, parameter => parameter.Name == "HiddenTransport");
             Assert.All(command.Syntax, syntax => Assert.DoesNotContain("HiddenTransport", syntax.Text, StringComparison.Ordinal));
 
+            var staleAliasDirectory = Path.Combine(root, "Lib", "Removed", "en-US");
+            Directory.CreateDirectory(staleAliasDirectory);
+            var staleAlias = Path.Combine(staleAliasDirectory, "Removed.dll-Help.xml");
+            File.WriteAllText(
+                staleAlias,
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("MetadataFixture") + "<helpItems />");
+
             var result = engine.Build(
                 "MetadataFixture",
                 root,
@@ -62,15 +69,17 @@ public sealed class DocumentationBinaryMetadataContractTests
                 {
                     Enable = true,
                     GenerateExternalHelp = true,
+                    ExternalHelpCulture = "fr-FR",
                     IncludeAboutTopics = false,
                     GenerateFallbackExamples = false
                 });
 
             Assert.True(result.Succeeded, result.ErrorMessage);
-            var primary = Path.Combine(root, "en-US", "MetadataFixture-help.xml");
-            var binaryAlias = Path.Combine(root, "Lib", "Core", "en-US", "BinaryDocFixture.dll-Help.xml");
+            var primary = Path.Combine(root, "fr-FR", "MetadataFixture-help.xml");
+            var binaryAlias = Path.Combine(root, "Lib", "Core", "fr-FR", "BinaryDocFixture.dll-Help.xml");
             Assert.True(File.Exists(primary));
             Assert.True(File.Exists(binaryAlias));
+            Assert.False(File.Exists(staleAlias));
             var primaryDocument = System.Xml.Linq.XDocument.Load(primary);
             var aliasDocument = System.Xml.Linq.XDocument.Load(binaryAlias);
             Assert.Equal(primaryDocument.Root!.ToString(), aliasDocument.Root!.ToString());
@@ -81,6 +90,62 @@ public sealed class DocumentationBinaryMetadataContractTests
         {
             try { Directory.Delete(root, true); } catch { }
             try { Directory.Delete(outputDirectory, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ExternalHelpAliases_PreserveAuthoredAndOtherModuleFiles()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-binary-alias-ownership-" + Guid.NewGuid().ToString("N"));
+        var cultureDirectory = Path.Combine(root, "en-US");
+        var coreDirectory = Path.Combine(root, "Lib", "Core");
+        var authoredDirectory = Path.Combine(root, "Lib", "Authored", "en-US");
+        Directory.CreateDirectory(cultureDirectory);
+        Directory.CreateDirectory(coreDirectory);
+        Directory.CreateDirectory(authoredDirectory);
+
+        try
+        {
+            var primary = Path.Combine(cultureDirectory, "Foo.dll-Help.xml");
+            File.WriteAllText(primary, "<helpItems />");
+            var assemblyPath = Path.Combine(coreDirectory, "Foo.dll");
+            File.WriteAllText(assemblyPath, string.Empty);
+            var authoredAssemblyPath = Path.Combine(root, "Lib", "Authored", "Authored.dll");
+            File.WriteAllText(authoredAssemblyPath, string.Empty);
+            var authoredAlias = Path.Combine(authoredDirectory, "Authored.dll-Help.xml");
+            File.WriteAllText(authoredAlias, "<authoredHelpItems />");
+            var otherAlias = Path.Combine(root, "Lib", "Other", "en-US", "Other.dll-Help.xml");
+            Directory.CreateDirectory(Path.GetDirectoryName(otherAlias)!);
+            File.WriteAllText(
+                otherAlias,
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("OtherModule") + "<helpItems />");
+
+            var payload = new DocumentationExtractionPayload
+            {
+                ModuleName = "OwnerModule",
+                Commands =
+                [
+                    new DocumentationCommandHelp { AssemblyPath = assemblyPath },
+                    new DocumentationCommandHelp { AssemblyPath = authoredAssemblyPath }
+                ]
+            };
+            var paths = DocumentationExternalHelpAliasWriter.WriteAliases(payload, primary, "OwnerModule");
+            var nestedAlias = Path.Combine(coreDirectory, "en-US", "Foo.dll-Help.xml");
+
+            Assert.Contains(nestedAlias, paths, StringComparer.OrdinalIgnoreCase);
+            Assert.True(File.Exists(nestedAlias));
+            Assert.Equal("<authoredHelpItems />", File.ReadAllText(authoredAlias));
+            Assert.DoesNotContain(authoredAlias, paths, StringComparer.OrdinalIgnoreCase);
+
+            DocumentationExternalHelpAliasWriter.PruneGeneratedAliases(root, "OwnerModule");
+
+            Assert.False(File.Exists(nestedAlias));
+            Assert.True(File.Exists(authoredAlias));
+            Assert.True(File.Exists(otherAlias));
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
         }
     }
 

--- a/PowerForge.Tests/DocumentationBuildResultCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationBuildResultCompatibilityTests.cs
@@ -1,0 +1,34 @@
+namespace PowerForge.Tests;
+
+public sealed class DocumentationBuildResultCompatibilityTests
+{
+    [Fact]
+    public void PublicEightArgumentConstructor_RemainsAvailableForBinaryCallers()
+    {
+        var constructor = typeof(DocumentationBuildResult).GetConstructor(
+        [
+            typeof(bool),
+            typeof(string),
+            typeof(string),
+            typeof(bool),
+            typeof(int),
+            typeof(int),
+            typeof(string),
+            typeof(string)
+        ]);
+
+        Assert.NotNull(constructor);
+        var result = Assert.IsType<DocumentationBuildResult>(constructor!.Invoke(
+        [
+            true,
+            "docs",
+            "readme",
+            true,
+            0,
+            1,
+            "module-help.xml",
+            null
+        ]));
+        Assert.Equal(new[] { "module-help.xml" }, result.ExternalHelpFilePaths);
+    }
+}

--- a/PowerForge.Tests/DocumentationEngineSafetyTests.cs
+++ b/PowerForge.Tests/DocumentationEngineSafetyTests.cs
@@ -7,6 +7,61 @@ namespace PowerForge.Tests;
 
 public sealed class DocumentationEngineSafetyTests
 {
+    [Theory]
+    [InlineData(".")]
+    [InlineData("..")]
+    public void Build_RejectsDotSegmentExternalHelpCulture(string culture)
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var stagingRoot = Path.Combine(root.FullName, "Staging");
+            Directory.CreateDirectory(stagingRoot);
+            var manifestPath = Path.Combine(stagingRoot, "TestModule.psd1");
+            File.WriteAllText(manifestPath, "@{ ModuleVersion = '1.0.0'; RootModule = 'TestModule.psm1' }");
+
+            var payload = new DocumentationExtractionPayload
+            {
+                ModuleName = "TestModule",
+                Commands =
+                [
+                    new DocumentationCommandHelp
+                    {
+                        Name = "Get-Test",
+                        Synopsis = "Gets a test item.",
+                        Description = "Gets a test item."
+                    }
+                ]
+            };
+
+            var engine = new DocumentationEngine(new PayloadPowerShellRunner(payload), new NullLogger());
+            var result = engine.Build(
+                moduleName: "TestModule",
+                stagingPath: stagingRoot,
+                moduleManifestPath: manifestPath,
+                documentation: new DocumentationConfiguration
+                {
+                    Path = "Docs",
+                    PathReadme = Path.Combine("Docs", "Readme.md")
+                },
+                buildDocumentation: new BuildDocumentationConfiguration
+                {
+                    Enable = true,
+                    GenerateExternalHelp = true,
+                    ExternalHelpCulture = culture
+                });
+
+            Assert.False(result.Succeeded);
+            Assert.Contains("cannot be '.' or '..'", result.ErrorMessage, StringComparison.Ordinal);
+            Assert.False(File.Exists(Path.Combine(stagingRoot, "TestModule-help.xml")));
+            Assert.False(File.Exists(Path.Combine(root.FullName, "TestModule-help.xml")));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     [Fact]
     public void Build_RefusesProjectRootDocsPathBeforeDeleting()
     {

--- a/PowerForge.Tests/DocumentationInputTypeNormalizationTests.cs
+++ b/PowerForge.Tests/DocumentationInputTypeNormalizationTests.cs
@@ -111,4 +111,40 @@ public sealed class DocumentationInputTypeNormalizationTests
         var markdown = MarkdownHelpWriter.RenderCommandMarkdown("DemoModule", command);
         Assert.Contains("- `System.String`: This is string input.", markdown, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void Normalize_UnwrapsNullablePipelineInputIdentity()
+    {
+        const string runtimeType = "System.Nullable`1[[VisibilityMode, Demo]][]";
+        var command = new DocumentationCommandHelp
+        {
+            Inputs = [new DocumentationTypeHelp { Name = runtimeType, ClrTypeName = runtimeType }],
+            RuntimeInputs =
+            [
+                new DocumentationTypeHelp
+                {
+                    Name = "Nullable`1[]",
+                    ClrTypeName = runtimeType
+                }
+            ],
+            Parameters =
+            [
+                new DocumentationParameterHelp
+                {
+                    Name = "Modes",
+                    Type = "Nullable`1[]",
+                    NullableUnderlyingTypeName = "VisibilityMode",
+                    NullableArrayRanks = [1],
+                    PipelineInput = "True (ByValue)"
+                }
+            ]
+        };
+
+        DocumentationMetadataNormalizer.Normalize(new DocumentationExtractionPayload { Commands = [command] });
+
+        var input = Assert.Single(command.Inputs);
+        Assert.Equal("VisibilityMode[]", input.Name);
+        Assert.Equal("VisibilityMode[]", input.ClrTypeName);
+        Assert.DoesNotContain("Nullable", MarkdownHelpWriter.RenderCommandMarkdown("Demo", command));
+    }
 }

--- a/PowerForge.Tests/DocumentationInputTypeNormalizationTests.cs
+++ b/PowerForge.Tests/DocumentationInputTypeNormalizationTests.cs
@@ -147,4 +147,43 @@ public sealed class DocumentationInputTypeNormalizationTests
         Assert.Equal("VisibilityMode[]", input.ClrTypeName);
         Assert.DoesNotContain("Nullable", MarkdownHelpWriter.RenderCommandMarkdown("Demo", command));
     }
+
+    [Fact]
+    public void Normalize_UnwrapsDistinctNullablePipelineInputsByClrIdentity()
+    {
+        const string firstClrType = "System.Nullable`1[[FirstMode, Demo]]";
+        const string secondClrType = "System.Nullable`1[[SecondMode, Demo]]";
+        var command = new DocumentationCommandHelp
+        {
+            RuntimeInputs =
+            [
+                new DocumentationTypeHelp { Name = "Nullable`1", ClrTypeName = firstClrType },
+                new DocumentationTypeHelp { Name = "Nullable`1", ClrTypeName = secondClrType }
+            ],
+            Parameters =
+            [
+                new DocumentationParameterHelp
+                {
+                    Name = "First",
+                    Type = "Nullable`1",
+                    NullableUnderlyingTypeName = "FirstMode",
+                    PipelineInput = "True (ByValue)"
+                },
+                new DocumentationParameterHelp
+                {
+                    Name = "Second",
+                    Type = "Nullable`1",
+                    NullableUnderlyingTypeName = "SecondMode",
+                    PipelineInput = "True (ByPropertyName)"
+                }
+            ]
+        };
+
+        DocumentationMetadataNormalizer.Normalize(new DocumentationExtractionPayload { Commands = [command] });
+
+        Assert.Collection(
+            command.Inputs,
+            input => Assert.Equal("FirstMode", input.Name),
+            input => Assert.Equal("SecondMode", input.Name));
+    }
 }

--- a/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
@@ -23,9 +23,16 @@ function Get-VisibilityFixture {
         [Parameter(Mandatory = $true, DontShow = $true, Position = 0, ValueFromPipelineByPropertyName = $true)] [string] $HiddenTransport
     )
 }
+function Get-GenericVisibilityFixture {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline = $true)]
+        [Nullable[System.Collections.Generic.KeyValuePair[string,int]]] $Pair
+    )
+}
 function GetDocumentationParameterDeclaringMetadata { throw 'Target helper shadow was invoked.' }
 function TestDocumentationParameterDontShow { throw 'Target helper shadow was invoked.' }
-Export-ModuleMember -Function Get-VisibilityFixture,GetDocumentationParameterDeclaringMetadata,TestDocumentationParameterDontShow
+Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture,GetDocumentationParameterDeclaringMetadata,TestDocumentationParameterDontShow
 """, new UTF8Encoding(false));
             File.WriteAllText(manifestPath, """
 @{
@@ -34,7 +41,7 @@ Export-ModuleMember -Function Get-VisibilityFixture,GetDocumentationParameterDec
     GUID = '34343434-3434-3434-3434-343434343434'
     Author = 'PowerForge.Tests'
     Description = 'Parameter visibility fixture.'
-    FunctionsToExport = @('Get-VisibilityFixture','GetDocumentationParameterDeclaringMetadata','TestDocumentationParameterDontShow')
+    FunctionsToExport = @('Get-VisibilityFixture','Get-GenericVisibilityFixture','GetDocumentationParameterDeclaringMetadata','TestDocumentationParameterDontShow')
     CmdletsToExport = @()
     AliasesToExport = @()
     VariablesToExport = @()
@@ -72,6 +79,13 @@ Export-ModuleMember -Function Get-VisibilityFixture,GetDocumentationParameterDec
                 var maml = File.ReadAllText(mamlPath);
                 Assert.DoesNotContain("HiddenTransport", maml, StringComparison.Ordinal);
                 Assert.DoesNotContain("Nullable", maml, StringComparison.OrdinalIgnoreCase);
+
+                var genericCommand = Assert.Single(payload.Commands, item => item.Name == "Get-GenericVisibilityFixture");
+                const string genericType = "System.Collections.Generic.KeyValuePair[System.String,System.Int32]";
+                Assert.Equal(genericType, Assert.Single(genericCommand.Parameters).Type);
+                Assert.Equal(genericType, Assert.Single(genericCommand.Inputs).Name);
+                Assert.All(genericCommand.Syntax, syntax =>
+                    Assert.DoesNotContain("KeyValuePair`2", syntax.Text, StringComparison.Ordinal));
             }
         }
         finally

--- a/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
@@ -76,10 +76,21 @@ function Get-SoleHiddenRequiredSetFixture {
         [string] $Shared
     )
 }
+function Get-HiddenRequiredAllSetsFixture {
+    [CmdletBinding(DefaultParameterSetName = 'ByName')]
+    param(
+        [Parameter(Mandatory = $true, DontShow = $true)]
+        [string] $Secret,
+        [Parameter(ParameterSetName = 'ByName')]
+        [string] $Name,
+        [Parameter(ParameterSetName = 'ById')]
+        [int] $Id
+    )
+}
 function GetDocumentationParameterDeclaringMetadata { throw 'Target helper shadow was invoked.' }
 function TestDocumentationParameterDontShow { throw 'Target helper shadow was invoked.' }
 function GetDocumentationRuntimeInputs { throw 'Target helper shadow was invoked.' }
-Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture,Get-GenericVisibilityCollisionFixture,Get-MixedVisibilityFixture,Get-HiddenOnlySetFixture,Get-HiddenOptionalDefaultSetFixture,Get-SoleHiddenRequiredSetFixture,GetDocumentationParameterDeclaringMetadata,TestDocumentationParameterDontShow,GetDocumentationRuntimeInputs
+Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture,Get-GenericVisibilityCollisionFixture,Get-MixedVisibilityFixture,Get-HiddenOnlySetFixture,Get-HiddenOptionalDefaultSetFixture,Get-SoleHiddenRequiredSetFixture,Get-HiddenRequiredAllSetsFixture,GetDocumentationParameterDeclaringMetadata,TestDocumentationParameterDontShow,GetDocumentationRuntimeInputs
 """, new UTF8Encoding(false));
             File.WriteAllText(manifestPath, """
 @{
@@ -88,7 +99,7 @@ Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture
     GUID = '34343434-3434-3434-3434-343434343434'
     Author = 'PowerForge.Tests'
     Description = 'Parameter visibility fixture.'
-    FunctionsToExport = @('Get-VisibilityFixture','Get-GenericVisibilityFixture','Get-GenericVisibilityCollisionFixture','Get-MixedVisibilityFixture','Get-HiddenOnlySetFixture','Get-HiddenOptionalDefaultSetFixture','Get-SoleHiddenRequiredSetFixture','GetDocumentationParameterDeclaringMetadata','TestDocumentationParameterDontShow','GetDocumentationRuntimeInputs')
+    FunctionsToExport = @('Get-VisibilityFixture','Get-GenericVisibilityFixture','Get-GenericVisibilityCollisionFixture','Get-MixedVisibilityFixture','Get-HiddenOnlySetFixture','Get-HiddenOptionalDefaultSetFixture','Get-SoleHiddenRequiredSetFixture','Get-HiddenRequiredAllSetsFixture','GetDocumentationParameterDeclaringMetadata','TestDocumentationParameterDontShow','GetDocumentationRuntimeInputs')
     CmdletsToExport = @()
     AliasesToExport = @()
     VariablesToExport = @()
@@ -213,6 +224,25 @@ Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture
                                    child.Value == "Get-SoleHiddenRequiredSetFixture"));
                 Assert.DoesNotContain(
                     soleHiddenCommandElement.Descendants(),
+                    element => element.Name.LocalName == "syntaxItem");
+
+                var hiddenAllSetsCommand = Assert.Single(payload.Commands, item => item.Name == "Get-HiddenRequiredAllSetsFixture");
+                Assert.Equal(2, hiddenAllSetsCommand.Parameters.Count);
+                Assert.Empty(hiddenAllSetsCommand.Syntax);
+                Assert.Empty(hiddenAllSetsCommand.Examples);
+                var hiddenAllSetsMarkdown = File.ReadAllText(Path.Combine(docsRoot, "Get-HiddenRequiredAllSetsFixture.md"));
+                Assert.DoesNotContain(
+                    "```powershell\nGet-HiddenRequiredAllSetsFixture\n```",
+                    hiddenAllSetsMarkdown.Replace("\r\n", "\n"),
+                    StringComparison.Ordinal);
+                var hiddenAllSetsCommandElement = Assert.Single(
+                    hiddenOnlyMaml.Descendants(),
+                    element => element.Name.LocalName == "command" &&
+                               element.Descendants().Any(child =>
+                                   child.Name.LocalName == "name" &&
+                                   child.Value == "Get-HiddenRequiredAllSetsFixture"));
+                Assert.DoesNotContain(
+                    hiddenAllSetsCommandElement.Descendants(),
                     element => element.Name.LocalName == "syntaxItem");
             }
         }

--- a/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
@@ -68,10 +68,18 @@ function Get-HiddenOptionalDefaultSetFixture {
         [switch] $Visible
     )
 }
+function Get-SoleHiddenRequiredSetFixture {
+    [CmdletBinding(DefaultParameterSetName = 'Only')]
+    param(
+        [Parameter(ParameterSetName = 'Only', DontShow = $true, Mandatory = $true)]
+        [string] $Secret,
+        [string] $Shared
+    )
+}
 function GetDocumentationParameterDeclaringMetadata { throw 'Target helper shadow was invoked.' }
 function TestDocumentationParameterDontShow { throw 'Target helper shadow was invoked.' }
 function GetDocumentationRuntimeInputs { throw 'Target helper shadow was invoked.' }
-Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture,Get-GenericVisibilityCollisionFixture,Get-MixedVisibilityFixture,Get-HiddenOnlySetFixture,Get-HiddenOptionalDefaultSetFixture,GetDocumentationParameterDeclaringMetadata,TestDocumentationParameterDontShow,GetDocumentationRuntimeInputs
+Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture,Get-GenericVisibilityCollisionFixture,Get-MixedVisibilityFixture,Get-HiddenOnlySetFixture,Get-HiddenOptionalDefaultSetFixture,Get-SoleHiddenRequiredSetFixture,GetDocumentationParameterDeclaringMetadata,TestDocumentationParameterDontShow,GetDocumentationRuntimeInputs
 """, new UTF8Encoding(false));
             File.WriteAllText(manifestPath, """
 @{
@@ -80,7 +88,7 @@ Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture
     GUID = '34343434-3434-3434-3434-343434343434'
     Author = 'PowerForge.Tests'
     Description = 'Parameter visibility fixture.'
-    FunctionsToExport = @('Get-VisibilityFixture','Get-GenericVisibilityFixture','Get-GenericVisibilityCollisionFixture','Get-MixedVisibilityFixture','Get-HiddenOnlySetFixture','Get-HiddenOptionalDefaultSetFixture','GetDocumentationParameterDeclaringMetadata','TestDocumentationParameterDontShow','GetDocumentationRuntimeInputs')
+    FunctionsToExport = @('Get-VisibilityFixture','Get-GenericVisibilityFixture','Get-GenericVisibilityCollisionFixture','Get-MixedVisibilityFixture','Get-HiddenOnlySetFixture','Get-HiddenOptionalDefaultSetFixture','Get-SoleHiddenRequiredSetFixture','GetDocumentationParameterDeclaringMetadata','TestDocumentationParameterDontShow','GetDocumentationRuntimeInputs')
     CmdletsToExport = @()
     AliasesToExport = @()
     VariablesToExport = @()
@@ -184,6 +192,22 @@ Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture
                         "HiddenDefault",
                         StringComparison.OrdinalIgnoreCase));
                 Assert.DoesNotContain("Secret", hiddenDefaultCommandElement.Value, StringComparison.Ordinal);
+
+                var soleHiddenCommand = Assert.Single(payload.Commands, item => item.Name == "Get-SoleHiddenRequiredSetFixture");
+                Assert.Single(soleHiddenCommand.Parameters, parameter => parameter.Name == "Shared");
+                Assert.Empty(soleHiddenCommand.Syntax);
+
+                var soleHiddenMarkdown = File.ReadAllText(Path.Combine(docsRoot, "Get-SoleHiddenRequiredSetFixture.md"));
+                Assert.DoesNotContain("### Only", soleHiddenMarkdown, StringComparison.OrdinalIgnoreCase);
+                var soleHiddenCommandElement = Assert.Single(
+                    hiddenOnlyMaml.Descendants(),
+                    element => element.Name.LocalName == "command" &&
+                               element.Descendants().Any(child =>
+                                   child.Name.LocalName == "name" &&
+                                   child.Value == "Get-SoleHiddenRequiredSetFixture"));
+                Assert.DoesNotContain(
+                    soleHiddenCommandElement.Descendants(),
+                    element => element.Name.LocalName == "syntaxItem");
             }
         }
         finally

--- a/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
@@ -102,6 +102,7 @@ Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture
             {
                 var engine = new DocumentationEngine(new ExecutablePowerShellRunner(host, root), new NullLogger());
                 var payload = engine.ExtractHelpPayload(root, manifestPath, TimeSpan.FromMinutes(1));
+                DocumentationFallbackEnricher.Enrich(payload, new NullLogger());
                 var command = Assert.Single(payload.Commands, item => item.Name == "Get-VisibilityFixture");
                 Assert.Equal(2, command.Parameters.Count);
                 var mode = Assert.Single(command.Parameters, parameter => parameter.Name == "Mode");
@@ -196,9 +197,14 @@ Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture
                 var soleHiddenCommand = Assert.Single(payload.Commands, item => item.Name == "Get-SoleHiddenRequiredSetFixture");
                 Assert.Single(soleHiddenCommand.Parameters, parameter => parameter.Name == "Shared");
                 Assert.Empty(soleHiddenCommand.Syntax);
+                Assert.Empty(soleHiddenCommand.Examples);
 
                 var soleHiddenMarkdown = File.ReadAllText(Path.Combine(docsRoot, "Get-SoleHiddenRequiredSetFixture.md"));
                 Assert.DoesNotContain("### Only", soleHiddenMarkdown, StringComparison.OrdinalIgnoreCase);
+                Assert.DoesNotContain(
+                    "```powershell\nGet-SoleHiddenRequiredSetFixture\n```",
+                    soleHiddenMarkdown.Replace("\r\n", "\n"),
+                    StringComparison.Ordinal);
                 var soleHiddenCommandElement = Assert.Single(
                     hiddenOnlyMaml.Descendants(),
                     element => element.Name.LocalName == "command" &&

--- a/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
@@ -1,0 +1,88 @@
+using System.Text;
+
+namespace PowerForge.Tests;
+
+public sealed class DocumentationParameterVisibilityCompatibilityTests
+{
+    [Fact]
+    public void Collector_UnwrapsNullableTypesAndOmitsDontShowParametersAcrossHosts()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-parameter-visibility-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var modulePath = Path.Combine(root, "VisibilityFixture.psm1");
+            var manifestPath = Path.Combine(root, "VisibilityFixture.psd1");
+            File.WriteAllText(modulePath, """
+enum VisibilityMode { Basic; Advanced }
+function Get-VisibilityFixture {
+    [CmdletBinding()]
+    param(
+        [Nullable[VisibilityMode]] $Mode,
+        [Parameter(DontShow = $true)] [string] $HiddenTransport
+    )
+}
+Export-ModuleMember -Function Get-VisibilityFixture
+""", new UTF8Encoding(false));
+            File.WriteAllText(manifestPath, """
+@{
+    RootModule = 'VisibilityFixture.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = '34343434-3434-3434-3434-343434343434'
+    Author = 'PowerForge.Tests'
+    Description = 'Parameter visibility fixture.'
+    FunctionsToExport = @('Get-VisibilityFixture')
+    CmdletsToExport = @()
+    AliasesToExport = @()
+    VariablesToExport = @()
+}
+""", new UTF8Encoding(false));
+
+            var hosts = OperatingSystem.IsWindows()
+                ? new[] { "pwsh.exe", "powershell.exe" }
+                : new[] { "pwsh" };
+            foreach (var host in hosts)
+            {
+                var engine = new DocumentationEngine(new ExecutablePowerShellRunner(host, root), new NullLogger());
+                var payload = engine.ExtractHelpPayload(root, manifestPath, TimeSpan.FromMinutes(1));
+                var command = Assert.Single(payload.Commands);
+                var mode = Assert.Single(command.Parameters);
+
+                Assert.Equal("Mode", mode.Name);
+                Assert.Equal("VisibilityMode", mode.Type);
+                Assert.Equal(new[] { "Advanced", "Basic" }, mode.PossibleValues.OrderBy(value => value));
+                Assert.All(command.Syntax, syntax => Assert.DoesNotContain("HiddenTransport", syntax.Text, StringComparison.Ordinal));
+
+                var mamlRoot = Path.Combine(root, host.Replace('.', '-'));
+                var mamlPath = new MamlHelpWriter().WriteExternalHelpFile(payload, "VisibilityFixture", mamlRoot);
+                var maml = File.ReadAllText(mamlPath);
+                Assert.DoesNotContain("HiddenTransport", maml, StringComparison.Ordinal);
+                Assert.DoesNotContain("Nullable`1", maml, StringComparison.Ordinal);
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+
+    private sealed class ExecutablePowerShellRunner : IPowerShellRunner
+    {
+        private readonly string _executable;
+        private readonly string _workingDirectory;
+        private readonly PowerShellRunner _inner = new();
+
+        public ExecutablePowerShellRunner(string executable, string workingDirectory)
+        {
+            _executable = executable;
+            _workingDirectory = workingDirectory;
+        }
+
+        public PowerShellRunResult Run(PowerShellRunRequest request)
+            => _inner.Run(new PowerShellRunRequest(
+                request.ScriptPath!, request.Arguments, request.Timeout, request.PreferPwsh,
+                request.WorkingDirectory ?? _workingDirectory, request.EnvironmentVariables,
+                _executable, request.CaptureOutput, request.CaptureError,
+                request.OutputLineReceived, request.ErrorLineReceived));
+    }
+}

--- a/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
@@ -20,7 +20,7 @@ function Get-VisibilityFixture {
     param(
         [Nullable[VisibilityMode]] $Mode,
         [Parameter(ValueFromPipeline = $true)] [Nullable[VisibilityMode][]] $Modes,
-        [Parameter(Mandatory = $true, DontShow = $true, Position = 0)] [string] $HiddenTransport
+        [Parameter(Mandatory = $true, DontShow = $true, Position = 0, ValueFromPipelineByPropertyName = $true)] [string] $HiddenTransport
     )
 }
 function GetDocumentationParameterDeclaringMetadata { throw 'Target helper shadow was invoked.' }

--- a/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
@@ -19,7 +19,7 @@ function Get-VisibilityFixture {
     [CmdletBinding()]
     param(
         [Nullable[VisibilityMode]] $Mode,
-        [Nullable[VisibilityMode][]] $Modes,
+        [Parameter(ValueFromPipeline = $true)] [Nullable[VisibilityMode][]] $Modes,
         [Parameter(Mandatory = $true, DontShow = $true, Position = 0)] [string] $HiddenTransport
     )
 }
@@ -56,6 +56,7 @@ Export-ModuleMember -Function Get-VisibilityFixture,GetDocumentationParameterDec
                 Assert.Equal("Mode", mode.Name);
                 Assert.Equal("VisibilityMode", mode.Type);
                 Assert.Equal("VisibilityMode[]", modes.Type);
+                Assert.Equal("VisibilityMode[]", Assert.Single(command.Inputs).Name);
                 Assert.Equal(new[] { "Advanced", "Basic" }, mode.PossibleValues.OrderBy(value => value));
                 Assert.All(command.Syntax, syntax => Assert.DoesNotContain("HiddenTransport", syntax.Text, StringComparison.Ordinal));
                 Assert.All(command.Syntax, syntax => Assert.DoesNotContain("Nullable", syntax.Text, StringComparison.OrdinalIgnoreCase));

--- a/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
@@ -59,10 +59,19 @@ function Get-HiddenOnlySetFixture {
         [switch] $Secret
     )
 }
+function Get-HiddenOptionalDefaultSetFixture {
+    [CmdletBinding(DefaultParameterSetName = 'HiddenDefault')]
+    param(
+        [Parameter(ParameterSetName = 'HiddenDefault', DontShow = $true)]
+        [switch] $Secret,
+        [Parameter(ParameterSetName = 'Visible')]
+        [switch] $Visible
+    )
+}
 function GetDocumentationParameterDeclaringMetadata { throw 'Target helper shadow was invoked.' }
 function TestDocumentationParameterDontShow { throw 'Target helper shadow was invoked.' }
 function GetDocumentationRuntimeInputs { throw 'Target helper shadow was invoked.' }
-Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture,Get-GenericVisibilityCollisionFixture,Get-MixedVisibilityFixture,Get-HiddenOnlySetFixture,GetDocumentationParameterDeclaringMetadata,TestDocumentationParameterDontShow,GetDocumentationRuntimeInputs
+Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture,Get-GenericVisibilityCollisionFixture,Get-MixedVisibilityFixture,Get-HiddenOnlySetFixture,Get-HiddenOptionalDefaultSetFixture,GetDocumentationParameterDeclaringMetadata,TestDocumentationParameterDontShow,GetDocumentationRuntimeInputs
 """, new UTF8Encoding(false));
             File.WriteAllText(manifestPath, """
 @{
@@ -71,7 +80,7 @@ Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture
     GUID = '34343434-3434-3434-3434-343434343434'
     Author = 'PowerForge.Tests'
     Description = 'Parameter visibility fixture.'
-    FunctionsToExport = @('Get-VisibilityFixture','Get-GenericVisibilityFixture','Get-GenericVisibilityCollisionFixture','Get-MixedVisibilityFixture','Get-HiddenOnlySetFixture','GetDocumentationParameterDeclaringMetadata','TestDocumentationParameterDontShow','GetDocumentationRuntimeInputs')
+    FunctionsToExport = @('Get-VisibilityFixture','Get-GenericVisibilityFixture','Get-GenericVisibilityCollisionFixture','Get-MixedVisibilityFixture','Get-HiddenOnlySetFixture','Get-HiddenOptionalDefaultSetFixture','GetDocumentationParameterDeclaringMetadata','TestDocumentationParameterDontShow','GetDocumentationRuntimeInputs')
     CmdletsToExport = @()
     AliasesToExport = @()
     VariablesToExport = @()
@@ -149,6 +158,32 @@ Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture
                 Assert.DoesNotContain(
                     hiddenOnlyCommandElement.Descendants().SelectMany(element => element.Attributes("parameterSetName")),
                     attribute => string.Equals(attribute.Value, "Hidden", StringComparison.OrdinalIgnoreCase));
+
+                var hiddenDefaultCommand = Assert.Single(payload.Commands, item => item.Name == "Get-HiddenOptionalDefaultSetFixture");
+                Assert.Single(hiddenDefaultCommand.Parameters, parameter => parameter.Name == "Visible");
+                var hiddenDefaultSyntax = Assert.Single(hiddenDefaultCommand.Syntax, syntax =>
+                    string.Equals(syntax.Name, "HiddenDefault", StringComparison.OrdinalIgnoreCase));
+                Assert.True(hiddenDefaultSyntax.IsDefault);
+                Assert.DoesNotContain("Secret", hiddenDefaultSyntax.Text, StringComparison.Ordinal);
+                Assert.Contains(hiddenDefaultCommand.Syntax, syntax =>
+                    string.Equals(syntax.Name, "Visible", StringComparison.OrdinalIgnoreCase));
+
+                var hiddenDefaultMarkdown = File.ReadAllText(Path.Combine(docsRoot, "Get-HiddenOptionalDefaultSetFixture.md"));
+                Assert.Contains("### HiddenDefault (Default)", hiddenDefaultMarkdown, StringComparison.Ordinal);
+                Assert.DoesNotContain("Secret", hiddenDefaultMarkdown, StringComparison.Ordinal);
+                var hiddenDefaultCommandElement = Assert.Single(
+                    hiddenOnlyMaml.Descendants(),
+                    element => element.Name.LocalName == "command" &&
+                               element.Descendants().Any(child =>
+                                   child.Name.LocalName == "name" &&
+                                   child.Value == "Get-HiddenOptionalDefaultSetFixture"));
+                Assert.Contains(
+                    hiddenDefaultCommandElement.Descendants().Where(element => element.Name.LocalName == "syntaxItem"),
+                    element => string.Equals(
+                        element.Attribute("parameterSetName")?.Value,
+                        "HiddenDefault",
+                        StringComparison.OrdinalIgnoreCase));
+                Assert.DoesNotContain("Secret", hiddenDefaultCommandElement.Value, StringComparison.Ordinal);
             }
         }
         finally

--- a/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
@@ -52,6 +52,7 @@ function Get-MixedVisibilityFixture {
 function Get-HiddenOnlySetFixture {
     [CmdletBinding(DefaultParameterSetName = 'Visible')]
     param(
+        [string] $Shared,
         [Parameter(ParameterSetName = 'Visible')]
         [switch] $Visible,
         [Parameter(ParameterSetName = 'Hidden', DontShow = $true, Mandatory = $true)]
@@ -128,7 +129,9 @@ Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture
                     syntax.Text.Contains("Shared", StringComparison.Ordinal));
 
                 var hiddenOnlyCommand = Assert.Single(payload.Commands, item => item.Name == "Get-HiddenOnlySetFixture");
-                Assert.Single(hiddenOnlyCommand.Parameters, parameter => parameter.Name == "Visible");
+                Assert.Equal(2, hiddenOnlyCommand.Parameters.Count);
+                Assert.Contains(hiddenOnlyCommand.Parameters, parameter => parameter.Name == "Shared");
+                Assert.Contains(hiddenOnlyCommand.Parameters, parameter => parameter.Name == "Visible");
                 Assert.DoesNotContain(hiddenOnlyCommand.Syntax, syntax =>
                     string.Equals(syntax.Name, "Hidden", StringComparison.OrdinalIgnoreCase));
                 Assert.Contains(hiddenOnlyCommand.Syntax, syntax =>

--- a/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
@@ -19,7 +19,8 @@ function Get-VisibilityFixture {
     [CmdletBinding()]
     param(
         [Nullable[VisibilityMode]] $Mode,
-        [Parameter(DontShow = $true, Position = 0)] [string] $HiddenTransport
+        [Nullable[VisibilityMode][]] $Modes,
+        [Parameter(Mandatory = $true, DontShow = $true, Position = 0)] [string] $HiddenTransport
     )
 }
 function GetDocumentationParameterDeclaringMetadata { throw 'Target helper shadow was invoked.' }
@@ -48,18 +49,28 @@ Export-ModuleMember -Function Get-VisibilityFixture,GetDocumentationParameterDec
                 var engine = new DocumentationEngine(new ExecutablePowerShellRunner(host, root), new NullLogger());
                 var payload = engine.ExtractHelpPayload(root, manifestPath, TimeSpan.FromMinutes(1));
                 var command = Assert.Single(payload.Commands, item => item.Name == "Get-VisibilityFixture");
-                var mode = Assert.Single(command.Parameters);
+                Assert.Equal(2, command.Parameters.Count);
+                var mode = Assert.Single(command.Parameters, parameter => parameter.Name == "Mode");
+                var modes = Assert.Single(command.Parameters, parameter => parameter.Name == "Modes");
 
                 Assert.Equal("Mode", mode.Name);
                 Assert.Equal("VisibilityMode", mode.Type);
+                Assert.Equal("VisibilityMode[]", modes.Type);
                 Assert.Equal(new[] { "Advanced", "Basic" }, mode.PossibleValues.OrderBy(value => value));
                 Assert.All(command.Syntax, syntax => Assert.DoesNotContain("HiddenTransport", syntax.Text, StringComparison.Ordinal));
+                Assert.All(command.Syntax, syntax => Assert.DoesNotContain("Nullable", syntax.Text, StringComparison.OrdinalIgnoreCase));
+
+                var docsRoot = Path.Combine(root, host.Replace('.', '-') + "-docs");
+                new MarkdownHelpWriter().WriteCommandHelpFiles(payload, "VisibilityFixture", docsRoot);
+                var markdown = File.ReadAllText(Path.Combine(docsRoot, "Get-VisibilityFixture.md"));
+                Assert.DoesNotContain("HiddenTransport", markdown, StringComparison.Ordinal);
+                Assert.DoesNotContain("Nullable", markdown, StringComparison.OrdinalIgnoreCase);
 
                 var mamlRoot = Path.Combine(root, host.Replace('.', '-'));
                 var mamlPath = new MamlHelpWriter().WriteExternalHelpFile(payload, "VisibilityFixture", mamlRoot);
                 var maml = File.ReadAllText(mamlPath);
                 Assert.DoesNotContain("HiddenTransport", maml, StringComparison.Ordinal);
-                Assert.DoesNotContain("Nullable`1", maml, StringComparison.Ordinal);
+                Assert.DoesNotContain("Nullable", maml, StringComparison.OrdinalIgnoreCase);
             }
         }
         finally

--- a/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
@@ -15,12 +15,23 @@ public sealed class DocumentationParameterVisibilityCompatibilityTests
             var manifestPath = Path.Combine(root, "VisibilityFixture.psd1");
             File.WriteAllText(modulePath, """
 enum VisibilityMode { Basic; Advanced }
+class HiddenPayload { [string] $Value }
+class VisiblePayload { [string] $Value }
 function Get-VisibilityFixture {
     [CmdletBinding()]
     param(
         [Nullable[VisibilityMode]] $Mode,
         [Parameter(ValueFromPipeline = $true)] [Nullable[VisibilityMode][]] $Modes,
         [Parameter(Mandatory = $true, DontShow = $true, Position = 0, ValueFromPipelineByPropertyName = $true)] [string] $HiddenTransport
+    )
+}
+function Get-GenericVisibilityCollisionFixture {
+    [CmdletBinding()]
+    param(
+        [Parameter(DontShow = $true, ValueFromPipeline = $true)]
+        [System.Collections.Generic.List[HiddenPayload]] $HiddenItems,
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [System.Collections.Generic.List[VisiblePayload]] $VisibleItems
     )
 }
 function Get-GenericVisibilityFixture {
@@ -32,7 +43,8 @@ function Get-GenericVisibilityFixture {
 }
 function GetDocumentationParameterDeclaringMetadata { throw 'Target helper shadow was invoked.' }
 function TestDocumentationParameterDontShow { throw 'Target helper shadow was invoked.' }
-Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture,GetDocumentationParameterDeclaringMetadata,TestDocumentationParameterDontShow
+function GetDocumentationRuntimeInputs { throw 'Target helper shadow was invoked.' }
+Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture,Get-GenericVisibilityCollisionFixture,GetDocumentationParameterDeclaringMetadata,TestDocumentationParameterDontShow,GetDocumentationRuntimeInputs
 """, new UTF8Encoding(false));
             File.WriteAllText(manifestPath, """
 @{
@@ -41,7 +53,7 @@ Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture
     GUID = '34343434-3434-3434-3434-343434343434'
     Author = 'PowerForge.Tests'
     Description = 'Parameter visibility fixture.'
-    FunctionsToExport = @('Get-VisibilityFixture','Get-GenericVisibilityFixture','GetDocumentationParameterDeclaringMetadata','TestDocumentationParameterDontShow')
+    FunctionsToExport = @('Get-VisibilityFixture','Get-GenericVisibilityFixture','Get-GenericVisibilityCollisionFixture','GetDocumentationParameterDeclaringMetadata','TestDocumentationParameterDontShow','GetDocumentationRuntimeInputs')
     CmdletsToExport = @()
     AliasesToExport = @()
     VariablesToExport = @()
@@ -86,6 +98,12 @@ Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture
                 Assert.Equal(genericType, Assert.Single(genericCommand.Inputs).Name);
                 Assert.All(genericCommand.Syntax, syntax =>
                     Assert.DoesNotContain("KeyValuePair`2", syntax.Text, StringComparison.Ordinal));
+
+                var collisionCommand = Assert.Single(payload.Commands, item => item.Name == "Get-GenericVisibilityCollisionFixture");
+                Assert.Single(collisionCommand.Parameters, parameter => parameter.Name == "VisibleItems");
+                var collisionInput = Assert.Single(collisionCommand.Inputs);
+                Assert.Contains("VisiblePayload", collisionInput.ClrTypeName, StringComparison.Ordinal);
+                Assert.DoesNotContain("HiddenPayload", collisionInput.ClrTypeName, StringComparison.Ordinal);
             }
         }
         finally

--- a/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
@@ -41,10 +41,18 @@ function Get-GenericVisibilityFixture {
         [Nullable[System.Collections.Generic.KeyValuePair[string,int]]] $Pair
     )
 }
+function Get-MixedVisibilityFixture {
+    [CmdletBinding(DefaultParameterSetName = 'Visible')]
+    param(
+        [Parameter(ParameterSetName = 'Hidden', DontShow = $true)]
+        [Parameter(ParameterSetName = 'Visible')]
+        [string] $Shared
+    )
+}
 function GetDocumentationParameterDeclaringMetadata { throw 'Target helper shadow was invoked.' }
 function TestDocumentationParameterDontShow { throw 'Target helper shadow was invoked.' }
 function GetDocumentationRuntimeInputs { throw 'Target helper shadow was invoked.' }
-Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture,Get-GenericVisibilityCollisionFixture,GetDocumentationParameterDeclaringMetadata,TestDocumentationParameterDontShow,GetDocumentationRuntimeInputs
+Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture,Get-GenericVisibilityCollisionFixture,Get-MixedVisibilityFixture,GetDocumentationParameterDeclaringMetadata,TestDocumentationParameterDontShow,GetDocumentationRuntimeInputs
 """, new UTF8Encoding(false));
             File.WriteAllText(manifestPath, """
 @{
@@ -53,7 +61,7 @@ Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture
     GUID = '34343434-3434-3434-3434-343434343434'
     Author = 'PowerForge.Tests'
     Description = 'Parameter visibility fixture.'
-    FunctionsToExport = @('Get-VisibilityFixture','Get-GenericVisibilityFixture','Get-GenericVisibilityCollisionFixture','GetDocumentationParameterDeclaringMetadata','TestDocumentationParameterDontShow','GetDocumentationRuntimeInputs')
+    FunctionsToExport = @('Get-VisibilityFixture','Get-GenericVisibilityFixture','Get-GenericVisibilityCollisionFixture','Get-MixedVisibilityFixture','GetDocumentationParameterDeclaringMetadata','TestDocumentationParameterDontShow','GetDocumentationRuntimeInputs')
     CmdletsToExport = @()
     AliasesToExport = @()
     VariablesToExport = @()
@@ -104,6 +112,11 @@ Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture
                 var collisionInput = Assert.Single(collisionCommand.Inputs);
                 Assert.Contains("VisiblePayload", collisionInput.ClrTypeName, StringComparison.Ordinal);
                 Assert.DoesNotContain("HiddenPayload", collisionInput.ClrTypeName, StringComparison.Ordinal);
+
+                var mixedCommand = Assert.Single(payload.Commands, item => item.Name == "Get-MixedVisibilityFixture");
+                Assert.Single(mixedCommand.Parameters, parameter => parameter.Name == "Shared");
+                Assert.Contains(mixedCommand.Syntax, syntax =>
+                    syntax.Text.Contains("Shared", StringComparison.Ordinal));
             }
         }
         finally

--- a/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
@@ -19,10 +19,12 @@ function Get-VisibilityFixture {
     [CmdletBinding()]
     param(
         [Nullable[VisibilityMode]] $Mode,
-        [Parameter(DontShow = $true)] [string] $HiddenTransport
+        [Parameter(DontShow = $true, Position = 0)] [string] $HiddenTransport
     )
 }
-Export-ModuleMember -Function Get-VisibilityFixture
+function GetDocumentationParameterDeclaringMetadata { throw 'Target helper shadow was invoked.' }
+function TestDocumentationParameterDontShow { throw 'Target helper shadow was invoked.' }
+Export-ModuleMember -Function Get-VisibilityFixture,GetDocumentationParameterDeclaringMetadata,TestDocumentationParameterDontShow
 """, new UTF8Encoding(false));
             File.WriteAllText(manifestPath, """
 @{
@@ -31,7 +33,7 @@ Export-ModuleMember -Function Get-VisibilityFixture
     GUID = '34343434-3434-3434-3434-343434343434'
     Author = 'PowerForge.Tests'
     Description = 'Parameter visibility fixture.'
-    FunctionsToExport = @('Get-VisibilityFixture')
+    FunctionsToExport = @('Get-VisibilityFixture','GetDocumentationParameterDeclaringMetadata','TestDocumentationParameterDontShow')
     CmdletsToExport = @()
     AliasesToExport = @()
     VariablesToExport = @()
@@ -45,7 +47,7 @@ Export-ModuleMember -Function Get-VisibilityFixture
             {
                 var engine = new DocumentationEngine(new ExecutablePowerShellRunner(host, root), new NullLogger());
                 var payload = engine.ExtractHelpPayload(root, manifestPath, TimeSpan.FromMinutes(1));
-                var command = Assert.Single(payload.Commands);
+                var command = Assert.Single(payload.Commands, item => item.Name == "Get-VisibilityFixture");
                 var mode = Assert.Single(command.Parameters);
 
                 Assert.Equal("Mode", mode.Name);

--- a/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationParameterVisibilityCompatibilityTests.cs
@@ -49,10 +49,19 @@ function Get-MixedVisibilityFixture {
         [string] $Shared
     )
 }
+function Get-HiddenOnlySetFixture {
+    [CmdletBinding(DefaultParameterSetName = 'Visible')]
+    param(
+        [Parameter(ParameterSetName = 'Visible')]
+        [switch] $Visible,
+        [Parameter(ParameterSetName = 'Hidden', DontShow = $true, Mandatory = $true)]
+        [switch] $Secret
+    )
+}
 function GetDocumentationParameterDeclaringMetadata { throw 'Target helper shadow was invoked.' }
 function TestDocumentationParameterDontShow { throw 'Target helper shadow was invoked.' }
 function GetDocumentationRuntimeInputs { throw 'Target helper shadow was invoked.' }
-Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture,Get-GenericVisibilityCollisionFixture,Get-MixedVisibilityFixture,GetDocumentationParameterDeclaringMetadata,TestDocumentationParameterDontShow,GetDocumentationRuntimeInputs
+Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture,Get-GenericVisibilityCollisionFixture,Get-MixedVisibilityFixture,Get-HiddenOnlySetFixture,GetDocumentationParameterDeclaringMetadata,TestDocumentationParameterDontShow,GetDocumentationRuntimeInputs
 """, new UTF8Encoding(false));
             File.WriteAllText(manifestPath, """
 @{
@@ -61,7 +70,7 @@ Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture
     GUID = '34343434-3434-3434-3434-343434343434'
     Author = 'PowerForge.Tests'
     Description = 'Parameter visibility fixture.'
-    FunctionsToExport = @('Get-VisibilityFixture','Get-GenericVisibilityFixture','Get-GenericVisibilityCollisionFixture','Get-MixedVisibilityFixture','GetDocumentationParameterDeclaringMetadata','TestDocumentationParameterDontShow','GetDocumentationRuntimeInputs')
+    FunctionsToExport = @('Get-VisibilityFixture','Get-GenericVisibilityFixture','Get-GenericVisibilityCollisionFixture','Get-MixedVisibilityFixture','Get-HiddenOnlySetFixture','GetDocumentationParameterDeclaringMetadata','TestDocumentationParameterDontShow','GetDocumentationRuntimeInputs')
     CmdletsToExport = @()
     AliasesToExport = @()
     VariablesToExport = @()
@@ -117,6 +126,26 @@ Export-ModuleMember -Function Get-VisibilityFixture,Get-GenericVisibilityFixture
                 Assert.Single(mixedCommand.Parameters, parameter => parameter.Name == "Shared");
                 Assert.Contains(mixedCommand.Syntax, syntax =>
                     syntax.Text.Contains("Shared", StringComparison.Ordinal));
+
+                var hiddenOnlyCommand = Assert.Single(payload.Commands, item => item.Name == "Get-HiddenOnlySetFixture");
+                Assert.Single(hiddenOnlyCommand.Parameters, parameter => parameter.Name == "Visible");
+                Assert.DoesNotContain(hiddenOnlyCommand.Syntax, syntax =>
+                    string.Equals(syntax.Name, "Hidden", StringComparison.OrdinalIgnoreCase));
+                Assert.Contains(hiddenOnlyCommand.Syntax, syntax =>
+                    string.Equals(syntax.Name, "Visible", StringComparison.OrdinalIgnoreCase));
+
+                var hiddenOnlyMarkdown = File.ReadAllText(Path.Combine(docsRoot, "Get-HiddenOnlySetFixture.md"));
+                Assert.DoesNotContain("### Hidden", hiddenOnlyMarkdown, StringComparison.OrdinalIgnoreCase);
+                var hiddenOnlyMaml = System.Xml.Linq.XDocument.Load(mamlPath);
+                var hiddenOnlyCommandElement = Assert.Single(
+                    hiddenOnlyMaml.Descendants(),
+                    element => element.Name.LocalName == "command" &&
+                               element.Descendants().Any(child =>
+                                   child.Name.LocalName == "name" &&
+                                   child.Value == "Get-HiddenOnlySetFixture"));
+                Assert.DoesNotContain(
+                    hiddenOnlyCommandElement.Descendants().SelectMany(element => element.Attributes("parameterSetName")),
+                    attribute => string.Equals(attribute.Value, "Hidden", StringComparison.OrdinalIgnoreCase));
             }
         }
         finally

--- a/PowerForge.Tests/Fixtures/BinaryDocFixture/BinaryDocFixture.csproj
+++ b/PowerForge.Tests/Fixtures/BinaryDocFixture/BinaryDocFixture.csproj
@@ -18,10 +18,11 @@
   <ItemGroup>
     <ProjectReference Include="AssemblyDistinctA\BinaryDocOutputAssemblyA.csproj" Aliases="DistinctA" />
     <ProjectReference Include="AssemblyDistinctB\BinaryDocOutputAssemblyB.csproj" Aliases="DistinctB" />
+    <ProjectReference Include="InheritedBase\BinaryDocInheritedBase.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="AssemblyDistinctA\**;AssemblyDistinctB\**" />
+    <Compile Remove="AssemblyDistinctA\**;AssemblyDistinctB\**;InheritedBase\**" />
   </ItemGroup>
 
 </Project>

--- a/PowerForge.Tests/Fixtures/BinaryDocFixture/DocumentationMetadataContractCommand.cs
+++ b/PowerForge.Tests/Fixtures/BinaryDocFixture/DocumentationMetadataContractCommand.cs
@@ -1,0 +1,21 @@
+using System.Management.Automation;
+using BinaryDocInheritedBase;
+
+namespace BinaryDocFixture;
+
+/// <summary>Returns metadata used to verify binary documentation normalization.</summary>
+[Cmdlet(VerbsCommon.Get, "BinaryDocMetadataContract")]
+public sealed class GetBinaryDocMetadataContractCommand : DocumentationMetadataContractCommandBase
+{
+    /// <summary>Optional nullable mode.</summary>
+    [Parameter]
+    public BinaryDocMode? NullableMode { get; set; }
+
+    /// <summary>Optional multidimensional nullable modes.</summary>
+    [Parameter]
+    public BinaryDocMode?[,] NullableModeMatrix { get; set; } = new BinaryDocMode?[0, 0];
+
+    /// <summary>Internal transport value that must not appear in public help.</summary>
+    [Parameter(DontShow = true)]
+    public string HiddenTransport { get; set; } = string.Empty;
+}

--- a/PowerForge.Tests/Fixtures/BinaryDocFixture/InheritedBase/BinaryDocInheritedBase.csproj
+++ b/PowerForge.Tests/Fixtures/BinaryDocFixture/InheritedBase/BinaryDocInheritedBase.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <WarningsAsErrors>CS1591</WarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/PowerForge.Tests/Fixtures/BinaryDocFixture/InheritedBase/DocumentationMetadataContractCommandBase.cs
+++ b/PowerForge.Tests/Fixtures/BinaryDocFixture/InheritedBase/DocumentationMetadataContractCommandBase.cs
@@ -1,0 +1,11 @@
+using System.Management.Automation;
+
+namespace BinaryDocInheritedBase;
+
+/// <summary>Provides shared parameters for documentation inheritance tests.</summary>
+public abstract class DocumentationMetadataContractCommandBase : PSCmdlet
+{
+    /// <summary>Inherited label documented in a separate declaring assembly.</summary>
+    [Parameter]
+    public string InheritedLabel { get; set; } = string.Empty;
+}

--- a/PowerForge.Tests/Fixtures/BinaryDocFixture/InheritedBase/packages.lock.json
+++ b/PowerForge.Tests/Fixtures/BinaryDocFixture/InheritedBase/packages.lock.json
@@ -7,15 +7,6 @@
         "requested": "[5.1.1, )",
         "resolved": "5.1.1",
         "contentHash": "e31xJjG+Kjbv6YF3Yq6D4Dl3or8v7LrNF41k3CXrWozW6hR1zcOe5KYuZJaGSiAgLnwP8wcW+I3+IWEzMPZKXQ=="
-      },
-      "binarydocinheritedbase": {
-        "type": "Project"
-      },
-      "binarydocoutputassemblya": {
-        "type": "Project"
-      },
-      "binarydocoutputassemblyb": {
-        "type": "Project"
       }
     }
   }

--- a/PowerForge.Tests/ModulePipelineDocumentationSyncTests.cs
+++ b/PowerForge.Tests/ModulePipelineDocumentationSyncTests.cs
@@ -130,7 +130,7 @@ public sealed class ModulePipelineDocumentationSyncTests
             File.WriteAllText(Path.Combine(targetHelpDir, "TestModule-help.xml"), "<oldHelpItems />");
             File.WriteAllText(
                 Path.Combine(targetHelpDir, "Removed.Binary.dll-Help.xml"),
-                generatedMarker + "<oldHelpItems />");
+                DocumentationExternalHelpAliasWriter.GetLegacyGeneratedAliasMarker() + "<oldHelpItems />");
             File.WriteAllText(Path.Combine(targetHelpDir, "Authored.Binary.dll-Help.xml"), "<oldHelpItems />");
             var staleNestedHelpDir = Path.Combine(projectRoot, "Lib", "Removed", "en-US");
             Directory.CreateDirectory(staleNestedHelpDir);
@@ -139,9 +139,10 @@ public sealed class ModulePipelineDocumentationSyncTests
                 generatedMarker + "<oldHelpItems />");
             var otherModuleHelp = Path.Combine(projectRoot, "Bundled", "en-US", "Bundled.dll-Help.xml");
             Directory.CreateDirectory(Path.GetDirectoryName(otherModuleHelp)!);
+            File.WriteAllText(Path.Combine(projectRoot, "Bundled", "Bundled.psd1"), "@{ RootModule = '' }");
             File.WriteAllText(
                 otherModuleHelp,
-                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("BundledModule") + "<oldHelpItems />");
+                DocumentationExternalHelpAliasWriter.GetLegacyGeneratedAliasMarker() + "<oldHelpItems />");
 
             var runner = new ModulePipelineRunner(new NullLogger());
             var plan = runner.Plan(new ModulePipelineSpec

--- a/PowerForge.Tests/ModulePipelineDocumentationSyncTests.cs
+++ b/PowerForge.Tests/ModulePipelineDocumentationSyncTests.cs
@@ -139,7 +139,7 @@ public sealed class ModulePipelineDocumentationSyncTests
                 generatedMarker + "<oldHelpItems />");
             var otherModuleHelp = Path.Combine(projectRoot, "Bundled", "en-US", "Bundled.dll-Help.xml");
             Directory.CreateDirectory(Path.GetDirectoryName(otherModuleHelp)!);
-            File.WriteAllText(Path.Combine(projectRoot, "Bundled", "Bundled.psd1"), "@{ RootModule = '' }");
+            File.WriteAllText(Path.Combine(projectRoot, "Bundled", "Bundled.psd1"), "@{ RootModule = ''; ModuleVersion = '1.0.0' }");
             File.WriteAllText(
                 otherModuleHelp,
                 DocumentationExternalHelpAliasWriter.GetLegacyGeneratedAliasMarker() + "<oldHelpItems />");

--- a/PowerForge.Tests/ModulePipelineDocumentationSyncTests.cs
+++ b/PowerForge.Tests/ModulePipelineDocumentationSyncTests.cs
@@ -116,6 +116,15 @@ public sealed class ModulePipelineDocumentationSyncTests
             Directory.CreateDirectory(stagedHelpDir);
             var stagedHelp = Path.Combine(stagedHelpDir, "TestModule-help.xml");
             File.WriteAllText(stagedHelp, "<helpItems />");
+            var stagedBinaryHelp = Path.Combine(stagedHelpDir, "TestModule.Binary.dll-Help.xml");
+            File.WriteAllText(stagedBinaryHelp, "<helpItems />");
+            var targetHelpDir = Path.Combine(projectRoot, "en-US");
+            Directory.CreateDirectory(targetHelpDir);
+            File.WriteAllText(Path.Combine(targetHelpDir, "TestModule-help.xml"), "<oldHelpItems />");
+            File.WriteAllText(
+                Path.Combine(targetHelpDir, "Removed.Binary.dll-Help.xml"),
+                "<!-- PowerForgeGeneratedExternalHelpAlias --><oldHelpItems />");
+            File.WriteAllText(Path.Combine(targetHelpDir, "Authored.Binary.dll-Help.xml"), "<oldHelpItems />");
 
             var runner = new ModulePipelineRunner(new NullLogger());
             var plan = runner.Plan(new ModulePipelineSpec
@@ -164,11 +173,15 @@ public sealed class ModulePipelineDocumentationSyncTests
                 exitCode: 0,
                 markdownFiles: 1,
                 externalHelpFilePath: stagedHelp,
-                errorMessage: null);
+                errorMessage: null,
+                externalHelpFilePaths: new[] { stagedHelp, stagedBinaryHelp });
 
             InvokeSync(runner, plan, result);
 
             Assert.True(File.Exists(Path.Combine(projectRoot, "en-US", "TestModule-help.xml")));
+            Assert.True(File.Exists(Path.Combine(projectRoot, "en-US", "TestModule.Binary.dll-Help.xml")));
+            Assert.False(File.Exists(Path.Combine(projectRoot, "en-US", "Removed.Binary.dll-Help.xml")));
+            Assert.True(File.Exists(Path.Combine(projectRoot, "en-US", "Authored.Binary.dll-Help.xml")));
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineDocumentationSyncTests.cs
+++ b/PowerForge.Tests/ModulePipelineDocumentationSyncTests.cs
@@ -118,22 +118,30 @@ public sealed class ModulePipelineDocumentationSyncTests
             File.WriteAllText(stagedHelp, "<helpItems />");
             var stagedBinaryHelp = Path.Combine(stagedHelpDir, "TestModule.Binary.dll-Help.xml");
             File.WriteAllText(stagedBinaryHelp, "<helpItems />");
+            var generatedMarker = DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker(moduleName);
+            var stagedAuthoredCollision = Path.Combine(stagedHelpDir, "Authored.Binary.dll-Help.xml");
+            File.WriteAllText(stagedAuthoredCollision, generatedMarker + "<replacementHelpItems />");
             var stagedNestedHelpDir = Path.Combine(root.FullName, "Staging", "Lib", "Core", "en-US");
             Directory.CreateDirectory(stagedNestedHelpDir);
             var stagedNestedBinaryHelp = Path.Combine(stagedNestedHelpDir, "Nested.Binary.dll-Help.xml");
-            File.WriteAllText(stagedNestedBinaryHelp, "<!-- PowerForgeGeneratedExternalHelpAlias --><helpItems />");
+            File.WriteAllText(stagedNestedBinaryHelp, generatedMarker + "<helpItems />");
             var targetHelpDir = Path.Combine(projectRoot, "en-US");
             Directory.CreateDirectory(targetHelpDir);
             File.WriteAllText(Path.Combine(targetHelpDir, "TestModule-help.xml"), "<oldHelpItems />");
             File.WriteAllText(
                 Path.Combine(targetHelpDir, "Removed.Binary.dll-Help.xml"),
-                "<!-- PowerForgeGeneratedExternalHelpAlias --><oldHelpItems />");
+                generatedMarker + "<oldHelpItems />");
             File.WriteAllText(Path.Combine(targetHelpDir, "Authored.Binary.dll-Help.xml"), "<oldHelpItems />");
             var staleNestedHelpDir = Path.Combine(projectRoot, "Lib", "Removed", "en-US");
             Directory.CreateDirectory(staleNestedHelpDir);
             File.WriteAllText(
                 Path.Combine(staleNestedHelpDir, "Removed.Nested.dll-Help.xml"),
-                "<!-- PowerForgeGeneratedExternalHelpAlias --><oldHelpItems />");
+                generatedMarker + "<oldHelpItems />");
+            var otherModuleHelp = Path.Combine(projectRoot, "Bundled", "en-US", "Bundled.dll-Help.xml");
+            Directory.CreateDirectory(Path.GetDirectoryName(otherModuleHelp)!);
+            File.WriteAllText(
+                otherModuleHelp,
+                DocumentationExternalHelpAliasWriter.GetGeneratedAliasMarker("BundledModule") + "<oldHelpItems />");
 
             var runner = new ModulePipelineRunner(new NullLogger());
             var plan = runner.Plan(new ModulePipelineSpec
@@ -183,7 +191,7 @@ public sealed class ModulePipelineDocumentationSyncTests
                 markdownFiles: 1,
                 externalHelpFilePath: stagedHelp,
                 errorMessage: null,
-                externalHelpFilePaths: new[] { stagedHelp, stagedBinaryHelp, stagedNestedBinaryHelp });
+                externalHelpFilePaths: new[] { stagedHelp, stagedBinaryHelp, stagedAuthoredCollision, stagedNestedBinaryHelp });
 
             InvokeSync(runner, plan, result);
 
@@ -192,7 +200,10 @@ public sealed class ModulePipelineDocumentationSyncTests
             Assert.True(File.Exists(Path.Combine(projectRoot, "Lib", "Core", "en-US", "Nested.Binary.dll-Help.xml")));
             Assert.False(File.Exists(Path.Combine(projectRoot, "en-US", "Removed.Binary.dll-Help.xml")));
             Assert.False(File.Exists(Path.Combine(staleNestedHelpDir, "Removed.Nested.dll-Help.xml")));
-            Assert.True(File.Exists(Path.Combine(projectRoot, "en-US", "Authored.Binary.dll-Help.xml")));
+            Assert.Equal(
+                "<oldHelpItems />",
+                File.ReadAllText(Path.Combine(projectRoot, "en-US", "Authored.Binary.dll-Help.xml")));
+            Assert.True(File.Exists(otherModuleHelp));
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineDocumentationSyncTests.cs
+++ b/PowerForge.Tests/ModulePipelineDocumentationSyncTests.cs
@@ -118,6 +118,10 @@ public sealed class ModulePipelineDocumentationSyncTests
             File.WriteAllText(stagedHelp, "<helpItems />");
             var stagedBinaryHelp = Path.Combine(stagedHelpDir, "TestModule.Binary.dll-Help.xml");
             File.WriteAllText(stagedBinaryHelp, "<helpItems />");
+            var stagedNestedHelpDir = Path.Combine(root.FullName, "Staging", "Lib", "Core", "en-US");
+            Directory.CreateDirectory(stagedNestedHelpDir);
+            var stagedNestedBinaryHelp = Path.Combine(stagedNestedHelpDir, "Nested.Binary.dll-Help.xml");
+            File.WriteAllText(stagedNestedBinaryHelp, "<!-- PowerForgeGeneratedExternalHelpAlias --><helpItems />");
             var targetHelpDir = Path.Combine(projectRoot, "en-US");
             Directory.CreateDirectory(targetHelpDir);
             File.WriteAllText(Path.Combine(targetHelpDir, "TestModule-help.xml"), "<oldHelpItems />");
@@ -125,6 +129,11 @@ public sealed class ModulePipelineDocumentationSyncTests
                 Path.Combine(targetHelpDir, "Removed.Binary.dll-Help.xml"),
                 "<!-- PowerForgeGeneratedExternalHelpAlias --><oldHelpItems />");
             File.WriteAllText(Path.Combine(targetHelpDir, "Authored.Binary.dll-Help.xml"), "<oldHelpItems />");
+            var staleNestedHelpDir = Path.Combine(projectRoot, "Lib", "Removed", "en-US");
+            Directory.CreateDirectory(staleNestedHelpDir);
+            File.WriteAllText(
+                Path.Combine(staleNestedHelpDir, "Removed.Nested.dll-Help.xml"),
+                "<!-- PowerForgeGeneratedExternalHelpAlias --><oldHelpItems />");
 
             var runner = new ModulePipelineRunner(new NullLogger());
             var plan = runner.Plan(new ModulePipelineSpec
@@ -174,13 +183,15 @@ public sealed class ModulePipelineDocumentationSyncTests
                 markdownFiles: 1,
                 externalHelpFilePath: stagedHelp,
                 errorMessage: null,
-                externalHelpFilePaths: new[] { stagedHelp, stagedBinaryHelp });
+                externalHelpFilePaths: new[] { stagedHelp, stagedBinaryHelp, stagedNestedBinaryHelp });
 
             InvokeSync(runner, plan, result);
 
             Assert.True(File.Exists(Path.Combine(projectRoot, "en-US", "TestModule-help.xml")));
             Assert.True(File.Exists(Path.Combine(projectRoot, "en-US", "TestModule.Binary.dll-Help.xml")));
+            Assert.True(File.Exists(Path.Combine(projectRoot, "Lib", "Core", "en-US", "Nested.Binary.dll-Help.xml")));
             Assert.False(File.Exists(Path.Combine(projectRoot, "en-US", "Removed.Binary.dll-Help.xml")));
+            Assert.False(File.Exists(Path.Combine(staleNestedHelpDir, "Removed.Nested.dll-Help.xml")));
             Assert.True(File.Exists(Path.Combine(projectRoot, "en-US", "Authored.Binary.dll-Help.xml")));
         }
         finally

--- a/PowerForge.Tests/ModulePipelineDocumentationSyncTests.cs
+++ b/PowerForge.Tests/ModulePipelineDocumentationSyncTests.cs
@@ -147,6 +147,27 @@ public sealed class ModulePipelineDocumentationSyncTests
             {
                 // Link creation is not available on every test host.
             }
+            var outsideFile = Path.Combine(outsideRoot, "linked-file.xml");
+            const string outsideFileContent = "<!-- PowerForgeGeneratedExternalHelpAlias --><outside />";
+            File.WriteAllText(outsideFile, outsideFileContent);
+            var linkedFileCreated = false;
+            var linkedFileTargetDirectory = Path.Combine(projectRoot, "FileLinked", "en-US");
+            Directory.CreateDirectory(linkedFileTargetDirectory);
+            var linkedFileTarget = Path.Combine(linkedFileTargetDirectory, "FileLinked.Binary.dll-Help.xml");
+            try
+            {
+                File.CreateSymbolicLink(linkedFileTarget, outsideFile);
+                linkedFileCreated = true;
+                var stagedFileLinkedHelpDirectory = Path.Combine(root.FullName, "Staging", "FileLinked", "en-US");
+                Directory.CreateDirectory(stagedFileLinkedHelpDirectory);
+                var stagedFileLinkedHelp = Path.Combine(stagedFileLinkedHelpDirectory, "FileLinked.Binary.dll-Help.xml");
+                File.WriteAllText(stagedFileLinkedHelp, generatedMarker + "<helpItems />");
+                externalHelpFilePaths.Add(stagedFileLinkedHelp);
+            }
+            catch (Exception exception) when (exception is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+            {
+                // Link creation is not available on every test host.
+            }
             var targetHelpDir = Path.Combine(projectRoot, "en-US");
             Directory.CreateDirectory(targetHelpDir);
             File.WriteAllText(Path.Combine(targetHelpDir, "TestModule-help.xml"), "<oldHelpItems />");
@@ -229,6 +250,8 @@ public sealed class ModulePipelineDocumentationSyncTests
             Assert.True(File.Exists(otherModuleHelp));
             if (linkedTargetCreated)
                 Assert.False(File.Exists(Path.Combine(outsideRoot, "en-US", "Linked.Binary.dll-Help.xml")));
+            if (linkedFileCreated)
+                Assert.Equal(outsideFileContent, File.ReadAllText(outsideFile));
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineDocumentationSyncTests.cs
+++ b/PowerForge.Tests/ModulePipelineDocumentationSyncTests.cs
@@ -100,6 +100,7 @@ public sealed class ModulePipelineDocumentationSyncTests
     public void SyncGeneratedDocumentationToProjectRoot_DocumentationGateSyncsExternalHelpByDefault()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var outsideRoot = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
         try
         {
             const string moduleName = "TestModule";
@@ -125,6 +126,27 @@ public sealed class ModulePipelineDocumentationSyncTests
             Directory.CreateDirectory(stagedNestedHelpDir);
             var stagedNestedBinaryHelp = Path.Combine(stagedNestedHelpDir, "Nested.Binary.dll-Help.xml");
             File.WriteAllText(stagedNestedBinaryHelp, generatedMarker + "<helpItems />");
+            var externalHelpFilePaths = new System.Collections.Generic.List<string>
+            {
+                stagedHelp, stagedBinaryHelp, stagedAuthoredCollision, stagedNestedBinaryHelp
+            };
+            Directory.CreateDirectory(outsideRoot);
+            var linkedTargetDirectory = Path.Combine(projectRoot, "Linked");
+            var linkedTargetCreated = false;
+            try
+            {
+                Directory.CreateSymbolicLink(linkedTargetDirectory, outsideRoot);
+                linkedTargetCreated = true;
+                var stagedLinkedHelpDirectory = Path.Combine(root.FullName, "Staging", "Linked", "en-US");
+                Directory.CreateDirectory(stagedLinkedHelpDirectory);
+                var stagedLinkedHelp = Path.Combine(stagedLinkedHelpDirectory, "Linked.Binary.dll-Help.xml");
+                File.WriteAllText(stagedLinkedHelp, generatedMarker + "<helpItems />");
+                externalHelpFilePaths.Add(stagedLinkedHelp);
+            }
+            catch (Exception exception) when (exception is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+            {
+                // Link creation is not available on every test host.
+            }
             var targetHelpDir = Path.Combine(projectRoot, "en-US");
             Directory.CreateDirectory(targetHelpDir);
             File.WriteAllText(Path.Combine(targetHelpDir, "TestModule-help.xml"), "<oldHelpItems />");
@@ -192,7 +214,7 @@ public sealed class ModulePipelineDocumentationSyncTests
                 markdownFiles: 1,
                 externalHelpFilePath: stagedHelp,
                 errorMessage: null,
-                externalHelpFilePaths: new[] { stagedHelp, stagedBinaryHelp, stagedAuthoredCollision, stagedNestedBinaryHelp });
+                externalHelpFilePaths: externalHelpFilePaths);
 
             InvokeSync(runner, plan, result);
 
@@ -205,10 +227,13 @@ public sealed class ModulePipelineDocumentationSyncTests
                 "<oldHelpItems />",
                 File.ReadAllText(Path.Combine(projectRoot, "en-US", "Authored.Binary.dll-Help.xml")));
             Assert.True(File.Exists(otherModuleHelp));
+            if (linkedTargetCreated)
+                Assert.False(File.Exists(Path.Combine(outsideRoot, "en-US", "Linked.Binary.dll-Help.xml")));
         }
         finally
         {
             try { root.Delete(recursive: true); } catch { /* best effort */ }
+            try { Directory.Delete(outsideRoot, recursive: true); } catch { /* best effort */ }
         }
     }
 

--- a/PowerForge/Models/DocumentationBuildResult.cs
+++ b/PowerForge/Models/DocumentationBuildResult.cs
@@ -51,8 +51,33 @@ public sealed class DocumentationBuildResult
         int exitCode,
         int markdownFiles,
         string externalHelpFilePath,
+        string? errorMessage)
+        : this(
+            enabled,
+            docsPath,
+            readmePath,
+            succeeded,
+            exitCode,
+            markdownFiles,
+            externalHelpFilePath,
+            errorMessage,
+            externalHelpFilePaths: null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new result instance with every generated external-help path.
+    /// </summary>
+    public DocumentationBuildResult(
+        bool enabled,
+        string docsPath,
+        string readmePath,
+        bool succeeded,
+        int exitCode,
+        int markdownFiles,
+        string externalHelpFilePath,
         string? errorMessage,
-        IReadOnlyList<string>? externalHelpFilePaths = null)
+        IReadOnlyList<string>? externalHelpFilePaths)
     {
         Enabled = enabled;
         DocsPath = docsPath;

--- a/PowerForge/Models/DocumentationBuildResult.cs
+++ b/PowerForge/Models/DocumentationBuildResult.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace PowerForge;
 
 /// <summary>
@@ -29,6 +32,11 @@ public sealed class DocumentationBuildResult
     /// </summary>
     public string ExternalHelpFilePath { get; }
 
+    /// <summary>
+    /// Full paths to every generated external-help file, including assembly-named aliases used by direct binary imports.
+    /// </summary>
+    public IReadOnlyList<string> ExternalHelpFilePaths { get; }
+
     /// <summary>Optional error message when <see cref="Succeeded"/> is false.</summary>
     public string? ErrorMessage { get; }
 
@@ -43,7 +51,8 @@ public sealed class DocumentationBuildResult
         int exitCode,
         int markdownFiles,
         string externalHelpFilePath,
-        string? errorMessage)
+        string? errorMessage,
+        IReadOnlyList<string>? externalHelpFilePaths = null)
     {
         Enabled = enabled;
         DocsPath = docsPath;
@@ -52,6 +61,10 @@ public sealed class DocumentationBuildResult
         ExitCode = exitCode;
         MarkdownFiles = markdownFiles;
         ExternalHelpFilePath = externalHelpFilePath ?? string.Empty;
+        ExternalHelpFilePaths = externalHelpFilePaths ??
+            (string.IsNullOrWhiteSpace(ExternalHelpFilePath)
+                ? Array.Empty<string>()
+                : new[] { ExternalHelpFilePath });
         ErrorMessage = errorMessage;
     }
 }

--- a/PowerForge/Scripts/Documentation/Export-HelpJson.Protocol.ps1
+++ b/PowerForge/Scripts/Documentation/Export-HelpJson.Protocol.ps1
@@ -33,6 +33,9 @@ function GetCollectorHelperFunctionNames {
     'GetDictionaryComparer',
     'GetDictionaryConstructorExpression',
     'GetDocumentedModuleCommands',
+    'GetDocumentationParameterDeclaringMetadata',
+    'GetDocumentationParameterNames',
+    'GetDocumentationParameterRuntimeMetadata',
     'GetExactLoadedTypeMatches',
     'GetKnownDictionaryComparerExpression',
     'GetKnownDictionaryComparerName',
@@ -53,6 +56,7 @@ function GetCollectorHelperFunctionNames {
     'TestCollectionHasItemOnlyBackingStore',
     'TestExactRuntimeValueType',
     'TestGenuineRuntimeTypeValue',
+    'TestDocumentationParameterDontShow',
     'TestPowerShellSimpleTypeName',
     'TestPowerShellTypeLiteral',
     'TestPowerShellTypeLiteralName',
@@ -98,6 +102,83 @@ function NewDocumentationModuleSnapshot([object]$manifest, [string]$moduleName) 
   }
 }
 
+function GetDocumentationParameterDeclaringMetadata([type]$implementingType, [string]$parameterName) {
+  if ($null -eq $implementingType -or [string]::IsNullOrWhiteSpace($parameterName)) { return $null }
+  try {
+    $property = $implementingType.GetProperty(
+      $parameterName,
+      [System.Reflection.BindingFlags]'Instance,Public,FlattenHierarchy')
+    if ($null -ne $property -and $null -ne $property.DeclaringType) {
+      return [pscustomobject]@{
+        TypeName = [string]$property.DeclaringType.FullName
+        AssemblyPath = $(try { [string]$property.DeclaringType.Assembly.Location } catch { $null })
+      }
+    }
+  } catch {
+    return $null
+  }
+  return $null
+}
+
+function TestDocumentationParameterDontShow([object[]]$attributes) {
+  foreach ($attribute in @($attributes)) {
+    if ($attribute -is [System.Management.Automation.ParameterAttribute] -and $attribute.DontShow) {
+      return $true
+    }
+  }
+  return $false
+}
+
+function GetDocumentationParameterRuntimeMetadata(
+  [System.Management.Automation.CommandInfo]$command,
+  [string]$parameterName
+) {
+  $metadata = $null
+  try { $metadata = $command.Parameters[$parameterName] } catch { $metadata = $null }
+  $parameterType = if ($null -ne $metadata) { $metadata.ParameterType } else { $null }
+  $nullableArrayRanks = Microsoft.PowerShell.Utility\New-Object System.Collections.Generic.List[int]
+  $elementType = $parameterType
+  while ($null -ne $elementType -and $elementType.IsArray) {
+    $nullableArrayRanks.Add([int]$elementType.GetArrayRank())
+    $elementType = $elementType.GetElementType()
+  }
+  $nullableUnderlyingType = if ($null -ne $elementType) {
+    [System.Nullable]::GetUnderlyingType($elementType)
+  } else { $null }
+  $enumType = if ($null -ne $nullableUnderlyingType) { $nullableUnderlyingType } else { $elementType }
+  $attributes = if ($null -ne $metadata) { @($metadata.Attributes) } else { @() }
+  $declaringMetadata = GetDocumentationParameterDeclaringMetadata $command.ImplementingType $parameterName
+  return [pscustomobject]@{
+    Metadata = $metadata
+    ParameterType = $parameterType
+    EnumType = $enumType
+    DisplayName = $(if ($null -ne $parameterType) { [string]$parameterType.Name } else { '' })
+    NullableUnderlyingTypeName = $(if ($null -ne $nullableUnderlyingType) { [string]$nullableUnderlyingType.Name } else { $null })
+    NullableArrayRanks = @($nullableArrayRanks)
+    DeclaringType = $(if ($null -ne $declaringMetadata) { $declaringMetadata.TypeName } else { $null })
+    DeclaringAssemblyPath = $(if ($null -ne $declaringMetadata) { $declaringMetadata.AssemblyPath } else { $null })
+    DontShow = TestDocumentationParameterDontShow $attributes
+  }
+}
+
+function GetDocumentationParameterNames(
+  [System.Management.Automation.CommandInfo]$command,
+  [object[]]$helpParameters
+) {
+  $commonNames = @(
+    'Verbose','Debug','ErrorAction','ErrorVariable','WarningAction','WarningVariable',
+    'InformationAction','InformationVariable','OutVariable','OutBuffer','PipelineVariable',
+    'WhatIf','Confirm','ProgressAction')
+  $names = @()
+  try { $names = @($command.Parameters.Keys) } catch { $names = @() }
+  foreach ($helpParameter in @($helpParameters)) {
+    try { $names += [string]$helpParameter.Name } catch { }
+  }
+  return @($names | Microsoft.PowerShell.Core\Where-Object {
+    $_ -and ($commonNames -notcontains $_)
+  } | Microsoft.PowerShell.Utility\Sort-Object -Unique)
+}
+
 function NewCollectorProtocol([System.Management.Automation.PSModuleInfo]$helperModule) {
   return [pscustomobject]@{
     ConvertToRuntimeDefaultValue = $helperModule.ExportedFunctions['ConvertToRuntimeDefaultValue']
@@ -105,6 +186,8 @@ function NewCollectorProtocol([System.Management.Automation.PSModuleInfo]$helper
     ConvertToUtf8SafeJsonText = $helperModule.ExportedFunctions['ConvertToUtf8SafeJsonText']
     EmitError = (Microsoft.PowerShell.Core\Get-Command EmitError -CommandType Function).ScriptBlock
     GetCanonicalTypeNameFromType = $helperModule.ExportedFunctions['GetCanonicalTypeNameFromType']
+    GetParameterRuntimeMetadata = (Microsoft.PowerShell.Core\Get-Command GetDocumentationParameterRuntimeMetadata -CommandType Function).ScriptBlock
+    GetParameterNames = (Microsoft.PowerShell.Core\Get-Command GetDocumentationParameterNames -CommandType Function).ScriptBlock
     GetDocumentedModuleCommands = (Microsoft.PowerShell.Core\Get-Command GetDocumentedModuleCommands -CommandType Function).ScriptBlock
     GetOutputTypeSnapshot = $helperModule.ExportedFunctions['GetOutputTypeSnapshot']
     GetText = $helperModule.ExportedFunctions['GetText']
@@ -115,6 +198,7 @@ function NewCollectorProtocol([System.Management.Automation.PSModuleInfo]$helper
     ResolveCanonicalTypeName = $helperModule.ExportedFunctions['ResolveCanonicalTypeName']
     TestValidateSetCaseSensitive = $helperModule.ExportedFunctions['TestValidateSetCaseSensitive']
     TestPSDefaultValueContainsAutomationNull = $helperModule.ExportedFunctions['TestPSDefaultValueContainsAutomationNull']
+    TestParameterDontShow = (Microsoft.PowerShell.Core\Get-Command TestDocumentationParameterDontShow -CommandType Function).ScriptBlock
   }
 }
 

--- a/PowerForge/Scripts/Documentation/Export-HelpJson.Protocol.ps1
+++ b/PowerForge/Scripts/Documentation/Export-HelpJson.Protocol.ps1
@@ -36,6 +36,7 @@ function GetCollectorHelperFunctionNames {
     'GetDocumentationParameterDeclaringMetadata',
     'GetDocumentationParameterNames',
     'GetDocumentationParameterRuntimeMetadata',
+    'GetDocumentationRuntimeInputs',
     'GetExactLoadedTypeMatches',
     'GetKnownDictionaryComparerExpression',
     'GetKnownDictionaryComparerName',
@@ -154,6 +155,12 @@ function GetDocumentationParameterRuntimeMetadata(
   return [pscustomobject]@{
     Metadata = $metadata
     ParameterType = $parameterType
+    RuntimeTypeName = $(if ($null -ne $parameterType) {
+      & $getCanonicalTypeName $parameterType
+    } else { '' })
+    RuntimeClrTypeName = $(if ($null -ne $parameterType -and -not [string]::IsNullOrEmpty($parameterType.FullName)) {
+      [string]$parameterType.FullName
+    } else { '' })
     EnumType = $enumType
     DisplayName = $(if ($null -ne $parameterType) { [string]$parameterType.Name } else { '' })
     NullableUnderlyingTypeName = $(if ($null -ne $nullableUnderlyingType) {
@@ -188,6 +195,55 @@ function GetDocumentationParameterNames(
   } | Microsoft.PowerShell.Utility\Sort-Object -Unique)
 }
 
+function GetDocumentationRuntimeInputs(
+  [System.Management.Automation.CommandInfo]$command,
+  [string[]]$parameterNames,
+  [scriptblock]$getCanonicalTypeName
+) {
+  $runtimeInputs = @()
+  $seenInputs = @{}
+  foreach ($parameterName in @($parameterNames)) {
+    $metadata = $null
+    try { $metadata = $command.Parameters[$parameterName] } catch { $metadata = $null }
+    if (-not $metadata) { continue }
+
+    $supportsPipeline = $false
+    try {
+      foreach ($setEntry in @($metadata.ParameterSets.GetEnumerator())) {
+        $setMetadata = $setEntry.Value
+        if ($setMetadata -and ($setMetadata.ValueFromPipeline -or $setMetadata.ValueFromPipelineByPropertyName)) {
+          $supportsPipeline = $true
+          break
+        }
+      }
+    } catch { }
+    if (-not $supportsPipeline) { continue }
+
+    $typeName = ''
+    $clrTypeName = ''
+    $canonicalTypeName = ''
+    try {
+      if ($metadata.ParameterType) {
+        $typeName = [string]$metadata.ParameterType.Name
+        $clrTypeName = [string]$metadata.ParameterType.FullName
+        $canonicalTypeName = & $getCanonicalTypeName $metadata.ParameterType
+      }
+    } catch { }
+    if (-not $typeName) { continue }
+
+    $key = if ($canonicalTypeName) { $canonicalTypeName } elseif ($clrTypeName) { $clrTypeName } else { $typeName }
+    if ($seenInputs.ContainsKey($key)) { continue }
+    $seenInputs[$key] = $true
+    $runtimeInputs += [ordered]@{
+      name = $typeName
+      clrTypeName = $clrTypeName
+      canonicalTypeName = $canonicalTypeName
+      description = ''
+    }
+  }
+  return @($runtimeInputs)
+}
+
 function NewCollectorProtocol([System.Management.Automation.PSModuleInfo]$helperModule) {
   return [pscustomobject]@{
     ConvertToRuntimeDefaultValue = $helperModule.ExportedFunctions['ConvertToRuntimeDefaultValue']
@@ -198,6 +254,7 @@ function NewCollectorProtocol([System.Management.Automation.PSModuleInfo]$helper
     GetParameterDeclaringMetadata = (Microsoft.PowerShell.Core\Get-Command GetDocumentationParameterDeclaringMetadata -CommandType Function).ScriptBlock
     GetParameterRuntimeMetadata = (Microsoft.PowerShell.Core\Get-Command GetDocumentationParameterRuntimeMetadata -CommandType Function).ScriptBlock
     GetParameterNames = (Microsoft.PowerShell.Core\Get-Command GetDocumentationParameterNames -CommandType Function).ScriptBlock
+    GetRuntimeInputs = (Microsoft.PowerShell.Core\Get-Command GetDocumentationRuntimeInputs -CommandType Function).ScriptBlock
     GetDocumentedModuleCommands = (Microsoft.PowerShell.Core\Get-Command GetDocumentedModuleCommands -CommandType Function).ScriptBlock
     GetOutputTypeSnapshot = $helperModule.ExportedFunctions['GetOutputTypeSnapshot']
     GetText = $helperModule.ExportedFunctions['GetText']

--- a/PowerForge/Scripts/Documentation/Export-HelpJson.Protocol.ps1
+++ b/PowerForge/Scripts/Documentation/Export-HelpJson.Protocol.ps1
@@ -131,7 +131,9 @@ function TestDocumentationParameterDontShow([object[]]$attributes) {
 
 function GetDocumentationParameterRuntimeMetadata(
   [System.Management.Automation.CommandInfo]$command,
-  [string]$parameterName
+  [string]$parameterName,
+  [scriptblock]$getDeclaringMetadata,
+  [scriptblock]$testDontShow
 ) {
   $metadata = $null
   try { $metadata = $command.Parameters[$parameterName] } catch { $metadata = $null }
@@ -147,7 +149,7 @@ function GetDocumentationParameterRuntimeMetadata(
   } else { $null }
   $enumType = if ($null -ne $nullableUnderlyingType) { $nullableUnderlyingType } else { $elementType }
   $attributes = if ($null -ne $metadata) { @($metadata.Attributes) } else { @() }
-  $declaringMetadata = GetDocumentationParameterDeclaringMetadata $command.ImplementingType $parameterName
+  $declaringMetadata = & $getDeclaringMetadata $command.ImplementingType $parameterName
   return [pscustomobject]@{
     Metadata = $metadata
     ParameterType = $parameterType
@@ -157,7 +159,7 @@ function GetDocumentationParameterRuntimeMetadata(
     NullableArrayRanks = @($nullableArrayRanks)
     DeclaringType = $(if ($null -ne $declaringMetadata) { $declaringMetadata.TypeName } else { $null })
     DeclaringAssemblyPath = $(if ($null -ne $declaringMetadata) { $declaringMetadata.AssemblyPath } else { $null })
-    DontShow = TestDocumentationParameterDontShow $attributes
+    DontShow = & $testDontShow $attributes
   }
 }
 
@@ -186,6 +188,7 @@ function NewCollectorProtocol([System.Management.Automation.PSModuleInfo]$helper
     ConvertToUtf8SafeJsonText = $helperModule.ExportedFunctions['ConvertToUtf8SafeJsonText']
     EmitError = (Microsoft.PowerShell.Core\Get-Command EmitError -CommandType Function).ScriptBlock
     GetCanonicalTypeNameFromType = $helperModule.ExportedFunctions['GetCanonicalTypeNameFromType']
+    GetParameterDeclaringMetadata = (Microsoft.PowerShell.Core\Get-Command GetDocumentationParameterDeclaringMetadata -CommandType Function).ScriptBlock
     GetParameterRuntimeMetadata = (Microsoft.PowerShell.Core\Get-Command GetDocumentationParameterRuntimeMetadata -CommandType Function).ScriptBlock
     GetParameterNames = (Microsoft.PowerShell.Core\Get-Command GetDocumentationParameterNames -CommandType Function).ScriptBlock
     GetDocumentedModuleCommands = (Microsoft.PowerShell.Core\Get-Command GetDocumentedModuleCommands -CommandType Function).ScriptBlock

--- a/PowerForge/Scripts/Documentation/Export-HelpJson.Protocol.ps1
+++ b/PowerForge/Scripts/Documentation/Export-HelpJson.Protocol.ps1
@@ -133,7 +133,8 @@ function GetDocumentationParameterRuntimeMetadata(
   [System.Management.Automation.CommandInfo]$command,
   [string]$parameterName,
   [scriptblock]$getDeclaringMetadata,
-  [scriptblock]$testDontShow
+  [scriptblock]$testDontShow,
+  [scriptblock]$getCanonicalTypeName
 ) {
   $metadata = $null
   try { $metadata = $command.Parameters[$parameterName] } catch { $metadata = $null }
@@ -155,7 +156,13 @@ function GetDocumentationParameterRuntimeMetadata(
     ParameterType = $parameterType
     EnumType = $enumType
     DisplayName = $(if ($null -ne $parameterType) { [string]$parameterType.Name } else { '' })
-    NullableUnderlyingTypeName = $(if ($null -ne $nullableUnderlyingType) { [string]$nullableUnderlyingType.Name } else { $null })
+    NullableUnderlyingTypeName = $(if ($null -ne $nullableUnderlyingType) {
+      if ($nullableUnderlyingType.IsGenericType) {
+        & $getCanonicalTypeName $nullableUnderlyingType
+      } else {
+        [string]$nullableUnderlyingType.Name
+      }
+    } else { $null })
     NullableArrayRanks = @($nullableArrayRanks)
     DeclaringType = $(if ($null -ne $declaringMetadata) { $declaringMetadata.TypeName } else { $null })
     DeclaringAssemblyPath = $(if ($null -ne $declaringMetadata) { $declaringMetadata.AssemblyPath } else { $null })
@@ -187,7 +194,7 @@ function NewCollectorProtocol([System.Management.Automation.PSModuleInfo]$helper
     ConvertToUtf16CodeUnits = $helperModule.ExportedFunctions['ConvertToUtf16CodeUnits']
     ConvertToUtf8SafeJsonText = $helperModule.ExportedFunctions['ConvertToUtf8SafeJsonText']
     EmitError = (Microsoft.PowerShell.Core\Get-Command EmitError -CommandType Function).ScriptBlock
-    GetCanonicalTypeNameFromType = $helperModule.ExportedFunctions['GetCanonicalTypeNameFromType']
+    GetCanonicalTypeNameFromType = $helperModule.ExportedFunctions['GetCanonicalTypeNameFromType'].ScriptBlock
     GetParameterDeclaringMetadata = (Microsoft.PowerShell.Core\Get-Command GetDocumentationParameterDeclaringMetadata -CommandType Function).ScriptBlock
     GetParameterRuntimeMetadata = (Microsoft.PowerShell.Core\Get-Command GetDocumentationParameterRuntimeMetadata -CommandType Function).ScriptBlock
     GetParameterNames = (Microsoft.PowerShell.Core\Get-Command GetDocumentationParameterNames -CommandType Function).ScriptBlock

--- a/PowerForge/Scripts/Documentation/Export-HelpJson.Protocol.ps1
+++ b/PowerForge/Scripts/Documentation/Export-HelpJson.Protocol.ps1
@@ -122,12 +122,10 @@ function GetDocumentationParameterDeclaringMetadata([type]$implementingType, [st
 }
 
 function TestDocumentationParameterDontShow([object[]]$attributes) {
-  foreach ($attribute in @($attributes)) {
-    if ($attribute -is [System.Management.Automation.ParameterAttribute] -and $attribute.DontShow) {
-      return $true
-    }
-  }
-  return $false
+  $parameterAttributes = @($attributes) |
+    Microsoft.PowerShell.Core\Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
+  return $parameterAttributes.Count -gt 0 -and
+    @($parameterAttributes | Microsoft.PowerShell.Core\Where-Object { -not $_.DontShow }).Count -eq 0
 }
 
 function GetDocumentationParameterRuntimeMetadata(

--- a/PowerForge/Scripts/Documentation/Export-HelpJson.ps1
+++ b/PowerForge/Scripts/Documentation/Export-HelpJson.ps1
@@ -392,7 +392,8 @@ try {
 
     $parameters = @()
     foreach ($pn in $paramNames) {
-      $parameterRuntimeMetadata = & $collectorProtocol.GetParameterRuntimeMetadata $c $pn
+      $parameterRuntimeMetadata = & $collectorProtocol.GetParameterRuntimeMetadata `
+        $c $pn $collectorProtocol.GetParameterDeclaringMetadata $collectorProtocol.TestParameterDontShow
       $pmeta = $parameterRuntimeMetadata.Metadata
 
       $aliases = @()

--- a/PowerForge/Scripts/Documentation/Export-HelpJson.ps1
+++ b/PowerForge/Scripts/Documentation/Export-HelpJson.ps1
@@ -393,7 +393,8 @@ try {
     $parameters = @()
     foreach ($pn in $paramNames) {
       $parameterRuntimeMetadata = & $collectorProtocol.GetParameterRuntimeMetadata `
-        $c $pn $collectorProtocol.GetParameterDeclaringMetadata $collectorProtocol.TestParameterDontShow
+        $c $pn $collectorProtocol.GetParameterDeclaringMetadata $collectorProtocol.TestParameterDontShow `
+        $collectorProtocol.GetCanonicalTypeNameFromType
       $pmeta = $parameterRuntimeMetadata.Metadata
 
       $aliases = @()

--- a/PowerForge/Scripts/Documentation/Export-HelpJson.ps1
+++ b/PowerForge/Scripts/Documentation/Export-HelpJson.ps1
@@ -552,6 +552,8 @@ try {
       $parameters += [ordered]@{
         name = $pn
         type = $typeName
+        runtimeTypeName = $parameterRuntimeMetadata.RuntimeTypeName
+        runtimeClrTypeName = $parameterRuntimeMetadata.RuntimeClrTypeName
         nullableUnderlyingTypeName = $parameterRuntimeMetadata.NullableUnderlyingTypeName
         nullableArrayRanks = @($parameterRuntimeMetadata.NullableArrayRanks)
         declaringType = $declaringType
@@ -643,45 +645,8 @@ try {
     } catch {
       # best effort: older hosts can omit or reshape InputTypes entirely
     }
-    $runtimeInputs = @()
-    $seenInputs = @{}
-    foreach ($pn in $paramNames) {
-        $pmeta = $null
-        try { $pmeta = $c.Parameters[$pn] } catch { $pmeta = $null }
-        if (-not $pmeta) { continue }
-
-        $supportsPipeline = $false
-        try {
-          foreach ($setEntry in @($pmeta.ParameterSets.GetEnumerator())) {
-            $psm = $setEntry.Value
-            if ($psm -and ($psm.ValueFromPipeline -or $psm.ValueFromPipelineByPropertyName)) {
-              $supportsPipeline = $true
-              break
-            }
-          }
-        } catch {
-          # best effort: pipeline metadata can differ between hosts and proxy commands
-        }
-
-        if (-not $supportsPipeline) { continue }
-
-        $inputTypeName = ''
-        $inputTypeClrName = ''
-        try {
-          if ($pmeta.ParameterType) {
-            $inputTypeName = [string]$pmeta.ParameterType.Name
-            $inputTypeClrName = [string]$pmeta.ParameterType.FullName
-          }
-        } catch {
-          # best effort: pipeline parameter type metadata is not always available on proxy commands
-        }
-
-        if (-not $inputTypeName) { continue }
-        $key = if ($inputTypeClrName) { $inputTypeClrName } else { $inputTypeName }
-        if ($seenInputs.ContainsKey($key)) { continue }
-        $seenInputs[$key] = $true
-        $runtimeInputs += [ordered]@{ name = $inputTypeName; clrTypeName = $inputTypeClrName; description = '' }
-    }
+    $runtimeInputs = @(& $collectorProtocol.GetRuntimeInputs `
+      $c $paramNames $collectorProtocol.GetCanonicalTypeNameFromType)
     if (-not $inputs -or $inputs.Count -eq 0) {
       $inputs = @($runtimeInputs)
     }

--- a/PowerForge/Scripts/Documentation/Export-HelpJson.ps1
+++ b/PowerForge/Scripts/Documentation/Export-HelpJson.ps1
@@ -388,37 +388,22 @@ try {
       }
     }
 
-    $commonParamNames = @('Verbose','Debug','ErrorAction','ErrorVariable','WarningAction','WarningVariable','InformationAction','InformationVariable','OutVariable','OutBuffer','PipelineVariable','WhatIf','Confirm','ProgressAction')
-    $paramNames = @()
-    try {
-      if ($c -and $c.Parameters) {
-        $paramNames = @($c.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\ForEach-Object { [string]$_.Key })
-      }
-    } catch { $paramNames = @() }
-    foreach ($hp in $helpParameters) { try { $paramNames += [string]$hp.Name } catch {
-      # best effort: keep extracting other parameters even when one help node is incomplete
-    } }
-    $paramNames = @($paramNames | Microsoft.PowerShell.Core\Where-Object { $_ -and ($commonParamNames -notcontains $_) } | Microsoft.PowerShell.Utility\Sort-Object -Unique)
+    $paramNames = @(& $collectorProtocol.GetParameterNames $c $helpParameters)
 
     $parameters = @()
     foreach ($pn in $paramNames) {
-      $pmeta = $null
-      try { $pmeta = $c.Parameters[$pn] } catch { $pmeta = $null }
+      $parameterRuntimeMetadata = & $collectorProtocol.GetParameterRuntimeMetadata $c $pn
+      $pmeta = $parameterRuntimeMetadata.Metadata
 
       $aliases = @()
       try { if ($pmeta -and $pmeta.Aliases) { foreach ($a in @($pmeta.Aliases)) { $aliases += [string]$a } } } catch { $aliases = @() }
 
-      $typeName = ''
-      $parameterType = $null
-      try {
-        if ($pmeta -and $pmeta.ParameterType) {
-          $parameterType = $pmeta.ParameterType
-          $typeName = [string]$pmeta.ParameterType.Name
-        }
-      } catch {
-        $parameterType = $null
-        $typeName = ''
-      }
+      $typeName = $parameterRuntimeMetadata.DisplayName
+      $parameterType = $parameterRuntimeMetadata.ParameterType
+      $enumType = $parameterRuntimeMetadata.EnumType
+      $declaringType = $parameterRuntimeMetadata.DeclaringType
+      $declaringAssemblyPath = $parameterRuntimeMetadata.DeclaringAssemblyPath
+      $dontShow = [bool]$parameterRuntimeMetadata.DontShow
       $possibleValues = @()
       $enumPossibleValues = @()
       $hasValidateSet = $false
@@ -497,8 +482,6 @@ try {
         # best effort: not every parameter exposes validation attributes in help metadata
       }
       try {
-        $enumType = $parameterType
-        if ($enumType -and $enumType.IsArray) { $enumType = $enumType.GetElementType() }
         if ($enumType -and $enumType.IsEnum) {
           foreach ($enumName in [System.Enum]::GetNames($enumType)) {
             if ($enumName) { $enumPossibleValues += [string]$enumName }
@@ -559,7 +542,6 @@ try {
       if (-not $sets -or $sets.Count -eq 0) { $sets = @('(All)') }
 
       $positionText = if ($named -or $null -eq $pos) { 'named' } else { [string]$pos }
-
       $pipelineInput = 'False'
       if ($pipeByValue -and $pipeByProp) { $pipelineInput = 'True (ByValue, ByPropertyName)' }
       elseif ($pipeByValue) { $pipelineInput = 'True (ByValue)' }
@@ -568,6 +550,11 @@ try {
       $parameters += [ordered]@{
         name = $pn
         type = $typeName
+        nullableUnderlyingTypeName = $parameterRuntimeMetadata.NullableUnderlyingTypeName
+        nullableArrayRanks = @($parameterRuntimeMetadata.NullableArrayRanks)
+        declaringType = $declaringType
+        declaringAssemblyPath = $declaringAssemblyPath
+        dontShow = [bool]$dontShow
         description = $desc
         parameterSets = @($sets)
         aliases = @($aliases)

--- a/PowerForge/Services/Documentation/DocumentationExtractionPayload.cs
+++ b/PowerForge/Services/Documentation/DocumentationExtractionPayload.cs
@@ -82,6 +82,9 @@ internal sealed class DocumentationCommandHelp
     [DataMember(Name = "syntax")]
     public List<DocumentationSyntaxHelp> Syntax { get; set; } = new();
 
+    /// <summary>Prevents writers from synthesizing syntax after every collected set was removed as unreachable.</summary>
+    internal bool SuppressSyntheticSyntax { get; set; }
+
     /// <summary>Parameter documentation entries.</summary>
     [DataMember(Name = "parameters")]
     public List<DocumentationParameterHelp> Parameters { get; set; } = new();

--- a/PowerForge/Services/Documentation/DocumentationExtractionPayload.cs
+++ b/PowerForge/Services/Documentation/DocumentationExtractionPayload.cs
@@ -240,6 +240,26 @@ internal sealed class DocumentationParameterHelp
     [DataMember(Name = "type")]
     public string Type { get; set; } = string.Empty;
 
+    /// <summary>Underlying nullable type name captured from the target runtime.</summary>
+    [DataMember(Name = "nullableUnderlyingTypeName")]
+    public string? NullableUnderlyingTypeName { get; set; }
+
+    /// <summary>Outer-to-inner CLR array ranks surrounding the nullable element type.</summary>
+    [DataMember(Name = "nullableArrayRanks")]
+    public List<int> NullableArrayRanks { get; set; } = new();
+
+    /// <summary>Full name of the .NET type that declares the cmdlet property.</summary>
+    [DataMember(Name = "declaringType")]
+    public string? DeclaringType { get; set; }
+
+    /// <summary>Assembly path of the .NET type that declares the cmdlet property.</summary>
+    [DataMember(Name = "declaringAssemblyPath")]
+    public string? DeclaringAssemblyPath { get; set; }
+
+    /// <summary>True when PowerShell marks the parameter as hidden from help.</summary>
+    [DataMember(Name = "dontShow")]
+    public bool DontShow { get; set; }
+
     /// <summary>Parameter description.</summary>
     [DataMember(Name = "description")]
     public string Description { get; set; } = string.Empty;

--- a/PowerForge/Services/Documentation/DocumentationExtractionPayload.cs
+++ b/PowerForge/Services/Documentation/DocumentationExtractionPayload.cs
@@ -240,6 +240,14 @@ internal sealed class DocumentationParameterHelp
     [DataMember(Name = "type")]
     public string Type { get; set; } = string.Empty;
 
+    /// <summary>Full CLR identity captured from the target runtime before display normalization.</summary>
+    [DataMember(Name = "runtimeTypeName")]
+    public string RuntimeTypeName { get; set; } = string.Empty;
+
+    /// <summary>Runtime <see cref="Type.FullName"/> captured for exact Get-Help identity matching.</summary>
+    [DataMember(Name = "runtimeClrTypeName")]
+    public string RuntimeClrTypeName { get; set; } = string.Empty;
+
     /// <summary>Underlying nullable type name captured from the target runtime.</summary>
     [DataMember(Name = "nullableUnderlyingTypeName")]
     public string? NullableUnderlyingTypeName { get; set; }

--- a/PowerForge/Services/Documentation/DocumentationFallbackEnricher.cs
+++ b/PowerForge/Services/Documentation/DocumentationFallbackEnricher.cs
@@ -36,7 +36,7 @@ internal static class DocumentationFallbackEnricher
     {
         var hasExamples = (cmd.Examples ?? new List<DocumentationExampleHelp>())
             .Any(e => e is not null && (!string.IsNullOrWhiteSpace(e.Code) || !string.IsNullOrWhiteSpace(e.Remarks)));
-        if (hasExamples) return;
+        if (hasExamples || cmd.SuppressSyntheticSyntax) return;
 
         var examples = new List<DocumentationExampleHelp>();
 

--- a/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
@@ -23,23 +23,41 @@ internal static class DocumentationHiddenParameterNormalizer
             .ToArray();
         if (hiddenNames.Length == 0) return;
 
-        var hiddenPipelineTypes = parameters
+        var hiddenRuntimeTypes = parameters
+            .Where(parameter => parameter is not null && parameter.DontShow && AcceptsPipelineInput(parameter))
+            .SelectMany(parameter => new[] { parameter.RuntimeTypeName, parameter.RuntimeClrTypeName })
+            .Where(type => type.Length > 0)
+            .ToHashSet(StringComparer.Ordinal);
+        var visibleRuntimeTypes = parameters
+            .Where(parameter => parameter is not null && !parameter.DontShow && AcceptsPipelineInput(parameter))
+            .SelectMany(parameter => new[] { parameter.RuntimeTypeName, parameter.RuntimeClrTypeName })
+            .Where(type => type.Length > 0)
+            .ToHashSet(StringComparer.Ordinal);
+        var hiddenDisplayTypes = parameters
             .Where(parameter => parameter is not null && parameter.DontShow && AcceptsPipelineInput(parameter))
             .Select(parameter => parameter.Type ?? string.Empty)
             .Where(type => type.Length > 0)
             .ToHashSet(StringComparer.Ordinal);
-        var visiblePipelineTypes = parameters
+        var visibleDisplayTypes = parameters
             .Where(parameter => parameter is not null && !parameter.DontShow && AcceptsPipelineInput(parameter))
             .Select(parameter => parameter.Type ?? string.Empty)
             .Where(type => type.Length > 0)
             .ToHashSet(StringComparer.Ordinal);
-        if (hiddenPipelineTypes.Count > 0)
+        if (hiddenRuntimeTypes.Count > 0 || hiddenDisplayTypes.Count > 0)
         {
-            command.RuntimeInputs = (command.RuntimeInputs ?? new List<DocumentationTypeHelp>())
-                .Where(input => input is not null &&
-                                (!MatchesParameterType(input, hiddenPipelineTypes) ||
-                                 MatchesParameterType(input, visiblePipelineTypes)))
-                .ToList();
+            command.Inputs = ExpandCollectedInputAggregates(command.Inputs, command.RuntimeInputs);
+            command.Inputs = FilterPipelineInputs(
+                command.Inputs,
+                hiddenRuntimeTypes,
+                visibleRuntimeTypes,
+                hiddenDisplayTypes,
+                visibleDisplayTypes);
+            command.RuntimeInputs = FilterPipelineInputs(
+                command.RuntimeInputs,
+                hiddenRuntimeTypes,
+                visibleRuntimeTypes,
+                hiddenDisplayTypes,
+                visibleDisplayTypes);
         }
 
         command.Parameters = parameters
@@ -64,9 +82,47 @@ internal static class DocumentationHiddenParameterNormalizer
         => !string.IsNullOrWhiteSpace(parameter.PipelineInput) &&
            !parameter.PipelineInput.StartsWith("False", StringComparison.OrdinalIgnoreCase);
 
-    private static bool MatchesParameterType(DocumentationTypeHelp input, ISet<string> parameterTypes)
-        => parameterTypes.Contains(input.Name ?? string.Empty) ||
-           parameterTypes.Contains(input.ClrTypeName ?? string.Empty);
+    private static bool MatchesRuntimeType(DocumentationTypeHelp input, ISet<string> parameterTypes)
+        => parameterTypes.Contains(input.ClrTypeName ?? string.Empty) ||
+           parameterTypes.Contains(input.CanonicalTypeName ?? string.Empty);
+
+    private static bool MatchesDisplayType(DocumentationTypeHelp input, ISet<string> parameterTypes)
+        => parameterTypes.Contains(input.Name ?? string.Empty);
+
+    private static bool HasExactRuntimeIdentity(DocumentationTypeHelp input)
+        => !string.IsNullOrEmpty(input.ClrTypeName) || !string.IsNullOrEmpty(input.CanonicalTypeName);
+
+    private static List<DocumentationTypeHelp> FilterPipelineInputs(
+        IEnumerable<DocumentationTypeHelp>? inputs,
+        ISet<string> hiddenRuntimeTypes,
+        ISet<string> visibleRuntimeTypes,
+        ISet<string> hiddenDisplayTypes,
+        ISet<string> visibleDisplayTypes)
+        => (inputs ?? Array.Empty<DocumentationTypeHelp>())
+            .Where(input => input is not null &&
+                            (!MatchesRuntimeType(input, hiddenRuntimeTypes) ||
+                             MatchesRuntimeType(input, visibleRuntimeTypes)) &&
+                            (!MatchesDisplayType(input, hiddenDisplayTypes) ||
+                             MatchesDisplayType(input, visibleDisplayTypes) ||
+                             HasExactRuntimeIdentity(input)))
+            .ToList();
+
+    private static List<DocumentationTypeHelp> ExpandCollectedInputAggregates(
+        IEnumerable<DocumentationTypeHelp>? inputs,
+        IReadOnlyList<DocumentationTypeHelp>? runtimeInputs)
+    {
+        var runtime = runtimeInputs ?? Array.Empty<DocumentationTypeHelp>();
+        var expanded = new List<DocumentationTypeHelp>();
+        foreach (var input in inputs ?? Array.Empty<DocumentationTypeHelp>())
+        {
+            if (input is not null &&
+                DocumentationInputNormalizer.TryParsePowerShellInputAggregate(input, runtime, out var parsed))
+                expanded.AddRange(parsed);
+            else if (input is not null)
+                expanded.Add(input);
+        }
+        return expanded;
+    }
 
     private static string StripSyntaxParameter(string? text, string name)
     {

--- a/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
@@ -60,8 +60,15 @@ internal static class DocumentationHiddenParameterNormalizer
                 visibleDisplayTypes);
         }
 
-        command.Syntax = (command.Syntax ?? new List<DocumentationSyntaxHelp>())
-            .Where(syntax => syntax is not null && !IsHiddenOnlyParameterSet(syntax, parameters))
+        var syntaxItems = command.Syntax ?? new List<DocumentationSyntaxHelp>();
+        var namedParameterSets = syntaxItems
+            .Where(syntax => syntax is not null && !string.IsNullOrWhiteSpace(syntax.Name))
+            .Select(syntax => syntax.Name)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        command.Syntax = syntaxItems
+            .Where(syntax => syntax is not null &&
+                             !IsHiddenOnlyParameterSet(syntax, parameters, namedParameterSets))
             .ToList();
 
         command.Parameters = parameters
@@ -88,15 +95,26 @@ internal static class DocumentationHiddenParameterNormalizer
 
     private static bool IsHiddenOnlyParameterSet(
         DocumentationSyntaxHelp syntax,
-        IEnumerable<DocumentationParameterHelp> parameters)
+        IEnumerable<DocumentationParameterHelp> parameters,
+        IReadOnlyCollection<string> namedParameterSets)
     {
         if (string.IsNullOrWhiteSpace(syntax.Name)) return false;
         var setSpecificParameters = parameters
             .Where(parameter => parameter is not null &&
                                 (parameter.ParameterSets ?? new List<string>()).Any(set =>
-                                    string.Equals(set, syntax.Name, StringComparison.OrdinalIgnoreCase)))
+                                    string.Equals(set, syntax.Name, StringComparison.OrdinalIgnoreCase)) &&
+                                !BelongsToEveryNamedSet(parameter, namedParameterSets))
             .ToArray();
         return setSpecificParameters.Length > 0 && setSpecificParameters.All(parameter => parameter.DontShow);
+    }
+
+    private static bool BelongsToEveryNamedSet(
+        DocumentationParameterHelp parameter,
+        IEnumerable<string> namedParameterSets)
+    {
+        var parameterSets = parameter.ParameterSets ?? new List<string>();
+        return namedParameterSets.All(name => parameterSets.Any(set =>
+            string.Equals(set, name, StringComparison.OrdinalIgnoreCase)));
     }
 
     private static bool MatchesRuntimeType(DocumentationTypeHelp input, ISet<string> parameterTypes)

--- a/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
@@ -47,6 +47,11 @@ internal static class DocumentationHiddenParameterNormalizer
         var escaped = Regex.Escape(name);
         value = Regex.Replace(
             value,
+            @"\s*\[\[-" + escaped + @"\](?:\s+<[^>\r\n]+>)?\]",
+            string.Empty,
+            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        value = Regex.Replace(
+            value,
             @"\s*\[-" + escaped + @"(?:\s+<[^>\r\n]+>)?\]",
             string.Empty,
             RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);

--- a/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
@@ -70,6 +70,7 @@ internal static class DocumentationHiddenParameterNormalizer
             .Where(syntax => syntax is not null &&
                              !IsHiddenOnlyParameterSet(syntax, parameters, namedParameterSets))
             .ToList();
+        command.SuppressSyntheticSyntax = syntaxItems.Count > 0 && command.Syntax.Count == 0;
 
         command.Parameters = parameters
             .Where(parameter => parameter is not null && !parameter.DontShow)
@@ -130,8 +131,19 @@ internal static class DocumentationHiddenParameterNormalizer
         DocumentationParameterHelp parameter,
         IEnumerable<string> namedParameterSets)
     {
+        var requiredBySet = parameter.ParameterSetRequired ?? new Dictionary<string, bool>();
+        if (requiredBySet.Keys.Any(name =>
+                string.Equals(name, "__AllParameterSets", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(name, "(All)", StringComparison.OrdinalIgnoreCase)))
+        {
+            return true;
+        }
+
+        var namedSets = namedParameterSets.ToArray();
+        if (namedSets.Length < 2) return false;
+
         var parameterSets = parameter.ParameterSets ?? new List<string>();
-        return namedParameterSets.All(name => parameterSets.Any(set =>
+        return namedSets.All(name => parameterSets.Any(set =>
             string.Equals(set, name, StringComparison.OrdinalIgnoreCase)));
     }
 

--- a/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
@@ -100,6 +100,14 @@ internal static class DocumentationHiddenParameterNormalizer
         IReadOnlyCollection<string> namedParameterSets)
     {
         if (string.IsNullOrWhiteSpace(syntax.Name)) return false;
+        if (parameters.Any(parameter => parameter is not null &&
+                                        parameter.DontShow &&
+                                        BelongsToEveryNamedSet(parameter, namedParameterSets) &&
+                                        IsRequiredInSet(parameter, syntax.Name)))
+        {
+            return true;
+        }
+
         var setSpecificParameters = parameters
             .Where(parameter => parameter is not null &&
                                 (parameter.ParameterSets ?? new List<string>()).Any(set =>
@@ -122,6 +130,15 @@ internal static class DocumentationHiddenParameterNormalizer
         {
             if (string.Equals(pair.Key, setName, StringComparison.OrdinalIgnoreCase))
                 return pair.Value;
+        }
+
+        foreach (var pair in requiredBySet)
+        {
+            if (string.Equals(pair.Key, "__AllParameterSets", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(pair.Key, "(All)", StringComparison.OrdinalIgnoreCase))
+            {
+                return pair.Value;
+            }
         }
 
         return requiredBySet.Count == 0 && parameter.Required;

--- a/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
@@ -60,6 +60,10 @@ internal static class DocumentationHiddenParameterNormalizer
                 visibleDisplayTypes);
         }
 
+        command.Syntax = (command.Syntax ?? new List<DocumentationSyntaxHelp>())
+            .Where(syntax => syntax is not null && !IsHiddenOnlyParameterSet(syntax, parameters))
+            .ToList();
+
         command.Parameters = parameters
             .Where(parameter => parameter is not null && !parameter.DontShow)
             .ToList();
@@ -81,6 +85,19 @@ internal static class DocumentationHiddenParameterNormalizer
     private static bool AcceptsPipelineInput(DocumentationParameterHelp parameter)
         => !string.IsNullOrWhiteSpace(parameter.PipelineInput) &&
            !parameter.PipelineInput.StartsWith("False", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsHiddenOnlyParameterSet(
+        DocumentationSyntaxHelp syntax,
+        IEnumerable<DocumentationParameterHelp> parameters)
+    {
+        if (string.IsNullOrWhiteSpace(syntax.Name)) return false;
+        var setSpecificParameters = parameters
+            .Where(parameter => parameter is not null &&
+                                (parameter.ParameterSets ?? new List<string>()).Any(set =>
+                                    string.Equals(set, syntax.Name, StringComparison.OrdinalIgnoreCase)))
+            .ToArray();
+        return setSpecificParameters.Length > 0 && setSpecificParameters.All(parameter => parameter.DontShow);
+    }
 
     private static bool MatchesRuntimeType(DocumentationTypeHelp input, ISet<string> parameterTypes)
         => parameterTypes.Contains(input.ClrTypeName ?? string.Empty) ||

--- a/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
@@ -105,7 +105,25 @@ internal static class DocumentationHiddenParameterNormalizer
                                     string.Equals(set, syntax.Name, StringComparison.OrdinalIgnoreCase)) &&
                                 !BelongsToEveryNamedSet(parameter, namedParameterSets))
             .ToArray();
-        return setSpecificParameters.Length > 0 && setSpecificParameters.All(parameter => parameter.DontShow);
+        if (setSpecificParameters.Length == 0 || setSpecificParameters.Any(parameter => !parameter.DontShow))
+            return false;
+
+        if (!syntax.IsDefault)
+            return true;
+
+        return setSpecificParameters.Any(parameter => IsRequiredInSet(parameter, syntax.Name));
+    }
+
+    private static bool IsRequiredInSet(DocumentationParameterHelp parameter, string setName)
+    {
+        var requiredBySet = parameter.ParameterSetRequired ?? new Dictionary<string, bool>();
+        foreach (var pair in requiredBySet)
+        {
+            if (string.Equals(pair.Key, setName, StringComparison.OrdinalIgnoreCase))
+                return pair.Value;
+        }
+
+        return requiredBySet.Count == 0 && parameter.Required;
     }
 
     private static bool BelongsToEveryNamedSet(

--- a/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace PowerForge;
+
+/// <summary>
+/// Removes parameters that PowerShell explicitly marks as hidden from public help.
+/// </summary>
+internal static class DocumentationHiddenParameterNormalizer
+{
+    public static void Normalize(DocumentationCommandHelp command)
+    {
+        if (command is null) throw new ArgumentNullException(nameof(command));
+
+        var parameters = command.Parameters ?? new List<DocumentationParameterHelp>();
+        var hiddenNames = parameters
+            .Where(parameter => parameter is not null && parameter.DontShow)
+            .Select(parameter => parameter.Name ?? string.Empty)
+            .Where(name => name.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (hiddenNames.Length == 0) return;
+
+        command.Parameters = parameters
+            .Where(parameter => parameter is not null && !parameter.DontShow)
+            .ToList();
+
+        foreach (var syntax in command.Syntax ?? new List<DocumentationSyntaxHelp>())
+        {
+            if (syntax is null || string.IsNullOrEmpty(syntax.Text)) continue;
+            foreach (var name in hiddenNames)
+                syntax.Text = StripSyntaxParameter(syntax.Text, name);
+        }
+
+        foreach (var name in hiddenNames)
+        {
+            command.Synopsis = StripSyntaxParameter(command.Synopsis, name);
+            command.Description = StripSyntaxParameter(command.Description, name);
+        }
+    }
+
+    private static string StripSyntaxParameter(string? text, string name)
+    {
+        var value = text ?? string.Empty;
+        var escaped = Regex.Escape(name);
+        value = Regex.Replace(
+            value,
+            @"\s*\[-" + escaped + @"(?:\s+<[^>\r\n]+>)?\]",
+            string.Empty,
+            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        return Regex.Replace(
+            value,
+            @"\s+-" + escaped + @"(?:\s+<[^>\r\n]+>)?(?=$|\s|[\]\[{}(),|:=])",
+            string.Empty,
+            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+    }
+}

--- a/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
@@ -52,6 +52,11 @@ internal static class DocumentationHiddenParameterNormalizer
             RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
         value = Regex.Replace(
             value,
+            @"\s*\[-" + escaped + @"\](?:\s+<[^>\r\n]+>)?",
+            string.Empty,
+            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        value = Regex.Replace(
+            value,
             @"\s*\[-" + escaped + @"(?:\s+<[^>\r\n]+>)?\]",
             string.Empty,
             RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);

--- a/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationHiddenParameterNormalizer.cs
@@ -23,6 +23,25 @@ internal static class DocumentationHiddenParameterNormalizer
             .ToArray();
         if (hiddenNames.Length == 0) return;
 
+        var hiddenPipelineTypes = parameters
+            .Where(parameter => parameter is not null && parameter.DontShow && AcceptsPipelineInput(parameter))
+            .Select(parameter => parameter.Type ?? string.Empty)
+            .Where(type => type.Length > 0)
+            .ToHashSet(StringComparer.Ordinal);
+        var visiblePipelineTypes = parameters
+            .Where(parameter => parameter is not null && !parameter.DontShow && AcceptsPipelineInput(parameter))
+            .Select(parameter => parameter.Type ?? string.Empty)
+            .Where(type => type.Length > 0)
+            .ToHashSet(StringComparer.Ordinal);
+        if (hiddenPipelineTypes.Count > 0)
+        {
+            command.RuntimeInputs = (command.RuntimeInputs ?? new List<DocumentationTypeHelp>())
+                .Where(input => input is not null &&
+                                (!MatchesParameterType(input, hiddenPipelineTypes) ||
+                                 MatchesParameterType(input, visiblePipelineTypes)))
+                .ToList();
+        }
+
         command.Parameters = parameters
             .Where(parameter => parameter is not null && !parameter.DontShow)
             .ToList();
@@ -40,6 +59,14 @@ internal static class DocumentationHiddenParameterNormalizer
             command.Description = StripSyntaxParameter(command.Description, name);
         }
     }
+
+    private static bool AcceptsPipelineInput(DocumentationParameterHelp parameter)
+        => !string.IsNullOrWhiteSpace(parameter.PipelineInput) &&
+           !parameter.PipelineInput.StartsWith("False", StringComparison.OrdinalIgnoreCase);
+
+    private static bool MatchesParameterType(DocumentationTypeHelp input, ISet<string> parameterTypes)
+        => parameterTypes.Contains(input.Name ?? string.Empty) ||
+           parameterTypes.Contains(input.ClrTypeName ?? string.Empty);
 
     private static string StripSyntaxParameter(string? text, string name)
     {

--- a/PowerForge/Services/Documentation/DocumentationInputNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationInputNormalizer.cs
@@ -21,6 +21,7 @@ internal static class DocumentationInputNormalizer
         {
             command.Inputs = runtimeInputs;
             command.RuntimeInputs = new List<DocumentationTypeHelp>();
+            NormalizeNullablePipelineInputs(command, runtimeInputs);
             return;
         }
 
@@ -38,6 +39,76 @@ internal static class DocumentationInputNormalizer
 
         command.Inputs = normalized;
         command.RuntimeInputs = new List<DocumentationTypeHelp>();
+        NormalizeNullablePipelineInputs(command, runtimeInputs);
+    }
+
+    private static void NormalizeNullablePipelineInputs(
+        DocumentationCommandHelp command,
+        IReadOnlyList<DocumentationTypeHelp> runtimeInputs)
+    {
+        var usedRuntimeInputs = new HashSet<int>();
+        foreach (var parameter in command.Parameters ?? new List<DocumentationParameterHelp>())
+        {
+            var displayType = DocumentationMetadataNormalizer.GetNullableParameterTypeName(parameter);
+            if (string.IsNullOrWhiteSpace(displayType) ||
+                string.IsNullOrWhiteSpace(parameter.PipelineInput) ||
+                parameter.PipelineInput.StartsWith("False", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var runtimeIndex = FindRuntimeInput(parameter.Type, runtimeInputs, usedRuntimeInputs);
+            if (runtimeIndex < 0) continue;
+            usedRuntimeInputs.Add(runtimeIndex);
+
+            var runtimeInput = runtimeInputs[runtimeIndex];
+            var rawNames = new HashSet<string>(StringComparer.Ordinal);
+            AddRawName(rawNames, runtimeInput.Name);
+            AddRawName(rawNames, runtimeInput.ClrTypeName);
+            AddRawName(rawNames, runtimeInput.CanonicalTypeName);
+
+            foreach (var input in command.Inputs ?? new List<DocumentationTypeHelp>())
+            {
+                if (input is null || !MatchesAnyIdentity(input, rawNames)) continue;
+                input.Name = displayType!;
+                input.ClrTypeName = displayType!;
+                input.CanonicalTypeName = displayType!;
+                input.LookupName = displayType!;
+                input.LookupClrTypeName = displayType!;
+            }
+        }
+    }
+
+    private static int FindRuntimeInput(
+        string parameterType,
+        IReadOnlyList<DocumentationTypeHelp> runtimeInputs,
+        ISet<int> usedRuntimeInputs)
+    {
+        for (var index = 0; index < runtimeInputs.Count; index++)
+        {
+            if (usedRuntimeInputs.Contains(index)) continue;
+            var runtimeInput = runtimeInputs[index];
+            if (string.Equals(parameterType, runtimeInput.Name, StringComparison.Ordinal) ||
+                string.Equals(parameterType, runtimeInput.ClrTypeName, StringComparison.Ordinal))
+                return index;
+        }
+        return -1;
+    }
+
+    private static bool MatchesAnyIdentity(DocumentationTypeHelp input, ISet<string> rawNames)
+        => MatchesRawIdentity(input.Name, rawNames) ||
+           MatchesRawIdentity(input.ClrTypeName, rawNames) ||
+           MatchesRawIdentity(input.CanonicalTypeName, rawNames);
+
+    private static bool MatchesRawIdentity(string? value, ISet<string> rawNames)
+    {
+        if (string.IsNullOrEmpty(value)) return false;
+        if (rawNames.Contains(value!)) return true;
+        var withoutHelpLineBreaks = value!.TrimEnd('\r', '\n');
+        return withoutHelpLineBreaks.Length != value.Length && rawNames.Contains(withoutHelpLineBreaks);
+    }
+
+    private static void AddRawName(ISet<string> rawNames, string? value)
+    {
+        if (!string.IsNullOrEmpty(value)) rawNames.Add(value!);
     }
 
     private static bool TryParsePowerShellInputAggregate(

--- a/PowerForge/Services/Documentation/DocumentationInputNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationInputNormalizer.cs
@@ -60,14 +60,10 @@ internal static class DocumentationInputNormalizer
             usedRuntimeInputs.Add(runtimeIndex);
 
             var runtimeInput = runtimeInputs[runtimeIndex];
-            var rawNames = new HashSet<string>(StringComparer.Ordinal);
-            AddRawName(rawNames, runtimeInput.Name);
-            AddRawName(rawNames, runtimeInput.ClrTypeName);
-            AddRawName(rawNames, runtimeInput.CanonicalTypeName);
 
             foreach (var input in command.Inputs ?? new List<DocumentationTypeHelp>())
             {
-                if (input is null || !MatchesAnyIdentity(input, rawNames)) continue;
+                if (input is null || !MatchesRuntimeInput(input, runtimeInput, runtimeInputs)) continue;
                 input.Name = displayType!;
                 input.ClrTypeName = displayType!;
                 input.CanonicalTypeName = displayType!;
@@ -93,22 +89,37 @@ internal static class DocumentationInputNormalizer
         return -1;
     }
 
-    private static bool MatchesAnyIdentity(DocumentationTypeHelp input, ISet<string> rawNames)
-        => MatchesRawIdentity(input.Name, rawNames) ||
-           MatchesRawIdentity(input.ClrTypeName, rawNames) ||
-           MatchesRawIdentity(input.CanonicalTypeName, rawNames);
-
-    private static bool MatchesRawIdentity(string? value, ISet<string> rawNames)
+    private static bool MatchesRuntimeInput(
+        DocumentationTypeHelp input,
+        DocumentationTypeHelp runtimeInput,
+        IReadOnlyList<DocumentationTypeHelp> runtimeInputs)
     {
-        if (string.IsNullOrEmpty(value)) return false;
-        if (rawNames.Contains(value!)) return true;
-        var withoutHelpLineBreaks = value!.TrimEnd('\r', '\n');
-        return withoutHelpLineBreaks.Length != value.Length && rawNames.Contains(withoutHelpLineBreaks);
+        foreach (var expected in new[] { runtimeInput.ClrTypeName, runtimeInput.CanonicalTypeName })
+        {
+            if (string.IsNullOrEmpty(expected)) continue;
+            if (MatchesIdentity(input.Name, expected) ||
+                MatchesIdentity(input.ClrTypeName, expected) ||
+                MatchesIdentity(input.CanonicalTypeName, expected))
+                return true;
+        }
+
+        if (string.IsNullOrEmpty(runtimeInput.Name) ||
+            runtimeInputs.Count(candidate => string.Equals(
+                candidate.Name, runtimeInput.Name, StringComparison.Ordinal)) != 1)
+            return false;
+
+        return MatchesIdentity(input.Name, runtimeInput.Name) ||
+               MatchesIdentity(input.ClrTypeName, runtimeInput.Name) ||
+               MatchesIdentity(input.CanonicalTypeName, runtimeInput.Name);
     }
 
-    private static void AddRawName(ISet<string> rawNames, string? value)
+    private static bool MatchesIdentity(string? actual, string? expected)
     {
-        if (!string.IsNullOrEmpty(value)) rawNames.Add(value!);
+        if (string.IsNullOrEmpty(actual) || string.IsNullOrEmpty(expected)) return false;
+        if (string.Equals(actual, expected, StringComparison.Ordinal)) return true;
+        var withoutHelpLineBreaks = actual!.TrimEnd('\r', '\n');
+        return withoutHelpLineBreaks.Length != actual.Length &&
+               string.Equals(withoutHelpLineBreaks, expected, StringComparison.Ordinal);
     }
 
     private static bool TryParsePowerShellInputAggregate(

--- a/PowerForge/Services/Documentation/DocumentationInputNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationInputNormalizer.cs
@@ -122,7 +122,7 @@ internal static class DocumentationInputNormalizer
                string.Equals(withoutHelpLineBreaks, expected, StringComparison.Ordinal);
     }
 
-    private static bool TryParsePowerShellInputAggregate(
+    internal static bool TryParsePowerShellInputAggregate(
         DocumentationTypeHelp input,
         IReadOnlyList<DocumentationTypeHelp> runtimeInputs,
         out IReadOnlyList<DocumentationTypeHelp> parsedInputs)

--- a/PowerForge/Services/Documentation/DocumentationMetadataNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationMetadataNormalizer.cs
@@ -330,6 +330,7 @@ internal static class DocumentationMetadataNormalizer
                     .Reverse()
                     .Select(rank => rank <= 1 ? "[]" : "[" + new string(',', rank - 1) + "]"));
                 parameter.Type = parameter.NullableUnderlyingTypeName! + suffix;
+                NormalizeSyntaxParameterType(command, parameter.Name, parameter.Type);
             }
             parameter.NullableUnderlyingTypeName = null;
             parameter.NullableArrayRanks = new List<int>();
@@ -367,6 +368,30 @@ internal static class DocumentationMetadataNormalizer
             parameter.HasMetadataDefault = false;
         }
     }
+
+    private static void NormalizeSyntaxParameterType(
+        DocumentationCommandHelp command,
+        string parameterName,
+        string parameterType)
+    {
+        if (string.IsNullOrEmpty(parameterName) || string.IsNullOrEmpty(parameterType)) return;
+
+        var pattern = @"(?<prefix>\[{0,2}-" + Regex.Escape(parameterName) + @"(?:\])?\s+)<[^>\r\n]+>";
+        foreach (var syntax in command.Syntax ?? new List<DocumentationSyntaxHelp>())
+        {
+            if (syntax is null || string.IsNullOrEmpty(syntax.Text)) continue;
+            syntax.Text = ReplaceSyntaxParameterType(syntax.Text, pattern, parameterType);
+        }
+        command.Synopsis = ReplaceSyntaxParameterType(command.Synopsis, pattern, parameterType);
+        command.Description = ReplaceSyntaxParameterType(command.Description, pattern, parameterType);
+    }
+
+    private static string ReplaceSyntaxParameterType(string? text, string pattern, string parameterType)
+        => Regex.Replace(
+            text ?? string.Empty,
+            pattern,
+            match => match.Groups["prefix"].Value + "<" + parameterType + ">",
+            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static void NormalizeOutputs(DocumentationCommandHelp command)
     {

--- a/PowerForge/Services/Documentation/DocumentationMetadataNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationMetadataNormalizer.cs
@@ -23,6 +23,7 @@ internal static class DocumentationMetadataNormalizer
         foreach (var command in payload.Commands ?? new List<DocumentationCommandHelp>())
         {
             if (command is null) continue;
+            DocumentationHiddenParameterNormalizer.Normalize(command);
             NormalizeBindableIdentities(command);
             NormalizeParameterSetIdentities(command);
             RestoreTypeIdentityText(command.Inputs);
@@ -321,6 +322,17 @@ internal static class DocumentationMetadataNormalizer
         foreach (var parameter in command.Parameters ?? new List<DocumentationParameterHelp>())
         {
             if (parameter is null) continue;
+
+            if (!string.IsNullOrWhiteSpace(parameter.NullableUnderlyingTypeName))
+            {
+                var suffix = string.Concat((parameter.NullableArrayRanks ?? new List<int>())
+                    .AsEnumerable()
+                    .Reverse()
+                    .Select(rank => rank <= 1 ? "[]" : "[" + new string(',', rank - 1) + "]"));
+                parameter.Type = parameter.NullableUnderlyingTypeName! + suffix;
+            }
+            parameter.NullableUnderlyingTypeName = null;
+            parameter.NullableArrayRanks = new List<int>();
 
             parameter.Aliases = (parameter.Aliases ?? new List<string>())
                 .Where(alias => !string.IsNullOrEmpty(alias))

--- a/PowerForge/Services/Documentation/DocumentationMetadataNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationMetadataNormalizer.cs
@@ -323,13 +323,10 @@ internal static class DocumentationMetadataNormalizer
         {
             if (parameter is null) continue;
 
-            if (!string.IsNullOrWhiteSpace(parameter.NullableUnderlyingTypeName))
+            var nullableTypeName = GetNullableParameterTypeName(parameter);
+            if (!string.IsNullOrWhiteSpace(nullableTypeName))
             {
-                var suffix = string.Concat((parameter.NullableArrayRanks ?? new List<int>())
-                    .AsEnumerable()
-                    .Reverse()
-                    .Select(rank => rank <= 1 ? "[]" : "[" + new string(',', rank - 1) + "]"));
-                parameter.Type = parameter.NullableUnderlyingTypeName! + suffix;
+                parameter.Type = nullableTypeName!;
                 NormalizeSyntaxParameterType(command, parameter.Name, parameter.Type);
             }
             parameter.NullableUnderlyingTypeName = null;
@@ -367,6 +364,18 @@ internal static class DocumentationMetadataNormalizer
             parameter.MetadataDefaultValue = null;
             parameter.HasMetadataDefault = false;
         }
+    }
+
+    internal static string? GetNullableParameterTypeName(DocumentationParameterHelp parameter)
+    {
+        if (parameter is null || string.IsNullOrWhiteSpace(parameter.NullableUnderlyingTypeName))
+            return null;
+
+        var suffix = string.Concat((parameter.NullableArrayRanks ?? new List<int>())
+            .AsEnumerable()
+            .Reverse()
+            .Select(rank => rank <= 1 ? "[]" : "[" + new string(',', rank - 1) + "]"));
+        return parameter.NullableUnderlyingTypeName + suffix;
     }
 
     private static void NormalizeSyntaxParameterType(

--- a/PowerForge/Services/Documentation/MamlHelpWriter.cs
+++ b/PowerForge/Services/Documentation/MamlHelpWriter.cs
@@ -112,7 +112,8 @@ internal sealed class MamlHelpWriter
 
         if (syntaxSets.Length == 0)
         {
-            WriteSyntaxItem(writer, commandName, setName: null, cmd.Parameters);
+            if (!cmd.SuppressSyntheticSyntax)
+                WriteSyntaxItem(writer, commandName, setName: null, cmd.Parameters);
             writer.WriteEndElement(); // syntax
             return;
         }

--- a/PowerForge/Services/Documentation/MarkdownHelpWriter.cs
+++ b/PowerForge/Services/Documentation/MarkdownHelpWriter.cs
@@ -135,7 +135,7 @@ internal sealed class MarkdownHelpWriter
         var syntax = (cmd.Syntax ?? Enumerable.Empty<DocumentationSyntaxHelp>())
             .Where(s => s is not null && !string.IsNullOrWhiteSpace(s.Text))
             .ToArray();
-        if (syntax.Length == 0)
+        if (syntax.Length == 0 && !cmd.SuppressSyntheticSyntax)
         {
             doc.CodeFence("powershell", cmd.Name.Trim());
         }
@@ -160,7 +160,7 @@ internal sealed class MarkdownHelpWriter
         var examples = (cmd.Examples ?? Enumerable.Empty<DocumentationExampleHelp>())
             .Where(e => e is not null)
             .ToArray();
-        if (examples.Length == 0)
+        if (examples.Length == 0 && !cmd.SuppressSyntheticSyntax)
         {
             doc.RawLine("### EXAMPLE 1");
             doc.CodeFence("powershell", cmd.Name.Trim());

--- a/PowerForge/Services/Documentation/XmlDocCommentEnricher.cs
+++ b/PowerForge/Services/Documentation/XmlDocCommentEnricher.cs
@@ -33,39 +33,44 @@ internal sealed class XmlDocCommentEnricher
         if (cmdlets.Length == 0) return;
 
         var xmlCache = new Dictionary<string, XmlDocFile>(StringComparer.OrdinalIgnoreCase);
-        foreach (var cmd in cmdlets)
+
+        XmlDocFile? LoadXmlForAssembly(string? assemblyPathRaw, string commandName)
         {
-            var implementingType = cmd.ImplementingType!.Trim();
-            var assemblyPathRaw = cmd.AssemblyPath!.Trim().Trim('"');
+            var candidate = (assemblyPathRaw ?? string.Empty).Trim().Trim('"');
+            if (candidate.Length == 0) return null;
 
             string assemblyPath;
-            try { assemblyPath = Path.GetFullPath(assemblyPathRaw); }
-            catch { assemblyPath = assemblyPathRaw; }
-
-            if (string.IsNullOrWhiteSpace(assemblyPath) || !File.Exists(assemblyPath))
-                continue;
+            try { assemblyPath = Path.GetFullPath(candidate); }
+            catch { assemblyPath = candidate; }
+            if (!File.Exists(assemblyPath)) return null;
 
             var xmlPath = Path.ChangeExtension(assemblyPath, ".xml");
             if (string.IsNullOrWhiteSpace(xmlPath) || !File.Exists(xmlPath))
             {
                 if (_logger.IsVerbose)
-                    _logger.Verbose($"XML docs not found for '{cmd.Name}' ({assemblyPath}). Expected: {xmlPath}");
-                continue;
+                    _logger.Verbose($"XML docs not found for '{commandName}' ({assemblyPath}). Expected: {xmlPath}");
+                return null;
             }
 
-            if (!xmlCache.TryGetValue(xmlPath, out var xml))
+            if (xmlCache.TryGetValue(xmlPath, out var cached)) return cached;
+            try
             {
-                try
-                {
-                    xml = XmlDocFile.Load(xmlPath);
-                    xmlCache[xmlPath] = xml;
-                }
-                catch (Exception ex)
-                {
-                    _logger.Warn($"Failed to read XML docs '{xmlPath}'. Error: {ex.Message}");
-                    continue;
-                }
+                var loaded = XmlDocFile.Load(xmlPath);
+                xmlCache[xmlPath] = loaded;
+                return loaded;
             }
+            catch (Exception ex)
+            {
+                _logger.Warn($"Failed to read XML docs '{xmlPath}'. Error: {ex.Message}");
+                return null;
+            }
+        }
+
+        foreach (var cmd in cmdlets)
+        {
+            var implementingType = cmd.ImplementingType!.Trim();
+            var xml = LoadXmlForAssembly(cmd.AssemblyPath, cmd.Name);
+            if (xml is null) continue;
 
             var typeMember = xml.TryGetMember("T:" + implementingType);
             if (typeMember is not null)
@@ -135,7 +140,15 @@ internal sealed class XmlDocCommentEnricher
                 if (!NeedsText(p.Description)) continue;
                 if (string.IsNullOrWhiteSpace(p.Name)) continue;
 
+                var declaringType = string.IsNullOrWhiteSpace(p.DeclaringType)
+                    ? implementingType
+                    : p.DeclaringType!.Trim();
+                var parameterXml = string.IsNullOrWhiteSpace(p.DeclaringAssemblyPath)
+                    ? xml
+                    : LoadXmlForAssembly(p.DeclaringAssemblyPath, cmd.Name) ?? xml;
                 var member =
+                    parameterXml.TryGetMember("P:" + declaringType + "." + p.Name.Trim()) ??
+                    parameterXml.TryGetMember("F:" + declaringType + "." + p.Name.Trim()) ??
                     xml.TryGetMember("P:" + implementingType + "." + p.Name.Trim()) ??
                     xml.TryGetMember("F:" + implementingType + "." + p.Name.Trim());
 

--- a/PowerForge/Services/Documentation/XmlDocCommentEnricher.cs
+++ b/PowerForge/Services/Documentation/XmlDocCommentEnricher.cs
@@ -70,66 +70,67 @@ internal sealed class XmlDocCommentEnricher
         {
             var implementingType = cmd.ImplementingType!.Trim();
             var xml = LoadXmlForAssembly(cmd.AssemblyPath, cmd.Name);
-            if (xml is null) continue;
-
-            var typeMember = xml.TryGetMember("T:" + implementingType);
-            if (typeMember is not null)
+            if (xml is not null)
             {
-                if (NeedsSynopsis(cmd.Name, cmd.Synopsis) && !string.IsNullOrWhiteSpace(typeMember.Summary))
-                    cmd.Synopsis = typeMember.Summary!;
-
-                if (NeedsText(cmd.Description) || LooksLikeSynopsisOnly(cmd.Description, cmd.Synopsis))
+                var typeMember = xml.TryGetMember("T:" + implementingType);
+                if (typeMember is not null)
                 {
-                    var desc = typeMember.Remarks;
-                    if (string.IsNullOrWhiteSpace(desc)) desc = typeMember.Body;
-                    if (string.IsNullOrWhiteSpace(desc)) desc = typeMember.Summary;
-                    if (!string.IsNullOrWhiteSpace(desc)) cmd.Description = desc!;
-                }
+                    if (NeedsSynopsis(cmd.Name, cmd.Synopsis) && !string.IsNullOrWhiteSpace(typeMember.Summary))
+                        cmd.Synopsis = typeMember.Summary!;
 
-                if (!HasMeaningfulExamples(cmd.Examples) && typeMember.Examples.Length > 0)
-                {
-                    cmd.Examples ??= new List<DocumentationExampleHelp>();      
-                    foreach (var ex in typeMember.Examples)
+                    if (NeedsText(cmd.Description) || LooksLikeSynopsisOnly(cmd.Description, cmd.Synopsis))
                     {
-                        cmd.Examples.Add(new DocumentationExampleHelp
-                        {
-                            Title = ex.Title ?? string.Empty,
-                            Introduction = ex.Introduction ?? string.Empty,
-                            Code = ex.Code ?? string.Empty,
-                            Remarks = ex.Remarks ?? string.Empty
-                        });
+                        var desc = typeMember.Remarks;
+                        if (string.IsNullOrWhiteSpace(desc)) desc = typeMember.Body;
+                        if (string.IsNullOrWhiteSpace(desc)) desc = typeMember.Summary;
+                        if (!string.IsNullOrWhiteSpace(desc)) cmd.Description = desc!;
                     }
-                }
 
-                if ((cmd.RelatedLinks?.Count ?? 0) == 0 && typeMember.SeeAlso.Length > 0)
-                {
-                    cmd.RelatedLinks ??= new List<DocumentationLinkHelp>();
-                    foreach (var link in typeMember.SeeAlso)
+                    if (!HasMeaningfulExamples(cmd.Examples) && typeMember.Examples.Length > 0)
                     {
-                        if (string.IsNullOrWhiteSpace(link.Uri) && string.IsNullOrWhiteSpace(link.Text))
-                            continue;
-
-                        cmd.RelatedLinks.Add(new DocumentationLinkHelp
+                        cmd.Examples ??= new List<DocumentationExampleHelp>();
+                        foreach (var ex in typeMember.Examples)
                         {
-                            Text = link.Text ?? string.Empty,
-                            Uri = link.Uri ?? string.Empty
-                        });
+                            cmd.Examples.Add(new DocumentationExampleHelp
+                            {
+                                Title = ex.Title ?? string.Empty,
+                                Introduction = ex.Introduction ?? string.Empty,
+                                Code = ex.Code ?? string.Empty,
+                                Remarks = ex.Remarks ?? string.Empty
+                            });
+                        }
                     }
-                }
 
-                if ((cmd.Notes?.Count ?? 0) == 0 && typeMember.Alerts.Length > 0)
-                {
-                    cmd.Notes ??= new List<DocumentationNoteHelp>();
-                    foreach (var alert in typeMember.Alerts)
+                    if ((cmd.RelatedLinks?.Count ?? 0) == 0 && typeMember.SeeAlso.Length > 0)
                     {
-                        if (string.IsNullOrWhiteSpace(alert.Title) && string.IsNullOrWhiteSpace(alert.Text))
-                            continue;
-
-                        cmd.Notes.Add(new DocumentationNoteHelp
+                        cmd.RelatedLinks ??= new List<DocumentationLinkHelp>();
+                        foreach (var link in typeMember.SeeAlso)
                         {
-                            Title = alert.Title ?? string.Empty,
-                            Text = alert.Text ?? string.Empty
-                        });
+                            if (string.IsNullOrWhiteSpace(link.Uri) && string.IsNullOrWhiteSpace(link.Text))
+                                continue;
+
+                            cmd.RelatedLinks.Add(new DocumentationLinkHelp
+                            {
+                                Text = link.Text ?? string.Empty,
+                                Uri = link.Uri ?? string.Empty
+                            });
+                        }
+                    }
+
+                    if ((cmd.Notes?.Count ?? 0) == 0 && typeMember.Alerts.Length > 0)
+                    {
+                        cmd.Notes ??= new List<DocumentationNoteHelp>();
+                        foreach (var alert in typeMember.Alerts)
+                        {
+                            if (string.IsNullOrWhiteSpace(alert.Title) && string.IsNullOrWhiteSpace(alert.Text))
+                                continue;
+
+                            cmd.Notes.Add(new DocumentationNoteHelp
+                            {
+                                Title = alert.Title ?? string.Empty,
+                                Text = alert.Text ?? string.Empty
+                            });
+                        }
                     }
                 }
             }
@@ -146,11 +147,12 @@ internal sealed class XmlDocCommentEnricher
                 var parameterXml = string.IsNullOrWhiteSpace(p.DeclaringAssemblyPath)
                     ? xml
                     : LoadXmlForAssembly(p.DeclaringAssemblyPath, cmd.Name) ?? xml;
+                if (parameterXml is null) continue;
                 var member =
                     parameterXml.TryGetMember("P:" + declaringType + "." + p.Name.Trim()) ??
                     parameterXml.TryGetMember("F:" + declaringType + "." + p.Name.Trim()) ??
-                    xml.TryGetMember("P:" + implementingType + "." + p.Name.Trim()) ??
-                    xml.TryGetMember("F:" + implementingType + "." + p.Name.Trim());
+                    xml?.TryGetMember("P:" + implementingType + "." + p.Name.Trim()) ??
+                    xml?.TryGetMember("F:" + implementingType + "." + p.Name.Trim());
 
                 if (member is null) continue;
 
@@ -160,8 +162,11 @@ internal sealed class XmlDocCommentEnricher
                 if (!string.IsNullOrWhiteSpace(desc)) p.Description = desc!;
             }
 
-            EnrichTypeDescriptions(cmd.Inputs, xml);
-            EnrichTypeDescriptions(cmd.Outputs, xml);
+            if (xml is not null)
+            {
+                EnrichTypeDescriptions(cmd.Inputs, xml);
+                EnrichTypeDescriptions(cmd.Outputs, xml);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- keep PowerShell as the runtime metadata collector while typed C# owns hidden-parameter removal and deterministic help normalization
- remove `DontShow` parameters, their pipeline input types, and parameter-set syntax variants that become unreachable after hidden parameters are removed
- invalidate every affected syntax when a mandatory hidden parameter belongs to all parameter sets, while retaining an invocable default set whose hidden-only parameters are optional
- suppress MAML, Markdown, and fallback-example synthesis when every collected set is unreachable because it requires a mandatory hidden parameter
- isolate collector helpers from target-module exports and preserve supported module and direct-binary Get-Help paths
- enrich inherited parameter help when declaring XML is available without making content cleanup part of this migration
- emit and synchronize direct-import help beside nested binaries with filesystem-aware staging and project-root boundaries
- reject alias writes and project sync copies whose destination traverses a directory link, including the generated culture directory, or is itself a file link
- reject `.` and `..` external-help culture segments before constructing output paths
- protect all aliases under same-name nested modules, DLL paths declared by differently named nested manifests, and DLLs imported through literal or `$PSScriptRoot`-relative paths by their script-module roots without suppressing unrelated outer binaries
- preserve authored help, migrate only aliases whose ownership is proven, and replace stale PowerForge-owned aliases after a module rename

## Result
Removing XmlDoc2CmdletDoc now preserves module and direct-DLL external help without exposing unreachable hidden-only syntax or synthetic invocations, removing an invocable hidden-default syntax, escaping staging or project roots, writing through linked directories or files, overwriting nested/authored aliases, deleting nested-module legacy help, suppressing unrelated outer-binary help, or retaining stale aliases after module/path changes.

## Validation
- focused hidden-parameter and alias-ownership contracts pass, including mandatory all-set suppression, renamed-owner replacement, shared nested-manifest directory ownership, and literal and `$PSScriptRoot`-relative DLLs imported by nested script-module roots
- external-help culture safety tests: 6/6, including `.` and `..`
- focused culture-link and parameter-visibility contracts pass through PowerShell 7 and Windows PowerShell 5.1
- generated Markdown and MAML omit unreachable mandatory-hidden syntax and synthetic examples while retaining an invocable optional hidden default
- DocumentationGenerationTests: 33/33 on the parent candidate; the current alias-only update passes its exact regression contract
- PowerForge.PowerShell net472 build: 0 warnings, 0 errors
- git diff --check passed

Documentation-content fidelity outside dependency removal and functional help availability remains separate follow-up work.
