### PR TITLE
Fix oversized project release ZIPs

### DIFF
--- a/Docs/PSPublishModule.ProjectBuild.md
+++ b/Docs/PSPublishModule.ProjectBuild.md
@@ -367,6 +367,7 @@ Staging and outputs
 - When a project defines `<PackageId>`, project-build uses that package identity for NuGet version lookup,
   planned `.nupkg` names, and release zip names. Otherwise it falls back to the csproj file name.
 - `CleanStaging`: if true, deletes the staging directory before a run. It does not clean project `bin`/`obj` directories; package correctness comes from the release rebuild and package-payload provenance check.
+- `CreateReleaseZip`: creates one framework-dependent archive containing the files recorded by the current MSBuild output manifest for every active target framework. Unrecorded stale files and separately generated publish/RID trees are excluded while declared content and dependency runtime assets remain included. Use tool targets when you also want self-contained per-platform archives.
 - `PlanOutputPath`: optional file path for a JSON plan output.
 - `IncludeSymbols`: when true, produces portable `.snupkg` files for every packable project. Plan output includes their expected paths, and build output discovery rejects stale symbol packages just as it does stale primary packages.
 

--- a/PowerForge.Tests/DotNetRepositoryReleaseZipTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseZipTests.cs
@@ -1,0 +1,132 @@
+using System.IO.Compression;
+
+namespace PowerForge.Tests;
+
+public sealed class DotNetRepositoryReleaseZipTests {
+    [Fact]
+    public void Execute_CreateReleaseZip_ExcludesStaleFrameworkAndNestedPublishOutputs() {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try {
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Package"));
+            File.WriteAllText(Path.Combine(projectDirectory.FullName, "Sample.Package.csproj"), """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <PackageId>Sample.Package</PackageId>
+                    <VersionPrefix>1.0.0</VersionPrefix>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <None Include="content/current.txt" CopyToOutputDirectory="PreserveNewest" />
+                    <None Include="content/publish/required.txt" CopyToOutputDirectory="PreserveNewest" TargetPath="publish/required.txt" />
+                    <None Include="content/runtimes/win-x64/native/native-dependency.bin" CopyToOutputDirectory="PreserveNewest" TargetPath="runtimes/win-x64/native/native-dependency.bin" />
+                  </ItemGroup>
+                </Project>
+                """);
+            File.WriteAllText(
+                Path.Combine(projectDirectory.FullName, "Class1.cs"),
+                "namespace Sample.Package; public static class Class1 { public static string Value => \"current\"; }");
+            var contentDirectory = Directory.CreateDirectory(Path.Combine(projectDirectory.FullName, "content"));
+            File.WriteAllText(Path.Combine(contentDirectory.FullName, "current.txt"), "current-build-content");
+            var publishContentDirectory = Directory.CreateDirectory(Path.Combine(contentDirectory.FullName, "publish"));
+            File.WriteAllText(Path.Combine(publishContentDirectory.FullName, "required.txt"), "required-publish-content");
+            var runtimeContentDirectory = Directory.CreateDirectory(Path.Combine(contentDirectory.FullName, "runtimes", "win-x64", "native"));
+            File.WriteAllText(Path.Combine(runtimeContentDirectory.FullName, "native-dependency.bin"), "required-runtime-content");
+
+            var currentOutput = Directory.CreateDirectory(Path.Combine(projectDirectory.FullName, "bin", "Release", "net8.0"));
+            var staleRuntimeOutput = Directory.CreateDirectory(Path.Combine(currentOutput.FullName, "win-x64"));
+            File.WriteAllText(Path.Combine(staleRuntimeOutput.FullName, "stale-runtime.bin"), "must-not-ship");
+            var stalePublishOutput = Directory.CreateDirectory(Path.Combine(currentOutput.FullName, "publish"));
+            File.WriteAllText(Path.Combine(stalePublishOutput.FullName, "stale-publish.bin"), "must-not-ship");
+            var staleNestedFrameworkOutput = Directory.CreateDirectory(Path.Combine(currentOutput.FullName, "legacy-output"));
+            File.WriteAllText(Path.Combine(staleNestedFrameworkOutput.FullName, "Sample.Package.deps.json"), "stale-output-marker");
+            File.WriteAllText(Path.Combine(staleNestedFrameworkOutput.FullName, "stale-nested.bin"), "must-not-ship");
+            var staleFrameworkOutput = Directory.CreateDirectory(Path.Combine(projectDirectory.FullName, "bin", "Release", "net9.0"));
+            File.WriteAllText(Path.Combine(staleFrameworkOutput.FullName, "stale-framework.bin"), "must-not-ship");
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(new DotNetRepositoryReleaseSpec {
+                RootPath = root.FullName,
+                Configuration = "Release",
+                OutputPath = Path.Combine(root.FullName, "packages"),
+                ReleaseZipOutputPath = Path.Combine(root.FullName, "releases"),
+                Pack = true,
+                Publish = false,
+                UpdateVersions = false,
+                CreateReleaseZip = true
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            var project = Assert.Single(result.Projects, item => item.IsPackable);
+            Assert.True(File.Exists(project.ReleaseZipPath));
+            using var archive = ZipFile.OpenRead(project.ReleaseZipPath!);
+            var entries = archive.Entries
+                .Where(static entry => !string.IsNullOrEmpty(entry.Name))
+                .Select(static entry => entry.FullName.Replace('\\', '/'))
+                .ToArray();
+            Assert.Contains("net8.0/Sample.Package.dll", entries);
+            Assert.Contains("net8.0/content/current.txt", entries);
+            Assert.Contains("net8.0/publish/required.txt", entries);
+            Assert.Contains("net8.0/runtimes/win-x64/native/native-dependency.bin", entries);
+            Assert.DoesNotContain("net8.0/win-x64/stale-runtime.bin", entries);
+            Assert.DoesNotContain(entries, static entry => entry.Contains("legacy-output", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(entries, static entry => entry.Contains("net9.0", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(entries, static entry => entry.Contains("stale", StringComparison.OrdinalIgnoreCase));
+        } finally {
+            try {
+                root.Delete(recursive: true);
+            } catch {
+                // Best-effort test cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public void ReleaseZipSourceTopology_DetectsOverlappingFrameworkOutputRoots() {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try {
+            var frameworkOutput = Directory.CreateDirectory(Path.Combine(root.FullName, "shared"));
+            var nestedFrameworkOutput = Directory.CreateDirectory(Path.Combine(frameworkOutput.FullName, "nested"));
+
+            Assert.True(DotNetRepositoryReleaseService.ReleaseZipPathsOverlap(
+                frameworkOutput.FullName,
+                nestedFrameworkOutput.FullName));
+            Assert.True(DotNetRepositoryReleaseService.ReleaseZipPathsOverlap(
+                nestedFrameworkOutput.FullName,
+                frameworkOutput.FullName));
+        } finally {
+            try {
+                root.Delete(recursive: true);
+            } catch {
+                // Best-effort test cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public void ReleaseZipPathValidation_RejectsLinkedTargetDirectory() {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var outside = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try {
+            var linkedOutput = Path.Combine(root.FullName, "linked-output");
+            try {
+                Directory.CreateSymbolicLink(linkedOutput, outside.FullName);
+            } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or PlatformNotSupportedException) {
+                return;
+            }
+
+            Assert.False(DotNetRepositoryReleaseService.TryValidateReleaseZipPath(linkedOutput, out var error));
+            Assert.Contains("linked", error, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            try {
+                root.Delete(recursive: true);
+            } catch {
+                // Best-effort test cleanup.
+            }
+            try {
+                outside.Delete(recursive: true);
+            } catch {
+                // Best-effort test cleanup.
+            }
+        }
+    }
+}

--- a/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
@@ -84,7 +84,10 @@ public sealed class DotNetRepositoryReleaseSpec
     /// <summary>Strategy used for packing selected projects.</summary>
     public DotNetRepositoryPackStrategy PackStrategy { get; set; } = DotNetRepositoryPackStrategy.PerProject;
 
-    /// <summary>When true, create a release zip from the build output.</summary>
+    /// <summary>
+    /// When true, creates one release ZIP containing files recorded by the current MSBuild
+    /// output manifest for every evaluated target framework.
+    /// </summary>
     public bool CreateReleaseZip { get; set; }
 
     /// <summary>Optional output path for release zips.</summary>

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -538,7 +538,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         {
                             _logger.Info($"Creating {project.ProjectName} release zip...");
                             var zipWatch = Stopwatch.StartNew();
-                            if (!TryCreateReleaseZip(project, spec.Configuration, zipPath, out var zipError, out var zippedFiles, out var zippedBytes))
+                            if (!TryCreateReleaseZip(project, spec.Configuration, zipPath, _logger, out var zipError, out var zippedFiles, out var zippedBytes))
                             {
                                 zipWatch.Stop();
                                 project.ErrorMessage = zipError;

--- a/PowerForge/Services/DotNetRepositoryReleaseService.ExpectedAndZip.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.ExpectedAndZip.cs
@@ -2,23 +2,20 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 namespace PowerForge;
 
-public sealed partial class DotNetRepositoryReleaseService
-{
-    private static Dictionary<string, string> BuildExpectedVersionMap(Dictionary<string, string>? map)
-    {
+public sealed partial class DotNetRepositoryReleaseService {
+    private static Dictionary<string, string> BuildExpectedVersionMap(Dictionary<string, string>? map) {
         var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         if (map is null) return result;
 
-        foreach (var kvp in map)
-        {
+        foreach (var kvp in map) {
             if (string.IsNullOrWhiteSpace(kvp.Key)) continue;
             if (string.IsNullOrWhiteSpace(kvp.Value)) continue;
             result[kvp.Key.Trim()] = kvp.Value.Trim();
@@ -27,10 +24,8 @@ public sealed partial class DotNetRepositoryReleaseService
         return result;
     }
 
-    private static bool IsPackable(string csprojPath)
-    {
-        try
-        {
+    private static bool IsPackable(string csprojPath) {
+        try {
             var doc = XDocument.Load(csprojPath);
             var value = doc.Descendants()
                 .FirstOrDefault(e => e.Name.LocalName.Equals("IsPackable", StringComparison.OrdinalIgnoreCase))
@@ -38,17 +33,13 @@ public sealed partial class DotNetRepositoryReleaseService
 
             if (string.IsNullOrWhiteSpace(value)) return true;
             return !string.Equals(value?.Trim(), "false", StringComparison.OrdinalIgnoreCase);
-        }
-        catch
-        {
+        } catch {
             return true;
         }
     }
 
-    private static string ResolvePackageId(string csprojPath, string fallbackProjectName)
-    {
-        try
-        {
+    private static string ResolvePackageId(string csprojPath, string fallbackProjectName) {
+        try {
             var doc = XDocument.Load(csprojPath);
             var packageId = doc.Descendants()
                 .FirstOrDefault(e => e.Name.LocalName.Equals("PackageId", StringComparison.OrdinalIgnoreCase))
@@ -57,15 +48,12 @@ public sealed partial class DotNetRepositoryReleaseService
             return string.IsNullOrWhiteSpace(packageId)
                 ? fallbackProjectName
                 : (packageId ?? string.Empty).Trim();
-        }
-        catch
-        {
+        } catch {
             return fallbackProjectName;
         }
     }
 
-    private static string BuildReleaseZipPath(DotNetRepositoryProjectResult project, DotNetRepositoryReleaseSpec spec)
-    {
+    private static string BuildReleaseZipPath(DotNetRepositoryProjectResult project, DotNetRepositoryReleaseSpec spec) {
         var csprojDir = Path.GetDirectoryName(project.CsprojPath) ?? string.Empty;
         var cfg = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
         var releasePath = string.IsNullOrWhiteSpace(spec.ReleaseZipOutputPath)
@@ -80,25 +68,19 @@ public sealed partial class DotNetRepositoryReleaseService
         DotNetRepositoryProjectResult project,
         string configuration,
         string zipPath,
+        ILogger logger,
         out string error,
         out int fileCount,
-        out long inputBytes)
-    {
+        out long inputBytes) {
         error = string.Empty;
         fileCount = 0;
         inputBytes = 0;
         var csprojDir = Path.GetDirectoryName(project.CsprojPath) ?? string.Empty;
         var cfg = string.IsNullOrWhiteSpace(configuration) ? "Release" : configuration.Trim();
-        var releasePath = Path.Combine(csprojDir, "bin", cfg);
-
-        if (!Directory.Exists(releasePath))
-        {
-            error = $"Release path not found: {releasePath}";
+        if (!TryResolveReleaseZipSources(project, csprojDir, cfg, logger, out var sources, out error))
             return false;
-        }
 
-        try
-        {
+        try {
             var zipDir = Path.GetDirectoryName(zipPath);
             if (!string.IsNullOrWhiteSpace(zipDir))
                 Directory.CreateDirectory(zipDir);
@@ -107,37 +89,261 @@ public sealed partial class DotNetRepositoryReleaseService
             var zipFull = Path.GetFullPath(zipPath);
 
             using var fs = new FileStream(zipPath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
-            using var archive = new System.IO.Compression.ZipArchive(fs, System.IO.Compression.ZipArchiveMode.Create);
+            using var archive = new ZipArchive(fs, ZipArchiveMode.Create);
+            var entryNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (var file in Directory.EnumerateFiles(releasePath, "*", SearchOption.AllDirectories))
-            {
-                try
-                {
+            foreach (var source in sources) {
+                foreach (var file in source.Files) {
                     if (string.Equals(Path.GetFullPath(file), zipFull, StringComparison.OrdinalIgnoreCase))
                         continue;
+
+                    if (file.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase) ||
+                        file.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase)) {
+                        continue;
+                    }
+
+                    var relativePath = ComputeRelativePath(source.Path, file).Replace('\\', '/');
+                    var entryName = string.IsNullOrWhiteSpace(source.EntryPrefix)
+                        ? relativePath
+                        : source.EntryPrefix + "/" + relativePath;
+                    if (!entryNames.Add(entryName))
+                        throw new InvalidDataException($"Release output maps more than one file to '{entryName}'.");
+
+                    var entry = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+                    entry.LastWriteTime = File.GetLastWriteTimeUtc(file);
+                    using var entryStream = entry.Open();
+                    using var fileStream = File.OpenRead(file);
+                    fileCount++;
+                    inputBytes += fileStream.Length;
+                    fileStream.CopyTo(entryStream);
                 }
-                catch { }
-
-                if (file.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase) ||
-                    file.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase))
-                    continue;
-
-                var rel = ComputeRelativePath(releasePath, file);
-                var entry = archive.CreateEntry(rel, System.IO.Compression.CompressionLevel.Optimal);
-                using var entryStream = entry.Open();
-                using var fileStream = File.OpenRead(file);
-                fileCount++;
-                inputBytes += fileStream.Length;
-                fileStream.CopyTo(entryStream);
             }
 
+            if (fileCount == 0)
+                throw new InvalidDataException($"No current build output files were found for {project.ProjectName}.");
+
             return true;
-        }
-        catch (Exception ex)
-        {
+        } catch (Exception ex) {
+            try {
+                if (File.Exists(zipPath))
+                    File.Delete(zipPath);
+            } catch {
+                // Preserve the original archive creation failure.
+            }
             error = $"Failed to create release zip: {ex.Message}";
             return false;
         }
     }
 
+    private static bool TryResolveReleaseZipSources(
+        DotNetRepositoryProjectResult project,
+        string projectDirectory,
+        string configuration,
+        ILogger logger,
+        out ReleaseZipSource[] sources,
+        out string error) {
+        if (!TryResolveActiveTargetFrameworks(
+                project,
+                projectDirectory,
+                configuration,
+                logger,
+                out var targetFrameworks,
+                out _,
+                out error)) {
+            sources = Array.Empty<ReleaseZipSource>();
+            return false;
+        }
+
+        var resolved = new List<ReleaseZipSource>();
+        foreach (var targetFramework in targetFrameworks) {
+            if (!TryEvaluateCleanupProperties(
+                    project,
+                    projectDirectory,
+                    configuration,
+                    targetFramework,
+                    runtimeIdentifier: null,
+                    "TargetDir,AssemblyName,IntermediateOutputPath,CleanFile",
+                    logger,
+                    out var properties,
+                    out _,
+                    out error)) {
+                sources = Array.Empty<ReleaseZipSource>();
+                return false;
+            }
+
+            var targetDirectories = ResolveEvaluatedRoots(properties, projectDirectory, "TargetDir");
+            if (targetDirectories.Length != 1) {
+                sources = Array.Empty<ReleaseZipSource>();
+                error = $"Could not resolve one exact TargetDir for {project.ProjectName}{FormatBuildDimensionContext(targetFramework, runtimeIdentifier: null)}.";
+                return false;
+            }
+
+            var targetDirectory = targetDirectories[0];
+            if (!Directory.Exists(targetDirectory)) {
+                sources = Array.Empty<ReleaseZipSource>();
+                error = $"Current build output path not found for {project.ProjectName}{FormatBuildDimensionContext(targetFramework, runtimeIdentifier: null)}: {targetDirectory}";
+                return false;
+            }
+
+            var entryPrefix = string.IsNullOrWhiteSpace(targetFramework) ? string.Empty : targetFramework!.Trim();
+            var overlappingSource = resolved.FirstOrDefault(source => ReleaseZipPathsOverlap(source.Path, targetDirectory));
+            if (overlappingSource is not null) {
+                sources = Array.Empty<ReleaseZipSource>();
+                error = $"Target framework outputs '{overlappingSource.EntryPrefix}' and '{entryPrefix}' overlap at '{overlappingSource.Path}' and '{targetDirectory}'. A deterministic release ZIP cannot be created from overlapping framework outputs.";
+                return false;
+            }
+
+            var assemblyName = properties.TryGetValue("AssemblyName", out var evaluatedAssemblyName) &&
+                               IsUsableAssemblyName(evaluatedAssemblyName)
+                ? evaluatedAssemblyName.Trim()
+                : project.ProjectName;
+            if (!TryResolveReleaseZipFiles(
+                    project,
+                    targetDirectory,
+                    assemblyName,
+                    properties,
+                    projectDirectory,
+                    out var files,
+                    out error)) {
+                sources = Array.Empty<ReleaseZipSource>();
+                return false;
+            }
+
+            resolved.Add(new ReleaseZipSource(targetDirectory, entryPrefix, files));
+        }
+
+        sources = resolved.ToArray();
+        if (sources.Length == 0) {
+            error = $"No exact current build output paths were resolved for {project.ProjectName}.";
+            return false;
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    private static bool TryResolveReleaseZipFiles(
+        DotNetRepositoryProjectResult project,
+        string targetDirectory,
+        string assemblyName,
+        IReadOnlyDictionary<string, string> properties,
+        string projectDirectory,
+        out string[] files,
+        out string error) {
+        var intermediateDirectories = ResolveEvaluatedRoots(properties, projectDirectory, "IntermediateOutputPath");
+        if (intermediateDirectories.Length != 1 ||
+            !properties.TryGetValue("CleanFile", out var cleanFile) ||
+            string.IsNullOrWhiteSpace(cleanFile)) {
+            files = Array.Empty<string>();
+            error = $"Could not resolve one exact MSBuild output manifest for {project.ProjectName}.";
+            return false;
+        }
+
+        var manifestPath = Path.IsPathRooted(cleanFile)
+            ? Path.GetFullPath(cleanFile)
+            : Path.GetFullPath(Path.Combine(intermediateDirectories[0], cleanFile.Trim()));
+        if (!File.Exists(manifestPath)) {
+            files = Array.Empty<string>();
+            error = $"Current MSBuild output manifest was not found for {project.ProjectName}: {manifestPath}";
+            return false;
+        }
+
+        if (!TryValidateReleaseZipPath(manifestPath, out error) ||
+            !TryValidateReleaseZipPath(targetDirectory, out error)) {
+            files = Array.Empty<string>();
+            return false;
+        }
+
+        var resolved = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var line in File.ReadLines(manifestPath)) {
+            var candidate = line.Trim();
+            if (candidate.Length == 0)
+                continue;
+            if (!Path.IsPathRooted(candidate)) {
+                files = Array.Empty<string>();
+                error = $"MSBuild output manifest contains a non-rooted path for {project.ProjectName}: {candidate}";
+                return false;
+            }
+
+            var fullPath = Path.GetFullPath(candidate);
+            if (!IsPathAtOrWithin(fullPath, targetDirectory))
+                continue;
+            if (!File.Exists(fullPath)) {
+                files = Array.Empty<string>();
+                error = $"MSBuild output manifest references a missing current output for {project.ProjectName}: {fullPath}";
+                return false;
+            }
+            if (!TryValidateReleaseZipPath(fullPath, out error)) {
+                files = Array.Empty<string>();
+                return false;
+            }
+            resolved.Add(fullPath);
+        }
+
+        var hasPrimaryAssembly = resolved.Any(path =>
+            string.Equals(Path.GetFileName(path), assemblyName + ".dll", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(Path.GetFileName(path), assemblyName + ".exe", StringComparison.OrdinalIgnoreCase));
+        if (!hasPrimaryAssembly) {
+            files = Array.Empty<string>();
+            error = $"MSBuild output manifest does not contain the primary assembly for {project.ProjectName}: {assemblyName}";
+            return false;
+        }
+
+        files = resolved.OrderBy(static path => path, StringComparer.OrdinalIgnoreCase).ToArray();
+        error = string.Empty;
+        return true;
+    }
+
+    internal static bool ReleaseZipPathsOverlap(string left, string right)
+        => IsPathAtOrWithin(left, right) || IsPathAtOrWithin(right, left);
+
+    private static bool IsPathAtOrWithin(string path, string root) {
+        var normalizedPath = Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var normalizedRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return string.Equals(normalizedPath, normalizedRoot, StringComparison.OrdinalIgnoreCase) ||
+               normalizedPath.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static bool TryValidateReleaseZipPath(string path, out string error) {
+        try {
+            var fullPath = Path.GetFullPath(path);
+            var volumeRoot = Path.GetPathRoot(fullPath) ?? string.Empty;
+            var current = volumeRoot;
+            if (!string.IsNullOrWhiteSpace(current) &&
+                (File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0) {
+                throw new InvalidDataException($"Release output path traverses a linked filesystem root: {current}");
+            }
+
+            var relativePath = fullPath.Substring(volumeRoot.Length);
+            foreach (var segment in relativePath.Split(
+                         new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+                         StringSplitOptions.RemoveEmptyEntries)) {
+                current = Path.Combine(current, segment);
+                if (!File.Exists(current) && !Directory.Exists(current))
+                    throw new FileNotFoundException("Release output path component was not found.", current);
+                if ((File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
+                    throw new InvalidDataException($"Release output path traverses a linked file or directory: {current}");
+            }
+
+            error = string.Empty;
+            return true;
+        } catch (Exception ex) {
+            error = $"Release output path cannot be archived safely: {ex.Message}";
+            return false;
+        }
+    }
+
+    private sealed class ReleaseZipSource {
+        internal ReleaseZipSource(string path, string entryPrefix, string[] files) {
+            Path = path;
+            EntryPrefix = entryPrefix;
+            Files = files;
+        }
+
+        internal string Path { get; }
+
+        internal string EntryPrefix { get; }
+
+        internal string[] Files { get; }
+    }
 }


### PR DESCRIPTION
## What changed

Project release ZIPs now contain only files recorded by the current MSBuild output manifest for each active target framework. This prevents accumulated `bin` content, old framework outputs, and separately generated publish/RID trees from being folded into a generic project archive.

The archive path now also:

- preserves declared content and dependency runtime assets, even under names such as `publish` and `runtimes`
- rejects overlapping target-framework output roots
- rejects linked output roots, ancestors, manifests, and files
- fails closed on missing or ambiguous current-output metadata
- removes partial ZIPs when creation fails

## Why it matters

`PowerForge.Web.Build.3.0.94.zip` had grown to about 1.08 GiB because it recursively captured accumulated output trees. The corrected real-project archive is 148.72 MiB with 521 current files, including the required runtime, Playwright, and ImageMagick content, and no top-level publish/RID output trees.

Self-contained platform archives remain owned by the configured tool targets.

## Compatibility

`CreateReleaseZip` remains one project archive containing all active target frameworks, with framework prefixes. Selection is now deterministic and based on the current MSBuild file manifest rather than the entire configuration directory.

No packages were published and no historical release assets were removed by this change.