### PR TITLE
Make subscription governance plans exhaustive

### DIFF
--- a/PowerForge.Tests/AppStoreConnectGovernanceTests.cs
+++ b/PowerForge.Tests/AppStoreConnectGovernanceTests.cs
@@ -745,6 +745,70 @@ public sealed partial class AppStoreConnectClientTests
     }
 
     [Fact]
+    public async Task GovernancePlan_SurfacesChildDriftAlongsideExistingParentUpdates()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [ { "type": "subscriptionGroups", "id": "group-1", "attributes": { "referenceName": "Legacy Pro" } } ] }"""),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [] }"""),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [ { "type": "subscriptions", "id": "sub-1", "attributes": { "productId": "pro.monthly", "name": "Legacy Monthly", "subscriptionPeriod": "ONE_MONTH", "familySharable": false } } ] }"""),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [ { "type": "subscriptionLocalizations", "id": "loc-1", "attributes": { "locale": "en-US", "name": "Legacy Monthly", "description": "Old description" } } ] }"""),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [] }"""),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [] }"""),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [] }"""));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var plan = await new AppStoreConnectGovernanceService(client).PlanAsync(new AppStoreConnectGovernanceSpec
+        {
+            AppId = "app-1",
+            SubscriptionGroups = [new AppStoreConnectSubscriptionGroupSpec
+            {
+                Id = "group-1",
+                ReferenceName = "Pro",
+                Subscriptions = [new AppStoreConnectSubscriptionSpec
+                {
+                    ProductId = "pro.monthly",
+                    Name = "Pro Monthly",
+                    SubscriptionPeriod = "ONE_MONTH",
+                    FamilySharable = true,
+                    Localizations = [new AppStoreConnectSubscriptionLocalizationSpec
+                    {
+                        Locale = "en-US",
+                        Name = "Pro Monthly",
+                        Description = "New description"
+                    }],
+                    IntroductoryOffers = [new AppStoreConnectSubscriptionIntroductoryOfferSpec
+                    {
+                        Duration = "TWO_WEEKS",
+                        OfferMode = "FREE_TRIAL",
+                        NumberOfPeriods = 1,
+                        TerritoryIds = ["USA"]
+                    }],
+                    Availabilities = [new AppStoreConnectSubscriptionAvailabilitySpec
+                    {
+                        PlanType = "UPFRONT",
+                        AvailableInNewTerritories = true,
+                        TerritoryIds = ["USA"]
+                    }]
+                }]
+            }]
+        });
+
+        Assert.Equal(
+            ["SubscriptionGroup", "Subscription", "SubscriptionLocalization", "SubscriptionIntroductoryOffer", "SubscriptionPlanAvailability"],
+            plan.Changes.Select(change => change.ResourceType).ToArray());
+        Assert.Equal(
+            [AppStoreConnectGovernanceChangeAction.Update, AppStoreConnectGovernanceChangeAction.Update,
+                AppStoreConnectGovernanceChangeAction.Update, AppStoreConnectGovernanceChangeAction.Create,
+                AppStoreConnectGovernanceChangeAction.Create],
+            plan.Changes.Select(change => change.Action).ToArray());
+        Assert.Contains(handler.RequestUris, uri => uri.AbsolutePath.EndsWith("/subscriptions/sub-1/subscriptionLocalizations", StringComparison.Ordinal));
+        Assert.Contains(handler.RequestUris, uri => uri.AbsolutePath.EndsWith("/subscriptions/sub-1/prices", StringComparison.Ordinal));
+        Assert.Contains(handler.RequestUris, uri => uri.AbsolutePath.EndsWith("/subscriptions/sub-1/introductoryOffers", StringComparison.Ordinal));
+        Assert.Contains(handler.RequestUris, uri => uri.AbsolutePath.EndsWith("/subscriptions/sub-1/planAvailabilities", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task GovernancePlan_DetectsExplicitPreserveCurrentPriceDrift()
     {
         var handler = new SequenceHandler(

--- a/PowerForge/Services/AppStoreConnectGovernanceService.cs
+++ b/PowerForge/Services/AppStoreConnectGovernanceService.cs
@@ -468,7 +468,6 @@ public sealed partial class AppStoreConnectGovernanceService
             {
                 Add(changes, "Subscriptions", "SubscriptionGroup", groupKey, AppStoreConnectGovernanceChangeAction.Update,
                     $"Rename subscription group to '{desiredGroup.ReferenceName}'.", group.Id);
-                continue;
             }
             await PlanSubscriptionGroupChildrenAsync(desiredGroup, group, changes, cancellationToken).ConfigureAwait(false);
         }
@@ -511,7 +510,6 @@ public sealed partial class AppStoreConnectGovernanceService
             {
                 Add(changes, "Subscriptions", "Subscription", desired.ProductId, AppStoreConnectGovernanceChangeAction.Update,
                     $"Update subscription '{desired.ProductId}'.", existing.Id, group.Id);
-                continue;
             }
             await PlanSubscriptionChildrenAsync(desired, existing, changes, cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
## Summary

- keep planning existing subscription-group descendants when the group itself needs an Update
- keep planning existing subscription descendants when the subscription itself needs an Update
- preserve parent-first Apply ordering and exact replan comparison before each mutation

## Why

A reviewed CasaRay Plan showed only two parent subscription Updates. After the first safe PATCH, the protected replan exposed localization and introductory-offer drift that the original Plan had hidden behind a `continue`. Apply correctly stopped before any unreviewed child mutation, but the original Plan was not exhaustive.

This change makes the initial Plan expose all addressable child drift alongside existing parent updates. Parent creation and immutable-period branches remain staged because descendants lack a safe applicable parent identity.

## Validation

- 135 App Store Connect tests pass
- focused regression covers group Update, subscription Update, localization Update, price enumeration, introductory-offer Create, and availability Create in one Plan
- PowerForge net472, net8, and net10 builds pass with zero warnings
- independent read-only review found no actionable issues
- diff checks clean

No App Store Connect mutation is performed by this PR.