### PR TITLE
Preserve image metadata safely during web optimization

### DIFF
--- a/Docs/PowerForge.Web.Pipeline.md
+++ b/Docs/PowerForge.Web.Pipeline.md
@@ -906,6 +906,7 @@ Applies critical CSS, minifies HTML/CSS/JS, optimizes images, and can hash asset
   "optimizeImages": true,
   "imageExtensions": [".png", ".jpg", ".jpeg", ".webp"],
   "imageQuality": 82,
+  "imageMetadataPolicy": "preserve",
   "imageGenerateWebp": true,
   "imagePreferNextGen": true,
   "imageWidths": [480, 960, 1440],
@@ -924,6 +925,9 @@ Notes:
 - `hashAssets` fingerprints files and rewrites references (HTML + CSS).
 - `cacheHeaders` writes `_headers` with cache-control rules (Netlify/Cloudflare Pages compatible).
 - `imageGenerateWebp` / `imageGenerateAvif` can create next-gen variants when they are smaller than source output.
+- `imageMetadataPolicy` controls the original file. `preserve` (default) leaves it byte-for-byte unchanged, including rights, color profiles, and Content Credentials. `stripAll` always rewrites the original after removing encoder-supported metadata, even when the rewritten file is larger.
+- Generated WebP, AVIF, and responsive files are derivatives. They do not inherit a valid C2PA signature from the source; sign them separately when their provenance must remain verifiable.
+- The older `imageStripMetadata: true` setting still maps to `stripAll`. Prefer the named policy in new configuration.
 - `imagePreferNextGen` rewrites `<img src>` to next-gen output when available.
 - `imageWidths` generates responsive variants and `srcset` entries.
 - `imageEnhanceTags` injects `loading=\"lazy\"`, `decoding=\"async\"`, and intrinsic `width`/`height` (when known) on rewritten image tags.

--- a/PowerForge.Tests/WebImageMetadataPolicyTests.cs
+++ b/PowerForge.Tests/WebImageMetadataPolicyTests.cs
@@ -1,0 +1,197 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using ImageMagick;
+using PowerForge.Web;
+using PowerForge.Web.Cli;
+
+namespace PowerForge.Tests;
+
+public partial class WebSiteAuditOptimizeBuildTests {
+    [Theory]
+    [InlineData(null, null, WebImageMetadataPolicy.Preserve)]
+    [InlineData("preserve", null, WebImageMetadataPolicy.Preserve)]
+    [InlineData("strip-all", null, WebImageMetadataPolicy.StripAll)]
+    [InlineData(null, true, WebImageMetadataPolicy.StripAll)]
+    [InlineData(null, false, WebImageMetadataPolicy.Preserve)]
+    public void ParseImageMetadataPolicy_MapsNamedAndLegacyValues(
+        string? value,
+        bool? legacyStripMetadata,
+        WebImageMetadataPolicy expected) {
+        Assert.Equal(expected, WebCliHelpers.ParseImageMetadataPolicy(value, legacyStripMetadata));
+    }
+
+    [Fact]
+    public void ParseImageMetadataPolicy_RejectsConflictingLegacyValue() {
+        Assert.Throws<ArgumentException>(() =>
+            WebCliHelpers.ParseImageMetadataPolicy("preserve", legacyStripMetadata: true));
+    }
+
+    [Fact]
+    public void WebPublishSpec_DeserializesNamedMetadataPolicy() {
+        const string json = """
+            {
+              "optimize": {
+                "imageMetadataPolicy": "stripAll"
+              }
+            }
+            """;
+
+        var spec = JsonSerializer.Deserialize<WebPublishSpec>(json, WebCliJson.Options);
+
+        Assert.NotNull(spec);
+        Assert.NotNull(spec.Optimize);
+        Assert.Equal(WebImageMetadataPolicy.StripAll, spec.Optimize.ImageMetadataPolicy);
+    }
+
+    [Fact]
+    public void WebPublishSchema_DeclaresNamedMetadataPolicy() {
+        var schemaPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            "Schemas",
+            "powerforge.web.publishspec.schema.json"));
+        var schema = JsonNode.Parse(File.ReadAllText(schemaPath));
+        var policy = schema?["$defs"]?["OptimizeSpec"]?["properties"]?["ImageMetadataPolicy"];
+
+        Assert.NotNull(policy);
+        Assert.Equal("string", policy["type"]?.GetValue<string>());
+        Assert.Equal("preserve", policy["enum"]?[0]?.GetValue<string>());
+        Assert.Equal("stripAll", policy["enum"]?[1]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void OptimizeDetailed_DefaultMetadataPolicy_PreservesOriginalBytes() {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-metadata-preserve-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try {
+            var imagePath = Path.Combine(root, "pixel.png");
+            var original = CreateMinimalPngWithComment("rights");
+            File.WriteAllBytes(imagePath, original);
+
+            var result = WebAssetOptimizer.OptimizeDetailed(new WebAssetOptimizerOptions {
+                SiteRoot = root,
+                OptimizeImages = true,
+                ImageExtensions = [".png"]
+            });
+
+            Assert.Equal(original, File.ReadAllBytes(imagePath));
+            Assert.Equal(WebImageMetadataPolicy.Preserve, result.ImageMetadataPolicy);
+            Assert.Equal(0, result.ImageMetadataPolicyAppliedCount);
+            Assert.Equal(0, result.ImageOptimizedCount);
+            Assert.DoesNotContain(result.UpdatedFiles, path => path.Equals("pixel.png", StringComparison.OrdinalIgnoreCase));
+        } finally {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void OptimizeDetailed_StripAll_RewritesOriginalEvenWhenOutputIsLarger() {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-metadata-strip-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try {
+            var imagePath = Path.Combine(root, "photo.jpg");
+            using (var source = new MagickImage(MagickColors.SlateBlue, 128, 128)) {
+                source.AddNoise(NoiseType.Random);
+                source.Quality = 10;
+                source.Comment = "x";
+                source.Write(imagePath, MagickFormat.Jpeg);
+            }
+            var original = File.ReadAllBytes(imagePath);
+
+            var result = WebAssetOptimizer.OptimizeDetailed(new WebAssetOptimizerOptions {
+                SiteRoot = root,
+                OptimizeImages = true,
+                ImageExtensions = [".jpg"],
+                ImageQuality = 100,
+                ImageMetadataPolicy = WebImageMetadataPolicy.StripAll
+            });
+
+            using var rewritten = new MagickImage(imagePath);
+            var rewrittenLength = new FileInfo(imagePath).Length;
+            Assert.True(
+                rewrittenLength > original.LongLength,
+                $"Expected stripped output ({rewrittenLength}) to exceed the compact source ({original.LongLength}).");
+            Assert.True(string.IsNullOrEmpty(rewritten.Comment));
+            Assert.Equal(WebImageMetadataPolicy.StripAll, result.ImageMetadataPolicy);
+            Assert.Equal(1, result.ImageMetadataPolicyAppliedCount);
+            Assert.Equal(1, result.ImageOptimizedCount);
+            Assert.Contains(result.UpdatedFiles, path => path.Equals("photo.jpg", StringComparison.OrdinalIgnoreCase));
+        } finally {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void OptimizeDetailed_LegacyStripSwitch_MapsToStripAll() {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-metadata-legacy-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try {
+            var imagePath = Path.Combine(root, "pixel.png");
+            File.WriteAllBytes(imagePath, CreateMinimalPngWithComment("legacy"));
+
+            var result = WebAssetOptimizer.OptimizeDetailed(new WebAssetOptimizerOptions {
+                SiteRoot = root,
+                OptimizeImages = true,
+                ImageExtensions = [".png"],
+                ImageStripMetadata = true
+            });
+
+            Assert.Equal(WebImageMetadataPolicy.StripAll, result.ImageMetadataPolicy);
+            Assert.Equal(1, result.ImageMetadataPolicyAppliedCount);
+        } finally {
+            Directory.Delete(root, true);
+        }
+    }
+
+    private static byte[] CreateMinimalPngWithComment(string comment) {
+        byte[] png = Convert.FromBase64String(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=");
+        byte[] payload = Encoding.ASCII.GetBytes("Comment\0" + comment);
+        byte[] chunk = CreatePngChunkForMetadataPolicy("tEXt", payload);
+        const int insertOffset = 33;
+        byte[] result = new byte[png.Length + chunk.Length];
+        Buffer.BlockCopy(png, 0, result, 0, insertOffset);
+        Buffer.BlockCopy(chunk, 0, result, insertOffset, chunk.Length);
+        Buffer.BlockCopy(png, insertOffset, result, insertOffset + chunk.Length, png.Length - insertOffset);
+        return result;
+    }
+
+    private static byte[] CreatePngChunkForMetadataPolicy(string type, byte[] payload) {
+        byte[] typeBytes = Encoding.ASCII.GetBytes(type);
+        byte[] chunk = new byte[12 + payload.Length];
+        WritePngUInt32(chunk, 0, (uint)payload.Length);
+        Buffer.BlockCopy(typeBytes, 0, chunk, 4, typeBytes.Length);
+        Buffer.BlockCopy(payload, 0, chunk, 8, payload.Length);
+
+        byte[] crcInput = new byte[typeBytes.Length + payload.Length];
+        Buffer.BlockCopy(typeBytes, 0, crcInput, 0, typeBytes.Length);
+        Buffer.BlockCopy(payload, 0, crcInput, typeBytes.Length, payload.Length);
+        WritePngUInt32(chunk, 8 + payload.Length, ComputePngCrcForMetadataPolicy(crcInput));
+        return chunk;
+    }
+
+    private static uint ComputePngCrcForMetadataPolicy(byte[] data) {
+        uint crc = 0xFFFFFFFF;
+        foreach (byte value in data) {
+            crc ^= value;
+            for (var bit = 0; bit < 8; bit++)
+                crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xEDB88320 : crc >> 1;
+        }
+
+        return ~crc;
+    }
+
+    private static void WritePngUInt32(byte[] value, int offset, uint number) {
+        value[offset] = (byte)(number >> 24);
+        value[offset + 1] = (byte)(number >> 16);
+        value[offset + 2] = (byte)(number >> 8);
+        value[offset + 3] = (byte)number;
+    }
+}

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.cs
@@ -130,7 +130,9 @@ internal static partial class WebCliCommandHandlers
                 ImageInclude = publishSpec.Optimize.ImageInclude ?? Array.Empty<string>(),
                 ImageExclude = publishSpec.Optimize.ImageExclude ?? Array.Empty<string>(),
                 ImageQuality = publishSpec.Optimize.ImageQuality ?? 82,
-                ImageStripMetadata = publishSpec.Optimize.ImageStripMetadata ?? true,
+                ImageMetadataPolicy = ParseImageMetadataPolicy(
+                    publishSpec.Optimize.ImageMetadataPolicy?.ToString(),
+                    publishSpec.Optimize.ImageStripMetadata),
                 ImageGenerateWebp = publishSpec.Optimize.ImageGenerateWebp,
                 ImageGenerateAvif = publishSpec.Optimize.ImageGenerateAvif,
                 ImagePreferNextGen = publishSpec.Optimize.ImagePreferNextGen,
@@ -691,7 +693,16 @@ internal static partial class WebCliCommandHandlers
         var imageInclude = ReadOptionList(subArgs, "--image-include");
         var imageExclude = ReadOptionList(subArgs, "--image-exclude");
         var imageQuality = ParseIntOption(TryGetOptionValue(subArgs, "--image-quality"), 82);
-        var imageStripMetadata = !HasOption(subArgs, "--image-keep-metadata");
+        if (HasOption(subArgs, "--image-strip-metadata") && HasOption(subArgs, "--image-keep-metadata"))
+            return Fail("--image-strip-metadata and --image-keep-metadata cannot be used together.", outputJson, logger, "web.optimize");
+
+        var imageMetadataPolicy = ParseImageMetadataPolicy(
+            TryGetOptionValue(subArgs, "--image-metadata-policy"),
+            HasOption(subArgs, "--image-strip-metadata")
+                ? true
+                : HasOption(subArgs, "--image-keep-metadata")
+                    ? false
+                    : null);
         var imageGenerateWebp = HasOption(subArgs, "--image-generate-webp");
         var imageGenerateAvif = HasOption(subArgs, "--image-generate-avif");
         var imagePreferNextGen = HasOption(subArgs, "--image-prefer-nextgen");
@@ -750,7 +761,7 @@ internal static partial class WebCliCommandHandlers
             ImageInclude = imageInclude.Count > 0 ? imageInclude.ToArray() : Array.Empty<string>(),
             ImageExclude = imageExclude.Count > 0 ? imageExclude.ToArray() : Array.Empty<string>(),
             ImageQuality = imageQuality,
-            ImageStripMetadata = imageStripMetadata,
+            ImageMetadataPolicy = imageMetadataPolicy,
             ImageGenerateWebp = imageGenerateWebp,
             ImageGenerateAvif = imageGenerateAvif,
             ImagePreferNextGen = imagePreferNextGen,

--- a/PowerForge.Web.Cli/WebCliHelpers.cs
+++ b/PowerForge.Web.Cli/WebCliHelpers.cs
@@ -104,7 +104,7 @@ internal static partial class WebCliHelpers
         Console.WriteLine("  powerforge-web optimize --site-root <dir> [--config <site.json>] [--critical-css <file>] [--css-pattern <regex>]");
         Console.WriteLine("                     [--minify-html] [--minify-css] [--minify-js]");
         Console.WriteLine("                     [--optimize-images] [--image-ext <.png,.jpg,.jpeg,.webp>] [--image-include <glob[,glob]>] [--image-exclude <glob[,glob]>]");
-        Console.WriteLine("                     [--image-quality <1-100>] [--image-keep-metadata] [--image-generate-webp] [--image-generate-avif]");
+        Console.WriteLine("                     [--image-quality <1-100>] [--image-metadata-policy <preserve|strip-all>] [--image-generate-webp] [--image-generate-avif]");
         Console.WriteLine("                     [--image-prefer-nextgen] [--image-widths <320,640,1024>] [--image-enhance-tags]");
         Console.WriteLine("                     [--image-max-bytes <n>] [--image-max-total-bytes <n>] [--image-fail-on-budget]");
         Console.WriteLine("                     [--hash-assets] [--hash-ext <.css,.js>] [--hash-exclude <glob[,glob]>] [--hash-manifest <file>]");
@@ -170,6 +170,35 @@ internal static partial class WebCliHelpers
         }
 
         return null;
+    }
+
+    internal static WebImageMetadataPolicy ParseImageMetadataPolicy(string? value, bool? legacyStripMetadata = null)
+    {
+        WebImageMetadataPolicy policy;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            policy = legacyStripMetadata == true
+                ? WebImageMetadataPolicy.StripAll
+                : WebImageMetadataPolicy.Preserve;
+        }
+        else
+        {
+            policy = value.Trim().Replace("-", string.Empty, StringComparison.Ordinal).ToLowerInvariant() switch
+            {
+                "preserve" => WebImageMetadataPolicy.Preserve,
+                "stripall" => WebImageMetadataPolicy.StripAll,
+                _ => throw new ArgumentException(
+                    $"Unsupported image metadata policy '{value}'. Use preserve or strip-all.")
+            };
+        }
+
+        if (legacyStripMetadata.HasValue &&
+            legacyStripMetadata.Value != (policy == WebImageMetadataPolicy.StripAll))
+        {
+            throw new ArgumentException("The legacy image metadata switch conflicts with imageMetadataPolicy.");
+        }
+
+        return policy;
     }
 
     internal static List<string> ReadOptionList(string[] argv, params string[] optionNames)

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.Optimize.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.Optimize.cs
@@ -36,7 +36,10 @@ internal static partial class WebPipelineRunner
         var imageInclude = GetArrayOfStrings(step, "imageInclude") ?? GetArrayOfStrings(step, "image-include");
         var imageExclude = GetArrayOfStrings(step, "imageExclude") ?? GetArrayOfStrings(step, "image-exclude");
         var imageQuality = GetInt(step, "imageQuality") ?? GetInt(step, "image-quality") ?? 82;
-        var imageStripMetadata = GetBool(step, "imageStripMetadata") ?? GetBool(step, "image-strip-metadata") ?? true;
+        var imageStripMetadata = GetBool(step, "imageStripMetadata") ?? GetBool(step, "image-strip-metadata");
+        var imageMetadataPolicy = WebCliHelpers.ParseImageMetadataPolicy(
+            GetString(step, "imageMetadataPolicy") ?? GetString(step, "image-metadata-policy"),
+            imageStripMetadata);
         var imageGenerateWebp = GetBool(step, "imageGenerateWebp") ?? GetBool(step, "image-generate-webp") ?? false;
         var imageGenerateAvif = GetBool(step, "imageGenerateAvif") ?? GetBool(step, "image-generate-avif") ?? false;
         var imagePreferNextGen = GetBool(step, "imagePreferNextGen") ?? GetBool(step, "image-prefer-nextgen") ?? false;
@@ -162,7 +165,7 @@ internal static partial class WebPipelineRunner
             ImageInclude = imageInclude ?? Array.Empty<string>(),
             ImageExclude = imageExclude ?? Array.Empty<string>(),
             ImageQuality = imageQuality,
-            ImageStripMetadata = imageStripMetadata,
+            ImageMetadataPolicy = imageMetadataPolicy,
             ImageGenerateWebp = imageGenerateWebp,
             ImageGenerateAvif = imageGenerateAvif,
             ImagePreferNextGen = imagePreferNextGen,

--- a/PowerForge.Web/Models/WebImageMetadataPolicy.cs
+++ b/PowerForge.Web/Models/WebImageMetadataPolicy.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace PowerForge.Web;
+
+/// <summary>Controls how image optimization handles metadata on original image files.</summary>
+[JsonConverter(typeof(WebImageMetadataPolicyJsonConverter))]
+public enum WebImageMetadataPolicy {
+    /// <summary>
+    /// Preserve the original file byte for byte. Generated variants are derivatives and do not inherit a valid C2PA signature.
+    /// </summary>
+    Preserve,
+
+    /// <summary>Remove all metadata understood by the image encoder and always rewrite the original file.</summary>
+    StripAll
+}
+
+/// <summary>Serializes image metadata policies using publish-spec camelCase values.</summary>
+public sealed class WebImageMetadataPolicyJsonConverter : JsonStringEnumConverter<WebImageMetadataPolicy> {
+    /// <summary>Initializes a camelCase image metadata policy converter.</summary>
+    public WebImageMetadataPolicyJsonConverter()
+        : base(JsonNamingPolicy.CamelCase, allowIntegerValues: false) {
+    }
+}

--- a/PowerForge.Web/Models/WebLlmsResult.cs
+++ b/PowerForge.Web/Models/WebLlmsResult.cs
@@ -199,6 +199,10 @@ public sealed class WebOptimizeResult
     public long ImageBytesSaved { get; set; }
     /// <summary>Number of images that failed to decode/optimize.</summary>
     public int ImageFailedCount { get; set; }
+    /// <summary>Metadata policy applied to original image files.</summary>
+    public WebImageMetadataPolicy ImageMetadataPolicy { get; set; } = WebImageMetadataPolicy.Preserve;
+    /// <summary>Number of original images rewritten to enforce the metadata policy.</summary>
+    public int ImageMetadataPolicyAppliedCount { get; set; }
     /// <summary>Detailed image optimization entries for files that changed.</summary>
     public WebOptimizeImageEntry[] OptimizedImages { get; set; } = Array.Empty<WebOptimizeImageEntry>();
     /// <summary>Detailed entries for image files that failed to decode/optimize.</summary>

--- a/PowerForge.Web/Models/WebPublishSpec.cs
+++ b/PowerForge.Web/Models/WebPublishSpec.cs
@@ -95,8 +95,10 @@ public sealed class WebPublishOptimizeSpec
     public string[] ImageExclude { get; set; } = Array.Empty<string>();
     /// <summary>Image quality target (1-100).</summary>
     public int? ImageQuality { get; set; }
-    /// <summary>When true, strip image metadata while optimizing.</summary>
+    /// <summary>Legacy compatibility setting. True maps to StripAll; false maps to Preserve.</summary>
     public bool? ImageStripMetadata { get; set; }
+    /// <summary>Metadata policy for original images. Preserve is the safe default.</summary>
+    public WebImageMetadataPolicy? ImageMetadataPolicy { get; set; }
     /// <summary>When true, generate WebP variants for supported source images.</summary>
     public bool ImageGenerateWebp { get; set; }
     /// <summary>When true, generate AVIF variants for supported source images.</summary>

--- a/PowerForge.Web/Services/WebAssetOptimizer.Images.cs
+++ b/PowerForge.Web/Services/WebAssetOptimizer.Images.cs
@@ -30,6 +30,8 @@ public static partial class WebAssetOptimizer
         var generatedVariants = new List<WebOptimizeImageVariantEntry>();
         var budgetWarnings = new List<string>();
         var rewritePlans = new Dictionary<string, ImageRewritePlan>(StringComparer.OrdinalIgnoreCase);
+        var metadataPolicy = ResolveImageMetadataPolicy(options);
+        result.ImageMetadataPolicy = metadataPolicy;
         foreach (var file in Directory.EnumerateFiles(siteRoot, "*.*", SearchOption.AllDirectories)
                      .Where(path => extensionSet.Contains(Path.GetExtension(path)) &&
                                     !protectedStoryArtifacts.Contains(Path.GetFullPath(path))))
@@ -52,31 +54,35 @@ public static partial class WebAssetOptimizer
                 using var image = new MagickImage(file);
                 imageWidth = (int)image.Width;
                 imageHeight = (int)image.Height;
-                if (options.ImageStripMetadata)
+                if (metadataPolicy == WebImageMetadataPolicy.StripAll)
                     image.Strip();
                 if (SupportsQualitySetting(image.Format))
                     image.Quality = (uint)quality;
 
-                using var optimizedStream = new MemoryStream();
-                image.Write(optimizedStream);
-                var optimizedBytes = optimizedStream.Length;
-                if (optimizedBytes > 0 && optimizedBytes < originalBytes)
+                if (metadataPolicy == WebImageMetadataPolicy.StripAll)
                 {
-                    optimizedStream.Position = 0;
-                    using var fileStream = new FileStream(file, FileMode.Create, FileAccess.Write, FileShare.None);
-                    optimizedStream.CopyTo(fileStream);
-                    finalBytes = optimizedBytes;
-                    var savedBytes = originalBytes - optimizedBytes;
-                    result.ImageOptimizedCount++;
-                    result.ImageBytesSaved += savedBytes;
-                    optimizedImages.Add(new WebOptimizeImageEntry
+                    using var optimizedStream = new MemoryStream();
+                    image.Write(optimizedStream);
+                    var optimizedBytes = optimizedStream.Length;
+                    if (optimizedBytes > 0)
                     {
-                        Path = relative,
-                        BytesBefore = originalBytes,
-                        BytesAfter = optimizedBytes,
-                        BytesSaved = savedBytes
-                    });
-                    onUpdated?.Invoke(file);
+                        optimizedStream.Position = 0;
+                        using var fileStream = new FileStream(file, FileMode.Create, FileAccess.Write, FileShare.None);
+                        optimizedStream.CopyTo(fileStream);
+                        finalBytes = optimizedBytes;
+                        var savedBytes = Math.Max(0, originalBytes - optimizedBytes);
+                        result.ImageOptimizedCount++;
+                        result.ImageMetadataPolicyAppliedCount++;
+                        result.ImageBytesSaved += savedBytes;
+                        optimizedImages.Add(new WebOptimizeImageEntry
+                        {
+                            Path = relative,
+                            BytesBefore = originalBytes,
+                            BytesAfter = optimizedBytes,
+                            BytesSaved = savedBytes
+                        });
+                        onUpdated?.Invoke(file);
+                    }
                 }
 
                 var plan = new ImageRewritePlan
@@ -201,6 +207,13 @@ public static partial class WebAssetOptimizer
         result.ImageVariantCount = result.GeneratedImageVariants.Length;
         result.ImageBudgetWarnings = budgetWarnings.ToArray();
         result.ImageBudgetExceeded = budgetWarnings.Count > 0;
+    }
+
+    private static WebImageMetadataPolicy ResolveImageMetadataPolicy(WebAssetOptimizerOptions options)
+    {
+        return options.ImageStripMetadata
+            ? WebImageMetadataPolicy.StripAll
+            : options.ImageMetadataPolicy;
     }
 
     private static void RewriteHtmlImageTags(

--- a/PowerForge.Web/Services/WebAssetOptimizer.Options.cs
+++ b/PowerForge.Web/Services/WebAssetOptimizer.Options.cs
@@ -33,8 +33,10 @@ public sealed class WebAssetOptimizerOptions
     public string[] ImageExclude { get; set; } = Array.Empty<string>();
     /// <summary>Image quality target in range 1-100.</summary>
     public int ImageQuality { get; set; } = 82;
-    /// <summary>When true, strip metadata from optimized images.</summary>
-    public bool ImageStripMetadata { get; set; } = true;
+    /// <summary>Metadata policy for original images. Preserve is the safe default.</summary>
+    public WebImageMetadataPolicy ImageMetadataPolicy { get; set; } = WebImageMetadataPolicy.Preserve;
+    /// <summary>Legacy compatibility switch. When true, overrides ImageMetadataPolicy with StripAll.</summary>
+    public bool ImageStripMetadata { get; set; } = false;
     /// <summary>When true, generate WebP variants for supported images.</summary>
     public bool ImageGenerateWebp { get; set; } = false;
     /// <summary>When true, generate AVIF variants for supported images.</summary>

--- a/Schemas/powerforge.web.publishspec.schema.json
+++ b/Schemas/powerforge.web.publishspec.schema.json
@@ -70,6 +70,7 @@
         "ImageExclude": { "type": "array", "items": { "type": "string" } },
         "ImageQuality": { "type": "integer", "minimum": 1, "maximum": 100 },
         "ImageStripMetadata": { "type": "boolean" },
+        "ImageMetadataPolicy": { "type": "string", "enum": ["preserve", "stripAll"] },
         "ImageGenerateWebp": { "type": "boolean" },
         "ImageGenerateAvif": { "type": "boolean" },
         "ImagePreferNextGen": { "type": "boolean" },


### PR DESCRIPTION
## What changed

- make `Preserve` the safe default for original images, keeping rights, licensing, ICC profiles, and Content Credentials byte-for-byte
- add an explicit `StripAll` policy that always rewrites the original after stripping encoder-supported metadata, even when the result is larger
- expose the policy through the direct API, `powerforge-web optimize`, pipeline tasks, publish JSON, schema, reports, and documentation
- retain legacy `imageStripMetadata` and CLI switches with conflict validation
- document that generated WebP, AVIF, and responsive variants are derivatives and need separate provenance signing

## Configuration

```json
{
  "optimizeImages": true,
  "imageMetadataPolicy": "preserve"
}
```

Use `stripAll` only when deliberate metadata removal is more important than retaining rights, color, and provenance data. Selective metadata removal remains owned by ImagePlayground rather than duplicated in PowerForge; PowerForge can consume that shared API after the corresponding package is released.