### PR TITLE
Harden Apple governance update recovery

### DIFF
--- a/PowerForge.Tests/AppStoreConnectClientTests.ReviewDetails.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.ReviewDetails.cs
@@ -141,6 +141,52 @@ public sealed partial class AppStoreConnectClientTests
         Assert.Null(result.ErrorMessage);
     }
 
+    [Fact]
+    public async Task ReviewDetailsApplyReportsOnlySafeProviderClassification()
+    {
+        var handler = new ReviewDetailsCopyHandler { FailVersionMutation = true };
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var service = new AppStoreConnectReviewDetailsCopyService(client);
+        var spec = ReviewDetailsCopySpec();
+        var reviewed = await service.PlanAsync(spec);
+
+        var result = await service.ApplyAsync(spec, reviewed, confirmApply: true);
+
+        Assert.False(result.Success);
+        Assert.Equal("create-target-version", result.FailureOperation);
+        Assert.Equal(409, result.ProviderStatusCode);
+        Assert.Equal(["ENTITY_ERROR.ATTRIBUTE.INVALID"], result.ProviderErrorCodes);
+        Assert.Equal(["/data/attributes/versionString"], result.ProviderErrorPointers);
+        var serialized = JsonSerializer.Serialize(result);
+        foreach (var sensitive in ReviewDetailsCopyHandler.SensitiveValues)
+            Assert.DoesNotContain(sensitive, serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("provider secret detail", serialized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ReviewDetailsApplyRejectsSecretBearingProviderClassification()
+    {
+        const string secret = "DemoPassword123";
+        var handler = new ReviewDetailsCopyHandler
+        {
+            VersionFailureBody = $$"""{ "errors": [{ "status": "409", "code": "{{secret}}", "source": { "pointer": "/data/attributes/demoAccountPassword/{{secret}}" } }] }"""
+        };
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var service = new AppStoreConnectReviewDetailsCopyService(client);
+        var spec = ReviewDetailsCopySpec();
+        var reviewed = await service.PlanAsync(spec);
+
+        var result = await service.ApplyAsync(spec, reviewed, confirmApply: true);
+
+        Assert.False(result.Success);
+        Assert.Equal(409, result.ProviderStatusCode);
+        Assert.Empty(result.ProviderErrorCodes);
+        Assert.Empty(result.ProviderErrorPointers);
+        Assert.DoesNotContain(secret, JsonSerializer.Serialize(result), StringComparison.Ordinal);
+    }
+
     private static AppStoreConnectReviewDetailsInfo CompleteReviewDetails()
         => new()
         {
@@ -185,6 +231,10 @@ public sealed partial class AppStoreConnectClientTests
 
         public bool ApplyThenFailDetailsMutation { get; set; }
 
+        public bool FailVersionMutation { get; set; }
+
+        public string? VersionFailureBody { get; set; }
+
         public List<string> MutationBodies { get; } = new();
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -199,6 +249,11 @@ public sealed partial class AppStoreConnectClientTests
             if (request.Method == HttpMethod.Post && path.EndsWith("/appStoreVersions", StringComparison.Ordinal))
             {
                 MutationBodies.Add(await request.Content!.ReadAsStringAsync(cancellationToken));
+                if (FailVersionMutation || VersionFailureBody is not null)
+                {
+                    return Json(HttpStatusCode.Conflict,
+                        VersionFailureBody ?? """{ "errors": [{ "status": "409", "code": "ENTITY_ERROR.ATTRIBUTE.INVALID", "detail": "provider secret detail review@example.test", "source": { "pointer": "/data/attributes/versionString" } }] }""");
+                }
                 TargetVersionExists = true;
                 return Json(HttpStatusCode.Created,
                     """{ "data": { "type": "appStoreVersions", "id": "target-version", "attributes": { "versionString": "0.1.0", "platform": "MAC_OS", "appStoreState": "PREPARE_FOR_SUBMISSION" } } }""");

--- a/PowerForge.Tests/AppStoreConnectGovernanceTests.cs
+++ b/PowerForge.Tests/AppStoreConnectGovernanceTests.cs
@@ -222,8 +222,13 @@ public sealed partial class AppStoreConnectClientTests
 
         using var clearBody = JsonDocument.Parse(handler.RequestBodies[0]);
         using var unmanagedBody = JsonDocument.Parse(handler.RequestBodies[1]);
-        Assert.Equal(string.Empty, clearBody.RootElement.GetProperty("data").GetProperty("attributes").GetProperty("reviewNote").GetString());
-        Assert.False(unmanagedBody.RootElement.GetProperty("data").GetProperty("attributes").TryGetProperty("reviewNote", out _));
+        var clearAttributes = clearBody.RootElement.GetProperty("data").GetProperty("attributes");
+        var unmanagedAttributes = unmanagedBody.RootElement.GetProperty("data").GetProperty("attributes");
+        Assert.Equal(string.Empty, clearAttributes.GetProperty("reviewNote").GetString());
+        Assert.False(unmanagedAttributes.TryGetProperty("reviewNote", out _));
+        Assert.False(clearAttributes.TryGetProperty("subscriptionPeriod", out _));
+        Assert.False(unmanagedAttributes.TryGetProperty("subscriptionPeriod", out _));
+        Assert.False(clearAttributes.TryGetProperty("productId", out _));
     }
 
     [Fact]
@@ -705,6 +710,38 @@ public sealed partial class AppStoreConnectClientTests
         Assert.Equal(AppStoreConnectGovernanceChangeAction.Blocked, change.Action);
         Assert.Contains("group-current", change.Summary, StringComparison.Ordinal);
         Assert.Equal(HttpMethod.Get, Assert.Single(handler.Methods));
+    }
+
+    [Fact]
+    public async Task GovernancePlan_BlocksImmutableSubscriptionPeriodDriftBeforeMutation()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [ { "type": "subscriptionGroups", "id": "group-1", "attributes": { "referenceName": "Pro" } } ] }"""),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [] }"""),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [ { "type": "subscriptions", "id": "sub-1", "attributes": { "productId": "pro.monthly", "name": "Pro Monthly", "subscriptionPeriod": "ONE_MONTH", "familySharable": false } } ] }"""));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var plan = await new AppStoreConnectGovernanceService(client).PlanAsync(new AppStoreConnectGovernanceSpec
+        {
+            AppId = "app-1",
+            SubscriptionGroups = [new AppStoreConnectSubscriptionGroupSpec
+            {
+                ReferenceName = "Pro",
+                Subscriptions = [new AppStoreConnectSubscriptionSpec
+                {
+                    ProductId = "pro.monthly",
+                    Name = "Pro Monthly Updated",
+                    SubscriptionPeriod = "ONE_YEAR",
+                    FamilySharable = true
+                }]
+            }]
+        });
+
+        var change = Assert.Single(plan.Changes);
+        Assert.Equal(AppStoreConnectGovernanceChangeAction.Blocked, change.Action);
+        Assert.Contains("immutable", change.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal([HttpMethod.Get, HttpMethod.Get, HttpMethod.Get], handler.Methods);
     }
 
     [Fact]

--- a/PowerForge/Models/AppStoreConnectReviewDetailsModels.cs
+++ b/PowerForge/Models/AppStoreConnectReviewDetailsModels.cs
@@ -121,6 +121,18 @@ public sealed class AppStoreConnectReviewDetailsCopyResult
     /// <summary>Privacy-safe remediation message without contact values.</summary>
     public string? ErrorMessage { get; set; }
 
+    /// <summary>Privacy-safe operation stage that failed, when known.</summary>
+    public string? FailureOperation { get; set; }
+
+    /// <summary>HTTP status returned by App Store Connect, without response details.</summary>
+    public int? ProviderStatusCode { get; set; }
+
+    /// <summary>Validated App Store Connect error codes without messages or attribute values.</summary>
+    public string[] ProviderErrorCodes { get; set; } = Array.Empty<string>();
+
+    /// <summary>Validated JSON pointers identifying rejected request fields without their values.</summary>
+    public string[] ProviderErrorPointers { get; set; } = Array.Empty<string>();
+
     /// <summary>Plan that was approved and revalidated immediately before mutation.</summary>
     public AppStoreConnectReviewDetailsCopyPlan InitialPlan { get; set; } = new();
 

--- a/PowerForge/Services/AppStoreConnectClient.SubscriptionManagement.cs
+++ b/PowerForge/Services/AppStoreConnectClient.SubscriptionManagement.cs
@@ -139,7 +139,7 @@ public sealed partial class AppStoreConnectClient
             data = new
             {
                 type = "subscriptions",
-                attributes = BuildSubscriptionAttributes(spec, includeProductId: true),
+                attributes = BuildSubscriptionAttributes(spec, includeCreateOnlyAttributes: true),
                 relationships = new
                 {
                     group = new { data = new { type = "subscriptionGroups", id = subscriptionGroupId.Trim() } }
@@ -163,7 +163,7 @@ public sealed partial class AppStoreConnectClient
             {
                 type = "subscriptions",
                 id = subscriptionId.Trim(),
-                attributes = BuildSubscriptionAttributes(spec, includeProductId: false)
+                attributes = BuildSubscriptionAttributes(spec, includeCreateOnlyAttributes: false)
             }
         };
         return PatchSingleAsync(
@@ -379,19 +379,21 @@ public sealed partial class AppStoreConnectClient
             cancellationToken);
     }
 
-    private static object BuildSubscriptionAttributes(AppStoreConnectSubscriptionSpec spec, bool includeProductId)
+    private static object BuildSubscriptionAttributes(AppStoreConnectSubscriptionSpec spec, bool includeCreateOnlyAttributes)
     {
         var attributes = new Dictionary<string, object?>
         {
             ["name"] = spec.Name.Trim(),
             ["familySharable"] = spec.FamilySharable,
-            ["subscriptionPeriod"] = spec.SubscriptionPeriod.Trim().ToUpperInvariant(),
             ["groupLevel"] = spec.GroupLevel
         };
         if (spec.ReviewNote is not null)
             attributes["reviewNote"] = spec.ReviewNote.Trim();
-        if (includeProductId)
+        if (includeCreateOnlyAttributes)
+        {
             attributes["productId"] = spec.ProductId.Trim();
+            attributes["subscriptionPeriod"] = spec.SubscriptionPeriod.Trim().ToUpperInvariant();
+        }
         return attributes.Where(static pair => pair.Value is not null)
             .ToDictionary(static pair => pair.Key, static pair => pair.Value);
     }

--- a/PowerForge/Services/AppStoreConnectGovernanceService.cs
+++ b/PowerForge/Services/AppStoreConnectGovernanceService.cs
@@ -501,7 +501,13 @@ public sealed partial class AppStoreConnectGovernanceService
                     $"Create subscription '{desired.ProductId}'.", parentId: group.Id);
                 continue;
             }
-            if (!SubscriptionMatches(existing, desired))
+            if (!Same(existing.SubscriptionPeriod, desired.SubscriptionPeriod))
+            {
+                Add(changes, "Subscriptions", "Subscription", desired.ProductId, AppStoreConnectGovernanceChangeAction.Blocked,
+                    $"Subscription period is immutable after creation: Apple has '{existing.SubscriptionPeriod}' while governance declares '{desired.SubscriptionPeriod}'. Correct the declaration or create a deliberately reviewed replacement product.", existing.Id, group.Id);
+                continue;
+            }
+            if (!SubscriptionMutableFactsMatch(existing, desired))
             {
                 Add(changes, "Subscriptions", "Subscription", desired.ProductId, AppStoreConnectGovernanceChangeAction.Update,
                     $"Update subscription '{desired.ProductId}'.", existing.Id, group.Id);
@@ -590,7 +596,7 @@ public sealed partial class AppStoreConnectGovernanceService
     private static bool PriceMatches(AppStoreConnectAppPriceInfo actual, AppStoreConnectAppPriceSpec desired) => Same(actual.AppPricePointId, desired.AppPricePointId) && Same(actual.TerritoryId, desired.TerritoryId) && SameDate(actual.StartDate, desired.StartDate) && SameDate(actual.EndDate, desired.EndDate);
     private static bool EncryptionMatches(AppStoreConnectEncryptionDeclarationInfo actual, AppStoreConnectEncryptionDeclarationSpec desired) => Same(actual.AppDescription, desired.AppDescription) && actual.ContainsProprietaryCryptography == desired.ContainsProprietaryCryptography && actual.ContainsThirdPartyCryptography == desired.ContainsThirdPartyCryptography && actual.AvailableOnFrenchStore == desired.AvailableOnFrenchStore;
     private static bool IsUsableEncryptionDeclaration(AppStoreConnectEncryptionDeclarationInfo declaration) => Same(declaration.State, "APPROVED");
-    private static bool SubscriptionMatches(AppStoreConnectSubscriptionInfo actual, AppStoreConnectSubscriptionSpec desired) => Same(actual.Name, desired.Name) && Same(actual.SubscriptionPeriod, desired.SubscriptionPeriod) && (!desired.FamilySharable.HasValue || actual.FamilySharable == desired.FamilySharable) && (desired.ReviewNote is null || SameOptional(actual.ReviewNote, desired.ReviewNote)) && (!desired.GroupLevel.HasValue || actual.GroupLevel == desired.GroupLevel);
+    private static bool SubscriptionMutableFactsMatch(AppStoreConnectSubscriptionInfo actual, AppStoreConnectSubscriptionSpec desired) => Same(actual.Name, desired.Name) && (!desired.FamilySharable.HasValue || actual.FamilySharable == desired.FamilySharable) && (desired.ReviewNote is null || SameOptional(actual.ReviewNote, desired.ReviewNote)) && (!desired.GroupLevel.HasValue || actual.GroupLevel == desired.GroupLevel);
     private static bool SubscriptionPriceMatches(AppStoreConnectSubscriptionPriceInfo actual, AppStoreConnectSubscriptionPriceSpec desired) => Same(actual.TerritoryId, desired.TerritoryId) && Same(actual.SubscriptionPricePointId, desired.SubscriptionPricePointId) && SameDate(actual.StartDate, desired.StartDate) && (desired.PlanType is null || SameOptional(actual.PlanType, desired.PlanType)) && (!desired.PreserveCurrentPrice.HasValue || actual.Preserved == desired.PreserveCurrentPrice);
     private static bool SubscriptionIntroductoryOfferMatches(AppStoreConnectSubscriptionIntroductoryOfferInfo actual, AppStoreConnectSubscriptionIntroductoryOfferSpec desired, string territoryId) => Same(actual.TerritoryId, territoryId) && Same(actual.Duration, desired.Duration) && Same(actual.OfferMode, desired.OfferMode) && actual.NumberOfPeriods == desired.NumberOfPeriods && SameDate(actual.StartDate, desired.StartDate) && SameDate(actual.EndDate, desired.EndDate) && SameOptional(actual.SubscriptionPricePointId, desired.SubscriptionPricePointId);
     private static bool SubscriptionAvailabilityMatches(AppStoreConnectSubscriptionAvailabilityInfo actual, AppStoreConnectSubscriptionAvailabilitySpec desired) => actual.AvailableInNewTerritories == desired.AvailableInNewTerritories && new HashSet<string>(actual.TerritoryIds, StringComparer.OrdinalIgnoreCase).SetEquals(desired.TerritoryIds);

--- a/PowerForge/Services/AppStoreConnectReviewDetailsCopyService.cs
+++ b/PowerForge/Services/AppStoreConnectReviewDetailsCopyService.cs
@@ -1,12 +1,41 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace PowerForge;
 
 /// <summary>Copies private App Review contact settings between exact versions without serializing the values.</summary>
 public sealed class AppStoreConnectReviewDetailsCopyService
 {
+    private static readonly HashSet<string> SafeProviderErrorCodes = new(StringComparer.Ordinal)
+    {
+        "ENTITY_ERROR.ATTRIBUTE.INVALID",
+        "ENTITY_ERROR.ATTRIBUTE.REQUIRED",
+        "ENTITY_ERROR.ATTRIBUTE.UNMODIFIABLE",
+        "ENTITY_ERROR.RELATIONSHIP.INVALID",
+        "ENTITY_ERROR.RELATIONSHIP.REQUIRED"
+    };
+
+    private static readonly HashSet<string> SafeProviderErrorPointers = new(StringComparer.Ordinal)
+    {
+        "/data/attributes/platform",
+        "/data/attributes/versionString",
+        "/data/attributes/contactFirstName",
+        "/data/attributes/contactLastName",
+        "/data/attributes/contactPhone",
+        "/data/attributes/contactEmail",
+        "/data/attributes/demoAccountRequired",
+        "/data/attributes/demoAccountName",
+        "/data/attributes/demoAccountPassword",
+        "/data/relationships/app",
+        "/data/relationships/app/data",
+        "/data/relationships/app/data/id",
+        "/data/relationships/appStoreVersion",
+        "/data/relationships/appStoreVersion/data",
+        "/data/relationships/appStoreVersion/data/id"
+    };
+
     private readonly AppStoreConnectClient _client;
 
     /// <summary>Creates the service.</summary>
@@ -83,11 +112,13 @@ public sealed class AppStoreConnectReviewDetailsCopyService
 
         var targetVersionId = current.TargetVersionId;
         var createdVersion = false;
+        var operation = "revalidate-target";
         AppStoreConnectReviewDetailsInfo? existing = null;
         try
         {
             if (!current.TargetVersionExists)
             {
+                operation = "create-target-version";
                 var created = await _client.CreateVersionAsync(
                     spec.Target.AppId.Trim(),
                     spec.Target.VersionString.Trim(),
@@ -99,15 +130,23 @@ public sealed class AppStoreConnectReviewDetailsCopyService
             if (string.IsNullOrWhiteSpace(targetVersionId))
                 throw new InvalidOperationException("The exact target App Store version could not be resolved for App Review details.");
 
+            operation = "read-target-details";
             existing = await _client.GetReviewDetailsAsync(targetVersionId!, cancellationToken).ConfigureAwait(false);
             if (!string.Equals(existing is null ? null : ComputeDetailsFingerprint(existing), current.ObservedFingerprint, StringComparison.Ordinal))
                 throw new InvalidOperationException("Target App Review details changed after review.");
 
             if (existing is null)
+            {
+                operation = "create-review-details";
                 await _client.CreateReviewDetailsAsync(targetVersionId!, source, cancellationToken).ConfigureAwait(false);
+            }
             else
+            {
+                operation = "update-review-details";
                 await _client.UpdateReviewDetailsAsync(existing.Id, source, cancellationToken).ConfigureAwait(false);
+            }
 
+            operation = "verify-final-state";
             var final = await PlanAsync(spec, cancellationToken).ConfigureAwait(false);
             return new AppStoreConnectReviewDetailsCopyResult
             {
@@ -119,6 +158,7 @@ public sealed class AppStoreConnectReviewDetailsCopyService
                 ErrorMessage = final.IsConverged
                     ? null
                     : "App Review details did not converge after mutation. Contact values were suppressed; generate a new Plan before retrying.",
+                FailureOperation = final.IsConverged ? null : operation,
                 InitialPlan = current,
                 FinalPlan = final
             };
@@ -130,10 +170,11 @@ public sealed class AppStoreConnectReviewDetailsCopyService
             {
                 finalAfterFailure = await PlanAsync(spec, cancellationToken).ConfigureAwait(false);
             }
-            catch
+            catch (Exception replanError) when (replanError is not OperationCanceledException)
             {
                 finalAfterFailure = current;
             }
+            var providerError = ExtractProviderError(ex);
             var convergedAfterFailure = finalAfterFailure.IsConverged;
             return new AppStoreConnectReviewDetailsCopyResult
             {
@@ -144,7 +185,11 @@ public sealed class AppStoreConnectReviewDetailsCopyService
                 ErrorCode = convergedAfterFailure ? null : "APPLE_REVIEW_DETAILS_APPLY_FAILED",
                 ErrorMessage = convergedAfterFailure
                     ? null
-                    : "App Review details did not converge. Contact values were suppressed; rerun Plan to inspect the remaining non-sensitive state before retrying.",
+                    : "App Review details did not converge. Contact values and provider messages were suppressed; use the operation, status, codes, and pointers in this receipt before retrying.",
+                FailureOperation = convergedAfterFailure ? null : operation,
+                ProviderStatusCode = convergedAfterFailure ? null : providerError.StatusCode,
+                ProviderErrorCodes = convergedAfterFailure ? Array.Empty<string>() : providerError.Codes,
+                ProviderErrorPointers = convergedAfterFailure ? Array.Empty<string>() : providerError.Pointers,
                 InitialPlan = current,
                 FinalPlan = finalAfterFailure
             };
@@ -245,5 +290,72 @@ public sealed class AppStoreConnectReviewDetailsCopyService
         });
         using var sha256 = SHA256.Create();
         return BitConverter.ToString(sha256.ComputeHash(Encoding.UTF8.GetBytes(binding))).Replace("-", string.Empty).ToLowerInvariant();
+    }
+
+    private static ProviderErrorSummary ExtractProviderError(Exception exception)
+    {
+        var message = exception.Message ?? string.Empty;
+        int? statusCode = null;
+        var status = Regex.Match(message, @"failed \((?<status>[0-9]{3})(?:\s|\))", RegexOptions.CultureInvariant);
+        if (status.Success && int.TryParse(status.Groups["status"].Value, out var parsedStatus))
+            statusCode = parsedStatus;
+
+        var codes = new HashSet<string>(StringComparer.Ordinal);
+        var pointers = new HashSet<string>(StringComparer.Ordinal);
+        var jsonStart = message.IndexOf('{');
+        if (jsonStart >= 0)
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(message.Substring(jsonStart));
+                if (document.RootElement.TryGetProperty("errors", out var errors) && errors.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var error in errors.EnumerateArray())
+                    {
+                        AddAllowlistedValue(error, "code", codes, SafeProviderErrorCodes);
+                        if (error.TryGetProperty("source", out var source) && source.ValueKind == JsonValueKind.Object)
+                            AddAllowlistedValue(source, "pointer", pointers, SafeProviderErrorPointers);
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                // Provider messages are never copied when the structured response cannot be parsed safely.
+            }
+        }
+
+        return new ProviderErrorSummary(
+            statusCode,
+            codes.OrderBy(static value => value, StringComparer.Ordinal).Take(10).ToArray(),
+            pointers.OrderBy(static value => value, StringComparer.Ordinal).Take(10).ToArray());
+    }
+
+    private static void AddAllowlistedValue(
+        JsonElement element,
+        string propertyName,
+        HashSet<string> destination,
+        HashSet<string> allowlist)
+    {
+        if (!element.TryGetProperty(propertyName, out var property) || property.ValueKind != JsonValueKind.String)
+            return;
+        var value = property.GetString();
+        if (!string.IsNullOrWhiteSpace(value) && allowlist.Contains(value!))
+            destination.Add(value!);
+    }
+
+    private sealed class ProviderErrorSummary
+    {
+        public ProviderErrorSummary(int? statusCode, string[] codes, string[] pointers)
+        {
+            StatusCode = statusCode;
+            Codes = codes;
+            Pointers = pointers;
+        }
+
+        public int? StatusCode { get; }
+
+        public string[] Codes { get; }
+
+        public string[] Pointers { get; }
     }
 }


### PR DESCRIPTION
## Summary

- send only mutable subscription fields during App Store Connect subscription updates
- block immutable subscription-period drift during Plan instead of attempting an ineffective Apply
- preserve actionable but privacy-safe App Review failure classification with exact operation, numeric status, and fixed allowlisted provider codes/pointers
- propagate cancellation during protected replanning

## Why

The reviewed CasaRay Apply failed safely because the subscription update serialized Apple’s immutable `subscriptionPeriod`. The EmailIMO draft-version Apply also failed safely, but the privacy boundary removed the exact operation and safe provider classification needed for remediation. Neither attempt changed App Store Connect state.

## Validation

- 10 focused governance/review-details recovery tests
- 134 App Store Connect tests
- PowerForge net472, net8, and net10 builds with zero warnings
- PowerForge CLI net10 build with zero warnings
- independent read-only review plus one targeted confirmation
- diff checks clean

No credential, private-key, contact, demo-account, or provider-message content is added to receipts.