### PR TITLE
fix(release): recover local-only coordinated checkpoints

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PublishOperations.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PublishOperations.cs
@@ -62,7 +62,8 @@ public sealed partial class ModulePipelineRunner
 
     private void PreflightSynchronizedPackageGitHubRetrySafety(
         ModulePipelinePlan plan,
-        ModulePipelineRunState state)
+        ModulePipelineRunState state,
+        bool onlyAvailableResults = false)
     {
         if (state.SynchronizedReleaseCheckpoint is null)
             return;
@@ -82,8 +83,14 @@ public sealed partial class ModulePipelineRunner
             if (ShouldSkipSynchronizedReleaseOperation(state, operationKey))
                 continue;
 
+            if (!TryGetProjectBuildReleaseForCoordinatedGitHubPreflight(state, segment, out var release))
+            {
+                if (onlyAvailableResults)
+                    continue;
+                throw CreateMissingCoordinatedGitHubPreflightReleaseException();
+            }
+
             var configPath = ResolvePackageBuildPath(plan.ProjectRoot, segment.Configuration.ConfigPath);
-            var release = RequireProjectBuildReleaseForCoordinatedGitHubPreflight(state, segment);
             ValidateCoordinatedProjectBuildGitHubRetrySafety(
                 LoadProjectBuildConfiguration(configPath, segment.Configuration),
                 release);
@@ -104,26 +111,38 @@ public sealed partial class ModulePipelineRunner
             if (ShouldSkipSynchronizedReleaseOperation(state, operationKey))
                 continue;
 
-            var release = RequireProjectBuildReleaseForCoordinatedGitHubPreflight(state, segment);
+            if (!TryGetProjectBuildReleaseForCoordinatedGitHubPreflight(state, segment, out var release))
+            {
+                if (onlyAvailableResults)
+                    continue;
+                throw CreateMissingCoordinatedGitHubPreflightReleaseException();
+            }
+
             ValidateCoordinatedProjectBuildGitHubRetrySafety(
                 MapPackageBuildConfiguration(segment.Configuration, plan.ProjectRoot),
                 release);
         }
     }
 
-    private static DotNetRepositoryReleaseResult RequireProjectBuildReleaseForCoordinatedGitHubPreflight(
+    private static bool TryGetProjectBuildReleaseForCoordinatedGitHubPreflight(
         ModulePipelineRunState state,
-        object segment)
+        object segment,
+        out DotNetRepositoryReleaseResult release)
     {
         if (state.PackageBuildResultsBySegment.TryGetValue(segment, out var existing) &&
             existing.Result.Release is not null)
         {
-            return existing.Result.Release;
+            release = existing.Result.Release;
+            return true;
         }
 
-        throw new InvalidOperationException(
-            "Coordinated GitHub retry preflight requires the planned package release result before any remote publish destination can run.");
+        release = null!;
+        return false;
     }
+
+    private static InvalidOperationException CreateMissingCoordinatedGitHubPreflightReleaseException()
+        => new(
+            "Coordinated GitHub retry preflight requires the planned package release result before any remote publish destination can run.");
 
     private static void ValidateCoordinatedProjectBuildGitHubRetrySafety(
         ProjectBuildConfiguration configuration,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Phases.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Phases.cs
@@ -24,6 +24,7 @@ public sealed partial class ModulePipelineRunner
             ExecutePackageBuildsBeforeModule(plan, session, state);
             SynchronizeModuleVersionFromReleaseSource(plan, state);
             InitializeSynchronizedReleaseCheckpoint(plan, state);
+            PreflightSynchronizedPackageGitHubRetrySafety(plan, state, onlyAvailableResults: true);
         }
 
         ExecuteActions(ModulePipelineActionStage.BeforeDependencies, plan, session, state);
@@ -35,6 +36,7 @@ public sealed partial class ModulePipelineRunner
             ExecutePackageBuildsBeforeModule(plan, session, state);
             SynchronizeModuleVersionFromReleaseSource(plan, state);
             InitializeSynchronizedReleaseCheckpoint(plan, state);
+            PreflightSynchronizedPackageGitHubRetrySafety(plan, state, onlyAvailableResults: true);
         }
 
         ExecuteActions(ModulePipelineActionStage.BeforeVersioning, plan, session, state);

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpoint.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpoint.cs
@@ -56,7 +56,7 @@ public sealed partial class ModulePipelineRunner
 
         if (!shouldUseCheckpoint && !sourceMutatingGate)
         {
-            if (IsResettableSynchronizedReleaseCheckpoint(checkpoint))
+            if (IsResettableSynchronizedReleaseCheckpoint(checkpoint, path))
             {
                 DeleteResettableSynchronizedReleaseCheckpoint(
                     path,
@@ -70,7 +70,7 @@ public sealed partial class ModulePipelineRunner
 
         if (sourceMutatingGate)
         {
-            if (IsResettableSynchronizedReleaseCheckpoint(checkpoint))
+            if (IsResettableSynchronizedReleaseCheckpoint(checkpoint, path))
             {
                 DeleteResettableSynchronizedReleaseCheckpoint(
                     path,
@@ -86,7 +86,7 @@ public sealed partial class ModulePipelineRunner
         {
             ValidateSynchronizedReleaseCheckpoint(plan, state, checkpoint, path);
         }
-        catch (InvalidOperationException) when (IsResettableSynchronizedReleaseCheckpoint(checkpoint))
+        catch (InvalidOperationException) when (IsResettableSynchronizedReleaseCheckpoint(checkpoint, path))
         {
             DeleteResettableSynchronizedReleaseCheckpoint(
                 path,
@@ -712,90 +712,7 @@ public sealed partial class ModulePipelineRunner
             ? "none"
             : $"{checkpoint.CompletedOperations.Length} of {checkpoint.PlannedOperations.Length}";
 
-    private void DeleteResettableSynchronizedReleaseCheckpoint(string path, string reason)
-    {
-        var payloadCachePath = ResolveSynchronizedReleasePayloadCachePath(path);
-        if (Directory.Exists(payloadCachePath))
-        {
-            if ((File.GetAttributes(payloadCachePath) & FileAttributes.ReparsePoint) != 0)
-                Directory.Delete(payloadCachePath, recursive: false);
-            else
-                DeleteDirectoryWithRetries(payloadCachePath);
-        }
-        else if (File.Exists(payloadCachePath))
-            File.Delete(payloadCachePath);
-
-        File.Delete(path);
-        DeleteEmptySynchronizedReleaseCheckpointDirectories(path);
-        _logger.Warn($"Discarded unused coordinated release checkpoint '{path}' {reason}.");
-    }
-
-    private static bool IsResettableSynchronizedReleaseCheckpoint(
-        SynchronizedReleaseCheckpoint checkpoint)
-        => !string.IsNullOrWhiteSpace(checkpoint.ModuleName) &&
-           Enum.IsDefined(typeof(ReleaseVersionSource), checkpoint.ReleaseSource) &&
-           (checkpoint.PrimaryProject is null || !string.IsNullOrWhiteSpace(checkpoint.PrimaryProject)) &&
-           checkpoint.Version is not null &&
-           checkpoint.PlannedOperations is { Length: > 0 } &&
-           checkpoint.PlannedOperations.All(IsSynchronizedReleaseFingerprint) &&
-           checkpoint.PlannedOperations.Distinct(StringComparer.OrdinalIgnoreCase).Count() == checkpoint.PlannedOperations.Length &&
-           checkpoint.AttemptedOperations is { Length: 0 } &&
-           checkpoint.CompletedOperations is { Length: 0 } &&
-           checkpoint.OperationFingerprints is { Length: > 0 } &&
-           checkpoint.OperationFingerprints.All(IsSynchronizedReleaseFingerprint) &&
-           checkpoint.SourceFingerprint is not null &&
-           checkpoint.SourceFingerprint.Length == 0 &&
-           checkpoint.SourceComponents is { Length: 0 } &&
-           checkpoint.PayloadFingerprint is not null &&
-           checkpoint.PayloadFingerprint.Length == 0 &&
-           checkpoint.PayloadComponents is { Length: 0 } &&
-           checkpoint.PlannedLanes is { Length: > 0 } &&
-           checkpoint.PlannedLanes.All(IsSynchronizedReleaseFingerprint) &&
-           checkpoint.PlannedLanes.Distinct(StringComparer.OrdinalIgnoreCase).Count() == checkpoint.PlannedLanes.Length &&
-           checkpoint.CreatedUtc != default &&
-           (checkpoint.Version.Length == 0 ||
-            PackageVersionUtility.TryNormalizeExact(checkpoint.Version, out _)) &&
-           checkpoint.AttemptedLanes is not null &&
-           checkpoint.AttemptedLanes.Distinct(StringComparer.OrdinalIgnoreCase).Count() == checkpoint.AttemptedLanes.Length &&
-           checkpoint.AttemptedLanes.All(lane =>
-               !string.IsNullOrWhiteSpace(lane) &&
-               checkpoint.PlannedLanes!.Contains(lane, StringComparer.OrdinalIgnoreCase)) &&
-           checkpoint.Lanes is not null &&
-           checkpoint.Lanes.Length == checkpoint.AttemptedLanes.Length &&
-           checkpoint.Lanes
-               .Select(lane => lane?.CheckpointKey)
-               .Where(key => !string.IsNullOrWhiteSpace(key))
-               .Distinct(StringComparer.OrdinalIgnoreCase)
-               .Count() == checkpoint.Lanes.Length &&
-           checkpoint.Lanes.All(lane =>
-               lane is not null &&
-               Enum.IsDefined(typeof(ReleaseVersionSource), lane.Source) &&
-               !string.IsNullOrWhiteSpace(lane.Label) &&
-               IsSynchronizedReleaseFingerprint(lane.CheckpointKey) &&
-               checkpoint.AttemptedLanes!.Contains(lane.CheckpointKey, StringComparer.OrdinalIgnoreCase) &&
-               PackageVersionUtility.TryNormalizeExact(lane.DefaultVersion, out _) &&
-               lane.VersionsByProject is not null &&
-               lane.VersionsByProject.All(entry =>
-                   !string.IsNullOrWhiteSpace(entry.Key) &&
-                   PackageVersionUtility.TryNormalizeExact(entry.Value, out _))) &&
-           !checkpoint.AuxiliaryRemoteSideEffectsObserved;
-
     private static string? NormalizeCheckpointValue(string? value)
         => string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
-
-    private static bool IsSynchronizedReleaseFingerprint(string? value)
-        => value?.Length == 64 && value.All(static character =>
-            character is >= '0' and <= '9' or >= 'a' and <= 'f' or >= 'A' and <= 'F');
-
-    private static bool IsValidSynchronizedReleaseFingerprintState(
-        string? fingerprint,
-        string[] components)
-        => IsSynchronizedReleaseFingerprint(fingerprint) &&
-           components.Length > 0 &&
-           components.All(static component => !string.IsNullOrWhiteSpace(component)) &&
-           string.Equals(
-               fingerprint,
-               CreateSynchronizedReleaseFingerprint(components),
-               StringComparison.OrdinalIgnoreCase);
 
 }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpointReset.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpointReset.cs
@@ -1,0 +1,335 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace PowerForge;
+
+public sealed partial class ModulePipelineRunner
+{
+    private void DeleteResettableSynchronizedReleaseCheckpoint(string path, string reason)
+    {
+        var payloadCachePath = ResolveSynchronizedReleasePayloadCachePath(path);
+        if (Directory.Exists(payloadCachePath))
+        {
+            if ((File.GetAttributes(payloadCachePath) & FileAttributes.ReparsePoint) != 0)
+                Directory.Delete(payloadCachePath, recursive: false);
+            else
+                DeleteDirectoryWithRetries(payloadCachePath);
+        }
+        else if (File.Exists(payloadCachePath))
+            File.Delete(payloadCachePath);
+
+        File.Delete(path);
+        DeleteEmptySynchronizedReleaseCheckpointDirectories(path);
+        _logger.Warn($"Discarded unused coordinated release checkpoint '{path}' {reason}.");
+    }
+
+    private static bool IsResettableSynchronizedReleaseCheckpoint(
+        SynchronizedReleaseCheckpoint checkpoint,
+        string checkpointPath)
+    {
+        var hasNoBoundPayload = checkpoint.SourceFingerprint is not null &&
+                                checkpoint.SourceFingerprint.Length == 0 &&
+                                checkpoint.SourceComponents is { Length: 0 } &&
+                                checkpoint.PayloadFingerprint is not null &&
+                                checkpoint.PayloadFingerprint.Length == 0 &&
+                                checkpoint.PayloadComponents is { Length: 0 };
+        var hasValidBoundPayload = checkpoint.SourceComponents is not null &&
+                                   checkpoint.PayloadComponents is not null &&
+                                   IsValidSynchronizedReleaseFingerprintState(
+                                       checkpoint.SourceFingerprint,
+                                       checkpoint.SourceComponents) &&
+                                   IsValidSynchronizedReleaseFingerprintState(
+                                       checkpoint.PayloadFingerprint,
+                                       checkpoint.PayloadComponents) &&
+                                   IsExactSynchronizedReleasePayloadCache(
+                                       checkpointPath,
+                                       checkpoint.PayloadComponents);
+
+        return !string.IsNullOrWhiteSpace(checkpoint.ModuleName) &&
+           Enum.IsDefined(typeof(ReleaseVersionSource), checkpoint.ReleaseSource) &&
+           (checkpoint.PrimaryProject is null || !string.IsNullOrWhiteSpace(checkpoint.PrimaryProject)) &&
+           checkpoint.Version is not null &&
+           checkpoint.PlannedOperations is { Length: > 0 } &&
+           checkpoint.PlannedOperations.All(IsSynchronizedReleaseFingerprint) &&
+           checkpoint.PlannedOperations.Distinct(StringComparer.OrdinalIgnoreCase).Count() == checkpoint.PlannedOperations.Length &&
+           checkpoint.AttemptedOperations is { Length: 0 } &&
+           checkpoint.CompletedOperations is { Length: 0 } &&
+           checkpoint.OperationFingerprints is { Length: > 0 } &&
+           checkpoint.OperationFingerprints.All(IsSynchronizedReleaseFingerprint) &&
+           (hasNoBoundPayload || hasValidBoundPayload) &&
+           checkpoint.PlannedLanes is { Length: > 0 } &&
+           checkpoint.PlannedLanes.All(IsSynchronizedReleaseFingerprint) &&
+           checkpoint.PlannedLanes.Distinct(StringComparer.OrdinalIgnoreCase).Count() == checkpoint.PlannedLanes.Length &&
+           checkpoint.CreatedUtc != default &&
+           (checkpoint.Version.Length == 0 ||
+            PackageVersionUtility.TryNormalizeExact(checkpoint.Version, out _)) &&
+           checkpoint.AttemptedLanes is not null &&
+           checkpoint.AttemptedLanes.Distinct(StringComparer.OrdinalIgnoreCase).Count() == checkpoint.AttemptedLanes.Length &&
+           checkpoint.AttemptedLanes.All(lane =>
+               !string.IsNullOrWhiteSpace(lane) &&
+               checkpoint.PlannedLanes!.Contains(lane, StringComparer.OrdinalIgnoreCase)) &&
+           checkpoint.Lanes is not null &&
+           checkpoint.Lanes.Length == checkpoint.AttemptedLanes.Length &&
+           checkpoint.Lanes
+               .Select(lane => lane?.CheckpointKey)
+               .Where(key => !string.IsNullOrWhiteSpace(key))
+               .Distinct(StringComparer.OrdinalIgnoreCase)
+               .Count() == checkpoint.Lanes.Length &&
+           checkpoint.Lanes.All(lane =>
+               lane is not null &&
+               Enum.IsDefined(typeof(ReleaseVersionSource), lane.Source) &&
+               !string.IsNullOrWhiteSpace(lane.Label) &&
+               IsSynchronizedReleaseFingerprint(lane.CheckpointKey) &&
+               checkpoint.AttemptedLanes!.Contains(lane.CheckpointKey, StringComparer.OrdinalIgnoreCase) &&
+               PackageVersionUtility.TryNormalizeExact(lane.DefaultVersion, out _) &&
+               lane.VersionsByProject is not null &&
+               lane.VersionsByProject.All(entry =>
+                   !string.IsNullOrWhiteSpace(entry.Key) &&
+                   PackageVersionUtility.TryNormalizeExact(entry.Value, out _))) &&
+           !checkpoint.AuxiliaryRemoteSideEffectsObserved;
+    }
+
+    private static bool IsExactSynchronizedReleasePayloadCache(
+        string checkpointPath,
+        string[] expectedComponents)
+    {
+        try
+        {
+            var cachePath = ResolveSynchronizedReleasePayloadCachePath(checkpointPath);
+            if (!IsNormalSynchronizedReleaseCacheDirectory(cachePath))
+                return false;
+            RequireNormalSynchronizedReleaseCacheTree(cachePath);
+            var rootEntries = RequireOnlyChildDirectories(cachePath);
+            var rootNames = rootEntries.Select(Path.GetFileName).ToArray();
+            if (!rootNames.Contains("module", StringComparer.Ordinal) ||
+                rootNames.Distinct(StringComparer.Ordinal).Count() != rootNames.Length ||
+                rootNames.Any(name => name is not ("module" or "artefact" or "package-lane")))
+            {
+                return false;
+            }
+
+            var components = new List<string>();
+            foreach (var identity in expectedComponents.Where(static component =>
+                         component.EndsWith("|identity", StringComparison.Ordinal)))
+            {
+                if (!IsValidSynchronizedReleasePayloadIdentity(identity))
+                    return false;
+                components.Add(identity);
+            }
+            AddSynchronizedReleaseExactPayloadPath(
+                components,
+                "module",
+                RequireSynchronizedReleaseCacheDirectory(cachePath, "module"));
+
+            AddCachedSynchronizedReleaseArtefactComponents(cachePath, components);
+            AddCachedSynchronizedReleasePackageComponents(cachePath, components);
+            components.Sort(StringComparer.Ordinal);
+
+            return expectedComponents.SequenceEqual(components, StringComparer.Ordinal);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private static void AddCachedSynchronizedReleaseArtefactComponents(
+        string cachePath,
+        ICollection<string> components)
+    {
+        var artefactRoot = Path.Combine(cachePath, "artefact");
+        if (!Directory.Exists(artefactRoot))
+            return;
+        RequireNormalSynchronizedReleaseCacheTree(artefactRoot);
+
+        var artefactPaths = RequireOnlyChildDirectories(artefactRoot);
+        if (artefactPaths.Length == 0)
+            throw new InvalidOperationException("The coordinated release artefact cache is empty.");
+        foreach (var artefactPath in artefactPaths)
+        {
+            var cacheKey = Path.GetFileName(artefactPath);
+            if (!IsSynchronizedReleaseFingerprint(cacheKey))
+                throw new InvalidOperationException("The coordinated release artefact cache key is invalid.");
+
+            AddSynchronizedReleasePayloadIdentity(components, $"artefact/{cacheKey}|identity");
+            AddSynchronizedReleaseExactPayloadPath(
+                components,
+                $"artefact/{cacheKey}/payload",
+                ResolveSingleCachedSynchronizedReleasePayloadPath(artefactPath, allowDirectory: true));
+        }
+    }
+
+    private static void AddCachedSynchronizedReleasePackageComponents(
+        string cachePath,
+        ICollection<string> components)
+    {
+        var laneRoot = Path.Combine(cachePath, "package-lane");
+        if (!Directory.Exists(laneRoot))
+            return;
+        RequireNormalSynchronizedReleaseCacheTree(laneRoot);
+
+        var lanePaths = RequireOnlyChildDirectories(laneRoot);
+        if (lanePaths.Length == 0)
+            throw new InvalidOperationException("The coordinated release package lane cache is empty.");
+        foreach (var lanePath in lanePaths)
+        {
+            var laneKey = Path.GetFileName(lanePath);
+            if (!IsSynchronizedReleaseFingerprint(laneKey))
+                throw new InvalidOperationException("The coordinated release package lane cache key is invalid.");
+            AddSynchronizedReleasePayloadIdentity(components, $"package-lane/{laneKey}|identity");
+
+            var projectRoot = RequireOnlySynchronizedReleaseCacheDirectory(lanePath, "project");
+            var projectPaths = RequireOnlyChildDirectories(projectRoot);
+            if (projectPaths.Length == 0)
+                throw new InvalidOperationException("The coordinated release project cache is empty.");
+            foreach (var projectPath in projectPaths)
+            {
+                var projectKey = Path.GetFileName(projectPath);
+                if (!IsSynchronizedReleaseFingerprint(projectKey))
+                    throw new InvalidOperationException("The coordinated release project cache key is invalid.");
+                AddSynchronizedReleasePayloadIdentity(
+                    components,
+                    $"package-lane/{laneKey}/project/{projectKey}|identity");
+
+                var kindPaths = RequireOnlyChildDirectories(projectPath);
+                if (kindPaths.Length == 0)
+                    throw new InvalidOperationException("The coordinated release project payload cache is empty.");
+                foreach (var kindPath in kindPaths)
+                {
+                    var kind = Path.GetFileName(kindPath);
+                    if (kind is not ("package" or "symbols" or "release-zip"))
+                        throw new InvalidOperationException("The coordinated release package cache kind is invalid.");
+
+                    var payloadPaths = RequireOnlyChildDirectories(kindPath);
+                    if (payloadPaths.Length == 0)
+                        throw new InvalidOperationException("The coordinated release package payload cache is empty.");
+                    foreach (var payloadPath in payloadPaths)
+                    {
+                        var payloadKey = Path.GetFileName(payloadPath);
+                        if (!IsSynchronizedReleaseFingerprint(payloadKey))
+                            throw new InvalidOperationException("The coordinated release payload cache key is invalid.");
+                        AddSynchronizedReleaseExactPayloadPath(
+                            components,
+                            $"package-lane/{laneKey}/project/{projectKey}/{kind}/{payloadKey}",
+                            ResolveSingleCachedSynchronizedReleasePayloadPath(payloadPath, allowDirectory: false));
+                    }
+                }
+            }
+        }
+    }
+
+    private static string ResolveSingleCachedSynchronizedReleasePayloadPath(
+        string entryPath,
+        bool allowDirectory)
+    {
+        RequireNormalSynchronizedReleaseCacheTree(entryPath);
+        var children = Directory.EnumerateFileSystemEntries(entryPath).ToArray();
+        if (children.Length != 1)
+            throw new InvalidOperationException("A coordinated release cache entry must contain exactly one payload.");
+
+        var container = children[0];
+        var containerName = Path.GetFileName(container);
+        if (containerName == "directory")
+        {
+            if (!allowDirectory || !Directory.Exists(container))
+                throw new InvalidOperationException("The coordinated release cache entry contains an invalid directory payload.");
+            return container;
+        }
+        if (containerName != "file" || !Directory.Exists(container))
+            throw new InvalidOperationException("The coordinated release cache entry contains an invalid file payload.");
+
+        var files = Directory.GetFiles(container);
+        if (files.Length != 1 || Directory.GetDirectories(container).Length != 0)
+            throw new InvalidOperationException("A coordinated release file cache entry must contain exactly one file.");
+        return files[0];
+    }
+
+    private static void AddSynchronizedReleasePayloadIdentity(
+        ICollection<string> components,
+        string identity)
+    {
+        if (!components.Contains(identity, StringComparer.Ordinal))
+            components.Add(identity);
+    }
+
+    private static bool IsValidSynchronizedReleasePayloadIdentity(string component)
+    {
+        var label = component.Substring(0, component.Length - "|identity".Length);
+        var parts = label.Split('/');
+        return parts.Length switch
+        {
+            2 => parts[0] is "artefact" or "package-lane" &&
+                 IsSynchronizedReleaseFingerprint(parts[1]),
+            4 => parts[0] == "package-lane" &&
+                 IsSynchronizedReleaseFingerprint(parts[1]) &&
+                 parts[2] == "project" &&
+                 IsSynchronizedReleaseFingerprint(parts[3]),
+            _ => false
+        };
+    }
+
+    private static string RequireOnlySynchronizedReleaseCacheDirectory(string parentPath, string name)
+    {
+        var children = Directory.EnumerateFileSystemEntries(parentPath).ToArray();
+        var path = Path.Combine(parentPath, name);
+        if (children.Length != 1 ||
+            !Directory.Exists(path) ||
+            !string.Equals(Path.GetFileName(children[0]), name, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"The coordinated release cache must contain only the '{name}' directory.");
+        }
+        return path;
+    }
+
+    private static string RequireSynchronizedReleaseCacheDirectory(string parentPath, string name)
+    {
+        var path = Path.Combine(parentPath, name);
+        if (!Directory.Exists(path) ||
+            !Directory.EnumerateDirectories(parentPath)
+                .Any(child => string.Equals(Path.GetFileName(child), name, StringComparison.Ordinal)))
+        {
+            throw new InvalidOperationException($"The coordinated release cache directory '{name}' is missing.");
+        }
+        return path;
+    }
+
+    private static string[] RequireOnlyChildDirectories(string path)
+    {
+        var entries = Directory.EnumerateFileSystemEntries(path).ToArray();
+        if (entries.Any(entry => !Directory.Exists(entry)))
+            throw new InvalidOperationException("The coordinated release cache contains an unexpected file.");
+        return entries;
+    }
+
+    private static bool IsNormalSynchronizedReleaseCacheDirectory(string path)
+        => Directory.Exists(path) &&
+           (File.GetAttributes(path) & FileAttributes.ReparsePoint) == 0;
+
+    private static void RequireNormalSynchronizedReleaseCacheTree(string rootPath)
+    {
+        if (!IsNormalSynchronizedReleaseCacheDirectory(rootPath))
+            throw new InvalidOperationException("The coordinated release payload cache is missing or unsafe.");
+
+        foreach (var path in Directory.EnumerateFileSystemEntries(rootPath, "*", SearchOption.AllDirectories))
+        {
+            if ((File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0)
+                throw new InvalidOperationException("The coordinated release payload cache contains a reparse point.");
+        }
+    }
+
+    private static bool IsSynchronizedReleaseFingerprint(string? value)
+        => value?.Length == 64 && value.All(static character =>
+            character is >= '0' and <= '9' or >= 'a' and <= 'f' or >= 'A' and <= 'F');
+
+    private static bool IsValidSynchronizedReleaseFingerprintState(
+        string? fingerprint,
+        string[] components)
+        => IsSynchronizedReleaseFingerprint(fingerprint) &&
+           components.Length > 0 &&
+           components.All(static component => !string.IsNullOrWhiteSpace(component)) &&
+           string.Equals(
+               fingerprint,
+               CreateSynchronizedReleaseFingerprint(components),
+               StringComparison.OrdinalIgnoreCase);
+}

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseCheckpointResetTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseCheckpointResetTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Xunit;
@@ -124,6 +125,117 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
     }
 
     [Fact]
+    public void Run_DiscardsValidBoundPayloadWithZeroRemoteAttemptsAfterConfigurationCorrection()
+    {
+        var fixture = CreateBoundPrePublishCredentialFailure();
+        try
+        {
+            var payloadCachePath = ResolveTestPayloadCachePath(fixture.CheckpointPath);
+            var secondHosted = new FakeHostedOperations(new List<string>());
+            var secondRunner = CreateRunner(secondHosted, fixture.ExecutePackageBuild);
+            var secondSpec = CreateGalleryReleaseSpec(
+                fixture.Root.FullName,
+                fixture.SecondStagingPath,
+                fixture.ModuleName);
+            SetGalleryRepositoryName(secondSpec, "CorrectedRepository");
+
+            var result = secondRunner.Run(secondSpec);
+
+            Assert.Equal("2.0.11", result.Plan.ResolvedVersion);
+            Assert.Equal(new[] { "2.0.11" }, secondHosted.PublishedModuleVersions);
+            Assert.False(File.Exists(fixture.CheckpointPath));
+            Assert.False(Directory.Exists(payloadCachePath));
+            Assert.Equal(2, fixture.PackageBuildCount());
+        }
+        finally
+        {
+            fixture.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Run_PreservesMalformedBoundPayloadAfterConfigurationCorrection()
+    {
+        var fixture = CreateBoundPrePublishCredentialFailure();
+        try
+        {
+            var payloadCachePath = ResolveTestPayloadCachePath(fixture.CheckpointPath);
+            var cachedModuleFiles = Directory.GetFiles(
+                Path.Combine(payloadCachePath, "module"),
+                "*",
+                SearchOption.AllDirectories);
+            Assert.NotEmpty(cachedModuleFiles);
+            var cachedModuleFile = cachedModuleFiles[0];
+            File.AppendAllText(cachedModuleFile, "tampered");
+
+            var hosted = new FakeHostedOperations(new List<string>());
+            var runner = CreateRunner(hosted, fixture.ExecutePackageBuild);
+            var spec = CreateGalleryReleaseSpec(
+                fixture.Root.FullName,
+                fixture.SecondStagingPath,
+                fixture.ModuleName);
+            SetGalleryRepositoryName(spec, "CorrectedRepository");
+
+            var exception = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+            Assert.Contains("configuration no longer matches", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Empty(hosted.PublishedModuleVersions);
+            Assert.True(File.Exists(fixture.CheckpointPath));
+            Assert.True(Directory.Exists(payloadCachePath));
+            Assert.Equal(1, fixture.PackageBuildCount());
+        }
+        finally
+        {
+            fixture.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Run_PreservesBoundPayloadCacheContainingNestedReparsePoint()
+    {
+        var fixture = CreateBoundPrePublishCredentialFailure();
+        try
+        {
+            var payloadCachePath = ResolveTestPayloadCachePath(fixture.CheckpointPath);
+            var outsidePath = Path.Combine(fixture.Root.FullName, "outside-bound-payload");
+            Directory.CreateDirectory(outsidePath);
+            var sentinelPath = Path.Combine(outsidePath, "sentinel.txt");
+            File.WriteAllText(sentinelPath, "preserve");
+            var linkPath = Path.Combine(payloadCachePath, "module", "linked");
+            try
+            {
+                Directory.CreateSymbolicLink(linkPath, outsidePath);
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+            {
+                return;
+            }
+
+            var hosted = new FakeHostedOperations(new List<string>());
+            var runner = CreateRunner(hosted, fixture.ExecutePackageBuild);
+            var spec = CreateGalleryReleaseSpec(
+                fixture.Root.FullName,
+                fixture.SecondStagingPath,
+                fixture.ModuleName);
+            SetGalleryRepositoryName(spec, "CorrectedRepository");
+
+            var exception = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+            Assert.Contains("configuration no longer matches", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Empty(hosted.PublishedModuleVersions);
+            Assert.True(File.Exists(fixture.CheckpointPath));
+            Assert.True(Directory.Exists(payloadCachePath));
+            Assert.True(File.Exists(sentinelPath));
+            Assert.Equal("preserve", File.ReadAllText(sentinelPath));
+            Assert.Equal(1, fixture.PackageBuildCount());
+        }
+        finally
+        {
+            fixture.Dispose();
+        }
+    }
+
+    [Fact]
     public void Run_UnlinksUnboundPayloadCacheReparsePointWithoutDeletingTarget()
     {
         var fixture = CreatePrePublishArtefactIdentityFailure();
@@ -195,6 +307,88 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
 
         Assert.Contains(expectedMessage, exception.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Empty(hosted.PublishedModuleVersions);
+    }
+
+    private static string ResolveTestPayloadCachePath(string checkpointPath)
+        => Path.Combine(
+            Path.GetDirectoryName(checkpointPath)!,
+            Path.GetFileNameWithoutExtension(checkpointPath) + ".payload");
+
+    private static void SetGalleryRepositoryName(ModulePipelineSpec spec, string repositoryName)
+    {
+        var publish = Assert.Single(spec.Segments.OfType<ConfigurationPublishSegment>());
+        publish.Configuration.RepositoryName = repositoryName;
+    }
+
+    private static PrePublishCheckpointFixture CreateBoundPrePublishCredentialFailure()
+    {
+        const string moduleName = "TestModule";
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        var firstStagingPath = Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests.Staging",
+            Guid.NewGuid().ToString("N"));
+        var secondStagingPath = Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests.Staging",
+            Guid.NewGuid().ToString("N"));
+        var packageBuildCount = 0;
+
+        ProjectBuildHostExecutionResult ExecutePackageBuild(
+            ProjectBuildHostRequest request,
+            ProjectBuildConfiguration? configuration,
+            string? configPath)
+        {
+            packageBuildCount++;
+            return CreateProjectBuildResult(
+                root.FullName,
+                moduleName,
+                "2.0.11",
+                Path.Combine(root.FullName, "Artifacts", "NuGet"),
+                request,
+                configPath,
+                includePackage: false);
+        }
+
+        WriteMinimalModule(root.FullName, moduleName, "2.0.10");
+        WriteSynchronizedProjectBuildConfig(
+            root.FullName,
+            "project.build.json",
+            moduleName,
+            publishNuGet: false);
+
+        var hosted = new FakeHostedOperations(new List<string>())
+        {
+            ModulePublishPreflightAction = (_, _) =>
+                throw new InvalidOperationException("Simulated missing publish credential.")
+        };
+        var runner = CreateRunner(hosted, ExecutePackageBuild);
+        var exception = Assert.Throws<InvalidOperationException>(() => runner.Run(
+            CreateGalleryReleaseSpec(root.FullName, firstStagingPath, moduleName)));
+
+        Assert.Contains("missing publish credential", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(hosted.PublishedModuleVersions);
+        var checkpointPath = Assert.Single(Directory.GetFiles(
+            GetCoordinatedReleaseCheckpointRoot(root.FullName),
+            "*.json"));
+        var checkpoint = JsonNode.Parse(File.ReadAllText(checkpointPath))!;
+        Assert.NotEqual(string.Empty, checkpoint["SourceFingerprint"]!.GetValue<string>());
+        Assert.NotEqual(string.Empty, checkpoint["PayloadFingerprint"]!.GetValue<string>());
+        Assert.Empty(checkpoint["AttemptedOperations"]!.AsArray());
+        Assert.Empty(checkpoint["CompletedOperations"]!.AsArray());
+        Assert.True(Directory.Exists(ResolveTestPayloadCachePath(checkpointPath)));
+
+        return new PrePublishCheckpointFixture(
+            root,
+            firstStagingPath,
+            secondStagingPath,
+            moduleName,
+            checkpointPath,
+            ExecutePackageBuild,
+            () => packageBuildCount);
     }
 
     private static PrePublishCheckpointFixture CreatePrePublishArtefactIdentityFailure()

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseRetrySafetyTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseRetrySafetyTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json.Nodes;
 using Xunit;
 
 namespace PowerForge.Tests;
@@ -31,7 +32,10 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
                 (request, configuration, configPath) =>
                 {
                     if (request.PublishNuget == true || request.PublishGitHub == true)
+                    {
+                        request.RemotePublishAttempted?.Invoke();
                         remotePublishRequests++;
+                    }
 
                     return CreateProjectBuildResult(
                         root.FullName,
@@ -45,6 +49,180 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             var spec = CreateNuGetOnlyReleaseSpec(root.FullName, stagingPath, moduleName);
             var release = Assert.IsType<ConfigurationReleaseSegment>(spec.Segments[^1]);
             release.Configuration.PublishOrder = new[] { "NuGet", "GitHub" };
+
+            var exception = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+            Assert.Contains("GitHubReleaseMode 'Single'", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(0, remotePublishRequests);
+            var checkpointPath = Assert.Single(Directory.GetFiles(
+                GetCoordinatedReleaseCheckpointRoot(root.FullName),
+                "*.json"));
+            var checkpoint = JsonNode.Parse(File.ReadAllText(checkpointPath))!;
+            Assert.Equal(string.Empty, checkpoint["SourceFingerprint"]!.GetValue<string>());
+            Assert.Equal(string.Empty, checkpoint["PayloadFingerprint"]!.GetValue<string>());
+
+            WriteSynchronizedProjectBuildConfig(
+                root.FullName,
+                "project.build.json",
+                moduleName,
+                publishNuGet: true,
+                publishGitHub: false);
+            var correctedRunner = CreateRunner(
+                new FakeHostedOperations(new List<string>()),
+                (request, configuration, configPath) =>
+                {
+                    if (request.PublishNuget == true || request.PublishGitHub == true)
+                    {
+                        request.RemotePublishAttempted?.Invoke();
+                        remotePublishRequests++;
+                    }
+
+                    return CreateProjectBuildResult(
+                        root.FullName,
+                        moduleName,
+                        "2.0.11",
+                        Path.Combine(root.FullName, "Artifacts", "NuGet"),
+                        request,
+                        configPath,
+                        includePackage: true);
+                });
+
+            var result = correctedRunner.Run(
+                CreateNuGetOnlyReleaseSpec(root.FullName, stagingPath, moduleName));
+
+            Assert.Equal("2.0.11", result.Plan.ResolvedVersion);
+            Assert.Equal(1, remotePublishRequests);
+            AssertNoCoordinatedReleaseCheckpoint(root.FullName);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+            try { if (Directory.Exists(stagingPath)) Directory.Delete(stagingPath, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Run_DefersGitHubRetryPreflightForPackageLaneBuiltAfterModule()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var stagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        try
+        {
+            const string moduleName = "TestModule";
+            const string companionName = "Companion";
+            WriteMinimalModule(root.FullName, moduleName, "2.0.10");
+            WriteSynchronizedProjectBuildConfig(
+                root.FullName,
+                "source.build.json",
+                moduleName,
+                publishNuGet: false);
+            WriteSynchronizedProjectBuildConfig(
+                root.FullName,
+                "companion.build.json",
+                companionName,
+                publishNuGet: false,
+                publishGitHub: true,
+                gitHubReleaseMode: "Single");
+
+            var githubPublishRequests = 0;
+            var runner = CreateRunner(
+                new FakeHostedOperations(new List<string>()),
+                (request, configuration, configPath) =>
+                {
+                    if (request.PublishGitHub == true)
+                    {
+                        request.RemotePublishAttempted?.Invoke();
+                        githubPublishRequests++;
+                    }
+
+                    var projectName = configPath!.EndsWith("companion.build.json", StringComparison.OrdinalIgnoreCase)
+                        ? companionName
+                        : moduleName;
+                    return CreateProjectBuildResult(
+                        root.FullName,
+                        projectName,
+                        "2.0.11",
+                        Path.Combine(root.FullName, "Artifacts", "NuGet"),
+                        request,
+                        configPath,
+                        includePackage: true);
+                });
+            var spec = CreatePackageOnlyReleaseSpec(
+                root.FullName,
+                stagingPath,
+                moduleName,
+                companionName,
+                companionBuildBeforeModule: false);
+            var release = Assert.IsType<ConfigurationReleaseSegment>(spec.Segments[^1]);
+            release.Configuration.PublishOrder = new[] { "GitHub" };
+
+            var result = runner.Run(spec);
+
+            Assert.Equal("2.0.11", result.Plan.ResolvedVersion);
+            Assert.Equal(1, githubPublishRequests);
+            AssertNoCoordinatedReleaseCheckpoint(root.FullName);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+            try { if (Directory.Exists(stagingPath)) Directory.Delete(stagingPath, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Run_RejectsUnsafeGitHubRetrySettingsForPackageLaneBuiltAfterModule()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var stagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        try
+        {
+            const string moduleName = "TestModule";
+            const string companionName = "Companion";
+            WriteMinimalModule(root.FullName, moduleName, "2.0.10");
+            WriteSynchronizedProjectBuildConfig(
+                root.FullName,
+                "source.build.json",
+                moduleName,
+                publishNuGet: false);
+            WriteSynchronizedProjectBuildConfig(
+                root.FullName,
+                "companion.build.json",
+                companionName,
+                publishNuGet: false,
+                publishGitHub: true,
+                gitHubReleaseMode: "PerProject");
+
+            var remotePublishRequests = 0;
+            var runner = CreateRunner(
+                new FakeHostedOperations(new List<string>()),
+                (request, configuration, configPath) =>
+                {
+                    if (request.PublishGitHub == true)
+                    {
+                        request.RemotePublishAttempted?.Invoke();
+                        remotePublishRequests++;
+                    }
+
+                    var projectName = configPath!.EndsWith("companion.build.json", StringComparison.OrdinalIgnoreCase)
+                        ? companionName
+                        : moduleName;
+                    return CreateProjectBuildResult(
+                        root.FullName,
+                        projectName,
+                        "2.0.11",
+                        Path.Combine(root.FullName, "Artifacts", "NuGet"),
+                        request,
+                        configPath,
+                        includePackage: true);
+                });
+            var spec = CreatePackageOnlyReleaseSpec(
+                root.FullName,
+                stagingPath,
+                moduleName,
+                companionName,
+                companionBuildBeforeModule: false);
+            var release = Assert.IsType<ConfigurationReleaseSegment>(spec.Segments[^1]);
+            release.Configuration.PublishOrder = new[] { "GitHub" };
 
             var exception = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
 


### PR DESCRIPTION
## Summary

- validates package GitHub retry safety as soon as each build result is available, before signed payload binding and any remote destination
- safely discards an authentic coordinated-release checkpoint when configuration changes before any publish attempt or auxiliary remote side effect
- verifies the exact cached payload topology and bytes before resetting a bound checkpoint, while preserving malformed, tampered, or reparse-backed state for explicit recovery
- keeps after-module package lanes deferred until their build results exist, with the final preflight remaining fail-closed

## Why this matters

A local build can bind the final signed payload and then fail a retry-safety preflight without publishing anything. Correcting the release configuration should be retryable without deleting checkpoint files by hand, while any checkpoint that might represent remote work or an unsafe cache must remain protected.

## Validation

- coordinated-release suite: 83 passed
- full Release solution build: 0 warnings, 0 errors
- independent read-only review plus targeted confirmation completed; all findings addressed

No packages were published as part of this change.