### PR TITLE
fix(release): reset unused coordinated checkpoints

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpoint.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpoint.cs
@@ -16,8 +16,9 @@ public sealed partial class ModulePipelineRunner
         var sourceMutatingGate = plan.GateMode is ConfigurationGateMode.Manifest or
             ConfigurationGateMode.Documentation or
             ConfigurationGateMode.Build;
+        var shouldUseCheckpoint = ShouldUseSynchronizedReleaseCheckpoint(plan, state);
         var inspectSourceMutatingGateCheckpoint = checkpointExists && sourceMutatingGate;
-        if (!ShouldUseSynchronizedReleaseCheckpoint(plan, state) && !inspectSourceMutatingGateCheckpoint)
+        if (!shouldUseCheckpoint && !inspectSourceMutatingGateCheckpoint)
         {
             if (plan.GateMode is ConfigurationGateMode.Manifest or
                 ConfigurationGateMode.Documentation or
@@ -25,12 +26,8 @@ public sealed partial class ModulePipelineRunner
             {
                 return;
             }
-            if (checkpointExists)
-            {
-                throw new InvalidOperationException(
-                    $"Coordinated release configuration no longer matches incomplete checkpoint '{path}'. Restore synchronization and publishing or delete the checkpoint only if that release should be abandoned.");
-            }
-            return;
+            if (!checkpointExists)
+                return;
         }
 
         state.SynchronizedReleaseCheckpointPath = path;
@@ -57,14 +54,27 @@ public sealed partial class ModulePipelineRunner
                 $"Coordinated release checkpoint '{path}' has an unsupported schema. Delete it only if the incomplete release should be abandoned.");
         }
 
+        if (!shouldUseCheckpoint && !sourceMutatingGate)
+        {
+            if (IsResettableSynchronizedReleaseCheckpoint(checkpoint))
+            {
+                DeleteResettableSynchronizedReleaseCheckpoint(
+                    path,
+                    "because release synchronization changed before any publish operation or remote side effect started");
+                return;
+            }
+
+            throw new InvalidOperationException(
+                $"Coordinated release configuration no longer matches incomplete checkpoint '{path}'. Restore synchronization and publishing or delete the checkpoint only if that release should be abandoned.");
+        }
+
         if (sourceMutatingGate)
         {
-            if (IsPristineSynchronizedReleaseCheckpoint(checkpoint))
+            if (IsResettableSynchronizedReleaseCheckpoint(checkpoint))
             {
-                File.Delete(path);
-                DeleteEmptySynchronizedReleaseCheckpointDirectories(path);
-                _logger.Warn(
-                    $"Discarded unused coordinated release checkpoint '{path}' before running the {plan.GateMode} gate because no package lane or publish operation had started.");
+                DeleteResettableSynchronizedReleaseCheckpoint(
+                    path,
+                    $"before running the {plan.GateMode} gate because no publish operation or remote side effect had started");
                 return;
             }
 
@@ -76,12 +86,11 @@ public sealed partial class ModulePipelineRunner
         {
             ValidateSynchronizedReleaseCheckpoint(plan, state, checkpoint, path);
         }
-        catch (InvalidOperationException) when (IsPristineSynchronizedReleaseCheckpoint(checkpoint))
+        catch (InvalidOperationException) when (IsResettableSynchronizedReleaseCheckpoint(checkpoint))
         {
-            File.Delete(path);
-            DeleteEmptySynchronizedReleaseCheckpointDirectories(path);
-            _logger.Warn(
-                $"Discarded unused coordinated release checkpoint '{path}' because release configuration changed before any package lane or publish operation started.");
+            DeleteResettableSynchronizedReleaseCheckpoint(
+                path,
+                "because release configuration changed before any publish operation or remote side effect started");
             return;
         }
 
@@ -703,20 +712,73 @@ public sealed partial class ModulePipelineRunner
             ? "none"
             : $"{checkpoint.CompletedOperations.Length} of {checkpoint.PlannedOperations.Length}";
 
-    private static bool IsPristineSynchronizedReleaseCheckpoint(SynchronizedReleaseCheckpoint checkpoint)
-        => (checkpoint.PlannedOperations?.Length ?? 0) > 0 &&
-           (checkpoint.PlannedLanes?.Length ?? 0) > 0 &&
-           (checkpoint.OperationFingerprints?.Length ?? 0) > 0 &&
-           string.IsNullOrWhiteSpace(checkpoint.SourceFingerprint) &&
-           (checkpoint.SourceComponents?.Length ?? 0) == 0 &&
-           string.IsNullOrWhiteSpace(checkpoint.PayloadFingerprint) &&
-           (checkpoint.PayloadComponents?.Length ?? 0) == 0 &&
-           string.IsNullOrWhiteSpace(checkpoint.Version) &&
-           (checkpoint.AttemptedLanes?.Length ?? 0) == 0 &&
-           (checkpoint.Lanes?.Length ?? 0) == 0 &&
-           !checkpoint.AuxiliaryRemoteSideEffectsObserved &&
-           (checkpoint.AttemptedOperations?.Length ?? 0) == 0 &&
-           (checkpoint.CompletedOperations?.Length ?? 0) == 0;
+    private void DeleteResettableSynchronizedReleaseCheckpoint(string path, string reason)
+    {
+        var payloadCachePath = ResolveSynchronizedReleasePayloadCachePath(path);
+        if (Directory.Exists(payloadCachePath))
+        {
+            if ((File.GetAttributes(payloadCachePath) & FileAttributes.ReparsePoint) != 0)
+                Directory.Delete(payloadCachePath, recursive: false);
+            else
+                DeleteDirectoryWithRetries(payloadCachePath);
+        }
+        else if (File.Exists(payloadCachePath))
+            File.Delete(payloadCachePath);
+
+        File.Delete(path);
+        DeleteEmptySynchronizedReleaseCheckpointDirectories(path);
+        _logger.Warn($"Discarded unused coordinated release checkpoint '{path}' {reason}.");
+    }
+
+    private static bool IsResettableSynchronizedReleaseCheckpoint(
+        SynchronizedReleaseCheckpoint checkpoint)
+        => !string.IsNullOrWhiteSpace(checkpoint.ModuleName) &&
+           Enum.IsDefined(typeof(ReleaseVersionSource), checkpoint.ReleaseSource) &&
+           (checkpoint.PrimaryProject is null || !string.IsNullOrWhiteSpace(checkpoint.PrimaryProject)) &&
+           checkpoint.Version is not null &&
+           checkpoint.PlannedOperations is { Length: > 0 } &&
+           checkpoint.PlannedOperations.All(IsSynchronizedReleaseFingerprint) &&
+           checkpoint.PlannedOperations.Distinct(StringComparer.OrdinalIgnoreCase).Count() == checkpoint.PlannedOperations.Length &&
+           checkpoint.AttemptedOperations is { Length: 0 } &&
+           checkpoint.CompletedOperations is { Length: 0 } &&
+           checkpoint.OperationFingerprints is { Length: > 0 } &&
+           checkpoint.OperationFingerprints.All(IsSynchronizedReleaseFingerprint) &&
+           checkpoint.SourceFingerprint is not null &&
+           checkpoint.SourceFingerprint.Length == 0 &&
+           checkpoint.SourceComponents is { Length: 0 } &&
+           checkpoint.PayloadFingerprint is not null &&
+           checkpoint.PayloadFingerprint.Length == 0 &&
+           checkpoint.PayloadComponents is { Length: 0 } &&
+           checkpoint.PlannedLanes is { Length: > 0 } &&
+           checkpoint.PlannedLanes.All(IsSynchronizedReleaseFingerprint) &&
+           checkpoint.PlannedLanes.Distinct(StringComparer.OrdinalIgnoreCase).Count() == checkpoint.PlannedLanes.Length &&
+           checkpoint.CreatedUtc != default &&
+           (checkpoint.Version.Length == 0 ||
+            PackageVersionUtility.TryNormalizeExact(checkpoint.Version, out _)) &&
+           checkpoint.AttemptedLanes is not null &&
+           checkpoint.AttemptedLanes.Distinct(StringComparer.OrdinalIgnoreCase).Count() == checkpoint.AttemptedLanes.Length &&
+           checkpoint.AttemptedLanes.All(lane =>
+               !string.IsNullOrWhiteSpace(lane) &&
+               checkpoint.PlannedLanes!.Contains(lane, StringComparer.OrdinalIgnoreCase)) &&
+           checkpoint.Lanes is not null &&
+           checkpoint.Lanes.Length == checkpoint.AttemptedLanes.Length &&
+           checkpoint.Lanes
+               .Select(lane => lane?.CheckpointKey)
+               .Where(key => !string.IsNullOrWhiteSpace(key))
+               .Distinct(StringComparer.OrdinalIgnoreCase)
+               .Count() == checkpoint.Lanes.Length &&
+           checkpoint.Lanes.All(lane =>
+               lane is not null &&
+               Enum.IsDefined(typeof(ReleaseVersionSource), lane.Source) &&
+               !string.IsNullOrWhiteSpace(lane.Label) &&
+               IsSynchronizedReleaseFingerprint(lane.CheckpointKey) &&
+               checkpoint.AttemptedLanes!.Contains(lane.CheckpointKey, StringComparer.OrdinalIgnoreCase) &&
+               PackageVersionUtility.TryNormalizeExact(lane.DefaultVersion, out _) &&
+               lane.VersionsByProject is not null &&
+               lane.VersionsByProject.All(entry =>
+                   !string.IsNullOrWhiteSpace(entry.Key) &&
+                   PackageVersionUtility.TryNormalizeExact(entry.Value, out _))) &&
+           !checkpoint.AuxiliaryRemoteSideEffectsObserved;
 
     private static string? NormalizeCheckpointValue(string? value)
         => string.IsNullOrWhiteSpace(value) ? null : value!.Trim();

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseCheckpointResetTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseCheckpointResetTests.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class ModulePipelineUnifiedReleaseTests
+{
+    [Fact]
+    public void Run_DiscardsPrePublishCheckpointAfterArtefactIdentityCorrection()
+    {
+        var fixture = CreatePrePublishArtefactIdentityFailure();
+        try
+        {
+            var secondHosted = new FakeHostedOperations(new List<string>());
+            var secondRunner = CreateRunner(secondHosted, fixture.ExecutePackageBuild);
+            var secondSpec = CreateGalleryReleaseSpec(
+                fixture.Root.FullName,
+                fixture.SecondStagingPath,
+                fixture.ModuleName);
+            AddDuplicatePackedArtefacts(
+                secondSpec,
+                fixture.Root.FullName,
+                fixture.ModuleName,
+                useExplicitIds: true);
+
+            var result = secondRunner.Run(secondSpec);
+
+            Assert.Equal("2.0.11", result.Plan.ResolvedVersion);
+            Assert.Equal(2, fixture.PackageBuildCount());
+            Assert.Equal(new[] { "2.0.11" }, secondHosted.PublishedModuleVersions);
+            AssertNoCoordinatedReleaseCheckpoint(fixture.Root.FullName);
+        }
+        finally
+        {
+            fixture.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Run_PreservesMalformedPrePublishCheckpointAfterArtefactIdentityCorrection()
+    {
+        var fixture = CreatePrePublishArtefactIdentityFailure();
+        try
+        {
+            var checkpointJson = File.ReadAllText(fixture.CheckpointPath);
+            checkpointJson = checkpointJson.Replace(
+                "\"AttemptedOperations\": []",
+                "\"AttemptedOperations\": null",
+                StringComparison.Ordinal);
+            File.WriteAllText(fixture.CheckpointPath, checkpointJson);
+
+            AssertCorrectedRetryFailsClosed(fixture, "incomplete or invalid");
+            Assert.True(File.Exists(fixture.CheckpointPath));
+            Assert.Equal(1, fixture.PackageBuildCount());
+        }
+        finally
+        {
+            fixture.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Run_PreservesPrePublishCheckpointWithMalformedPlannedTopology()
+    {
+        var fixture = CreatePrePublishArtefactIdentityFailure();
+        try
+        {
+            var checkpoint = JsonNode.Parse(File.ReadAllText(fixture.CheckpointPath))!;
+            checkpoint["PlannedOperations"]![0] = "corrupt";
+            File.WriteAllText(
+                fixture.CheckpointPath,
+                checkpoint.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+
+            AssertCorrectedRetryFailsClosed(fixture, "configuration no longer matches");
+            Assert.True(File.Exists(fixture.CheckpointPath));
+            Assert.Equal(1, fixture.PackageBuildCount());
+        }
+        finally
+        {
+            fixture.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Run_DiscardsUnboundPayloadCacheWithResettablePrePublishCheckpoint()
+    {
+        var fixture = CreatePrePublishArtefactIdentityFailure();
+        try
+        {
+            var payloadCachePath = Path.Combine(
+                Path.GetDirectoryName(fixture.CheckpointPath)!,
+                Path.GetFileNameWithoutExtension(fixture.CheckpointPath) + ".payload");
+            Directory.CreateDirectory(payloadCachePath);
+            File.WriteAllText(Path.Combine(payloadCachePath, "orphaned.bin"), "signed payload");
+
+            var secondHosted = new FakeHostedOperations(new List<string>());
+            var secondRunner = CreateRunner(secondHosted, fixture.ExecutePackageBuild);
+            var secondSpec = CreateGalleryReleaseSpec(
+                fixture.Root.FullName,
+                fixture.SecondStagingPath,
+                fixture.ModuleName);
+            AddDuplicatePackedArtefacts(
+                secondSpec,
+                fixture.Root.FullName,
+                fixture.ModuleName,
+                useExplicitIds: true);
+
+            var result = secondRunner.Run(secondSpec);
+
+            Assert.Equal("2.0.11", result.Plan.ResolvedVersion);
+            Assert.Equal(new[] { "2.0.11" }, secondHosted.PublishedModuleVersions);
+            Assert.False(File.Exists(fixture.CheckpointPath));
+            Assert.False(Directory.Exists(payloadCachePath));
+            Assert.Equal(2, fixture.PackageBuildCount());
+        }
+        finally
+        {
+            fixture.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Run_UnlinksUnboundPayloadCacheReparsePointWithoutDeletingTarget()
+    {
+        var fixture = CreatePrePublishArtefactIdentityFailure();
+        try
+        {
+            var payloadCachePath = Path.Combine(
+                Path.GetDirectoryName(fixture.CheckpointPath)!,
+                Path.GetFileNameWithoutExtension(fixture.CheckpointPath) + ".payload");
+            if (Directory.Exists(payloadCachePath))
+                Directory.Delete(payloadCachePath, recursive: true);
+
+            var outsidePath = Path.Combine(fixture.Root.FullName, "outside-payload");
+            Directory.CreateDirectory(outsidePath);
+            var sentinelPath = Path.Combine(outsidePath, "sentinel.txt");
+            File.WriteAllText(sentinelPath, "preserve");
+            try
+            {
+                Directory.CreateSymbolicLink(payloadCachePath, outsidePath);
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+            {
+                return;
+            }
+
+            var secondHosted = new FakeHostedOperations(new List<string>());
+            var secondRunner = CreateRunner(secondHosted, fixture.ExecutePackageBuild);
+            var secondSpec = CreateGalleryReleaseSpec(
+                fixture.Root.FullName,
+                fixture.SecondStagingPath,
+                fixture.ModuleName);
+            AddDuplicatePackedArtefacts(
+                secondSpec,
+                fixture.Root.FullName,
+                fixture.ModuleName,
+                useExplicitIds: true);
+
+            var result = secondRunner.Run(secondSpec);
+
+            Assert.Equal("2.0.11", result.Plan.ResolvedVersion);
+            Assert.Equal(new[] { "2.0.11" }, secondHosted.PublishedModuleVersions);
+            Assert.False(Directory.Exists(payloadCachePath));
+            Assert.True(File.Exists(sentinelPath));
+            Assert.Equal("preserve", File.ReadAllText(sentinelPath));
+            Assert.Equal(2, fixture.PackageBuildCount());
+        }
+        finally
+        {
+            fixture.Dispose();
+        }
+    }
+
+    private static void AssertCorrectedRetryFailsClosed(
+        PrePublishCheckpointFixture fixture,
+        string expectedMessage)
+    {
+        var hosted = new FakeHostedOperations(new List<string>());
+        var runner = CreateRunner(hosted, fixture.ExecutePackageBuild);
+        var spec = CreateGalleryReleaseSpec(
+            fixture.Root.FullName,
+            fixture.SecondStagingPath,
+            fixture.ModuleName);
+        AddDuplicatePackedArtefacts(
+            spec,
+            fixture.Root.FullName,
+            fixture.ModuleName,
+            useExplicitIds: true);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+        Assert.Contains(expectedMessage, exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(hosted.PublishedModuleVersions);
+    }
+
+    private static PrePublishCheckpointFixture CreatePrePublishArtefactIdentityFailure()
+    {
+        const string moduleName = "TestModule";
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        var firstStagingPath = Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests.Staging",
+            Guid.NewGuid().ToString("N"));
+        var secondStagingPath = Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests.Staging",
+            Guid.NewGuid().ToString("N"));
+        var packageBuildCount = 0;
+
+        ProjectBuildHostExecutionResult ExecutePackageBuild(
+            ProjectBuildHostRequest request,
+            ProjectBuildConfiguration? configuration,
+            string? configPath)
+        {
+            packageBuildCount++;
+            return CreateProjectBuildResult(
+                root.FullName,
+                moduleName,
+                "2.0.11",
+                Path.Combine(root.FullName, "Artifacts", "NuGet"),
+                request,
+                configPath,
+                includePackage: false);
+        }
+
+        WriteMinimalModule(root.FullName, moduleName, "2.0.10");
+        WriteSynchronizedProjectBuildConfig(
+            root.FullName,
+            "project.build.json",
+            moduleName,
+            publishNuGet: false);
+
+        var hosted = new FakeHostedOperations(new List<string>());
+        var runner = CreateRunner(hosted, ExecutePackageBuild);
+        var spec = CreateGalleryReleaseSpec(root.FullName, firstStagingPath, moduleName);
+        AddDuplicatePackedArtefacts(spec, root.FullName, moduleName, useExplicitIds: false);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+        Assert.Contains("duplicate artefact identity", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(hosted.PublishedModuleVersions);
+        var checkpointPath = Assert.Single(Directory.GetFiles(
+            GetCoordinatedReleaseCheckpointRoot(root.FullName),
+            "*.json"));
+        var checkpointJson = File.ReadAllText(checkpointPath);
+        Assert.Contains("\"Version\": \"2.0.11\"", checkpointJson, StringComparison.Ordinal);
+        Assert.Contains("\"AttemptedOperations\": []", checkpointJson, StringComparison.Ordinal);
+        Assert.Contains("\"CompletedOperations\": []", checkpointJson, StringComparison.Ordinal);
+        Assert.Contains("\"AuxiliaryRemoteSideEffectsObserved\": false", checkpointJson, StringComparison.Ordinal);
+
+        return new PrePublishCheckpointFixture(
+            root,
+            firstStagingPath,
+            secondStagingPath,
+            moduleName,
+            checkpointPath,
+            ExecutePackageBuild,
+            () => packageBuildCount);
+    }
+
+    private sealed class PrePublishCheckpointFixture : IDisposable
+    {
+        public PrePublishCheckpointFixture(
+            DirectoryInfo root,
+            string firstStagingPath,
+            string secondStagingPath,
+            string moduleName,
+            string checkpointPath,
+            ModulePipelineRunnerDefaults.ModulePackageBuildExecutor executePackageBuild,
+            Func<int> packageBuildCount)
+        {
+            Root = root;
+            FirstStagingPath = firstStagingPath;
+            SecondStagingPath = secondStagingPath;
+            ModuleName = moduleName;
+            CheckpointPath = checkpointPath;
+            ExecutePackageBuild = executePackageBuild;
+            PackageBuildCount = packageBuildCount;
+        }
+
+        public DirectoryInfo Root { get; }
+        public string FirstStagingPath { get; }
+        public string SecondStagingPath { get; }
+        public string ModuleName { get; }
+        public string CheckpointPath { get; }
+        public ModulePipelineRunnerDefaults.ModulePackageBuildExecutor ExecutePackageBuild { get; }
+        public Func<int> PackageBuildCount { get; }
+
+        public void Dispose()
+        {
+            try { Root.Delete(recursive: true); } catch { }
+            try { if (Directory.Exists(FirstStagingPath)) Directory.Delete(FirstStagingPath, recursive: true); } catch { }
+            try { if (Directory.Exists(SecondStagingPath)) Directory.Delete(SecondStagingPath, recursive: true); } catch { }
+        }
+    }
+}

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseCheckpointTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseCheckpointTests.cs
@@ -738,6 +738,32 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             }
         };
 
+    private static void AddDuplicatePackedArtefacts(
+        ModulePipelineSpec spec,
+        string rootPath,
+        string moduleName,
+        bool useExplicitIds)
+    {
+        var outputPath = Path.Combine(rootPath, "Artifacts", "Module");
+        var artefacts = new[] { "Primary", "Secondary" }
+            .Select(id => new ConfigurationArtefactSegment
+            {
+                ArtefactType = ArtefactType.Packed,
+                Configuration = new ArtefactConfiguration
+                {
+                    ID = useExplicitIds ? id : null,
+                    Enabled = true,
+                    Path = outputPath,
+                    ArtefactName = $"{moduleName}.zip"
+                }
+            })
+            .Cast<IConfigurationSegment>();
+        spec.Segments = spec.Segments.Take(1)
+            .Concat(artefacts)
+            .Concat(spec.Segments.Skip(1))
+            .ToArray();
+    }
+
     private static ModulePipelineSpec CreateGitHubPostPublishSpec(
         string rootPath,
         string stagingPath,


### PR DESCRIPTION
## Summary

- safely discard coordinated-release checkpoints created before any publish operation or auxiliary remote side effect
- preserve fail-closed behavior for malformed checkpoints, bound payloads, and any attempted or completed remote work
- remove unbound payload caches safely, including reparse-point roots, before resetting the checkpoint

## Why it matters

A package lane can resolve and synchronize versions before a later pre-publish validation rejects corrected configuration such as duplicate artifact identities. Once the configuration is fixed, the release can now restart without manual checkpoint deletion—but only when the stored journal proves that nothing remote occurred.

## Tests

- exact reset, malformed topology, payload-cache, and reparse-point regressions: 5/5
- coordinated-release suite: 78/78
- full Release solution build: 0 warnings, 0 errors