### PR TITLE
Keep Apple monitor incidents error-driven

### DIFF
--- a/.github/workflows/powerforge-apple-monitor.yml
+++ b/.github/workflows/powerforge-apple-monitor.yml
@@ -162,8 +162,12 @@ jobs:
           } else {
             @($env:STRUCTURED_DIAGNOSTICS | ConvertFrom-Json -Depth 20)
           }
+          # Doctor warnings remain available in the compact receipt, but only an
+          # execution failure or an error-level diagnostic should create a red
+          # proactive incident. Warning-only runs are advisory and recover any
+          # earlier monitor incident instead of keeping required CI red forever.
           $unhealthy = $env:DOCTOR_OUTCOME -ne 'success' -or
-            @($structured | Where-Object { $_.severity -in @('error', 'warning') }).Count -gt 0
+            @($structured | Where-Object { $_.severity -eq 'error' }).Count -gt 0
           $healthyOutput = (!$unhealthy).ToString().ToLowerInvariant()
           "healthy=$healthyOutput" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           if (-not $unhealthy) {
@@ -181,7 +185,18 @@ jobs:
           if ($receiptDiagnostics.Count -eq 0) {
             $receiptDiagnostics = @($structured)
           }
-          $stateDiagnostics = @($receiptDiagnostics | ForEach-Object {
+          $errorDiagnostics = @($receiptDiagnostics | Where-Object { $_.severity -eq 'error' })
+          $specificErrors = @($errorDiagnostics | Where-Object { $_.code -ne 'APPLE_UNKNOWN' })
+          $incidentDiagnostics = if ($specificErrors.Count -gt 0) {
+            $specificErrors
+          } elseif ($errorDiagnostics.Count -gt 0) {
+            $errorDiagnostics
+          } else {
+            # An execution failure can precede structured classification. Keep
+            # whatever diagnostics exist, then fall back to the linked run.
+            $receiptDiagnostics
+          }
+          $stateDiagnostics = @($incidentDiagnostics | ForEach-Object {
             [ordered]@{
               code = [string] $_.code
               severity = [string] $_.severity
@@ -207,7 +222,7 @@ jobs:
           $maxRenderedDiagnosticCharacters = 48000
           $renderedDiagnostics = [Collections.Generic.List[string]]::new()
           $renderedCharacters = 0
-          foreach ($diagnostic in $receiptDiagnostics) {
+          foreach ($diagnostic in $incidentDiagnostics) {
             $line = "- **$($diagnostic.code)** [$($diagnostic.severity)]: $($diagnostic.summary)`n  - Action: $($diagnostic.action)"
             if ($line.Length -gt $maxDiagnosticEntryLength) {
               $line = $line.Substring(0, $maxDiagnosticEntryLength - 1) + '…'
@@ -218,7 +233,7 @@ jobs:
             $renderedDiagnostics.Add($line)
             $renderedCharacters += $line.Length + 1
           }
-          $omittedDiagnosticCount = $receiptDiagnostics.Count - $renderedDiagnostics.Count
+          $omittedDiagnosticCount = $incidentDiagnostics.Count - $renderedDiagnostics.Count
           $diagnosticLines = if ($renderedDiagnostics.Count -gt 0) {
             $renderedDiagnostics -join "`n"
           } else {

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.RunnerLocalCredentials.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.RunnerLocalCredentials.cs
@@ -68,6 +68,10 @@ public sealed partial class AppleReleaseWorkflowTests
         Assert.Contains("$start.Environment.Clear()", script, StringComparison.Ordinal);
         Assert.Contains("-IncludeAppleCredentials", script, StringComparison.Ordinal);
         Assert.Contains("Assert-FixedAppleToolConfiguration", script, StringComparison.Ordinal);
+        Assert.Contains("$script:validatedReleaseConfigPaths", script, StringComparison.Ordinal);
+        Assert.Contains("if ($command -eq 'apple-release' -and $config)", script, StringComparison.Ordinal);
+        Assert.Contains("Get-OptionValue -Option '--release-config'", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("$script:validatedConfigPaths", script, StringComparison.Ordinal);
         Assert.Contains("/usr/bin/xcodebuild", script, StringComparison.Ordinal);
         Assert.DoesNotContain("[string] $DotNet =", script, StringComparison.Ordinal);
 

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.cs
@@ -322,6 +322,9 @@ public sealed partial class AppleReleaseWorkflowTests
         Assert.DoesNotContain("Select-Object -First 10", workflow, StringComparison.Ordinal);
         Assert.Contains("$maxDiagnosticEntryLength = 4000", workflow, StringComparison.Ordinal);
         Assert.Contains("$maxRenderedDiagnosticCharacters = 48000", workflow, StringComparison.Ordinal);
+        Assert.Contains("$errorDiagnostics = @($receiptDiagnostics | Where-Object { $_.severity -eq 'error' })", workflow, StringComparison.Ordinal);
+        Assert.Contains("$specificErrors = @($errorDiagnostics | Where-Object { $_.code -ne 'APPLE_UNKNOWN' })", workflow, StringComparison.Ordinal);
+        Assert.Contains("foreach ($diagnostic in $incidentDiagnostics)", workflow, StringComparison.Ordinal);
         Assert.Contains("$omittedDiagnosticCount additional diagnostics omitted", workflow, StringComparison.Ordinal);
         Assert.Contains("Diagnostic state: ``$stateHash``", workflow, StringComparison.Ordinal);
         Assert.Contains("$previousState.Groups[1].Value -ne $stateHash", workflow, StringComparison.Ordinal);
@@ -333,6 +336,8 @@ public sealed partial class AppleReleaseWorkflowTests
         Assert.Contains("GH_REPO: ${{ github.repository }}", workflow, StringComparison.Ordinal);
         Assert.Contains("source-commit: ${{ inputs.source_ref }}", workflow, StringComparison.Ordinal);
         Assert.Contains("Fail when Apple Doctor found a problem", workflow, StringComparison.Ordinal);
+        Assert.Contains("Where-Object { $_.severity -eq 'error' }", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("$_.severity -in @('error', 'warning')", workflow, StringComparison.Ordinal);
         Assert.Contains("diagnostics:", action, StringComparison.Ordinal);
         Assert.Contains("'Status', 'Doctor'", script, StringComparison.Ordinal);
         Assert.Contains("reportedDiagnostics", script, StringComparison.Ordinal);

--- a/scripts/Invoke-PinnedPowerForge.ps1
+++ b/scripts/Invoke-PinnedPowerForge.ps1
@@ -205,13 +205,19 @@ function Assert-SafeArguments {
         ($command -eq 'apple-governance' -and $operation -ne 'snapshot')) -and -not $config) {
         throw "$command requires an explicit --config at the pinned local operator boundary."
     }
-    $script:validatedConfigPaths = @()
+    $script:validatedReleaseConfigPaths = @()
     foreach ($option in @('--config', '--release-config')) {
         $value = Get-OptionValue -Option $option
         if ($value) {
             Assert-TrackedConsumerInput -Value $value -Option $option
-            $script:validatedConfigPaths += Resolve-OptionPath -Value $value
         }
+    }
+    if ($command -eq 'apple-release' -and $config) {
+        $script:validatedReleaseConfigPaths += Resolve-OptionPath -Value $config
+    }
+    $releaseConfig = Get-OptionValue -Option '--release-config'
+    if ($releaseConfig) {
+        $script:validatedReleaseConfigPaths += Resolve-OptionPath -Value $releaseConfig
     }
     foreach ($option in @('--capture-provenance', '--reviewed-plan')) {
         $value = Get-OptionValue -Option $option
@@ -253,7 +259,7 @@ function Assert-FixedAppleToolConfiguration {
             Test-Node -Node $property.Value
         }
     }
-    foreach ($configPath in @($script:validatedConfigPaths | Sort-Object -Unique)) {
+    foreach ($configPath in @($script:validatedReleaseConfigPaths | Sort-Object -Unique)) {
         Test-Node -Node (Get-Content -LiteralPath $configPath -Raw | ConvertFrom-Json)
     }
 }
@@ -266,7 +272,7 @@ function Invoke-TrackedInputValidator {
     Invoke-GitText -Root $toolRoot -Arguments @('ls-files', '--error-unmatch', '--', $relative) | Out-Null
     Invoke-GitText -Root $toolRoot -Arguments @('diff', '--quiet', 'HEAD', '--', $relative) | Out-Null
     $allowMissingProject = $ArgumentList[0] -eq 'apple-release' -and $ArgumentList.Count -gt 1 -and $ArgumentList[1] -ieq 'Cleanup'
-    foreach ($configPath in @($script:validatedConfigPaths | Select-Object -Unique)) {
+    foreach ($configPath in @($script:validatedReleaseConfigPaths | Select-Object -Unique)) {
         & $validator `
             -ConfigPath $configPath `
             -SourceCommit $SourceCommit `


### PR DESCRIPTION
## Summary

- keep warning-only Apple Doctor results advisory in compact receipts instead of failing CI or preserving a red incident
- render proactive incident bodies from error-level diagnostics only and suppress `APPLE_UNKNOWN` when a specific error already explains the failure
- retain incident creation for execution failures and error-level diagnostics, including the structured fallback when execution fails before a receipt exists
- let the pinned local operator validate governance and screenshot configs as tracked inputs without misclassifying them as full release configs

This closes stale warning-only incidents after consumers repin while preserving the real CasaRay and EmailIMO readiness blockers. It also restores safe local `apple-governance plan` execution needed to inspect CasaRay drift before any reviewed apply.