### PR TITLE
Coordinate public versions across module and NuGet releases

### DIFF
--- a/Docs/PSPublishModule.UnifiedModuleProjectRelease.md
+++ b/Docs/PSPublishModule.UnifiedModuleProjectRelease.md
@@ -164,8 +164,14 @@ hashtable for additional fields.
 
 ## How Version Coordination Works
 
-`-SynchronizeModuleVersion` coordinates the module with `-PrimaryProject`. It does not, by itself, assign one version
-to every NuGet package in the repository.
+`New-ConfigurationRelease` automatically coordinates the module with `-PrimaryProject` when `ProjectBuild` or
+`PackageBuild` is selected as the version source. `-SynchronizeModuleVersion` remains available as an explicit
+declaration for readability. This does not, by itself, assign one version to every NuGet package in the repository;
+use `AlignPackageVersions` or a shared version track for that package group.
+
+For an initial coordinated publish, duplicate NuGet versions are release conflicts rather than successful skips.
+Duplicate tolerance is enabled only when resuming a checkpoint that proves the same NuGet lane was already
+attempted, so an occupied package version cannot silently lead to an older PSGallery or GitHub release.
 
 PowerForge makes the version decision in this order:
 

--- a/Module/Docs/New-ConfigurationRelease.md
+++ b/Module/Docs/New-ConfigurationRelease.md
@@ -94,6 +94,7 @@ Accept wildcard characters: False
 
 ### -SynchronizeModuleVersion
 Coordinates the module and selected primary package on one version.
+This is enabled automatically when VersionSource is ProjectBuild or PackageBuild and PrimaryProject is configured.
 The next available module version becomes a floor for the primary package; a higher numeric package version still wins.
 At the same numeric version, a stable X-pattern candidate does not erase the configured module prerelease;
 explicit prerelease versions retain normal semantic-version ordering.

--- a/Module/en-US/PSPublishModule-help.xml
+++ b/Module/en-US/PSPublishModule-help.xml
@@ -52815,6 +52815,8 @@ Required by SynchronizeModuleVersion to identify the package coordinated with mo
           <maml:name>SynchronizeModuleVersion</maml:name>
           <maml:description>
             <maml:para>Coordinates the module and selected primary package on one version.&#xD;
+This is enabled automatically when VersionSource is ProjectBuild or&#xD;
+PackageBuild and PrimaryProject is configured.&#xD;
 The next available module version becomes a floor for the primary package; a higher numeric package version still wins.&#xD;
 At the same numeric version, a stable X-pattern candidate does not erase the configured module prerelease;&#xD;
 explicit prerelease versions retain normal semantic-version ordering.&#xD;
@@ -52916,6 +52918,8 @@ Required by SynchronizeModuleVersion to identify the package coordinated with mo
         <maml:name>SynchronizeModuleVersion</maml:name>
         <maml:description>
           <maml:para>Coordinates the module and selected primary package on one version.&#xD;
+This is enabled automatically when VersionSource is ProjectBuild or&#xD;
+PackageBuild and PrimaryProject is configured.&#xD;
 The next available module version becomes a floor for the primary package; a higher numeric package version still wins.&#xD;
 At the same numeric version, a stable X-pattern candidate does not erase the configured module prerelease;&#xD;
 explicit prerelease versions retain normal semantic-version ordering.&#xD;

--- a/PSPublishModule/Cmdlets/NewConfigurationPackageBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationPackageBuildCommand.cs
@@ -434,6 +434,8 @@ public sealed class NewConfigurationReleaseCommand : PSCmdlet
 
     /// <summary>
     /// Coordinates the module and selected primary package on one version.
+    /// This is enabled automatically when <c>VersionSource</c> is <c>ProjectBuild</c> or
+    /// <c>PackageBuild</c> and <c>PrimaryProject</c> is configured.
     /// The next available module version becomes a floor for the primary package; a higher numeric package version still wins.
     /// At the same numeric version, a stable X-pattern candidate does not erase the configured module prerelease;
     /// explicit prerelease versions retain normal semantic-version ordering.
@@ -461,7 +463,9 @@ public sealed class NewConfigurationReleaseCommand : PSCmdlet
                 VersionSource = VersionSource,
                 Version = Normalize(Version),
                 PrimaryProject = Normalize(PrimaryProject),
-                SynchronizeModuleVersion = SynchronizeModuleVersion.IsPresent,
+                SynchronizeModuleVersion = SynchronizeModuleVersion.IsPresent ||
+                    (!string.IsNullOrWhiteSpace(PrimaryProject) &&
+                     VersionSource is ReleaseVersionSource.ProjectBuild or ReleaseVersionSource.PackageBuild),
                 BuildOrder = BuildOrder,
                 PublishOrder = PublishOrder
             }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -164,7 +164,10 @@ public sealed partial class ModulePipelineRunner
         var cfg = segment.Configuration ?? throw new InvalidOperationException("ProjectBuild configuration is missing.");
         var configPath = ResolvePackageBuildPath(plan.ProjectRoot, cfg.ConfigPath);
         var configuration = LoadProjectBuildConfiguration(configPath, cfg);
-        ApplySynchronizedNuGetRetryPolicy(configuration, useDuplicateTolerantNuGetRetry);
+        ApplySynchronizedNuGetRetryPolicy(
+            configuration,
+            useDuplicateTolerantNuGetRetry,
+            coordinatedReleaseCheckpointActive);
         if (!CanPublishExistingPackageBuildResult(configuration, configPath, destination))
             return false;
         if (!HasReusablePackageBuildArtifacts(existing.Result.Release, destination))
@@ -207,7 +210,10 @@ public sealed partial class ModulePipelineRunner
             return false;
 
         var configuration = MapPackageBuildConfiguration(segment.Configuration, plan.ProjectRoot);
-        ApplySynchronizedNuGetRetryPolicy(configuration, useDuplicateTolerantNuGetRetry);
+        ApplySynchronizedNuGetRetryPolicy(
+            configuration,
+            useDuplicateTolerantNuGetRetry,
+            coordinatedReleaseCheckpointActive);
         var configPath = Path.Combine(plan.ProjectRoot, "module.packagebuild.inline.json");
         if (!CanPublishExistingPackageBuildResult(configuration, configPath, destination))
             return false;
@@ -285,10 +291,17 @@ public sealed partial class ModulePipelineRunner
 
     private static void ApplySynchronizedNuGetRetryPolicy(
         ProjectBuildConfiguration configuration,
-        bool useDuplicateTolerantNuGetRetry)
+        bool useDuplicateTolerantNuGetRetry,
+        bool coordinatedReleaseCheckpointActive)
     {
-        if (useDuplicateTolerantNuGetRetry)
-            configuration.SkipDuplicate = true;
+        if (!coordinatedReleaseCheckpointActive)
+        {
+            if (useDuplicateTolerantNuGetRetry)
+                configuration.SkipDuplicate = true;
+            return;
+        }
+
+        configuration.SkipDuplicate = useDuplicateTolerantNuGetRetry;
     }
 
     private void PublishExistingPackageBuildResult(
@@ -654,7 +667,10 @@ public sealed partial class ModulePipelineRunner
 
         var configPath = ResolvePackageBuildPath(plan.ProjectRoot, cfg.ConfigPath);
         var configuration = LoadProjectBuildConfiguration(configPath, cfg);
-        ApplySynchronizedNuGetRetryPolicy(configuration, useDuplicateTolerantNuGetRetry);
+        ApplySynchronizedNuGetRetryPolicy(
+            configuration,
+            useDuplicateTolerantNuGetRetry,
+            coordinatedReleaseCheckpointActive);
         var laneLabel = cfg.Name ?? configPath;
         var checkpointKey = ResolveSynchronizedReleaseLaneKey(
             plan,
@@ -710,7 +726,10 @@ public sealed partial class ModulePipelineRunner
     {
         var cfg = segment.Configuration ?? throw new InvalidOperationException("PackageBuild configuration is missing.");
         var projectBuildConfig = MapPackageBuildConfiguration(cfg, plan.ProjectRoot);
-        ApplySynchronizedNuGetRetryPolicy(projectBuildConfig, useDuplicateTolerantNuGetRetry);
+        ApplySynchronizedNuGetRetryPolicy(
+            projectBuildConfig,
+            useDuplicateTolerantNuGetRetry,
+            coordinatedReleaseCheckpointActive);
         var laneLabel = cfg.Name ?? Path.Combine(plan.ProjectRoot, "module.packagebuild.inline.json");
         var checkpointKey = ResolveSynchronizedReleaseLaneKey(
             plan,

--- a/PowerForge.Tests/DotNetRepositoryReleaseService.VersioningTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseService.VersioningTests.cs
@@ -54,6 +54,7 @@ public sealed class DotNetRepositoryReleaseServiceVersioningTests
 
     [Theory]
     [InlineData("2.0.12", "2.1.7", "2.1.7")]
+    [InlineData("2.1.7", "2.1.7", "2.1.8")]
     [InlineData("2.1.9", "2.1.7", "2.1.10")]
     [InlineData("2.1.6", "2.1.7-beta.2", "2.1.7-beta.2")]
     [InlineData("2.1.7", "2.1.7-beta.2", "2.1.8")]

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseRetrySafetyTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseRetrySafetyTests.cs
@@ -251,11 +251,11 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
                 "project.build.json",
                 moduleName,
                 publishNuGet: true,
-                skipDuplicate: false);
+                skipDuplicate: true);
 
             var runNumber = 1;
             var publishAttempts = 0;
-            var firstAttemptPreservedConfiguration = false;
+            var firstAttemptRejectedDuplicateTolerance = false;
             var retryUsedDuplicateTolerance = false;
             ProjectBuildHostExecutionResult ExecutePackageBuild(
                 ProjectBuildHostRequest request,
@@ -276,7 +276,7 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
                     publishAttempts++;
                     if (runNumber == 1)
                     {
-                        firstAttemptPreservedConfiguration = configuration?.SkipDuplicate == false;
+                        firstAttemptRejectedDuplicateTolerance = configuration?.SkipDuplicate == false;
                         result.Success = false;
                         result.ErrorMessage = "Simulated second-package failure after the first package was published.";
                     }
@@ -299,7 +299,7 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             var result = secondRunner.Run(CreateNuGetOnlyReleaseSpec(root.FullName, secondStagingPath, moduleName));
 
             Assert.Equal("2.0.11", result.Plan.ResolvedVersion);
-            Assert.True(firstAttemptPreservedConfiguration);
+            Assert.True(firstAttemptRejectedDuplicateTolerance);
             Assert.True(retryUsedDuplicateTolerance);
             Assert.Equal(2, publishAttempts);
             AssertNoCoordinatedReleaseCheckpoint(root.FullName);

--- a/PowerForge.Tests/PowerForgeProjectCmdletTests.cs
+++ b/PowerForge.Tests/PowerForgeProjectCmdletTests.cs
@@ -216,7 +216,6 @@ public sealed class PowerForgeProjectCmdletTests
         ps.AddCommand("New-ConfigurationRelease")
             .AddParameter("VersionSource", ReleaseVersionSource.PackageBuild)
             .AddParameter("PrimaryProject", "HtmlTinkerX")
-            .AddParameter("SynchronizeModuleVersion")
             .AddParameter("BuildOrder", new[] { "PackageBuild", "Module" })
             .AddParameter("PublishOrder", new[] { "NuGet", "PowerShellGallery", "GitHub" });
 

--- a/PowerForge/Models/Configuration/ConfigurationPackageBuildSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationPackageBuildSegment.cs
@@ -463,7 +463,9 @@ public sealed class ReleaseConfiguration
     public string? PrimaryProject { get; set; }
 
     /// <summary>
-    /// When enabled, coordinates the module and selected primary package on one version.
+    /// Coordinates the module and selected primary package on one version.
+    /// The PowerShell <c>New-ConfigurationRelease</c> surface enables this automatically when
+    /// <see cref="VersionSource"/> is a project/package build and <see cref="PrimaryProject"/> is configured.
     /// The next available module version becomes a floor for the primary package; a higher numeric package version still wins.
     /// At the same numeric version, a stable X-pattern candidate does not erase the configured module prerelease;
     /// explicit prerelease versions retain normal semantic-version ordering.


### PR DESCRIPTION
## Summary

- coordinate the module automatically when a project or package build is the selected release source
- treat occupied NuGet versions as conflicts on the initial coordinated publish
- allow duplicate-tolerant NuGet behavior only for a checkpoint-proven retry of the same attempted lane
- document and regenerate the public PowerShell help for the coordinated release contract

## Why

A coordinated release must publish one version across its module and aligned NuGet packages. This prevents a duplicate package from being reported as success while PSGallery and GitHub continue with an older module version.

No package is published by this pull request.