### PR TITLE
fix(release): recover atomic coordinated checkpoints

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpoint.Storage.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpoint.Storage.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 
 namespace PowerForge;
@@ -81,7 +82,7 @@ public sealed partial class ModulePipelineRunner
     {
         state.PlannedSynchronizedOperationCount = ResolvePlannedSynchronizedPublishOperationKeys(plan).Length;
         var checkpointPath = ResolveSynchronizedReleaseCheckpointPath(plan);
-        if (state.PlannedSynchronizedOperationCount == 0 && !File.Exists(checkpointPath))
+        if (state.PlannedSynchronizedOperationCount == 0 && !HasSynchronizedReleaseCheckpoint(checkpointPath))
             return;
 
         var lockPath = checkpointPath + ".lock";
@@ -120,13 +121,246 @@ public sealed partial class ModulePipelineRunner
             $"Coordinated release checkpoint path '{path}' has no parent directory.");
         Directory.CreateDirectory(directory);
         var temporaryPath = path + ".tmp";
-        File.WriteAllText(
+        WriteSynchronizedReleaseCheckpointFile(
             temporaryPath,
             JsonSerializer.Serialize(checkpoint, new JsonSerializerOptions { WriteIndented = true }));
+        PromoteSynchronizedReleaseCheckpointFile(temporaryPath, path);
+    }
+
+    private static bool HasSynchronizedReleaseCheckpoint(string path)
+        => File.Exists(path) || File.Exists(path + ".tmp");
+
+    private static SynchronizedReleaseCheckpointRead ReadSynchronizedReleaseCheckpoint(string path)
+    {
+        var temporaryPath = path + ".tmp";
+        var primaryExists = File.Exists(path);
+        var temporaryExists = File.Exists(temporaryPath);
+        if (!primaryExists && !temporaryExists)
+        {
+            throw new InvalidOperationException(
+                $"Coordinated release checkpoint '{path}' disappeared while the release lock was being acquired.");
+        }
+
+        var primary = primaryExists ? DeserializeSynchronizedReleaseCheckpoint(path) : null;
+        if (!temporaryExists)
+            return new SynchronizedReleaseCheckpointRead(primary!, temporaryPath: null);
+
+        var temporary = DeserializeSynchronizedReleaseCheckpoint(temporaryPath);
+        if (primary is not null && !IsMonotonicSynchronizedReleaseCheckpointSuccessor(primary, temporary))
+        {
+            throw new InvalidOperationException(
+                $"Temporary coordinated release checkpoint '{temporaryPath}' cannot be proven to be a newer state of '{path}'. Preserve both files and inspect the release state before retrying.");
+        }
+
+        return new SynchronizedReleaseCheckpointRead(temporary, temporaryPath);
+    }
+
+    private static SynchronizedReleaseCheckpoint DeserializeSynchronizedReleaseCheckpoint(string path)
+    {
+        try
+        {
+            RequireNormalSynchronizedReleaseCheckpointFile(path);
+            var checkpoint = JsonSerializer.Deserialize<SynchronizedReleaseCheckpoint>(
+                File.ReadAllText(path),
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            if (checkpoint is null || checkpoint.SchemaVersion != 5)
+            {
+                throw new InvalidOperationException(
+                    $"Coordinated release checkpoint '{path}' has an unsupported schema.");
+            }
+            return checkpoint;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            throw new InvalidOperationException(
+                $"Coordinated release checkpoint '{path}' could not be read. Preserve it and inspect the incomplete release state before retrying. {ex.Message}",
+                ex);
+        }
+    }
+
+    private static bool IsMonotonicSynchronizedReleaseCheckpointSuccessor(
+        SynchronizedReleaseCheckpoint previous,
+        SynchronizedReleaseCheckpoint candidate)
+    {
+        if (previous.PlannedOperations is null || candidate.PlannedOperations is null ||
+            previous.AttemptedOperations is null || candidate.AttemptedOperations is null ||
+            previous.CompletedOperations is null || candidate.CompletedOperations is null ||
+            previous.OperationFingerprints is null || candidate.OperationFingerprints is null ||
+            previous.SourceComponents is null || candidate.SourceComponents is null ||
+            previous.PayloadComponents is null || candidate.PayloadComponents is null ||
+            previous.PlannedLanes is null || candidate.PlannedLanes is null ||
+            previous.AttemptedLanes is null || candidate.AttemptedLanes is null ||
+            previous.Lanes is null || candidate.Lanes is null)
+        {
+            return false;
+        }
+
+        var sameIdentity = previous.SchemaVersion == candidate.SchemaVersion &&
+                           previous.SchemaVersion == 5 &&
+                           string.Equals(previous.ModuleName, candidate.ModuleName, StringComparison.OrdinalIgnoreCase) &&
+                           previous.ReleaseSource == candidate.ReleaseSource &&
+                           string.Equals(previous.PrimaryProject, candidate.PrimaryProject, StringComparison.OrdinalIgnoreCase) &&
+                           previous.CreatedUtc == candidate.CreatedUtc &&
+                           SetsEqual(previous.PlannedOperations, candidate.PlannedOperations) &&
+                           SetsEqual(previous.OperationFingerprints, candidate.OperationFingerprints) &&
+                           SetsEqual(previous.PlannedLanes, candidate.PlannedLanes);
+        if (!sameIdentity ||
+            !CanAdvanceSynchronizedReleaseVersion(previous.Version, candidate.Version) ||
+            !CanAdvanceSynchronizedReleaseFingerprint(
+                previous.SourceFingerprint,
+                previous.SourceComponents,
+                candidate.SourceFingerprint,
+                candidate.SourceComponents) ||
+            !CanAdvanceSynchronizedReleaseFingerprint(
+                previous.PayloadFingerprint,
+                previous.PayloadComponents,
+                candidate.PayloadFingerprint,
+                candidate.PayloadComponents))
+        {
+            return false;
+        }
+
+        if (!IsValidCheckpointSet(candidate.AttemptedOperations, candidate.PlannedOperations) ||
+            !IsValidCheckpointSet(candidate.CompletedOperations, candidate.AttemptedOperations) ||
+            !IsValidCheckpointSet(candidate.AttemptedLanes, candidate.PlannedLanes) ||
+            !IsSetSubset(previous.AttemptedOperations, candidate.AttemptedOperations) ||
+            !IsSetSubset(previous.CompletedOperations, candidate.CompletedOperations) ||
+            !IsSetSubset(previous.AttemptedLanes, candidate.AttemptedLanes) ||
+            (previous.AuxiliaryRemoteSideEffectsObserved && !candidate.AuxiliaryRemoteSideEffectsObserved))
+        {
+            return false;
+        }
+
+        if (candidate.Lanes.Length != candidate.AttemptedLanes.Length ||
+            candidate.Lanes.Any(static lane => lane is null) ||
+            candidate.Lanes.Select(static lane => lane.CheckpointKey)
+                .Distinct(StringComparer.OrdinalIgnoreCase).Count() != candidate.Lanes.Length ||
+            candidate.Lanes.Any(lane =>
+                !candidate.AttemptedLanes.Contains(lane.CheckpointKey, StringComparer.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+
+        foreach (var previousLane in previous.Lanes)
+        {
+            var candidateLane = candidate.Lanes.FirstOrDefault(lane =>
+                string.Equals(lane.CheckpointKey, previousLane.CheckpointKey, StringComparison.OrdinalIgnoreCase));
+            if (candidateLane is null ||
+                candidateLane.Source != previousLane.Source ||
+                !string.Equals(candidateLane.Label, previousLane.Label, StringComparison.Ordinal) ||
+                !SynchronizedReleaseLaneVersionsEqual(previousLane, candidateLane))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool CanAdvanceSynchronizedReleaseVersion(string? previous, string? candidate)
+    {
+        if (string.Equals(previous, candidate, StringComparison.OrdinalIgnoreCase))
+            return true;
+        return string.IsNullOrWhiteSpace(previous) &&
+               PackageVersionUtility.TryNormalizeExact(candidate, out _);
+    }
+
+    private static bool CanAdvanceSynchronizedReleaseFingerprint(
+        string? previousFingerprint,
+        string[] previousComponents,
+        string? candidateFingerprint,
+        string[] candidateComponents)
+    {
+        if (string.Equals(previousFingerprint, candidateFingerprint, StringComparison.OrdinalIgnoreCase) &&
+            previousComponents.SequenceEqual(candidateComponents, StringComparer.Ordinal))
+        {
+            return true;
+        }
+
+        return string.IsNullOrWhiteSpace(previousFingerprint) &&
+               previousComponents.Length == 0 &&
+               IsValidSynchronizedReleaseFingerprintState(candidateFingerprint, candidateComponents);
+    }
+
+    private static bool IsValidCheckpointSet(string[] values, string[] allowed)
+        => values.Distinct(StringComparer.OrdinalIgnoreCase).Count() == values.Length &&
+           values.All(value => allowed.Contains(value, StringComparer.OrdinalIgnoreCase));
+
+    private static bool IsSetSubset(string[] subset, string[] superset)
+        => subset.All(value => superset.Contains(value, StringComparer.OrdinalIgnoreCase));
+
+    private static bool SetsEqual(string[] first, string[] second)
+        => first.Length == second.Length && IsSetSubset(first, second);
+
+    private static void WriteSynchronizedReleaseCheckpointFile(string path, string content)
+    {
         if (File.Exists(path))
-            File.Replace(temporaryPath, path, destinationBackupFileName: null);
-        else
-            File.Move(temporaryPath, path);
+            RequireNormalSynchronizedReleaseCheckpointFile(path);
+        using var stream = new FileStream(
+            path,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 4096,
+            FileOptions.WriteThrough);
+        using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), 4096, leaveOpen: true);
+        writer.Write(content);
+        writer.Flush();
+        stream.Flush(flushToDisk: true);
+    }
+
+    private static void PromoteSynchronizedReleaseCheckpointFile(string temporaryPath, string path)
+    {
+        RequireNormalSynchronizedReleaseCheckpointFile(temporaryPath);
+        if (File.Exists(path))
+            RequireNormalSynchronizedReleaseCheckpointFile(path);
+
+        const int maximumAttempts = 6;
+        for (var attempt = 1; attempt <= maximumAttempts; attempt++)
+        {
+            try
+            {
+                if (File.Exists(path))
+                    File.Replace(temporaryPath, path, destinationBackupFileName: null, ignoreMetadataErrors: true);
+                else
+                    File.Move(temporaryPath, path);
+                return;
+            }
+            catch (Exception ex) when (
+                attempt < maximumAttempts &&
+                ex is IOException or UnauthorizedAccessException)
+            {
+                System.Threading.Thread.Sleep(50 * (1 << (attempt - 1)));
+            }
+        }
+    }
+
+    private static void RequireNormalSynchronizedReleaseCheckpointFile(string path)
+    {
+        if (!File.Exists(path))
+            throw new InvalidOperationException($"Coordinated release checkpoint file '{path}' is missing.");
+
+        var attributes = File.GetAttributes(path);
+        if ((attributes & (FileAttributes.Directory | FileAttributes.ReparsePoint)) != 0)
+        {
+            throw new InvalidOperationException(
+                $"Coordinated release checkpoint file '{path}' is not a normal file.");
+        }
+    }
+
+    private sealed class SynchronizedReleaseCheckpointRead
+    {
+        internal SynchronizedReleaseCheckpointRead(
+            SynchronizedReleaseCheckpoint checkpoint,
+            string? temporaryPath)
+        {
+            Checkpoint = checkpoint;
+            TemporaryPath = temporaryPath;
+        }
+
+        internal SynchronizedReleaseCheckpoint Checkpoint { get; }
+
+        internal string? TemporaryPath { get; }
     }
 
     private static void DeleteEmptySynchronizedReleaseCheckpointDirectories(string checkpointPath)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpoint.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpoint.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.Json;
 
 namespace PowerForge;
 
@@ -12,7 +11,7 @@ public sealed partial class ModulePipelineRunner
         ModulePipelineRunState state)
     {
         var path = ResolveSynchronizedReleaseCheckpointPath(plan);
-        var checkpointExists = File.Exists(path);
+        var checkpointExists = HasSynchronizedReleaseCheckpoint(path);
         var sourceMutatingGate = plan.GateMode is ConfigurationGateMode.Manifest or
             ConfigurationGateMode.Documentation or
             ConfigurationGateMode.Build;
@@ -34,25 +33,8 @@ public sealed partial class ModulePipelineRunner
         if (!checkpointExists)
             return;
 
-        SynchronizedReleaseCheckpoint? checkpoint;
-        try
-        {
-            checkpoint = JsonSerializer.Deserialize<SynchronizedReleaseCheckpoint>(
-                File.ReadAllText(path),
-                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidOperationException(
-                $"Coordinated release checkpoint '{path}' could not be read. Delete it only if the incomplete release should be abandoned. {ex.Message}",
-                ex);
-        }
-
-        if (checkpoint is null || checkpoint.SchemaVersion != 5)
-        {
-            throw new InvalidOperationException(
-                $"Coordinated release checkpoint '{path}' has an unsupported schema. Delete it only if the incomplete release should be abandoned.");
-        }
+        var checkpointRead = ReadSynchronizedReleaseCheckpoint(path);
+        var checkpoint = checkpointRead.Checkpoint;
 
         if (!shouldUseCheckpoint && !sourceMutatingGate)
         {
@@ -92,6 +74,13 @@ public sealed partial class ModulePipelineRunner
                 path,
                 "because release configuration changed before any publish operation or remote side effect started");
             return;
+        }
+
+        if (checkpointRead.TemporaryPath is not null)
+        {
+            PromoteSynchronizedReleaseCheckpointFile(checkpointRead.TemporaryPath, path);
+            _logger.Warn(
+                $"Recovered a newer durable coordinated release checkpoint from '{checkpointRead.TemporaryPath}'.");
         }
 
         state.SynchronizedReleaseCheckpoint = checkpoint;
@@ -469,6 +458,9 @@ public sealed partial class ModulePipelineRunner
 
         if (File.Exists(path))
             File.Delete(path);
+        var temporaryPath = path + ".tmp";
+        if (File.Exists(temporaryPath))
+            File.Delete(temporaryPath);
         var payloadCachePath = ResolveSynchronizedReleasePayloadCachePath(path!);
         if (Directory.Exists(payloadCachePath))
         {

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpointReset.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpointReset.cs
@@ -20,6 +20,7 @@ public sealed partial class ModulePipelineRunner
             File.Delete(payloadCachePath);
 
         File.Delete(path);
+        File.Delete(path + ".tmp");
         DeleteEmptySynchronizedReleaseCheckpointDirectories(path);
         _logger.Warn($"Discarded unused coordinated release checkpoint '{path}' {reason}.");
     }

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseCheckpointStorageTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseCheckpointStorageTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -9,6 +11,207 @@ namespace PowerForge.Tests;
 
 public sealed partial class ModulePipelineUnifiedReleaseTests
 {
+    [Fact]
+    public void Run_RecoversNewerTemporaryCheckpointWithoutRepeatingCompletedPublish()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var firstStagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        var secondStagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "2.0.10");
+            WriteSynchronizedProjectBuildConfig(root.FullName, "project.build.json", moduleName, publishNuGet: false);
+
+            var firstHosted = new FakeHostedOperations(new List<string>())
+            {
+                ModulePublishAction = (_, _) => throw new InvalidOperationException("Simulated interruption after the remote side effect.")
+            };
+            var firstRunner = CreateRunner(
+                firstHosted,
+                (request, configuration, configPath) => CreateProjectBuildResult(
+                    root.FullName,
+                    moduleName,
+                    "2.0.11",
+                    Path.Combine(root.FullName, "Artifacts", "NuGet"),
+                    request,
+                    configPath,
+                    includePackage: false));
+            Assert.Throws<InvalidOperationException>(() => firstRunner.Run(
+                CreateGalleryReleaseSpec(root.FullName, firstStagingPath, moduleName)));
+
+            var checkpointPath = Assert.Single(Directory.GetFiles(
+                GetCoordinatedReleaseCheckpointRoot(root.FullName),
+                "*.json"));
+            WriteCompletedTemporaryCheckpoint(checkpointPath);
+
+            var repeatedPublishes = 0;
+            var secondHosted = new FakeHostedOperations(new List<string>())
+            {
+                ModulePublishAction = (_, _) => repeatedPublishes++
+            };
+            var secondRunner = CreateRunner(
+                secondHosted,
+                (request, configuration, configPath) => CreateProjectBuildResult(
+                    root.FullName,
+                    moduleName,
+                    "2.0.11",
+                    Path.Combine(root.FullName, "Artifacts", "NuGet"),
+                    request,
+                    configPath,
+                    includePackage: false));
+
+            secondRunner.Run(CreateGalleryReleaseSpec(root.FullName, secondStagingPath, moduleName));
+
+            Assert.Equal(0, repeatedPublishes);
+            Assert.False(File.Exists(checkpointPath));
+            Assert.False(File.Exists(checkpointPath + ".tmp"));
+            AssertNoCoordinatedReleaseCheckpoint(root.FullName);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+            try { if (Directory.Exists(firstStagingPath)) Directory.Delete(firstStagingPath, recursive: true); } catch { }
+            try { if (Directory.Exists(secondStagingPath)) Directory.Delete(secondStagingPath, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Run_RejectsTemporaryCheckpointThatChangesReleaseIdentity()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var firstStagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        var secondStagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "2.0.10");
+            WriteSynchronizedProjectBuildConfig(root.FullName, "project.build.json", moduleName, publishNuGet: false);
+
+            var firstHosted = new FakeHostedOperations(new List<string>())
+            {
+                ModulePublishAction = (_, _) => throw new InvalidOperationException("Simulated interruption after the remote side effect.")
+            };
+            var firstRunner = CreateRunner(
+                firstHosted,
+                (request, configuration, configPath) => CreateProjectBuildResult(
+                    root.FullName,
+                    moduleName,
+                    "2.0.11",
+                    Path.Combine(root.FullName, "Artifacts", "NuGet"),
+                    request,
+                    configPath,
+                    includePackage: false));
+            Assert.Throws<InvalidOperationException>(() => firstRunner.Run(
+                CreateGalleryReleaseSpec(root.FullName, firstStagingPath, moduleName)));
+
+            var checkpointPath = Assert.Single(Directory.GetFiles(
+                GetCoordinatedReleaseCheckpointRoot(root.FullName),
+                "*.json"));
+            var temporary = WriteCompletedTemporaryCheckpoint(checkpointPath);
+            temporary["ModuleName"] = "DifferentModule";
+            File.WriteAllText(
+                checkpointPath + ".tmp",
+                temporary.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+
+            var repeatedPublishes = 0;
+            var secondHosted = new FakeHostedOperations(new List<string>())
+            {
+                ModulePublishAction = (_, _) => repeatedPublishes++
+            };
+            var secondRunner = CreateRunner(
+                secondHosted,
+                (request, configuration, configPath) => CreateProjectBuildResult(
+                    root.FullName,
+                    moduleName,
+                    "2.0.11",
+                    Path.Combine(root.FullName, "Artifacts", "NuGet"),
+                    request,
+                    configPath,
+                    includePackage: false));
+
+            var exception = Assert.Throws<InvalidOperationException>(() => secondRunner.Run(
+                CreateGalleryReleaseSpec(root.FullName, secondStagingPath, moduleName)));
+
+            Assert.Contains("cannot be proven", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(0, repeatedPublishes);
+            Assert.True(File.Exists(checkpointPath));
+            Assert.True(File.Exists(checkpointPath + ".tmp"));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+            try { if (Directory.Exists(firstStagingPath)) Directory.Delete(firstStagingPath, recursive: true); } catch { }
+            try { if (Directory.Exists(secondStagingPath)) Directory.Delete(secondStagingPath, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Run_FailsClosedWhenTemporaryCheckpointIsUnreadable()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var firstStagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        var secondStagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "2.0.10");
+            WriteSynchronizedProjectBuildConfig(root.FullName, "project.build.json", moduleName, publishNuGet: false);
+
+            var firstHosted = new FakeHostedOperations(new List<string>())
+            {
+                ModulePublishAction = (_, _) => throw new InvalidOperationException("Simulated interruption after the remote side effect.")
+            };
+            var firstRunner = CreateRunner(
+                firstHosted,
+                (request, configuration, configPath) => CreateProjectBuildResult(
+                    root.FullName,
+                    moduleName,
+                    "2.0.11",
+                    Path.Combine(root.FullName, "Artifacts", "NuGet"),
+                    request,
+                    configPath,
+                    includePackage: false));
+            Assert.Throws<InvalidOperationException>(() => firstRunner.Run(
+                CreateGalleryReleaseSpec(root.FullName, firstStagingPath, moduleName)));
+
+            var checkpointPath = Assert.Single(Directory.GetFiles(
+                GetCoordinatedReleaseCheckpointRoot(root.FullName),
+                "*.json"));
+            File.WriteAllText(checkpointPath + ".tmp", "{");
+
+            var repeatedPublishes = 0;
+            var secondHosted = new FakeHostedOperations(new List<string>())
+            {
+                ModulePublishAction = (_, _) => repeatedPublishes++
+            };
+            var secondRunner = CreateRunner(
+                secondHosted,
+                (request, configuration, configPath) => CreateProjectBuildResult(
+                    root.FullName,
+                    moduleName,
+                    "2.0.11",
+                    Path.Combine(root.FullName, "Artifacts", "NuGet"),
+                    request,
+                    configPath,
+                    includePackage: false));
+
+            var exception = Assert.Throws<InvalidOperationException>(() => secondRunner.Run(
+                CreateGalleryReleaseSpec(root.FullName, secondStagingPath, moduleName)));
+
+            Assert.Contains("could not be read", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(0, repeatedPublishes);
+            Assert.True(File.Exists(checkpointPath));
+            Assert.True(File.Exists(checkpointPath + ".tmp"));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+            try { if (Directory.Exists(firstStagingPath)) Directory.Delete(firstStagingPath, recursive: true); } catch { }
+            try { if (Directory.Exists(secondStagingPath)) Directory.Delete(secondStagingPath, recursive: true); } catch { }
+        }
+    }
+
     [Fact]
     public void ResolveCheckpointStateRoot_UsesUserLocalStorageOutsideNonGitProject()
     {
@@ -138,5 +341,19 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             try { if (Directory.Exists(firstStagingPath)) Directory.Delete(firstStagingPath, recursive: true); } catch { }
             try { if (Directory.Exists(secondStagingPath)) Directory.Delete(secondStagingPath, recursive: true); } catch { }
         }
+    }
+
+    private static JsonObject WriteCompletedTemporaryCheckpoint(string checkpointPath)
+    {
+        var checkpoint = JsonNode.Parse(File.ReadAllText(checkpointPath))!.AsObject();
+        var attempted = checkpoint["AttemptedOperations"]!.AsArray();
+        var completed = new JsonArray();
+        foreach (var operation in attempted)
+            completed.Add(operation!.GetValue<string>());
+        checkpoint["CompletedOperations"] = completed;
+        File.WriteAllText(
+            checkpointPath + ".tmp",
+            checkpoint.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+        return checkpoint;
     }
 }


### PR DESCRIPTION
## Summary

- make coordinated-release checkpoint writes durable and retry transient atomic replacement failures
- recover a newer `.json.tmp` checkpoint only when it is a provable monotonic successor of the same release
- fail closed for corrupt, reparse-backed, or identity-changing checkpoint state
- remove temporary checkpoint state during successful completion and explicit reset

## Why this matters

A remote publish can succeed immediately before Windows blocks replacement of the local checkpoint. Previously, the durable temporary state was stranded and the next run could repeat an already-completed channel. Recovery now preserves the completed operation ledger without treating unrelated or tampered state as resumable.

## Validation

- coordinated-release suite: 85/85
- focused recovery regressions: 3/3
- PowerForge.PowerShell Release build for net472, net8.0, and net10.0: clean
- full Release solution build: 0 warnings, 0 errors
- independent read-only review: no actionable findings

No package was published while validating this change.