### PR TITLE
Fix coordinated releases with multiple unnamed artifacts

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleasePayloadCacheIdentity.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleasePayloadCacheIdentity.cs
@@ -49,12 +49,6 @@ public sealed partial class ModulePipelineRunner
         foreach (var result in state.ArtefactResults)
         {
             var id = result.Id?.Trim();
-            if (state.ArtefactResults.Count > 1 && string.IsNullOrWhiteSpace(id))
-            {
-                throw new InvalidOperationException(
-                    "A coordinated release with multiple module artefacts requires a stable ID on every artefact.");
-            }
-
             var normalizedOutputPath = result.OutputPath.TrimEnd(
                 Path.DirectorySeparatorChar,
                 Path.AltDirectorySeparatorChar);
@@ -69,8 +63,11 @@ public sealed partial class ModulePipelineRunner
             var identity = result.Type + "\n" + stableId + "\n" + outputName;
             if (!identities.Add(identity))
             {
+                var idGuidance = string.IsNullOrWhiteSpace(id)
+                    ? " Assign explicit unique artefact IDs to disambiguate outputs with the same type and filename."
+                    : string.Empty;
                 throw new InvalidOperationException(
-                    $"Coordinated release contains duplicate artefact identity '{result.Type}'/'{stableId}'/'{outputName}'.");
+                    $"Coordinated release contains duplicate artefact identity '{result.Type}'/'{stableId}'/'{outputName}'.{idGuidance}");
             }
 
             artefacts.Add(new SynchronizedReleasePayloadArtefact(

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseCheckpointTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseCheckpointTests.cs
@@ -124,6 +124,125 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
     }
 
     [Fact]
+    public void Run_DerivesCheckpointIdentityForMultipleUnidentifiedArtefacts()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var stagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        try
+        {
+            const string moduleName = "TestModule";
+            const string synchronizedVersion = "2.0.11";
+            WriteMinimalModule(root.FullName, moduleName, "2.0.10");
+            WriteSynchronizedProjectBuildConfig(root.FullName, "project.build.json", moduleName, publishNuGet: false);
+
+            var hosted = new FakeHostedOperations(new List<string>())
+            {
+                ModulePublishAction = (_, _) => throw new InvalidOperationException("Simulated gallery outage.")
+            };
+            var runner = CreateRunner(
+                hosted,
+                (request, configuration, configPath) => CreateProjectBuildResult(
+                    root.FullName,
+                    moduleName,
+                    synchronizedVersion,
+                    Path.Combine(root.FullName, "PackageOutput", "NuGet"),
+                    request,
+                    configPath,
+                    includePackage: false));
+            var spec = CreateGalleryReleaseSpec(root.FullName, stagingPath, moduleName);
+            var segments = spec.Segments.ToList();
+            segments.Insert(1, new ConfigurationArtefactSegment
+            {
+                ArtefactType = ArtefactType.Unpacked,
+                Configuration = new ArtefactConfiguration
+                {
+                    Enabled = true,
+                    Path = Path.Combine(root.FullName, "Artifacts", "Unpacked")
+                }
+            });
+            segments.Insert(2, new ConfigurationArtefactSegment
+            {
+                ArtefactType = ArtefactType.Packed,
+                Configuration = new ArtefactConfiguration
+                {
+                    Enabled = true,
+                    Path = Path.Combine(root.FullName, "Artifacts", "Packed"),
+                    ArtefactName = $"{moduleName}.zip"
+                }
+            });
+            spec.Segments = segments.ToArray();
+
+            var exception = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+            Assert.Contains("gallery outage", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Single(Directory.GetFiles(GetCoordinatedReleaseCheckpointRoot(root.FullName), "*.json"));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+            try { if (Directory.Exists(stagingPath)) Directory.Delete(stagingPath, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Run_RequiresIdsOnlyWhenUnidentifiedArtefactIdentityIsAmbiguous()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var stagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        try
+        {
+            const string moduleName = "TestModule";
+            const string synchronizedVersion = "2.0.11";
+            WriteMinimalModule(root.FullName, moduleName, "2.0.10");
+            WriteSynchronizedProjectBuildConfig(root.FullName, "project.build.json", moduleName, publishNuGet: false);
+
+            var runner = CreateRunner(
+                new FakeHostedOperations(new List<string>()),
+                (request, configuration, configPath) => CreateProjectBuildResult(
+                    root.FullName,
+                    moduleName,
+                    synchronizedVersion,
+                    Path.Combine(root.FullName, "PackageOutput", "NuGet"),
+                    request,
+                    configPath,
+                    includePackage: false));
+            var spec = CreateGalleryReleaseSpec(root.FullName, stagingPath, moduleName);
+            var segments = spec.Segments.ToList();
+            segments.Insert(1, new ConfigurationArtefactSegment
+            {
+                ArtefactType = ArtefactType.Packed,
+                Configuration = new ArtefactConfiguration
+                {
+                    Enabled = true,
+                    Path = Path.Combine(root.FullName, "Artifacts", "First"),
+                    ArtefactName = $"{moduleName}.zip"
+                }
+            });
+            segments.Insert(2, new ConfigurationArtefactSegment
+            {
+                ArtefactType = ArtefactType.Packed,
+                Configuration = new ArtefactConfiguration
+                {
+                    Enabled = true,
+                    Path = Path.Combine(root.FullName, "Artifacts", "Second"),
+                    ArtefactName = $"{moduleName}.zip"
+                }
+            });
+            spec.Segments = segments.ToArray();
+
+            var exception = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+            Assert.Contains("duplicate artefact identity", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("explicit unique artefact IDs", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+            try { if (Directory.Exists(stagingPath)) Directory.Delete(stagingPath, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void Run_SkipsCompletedModuleGitHubPublishAfterPostPublishFailure()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));


### PR DESCRIPTION
Coordinated module releases no longer fail merely because more than one generated artifact omits `-ID`.

Checkpoint identity now uses the artifact type, optional ID, and exact output filename. Existing wrappers with distinct `Packed` and `Unpacked` outputs therefore remain resumable without extra configuration. When two outputs still produce the same identity, PowerForge rejects the ambiguity and tells the maintainer to assign explicit unique IDs.

Explicit IDs remain supported and are still useful when a publish destination needs to select a particular artifact.