### PR TITLE
Block immutable subscription localization drift

### DIFF
--- a/PowerForge.Tests/AppStoreConnectGovernanceLocalizationTests.cs
+++ b/PowerForge.Tests/AppStoreConnectGovernanceLocalizationTests.cs
@@ -1,0 +1,183 @@
+using System.Net;
+using System.Net.Http;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class AppStoreConnectClientTests
+{
+    [Fact]
+    public void GovernanceConfiguration_RejectsSubscriptionLocalizationDescriptionsOverAppleLimit()
+    {
+        var findings = new AppStoreConnectGovernanceConfiguration().Validate(new AppStoreConnectGovernanceSpec
+        {
+            AppId = "app-1",
+            SubscriptionGroups = [new AppStoreConnectSubscriptionGroupSpec
+            {
+                ReferenceName = "Pro",
+                Subscriptions = [new AppStoreConnectSubscriptionSpec
+                {
+                    ProductId = "pro.monthly",
+                    Name = "Pro Monthly",
+                    SubscriptionPeriod = "ONE_MONTH",
+                    Localizations = [new AppStoreConnectSubscriptionLocalizationSpec
+                    {
+                        Locale = "en-US",
+                        Name = "Pro Monthly",
+                        Description = new string('x', 56)
+                    }]
+                }]
+            }]
+        });
+
+        var finding = Assert.Single(findings, item => item.Code == "Governance.Subscriptions.LocalizationDescriptionTooLong");
+        Assert.True(finding.IsError);
+        Assert.EndsWith(".description", finding.Path, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GovernanceConfiguration_ValidatesNormalizedSubscriptionLocalizationDescriptionLength()
+    {
+        var findings = new AppStoreConnectGovernanceConfiguration().Validate(new AppStoreConnectGovernanceSpec
+        {
+            AppId = "app-1",
+            SubscriptionGroups = [new AppStoreConnectSubscriptionGroupSpec
+            {
+                ReferenceName = "Pro",
+                Subscriptions = [new AppStoreConnectSubscriptionSpec
+                {
+                    ProductId = "pro.monthly",
+                    Name = "Pro Monthly",
+                    SubscriptionPeriod = "ONE_MONTH",
+                    Localizations = [new AppStoreConnectSubscriptionLocalizationSpec
+                    {
+                        Locale = "en-US",
+                        Name = "Pro Monthly",
+                        Description = " " + new string('x', 55) + " "
+                    }]
+                }]
+            }]
+        });
+
+        Assert.DoesNotContain(findings, item => item.Code == "Governance.Subscriptions.LocalizationDescriptionTooLong");
+    }
+
+    [Fact]
+    public async Task UpdateSubscriptionLocalizationAsync_RejectsDescriptionsOverAppleLimitBeforeHttp()
+    {
+        var handler = new SequenceHandler();
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => client.UpdateSubscriptionLocalizationAsync(
+            "localization-1",
+            new AppStoreConnectSubscriptionLocalizationSpec
+            {
+                Locale = "en-US",
+                Name = "Pro Monthly",
+                Description = new string('x', 56)
+            }));
+
+        Assert.Contains("55", exception.Message, StringComparison.Ordinal);
+        Assert.Empty(handler.Methods);
+    }
+
+    [Fact]
+    public async Task UpdateSubscriptionLocalizationAsync_AcceptsAndSendsNormalizedDescriptionAtAppleLimit()
+    {
+        var handler = new SequenceHandler(new SequenceResponse(HttpStatusCode.OK,
+            """{ "data": { "type": "subscriptionLocalizations", "id": "localization-1", "attributes": { "locale": "en-US", "name": "Pro Monthly", "description": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "state": "PREPARE_FOR_SUBMISSION" } } }"""));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var result = await client.UpdateSubscriptionLocalizationAsync(
+            "localization-1",
+            new AppStoreConnectSubscriptionLocalizationSpec
+            {
+                Locale = "en-US",
+                Name = "Pro Monthly",
+                Description = " " + new string('x', 55) + " "
+            });
+
+        Assert.Equal(new string('x', 55), result.Description);
+        using var body = System.Text.Json.JsonDocument.Parse(Assert.Single(handler.RequestBodies));
+        Assert.Equal(new string('x', 55), body.RootElement.GetProperty("data").GetProperty("attributes").GetProperty("description").GetString());
+    }
+
+    [Theory]
+    [InlineData("APPROVED")]
+    [InlineData("WAITING_FOR_REVIEW")]
+    [InlineData("FUTURE_STATE")]
+    public async Task GovernancePlan_BlocksDriftForImmutableSubscriptionLocalizationBeforeMutation(string state)
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [ { "type": "subscriptionGroups", "id": "group-1", "attributes": { "referenceName": "Pro" } } ] }"""),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [] }"""),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [ { "type": "subscriptions", "id": "sub-1", "attributes": { "productId": "pro.monthly", "name": "Pro Monthly", "subscriptionPeriod": "ONE_MONTH" } } ] }"""),
+            new SequenceResponse(HttpStatusCode.OK, $$"""{ "data": [ { "type": "subscriptionLocalizations", "id": "localization-1", "attributes": { "locale": "en-US", "name": "Pro Monthly", "description": "Accepted description", "state": "{{state}}" } } ] }"""),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [] }"""));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var plan = await new AppStoreConnectGovernanceService(client).PlanAsync(new AppStoreConnectGovernanceSpec
+        {
+            AppId = "app-1",
+            SubscriptionGroups = [new AppStoreConnectSubscriptionGroupSpec
+            {
+                ReferenceName = "Pro",
+                Subscriptions = [new AppStoreConnectSubscriptionSpec
+                {
+                    ProductId = "pro.monthly",
+                    Name = "Pro Monthly",
+                    SubscriptionPeriod = "ONE_MONTH",
+                    Localizations = [new AppStoreConnectSubscriptionLocalizationSpec
+                    {
+                        Locale = "en-US",
+                        Name = "Pro Monthly",
+                        Description = "Replacement description"
+                    }]
+                }]
+            }]
+        });
+
+        var change = Assert.Single(plan.Changes);
+        Assert.Equal("SubscriptionLocalization", change.ResourceType);
+        Assert.Equal(AppStoreConnectGovernanceChangeAction.Blocked, change.Action);
+        Assert.Contains(state, change.Summary, StringComparison.Ordinal);
+        Assert.All(handler.Methods, method => Assert.Equal(HttpMethod.Get, method));
+    }
+
+    [Theory]
+    [InlineData("APPROVED")]
+    [InlineData("WAITING_FOR_REVIEW")]
+    [InlineData("FUTURE_STATE")]
+    public async Task GovernancePlan_BlocksDriftForImmutableSubscriptionGroupLocalizationBeforeMutation(string state)
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [ { "type": "subscriptionGroups", "id": "group-1", "attributes": { "referenceName": "Pro" } } ] }"""),
+            new SequenceResponse(HttpStatusCode.OK, $$"""{ "data": [ { "type": "subscriptionGroupLocalizations", "id": "group-localization-1", "attributes": { "locale": "en-US", "name": "Accepted Pro", "state": "{{state}}" } } ] }"""),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [] }"""));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var plan = await new AppStoreConnectGovernanceService(client).PlanAsync(new AppStoreConnectGovernanceSpec
+        {
+            AppId = "app-1",
+            SubscriptionGroups = [new AppStoreConnectSubscriptionGroupSpec
+            {
+                ReferenceName = "Pro",
+                Localizations = [new AppStoreConnectSubscriptionGroupLocalizationSpec
+                {
+                    Locale = "en-US",
+                    Name = "Replacement Pro"
+                }]
+            }]
+        });
+
+        var change = Assert.Single(plan.Changes);
+        Assert.Equal("SubscriptionGroupLocalization", change.ResourceType);
+        Assert.Equal(AppStoreConnectGovernanceChangeAction.Blocked, change.Action);
+        Assert.Contains(state, change.Summary, StringComparison.Ordinal);
+        Assert.All(handler.Methods, method => Assert.Equal(HttpMethod.Get, method));
+    }
+}

--- a/PowerForge.Tests/AppStoreConnectGovernanceTests.cs
+++ b/PowerForge.Tests/AppStoreConnectGovernanceTests.cs
@@ -751,7 +751,7 @@ public sealed partial class AppStoreConnectClientTests
             new SequenceResponse(HttpStatusCode.OK, """{ "data": [ { "type": "subscriptionGroups", "id": "group-1", "attributes": { "referenceName": "Legacy Pro" } } ] }"""),
             new SequenceResponse(HttpStatusCode.OK, """{ "data": [] }"""),
             new SequenceResponse(HttpStatusCode.OK, """{ "data": [ { "type": "subscriptions", "id": "sub-1", "attributes": { "productId": "pro.monthly", "name": "Legacy Monthly", "subscriptionPeriod": "ONE_MONTH", "familySharable": false } } ] }"""),
-            new SequenceResponse(HttpStatusCode.OK, """{ "data": [ { "type": "subscriptionLocalizations", "id": "loc-1", "attributes": { "locale": "en-US", "name": "Legacy Monthly", "description": "Old description" } } ] }"""),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [ { "type": "subscriptionLocalizations", "id": "loc-1", "attributes": { "locale": "en-US", "name": "Legacy Monthly", "description": "Old description", "state": "PREPARE_FOR_SUBMISSION" } } ] }"""),
             new SequenceResponse(HttpStatusCode.OK, """{ "data": [] }"""),
             new SequenceResponse(HttpStatusCode.OK, """{ "data": [] }"""),
             new SequenceResponse(HttpStatusCode.OK, """{ "data": [] }"""));

--- a/PowerForge/Models/AppStoreConnectGovernanceModels.cs
+++ b/PowerForge/Models/AppStoreConnectGovernanceModels.cs
@@ -288,6 +288,7 @@ public sealed class AppStoreConnectSubscriptionLocalizationInfo
     public string? Locale { get; set; }
     public string? Name { get; set; }
     public string? Description { get; set; }
+    public string? State { get; set; }
 }
 
 public sealed class AppStoreConnectSubscriptionGroupLocalizationInfo
@@ -296,6 +297,7 @@ public sealed class AppStoreConnectSubscriptionGroupLocalizationInfo
     public string? Locale { get; set; }
     public string? Name { get; set; }
     public string? CustomAppName { get; set; }
+    public string? State { get; set; }
 }
 
 public sealed class AppStoreConnectSubscriptionPriceInfo

--- a/PowerForge/Services/AppStoreConnectClient.SubscriptionManagement.cs
+++ b/PowerForge/Services/AppStoreConnectClient.SubscriptionManagement.cs
@@ -406,7 +406,8 @@ public sealed partial class AppStoreConnectClient
             Id = GetString(item, "id") ?? string.Empty,
             Locale = GetString(attributes, "locale"),
             Name = GetString(attributes, "name"),
-            CustomAppName = GetString(attributes, "customAppName")
+            CustomAppName = GetString(attributes, "customAppName"),
+            State = GetString(attributes, "state")
         };
     }
 
@@ -418,7 +419,8 @@ public sealed partial class AppStoreConnectClient
             Id = GetString(item, "id") ?? string.Empty,
             Locale = GetString(attributes, "locale"),
             Name = GetString(attributes, "name"),
-            Description = GetString(attributes, "description")
+            Description = GetString(attributes, "description"),
+            State = GetString(attributes, "state")
         };
     }
 
@@ -478,6 +480,8 @@ public sealed partial class AppStoreConnectClient
         if (spec is null) throw new ArgumentNullException(nameof(spec));
         RequireValue(spec.Locale, nameof(spec), "Locale");
         RequireValue(spec.Name, nameof(spec), "Name");
+        if (Normalize(spec.Description) is { Length: > 55 })
+            throw new ArgumentException("Subscription localization Description must not exceed 55 characters.", nameof(spec));
     }
 
     private static void ValidateSubscription(AppStoreConnectSubscriptionSpec spec)

--- a/PowerForge/Services/AppStoreConnectGovernanceConfiguration.cs
+++ b/PowerForge/Services/AppStoreConnectGovernanceConfiguration.cs
@@ -197,6 +197,8 @@ public sealed class AppStoreConnectGovernanceConfiguration
             if (item is null) { Error(findings, "Governance.Subscriptions.NullLocalization", path, "Localization must not be null."); continue; }
             Required(findings, item.Locale, path + ".locale", "Governance.Subscriptions.Locale", "Locale is required.");
             Required(findings, item.Name, path + ".name", "Governance.Subscriptions.LocalizationName", "Localized name is required.");
+            if (item.Description?.Trim() is { Length: > 55 })
+                Error(findings, "Governance.Subscriptions.LocalizationDescriptionTooLong", path + ".description", "Localized description must not exceed 55 characters.");
         }
     }
 

--- a/PowerForge/Services/AppStoreConnectGovernanceService.cs
+++ b/PowerForge/Services/AppStoreConnectGovernanceService.cs
@@ -487,7 +487,19 @@ public sealed partial class AppStoreConnectGovernanceService
             if (existing is null)
                 Add(changes, "Subscriptions", "SubscriptionGroupLocalization", key, AppStoreConnectGovernanceChangeAction.Create, $"Create group localization '{desired.Locale}'.", parentId: group.Id);
             else if (!Same(existing.Name, desired.Name) || !SameOptional(existing.CustomAppName, desired.CustomAppName))
-                Add(changes, "Subscriptions", "SubscriptionGroupLocalization", key, AppStoreConnectGovernanceChangeAction.Update, $"Update group localization '{desired.Locale}'.", existing.Id, group.Id);
+            {
+                if (!SubscriptionLocalizationCanUpdate(existing.State))
+                {
+                    var observedState = string.IsNullOrWhiteSpace(existing.State) ? "unknown" : existing.State;
+                    Add(changes, "Subscriptions", "SubscriptionGroupLocalization", key, AppStoreConnectGovernanceChangeAction.Blocked,
+                        $"Subscription group localization '{desired.Locale}' is {observedState} and cannot be safely edited. Align governance with the accepted App Store Connect localization.", existing.Id, group.Id);
+                }
+                else
+                {
+                    Add(changes, "Subscriptions", "SubscriptionGroupLocalization", key, AppStoreConnectGovernanceChangeAction.Update,
+                        $"Update group localization '{desired.Locale}'.", existing.Id, group.Id);
+                }
+            }
         }
 
         var subscriptions = await _client.GetSubscriptionsAsync(group.Id, cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -529,7 +541,19 @@ public sealed partial class AppStoreConnectGovernanceService
             if (existing is null)
                 Add(changes, "Subscriptions", "SubscriptionLocalization", key, AppStoreConnectGovernanceChangeAction.Create, $"Create subscription localization '{desiredLocalization.Locale}'.", parentId: subscription.Id);
             else if (!Same(existing.Name, desiredLocalization.Name) || !SameOptional(existing.Description, desiredLocalization.Description))
-                Add(changes, "Subscriptions", "SubscriptionLocalization", key, AppStoreConnectGovernanceChangeAction.Update, $"Update subscription localization '{desiredLocalization.Locale}'.", existing.Id, subscription.Id);
+            {
+                if (!SubscriptionLocalizationCanUpdate(existing.State))
+                {
+                    var observedState = string.IsNullOrWhiteSpace(existing.State) ? "unknown" : existing.State;
+                    Add(changes, "Subscriptions", "SubscriptionLocalization", key, AppStoreConnectGovernanceChangeAction.Blocked,
+                        $"Subscription localization '{desiredLocalization.Locale}' is {observedState} and cannot be safely edited. Align governance with the accepted App Store Connect localization.", existing.Id, subscription.Id);
+                }
+                else
+                {
+                    Add(changes, "Subscriptions", "SubscriptionLocalization", key, AppStoreConnectGovernanceChangeAction.Update,
+                        $"Update subscription localization '{desiredLocalization.Locale}'.", existing.Id, subscription.Id);
+                }
+            }
         }
 
         var prices = await _client.GetSubscriptionPricesAsync(subscription.Id, cancellationToken).ConfigureAwait(false);
@@ -569,6 +593,9 @@ public sealed partial class AppStoreConnectGovernanceService
             }
         }
     }
+
+    private static bool SubscriptionLocalizationCanUpdate(string? state) =>
+        Same(state, "PREPARE_FOR_SUBMISSION") || Same(state, "REJECTED");
 
     private static void Add(List<AppStoreConnectGovernanceChange> changes, string section, string type, string key,
         AppStoreConnectGovernanceChangeAction action, string summary, string? resourceId = null, string? parentId = null) =>


### PR DESCRIPTION
## Summary

- capture App Store Connect lifecycle state for subscription and subscription-group localizations
- fail closed during governance planning when localization drift is not in a known editable state
- validate subscription descriptions against the Apple 55-character limit after the same normalization used for transport
- cover approved, in-review, unknown, editable, over-limit, and exact-boundary behavior

## Why

A guarded CasaRay governance apply proved that App Store Connect rejects edits to accepted subscription localizations. The previous planner still represented that drift as executable, so a reviewed apply could reach a provider 409 after earlier mutations. This change moves the provider constraint into the read-only plan and blocks the whole apply before mutation.

This does not alter CasaRay or App Store Connect data. A follow-up CasaRay PR will align tracked descriptions with the already accepted store text, leaving only the separately approved yearly subscription update.

## Validation

- 145 App Store Connect tests
- PowerForge builds for net472, net8.0, and net10.0 with zero warnings
- independent local review plus one targeted confirmation; both findings addressed