### PR TITLE
Fix stable release progress counters and viewport

### DIFF
--- a/PowerForge.ConsoleShared/SpectreModulePipelineConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectreModulePipelineConsoleUi.cs
@@ -189,6 +189,7 @@ internal static class SpectreModulePipelineConsoleUi
             Title = item.Title,
             Kind = item.Kind,
             Target = item.Target,
+            CounterLabel = "Module",
             Position = item.Position,
             Total = item.Total
         };

--- a/PowerForge.ConsoleShared/SpectrePowerForgeReleaseConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectrePowerForgeReleaseConsoleUi.cs
@@ -30,6 +30,13 @@ internal static class SpectrePowerForgeReleaseConsoleUi
         var phaseNames = phases.ToDictionary(
             phase => phase,
             phase => GetPhaseName(phase, spec, request));
+        var phaseCounters = phases
+            .Select((phase, index) => new
+            {
+                Phase = phase,
+                Counter = ProgressCounterFormatter.Format("Phase", index + 1, phases.Length)
+            })
+            .ToDictionary(entry => entry.Phase, entry => entry.Counter);
         WriteHeader(console, spec, request, phases, phaseNames);
         PowerForgeReleaseResult? result = null;
         Exception? failure = null;
@@ -43,11 +50,14 @@ internal static class SpectrePowerForgeReleaseConsoleUi
             {
                 var tasks = phases.ToDictionary(
                     phase => phase,
-                    phase => context.AddTask($"{phaseNames[phase]} — pending", maxValue: 100, autoStart: false));
+                    phase => context.AddTask(
+                        $"{phaseCounters[phase]} — {phaseNames[phase]} — pending",
+                        maxValue: 100,
+                        autoStart: false));
                 foreach (var entry in tasks)
                     presentation.Register(entry.Value, entry.Key.ToString());
 
-                reporter = new Reporter(console, context, tasks, phaseNames, presentation);
+                reporter = new Reporter(console, context, tasks, phaseNames, phaseCounters, presentation);
                 try
                 {
                     result = run(reporter);
@@ -209,6 +219,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
         private readonly IAnsiConsole _console;
         private readonly IReadOnlyDictionary<PowerForgeReleaseProgressPhase, ProgressTask> _tasks;
         private readonly IReadOnlyDictionary<PowerForgeReleaseProgressPhase, string> _phaseNames;
+        private readonly IReadOnlyDictionary<PowerForgeReleaseProgressPhase, string> _phaseCounters;
         private readonly HashSet<PowerForgeReleaseProgressPhase> _failed = new();
         private readonly SpectreProgressLedger _ledger;
         private readonly SpectreProgressPresentation _presentation;
@@ -218,12 +229,14 @@ internal static class SpectrePowerForgeReleaseConsoleUi
             ProgressContext context,
             IReadOnlyDictionary<PowerForgeReleaseProgressPhase, ProgressTask> tasks,
             IReadOnlyDictionary<PowerForgeReleaseProgressPhase, string> phaseNames,
+            IReadOnlyDictionary<PowerForgeReleaseProgressPhase, string> phaseCounters,
             SpectreProgressPresentation presentation)
         {
             _console = console;
             _context = context;
             _tasks = tasks;
             _phaseNames = phaseNames;
+            _phaseCounters = phaseCounters;
             _presentation = presentation;
             _ledger = new SpectreProgressLedger(context, presentation);
         }
@@ -329,7 +342,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
         {
             var prefix = string.IsNullOrWhiteSpace(status) ? string.Empty : status + " ";
             var suffix = string.IsNullOrWhiteSpace(detail) ? string.Empty : " — " + detail;
-            return prefix + _phaseNames[phase] + suffix;
+            return prefix + _phaseCounters[phase] + " — " + _phaseNames[phase] + suffix;
         }
 
         private void UpdatePhaseProgress(PowerForgeReleaseProgressPhase phase)
@@ -361,11 +374,23 @@ internal static class SpectrePowerForgeReleaseConsoleUi
                 Title = item.Title,
                 Kind = item.Kind,
                 Target = item.Target,
+                CounterLabel = GetCounterLabel(item.Phase),
                 Position = item.Position,
                 Total = item.Total,
                 ProgressValue = item.ProgressValue,
                 ProgressMaximum = item.ProgressMaximum,
                 Duration = item.Duration
+            };
+
+        private static string GetCounterLabel(PowerForgeReleaseProgressPhase phase)
+            => phase switch
+            {
+                PowerForgeReleaseProgressPhase.Versioning => "Version",
+                PowerForgeReleaseProgressPhase.Module => "Module",
+                PowerForgeReleaseProgressPhase.Packages => "Project",
+                PowerForgeReleaseProgressPhase.Tools => "Tool",
+                PowerForgeReleaseProgressPhase.GitHub => "Asset",
+                _ => "Item"
             };
     }
 }

--- a/PowerForge.ConsoleShared/SpectreProgressDisplay.cs
+++ b/PowerForge.ConsoleShared/SpectreProgressDisplay.cs
@@ -26,6 +26,7 @@ internal static class SpectreProgressDisplay
         if (action is null) throw new ArgumentNullException(nameof(action));
 
         IRenderable? finalFrame = null;
+        var viewport = new SpectreProgressViewportState();
         console.Progress()
             .AutoRefresh(true)
             .AutoClear(true)
@@ -35,7 +36,7 @@ internal static class SpectreProgressDisplay
             {
                 finalFrame = renderable;
                 taskObserver?.Invoke(tasks);
-                return SpectreProgressViewport.Project(
+                return viewport.Project(
                     renderable,
                     tasks,
                     Math.Max(1, console.Profile.Height - 2));

--- a/PowerForge.ConsoleShared/SpectreProgressLedger.cs
+++ b/PowerForge.ConsoleShared/SpectreProgressLedger.cs
@@ -167,6 +167,7 @@ internal sealed class SpectreProgressLedger
                     entry.Item.Total,
                     entry.Item.Title,
                     entry.Item.Target,
+                    entry.Item.CounterLabel,
                     entry.State,
                     entry.Detail,
                     entry.Duration ?? entry.Item.Duration ?? TimeSpan.Zero))
@@ -209,7 +210,7 @@ internal sealed class SpectreProgressLedger
 
             var (icon, color) = GetStateVisual(snapshot.State, unicode);
             var ordinal = snapshot.Position > 0 && snapshot.Total > 0
-                ? $"{snapshot.Position:00}/{snapshot.Total:00}"
+                ? ProgressCounterFormatter.Format(snapshot.CounterLabel, snapshot.Position, snapshot.Total)
                 : "–";
             var result = string.Join(
                 " — ",
@@ -291,7 +292,7 @@ internal sealed class SpectreProgressLedger
         var unicode = ConsoleEncoding.ShouldRenderUnicode(AnsiConsole.Profile.Capabilities.Unicode);
         var (icon, color) = GetStateVisual(entry.State, unicode);
         var ordinal = entry.Item.Position > 0 && entry.Item.Total > 0
-            ? $"{entry.Item.Position:00}/{entry.Item.Total:00} "
+            ? ProgressCounterFormatter.Format(entry.Item.CounterLabel, entry.Item.Position, entry.Item.Total) + " "
             : string.Empty;
         var suffix = string.IsNullOrWhiteSpace(entry.Detail) ? string.Empty : $" — {entry.Detail}";
         return $"[{color}]{Markup.Escape($"  {icon} {ordinal}{entry.Item.Title}{suffix}")}[/]";
@@ -357,6 +358,7 @@ internal sealed class SpectreProgressLedgerItem
     internal string Title { get; set; } = string.Empty;
     internal string? Kind { get; set; }
     internal string? Target { get; set; }
+    internal string? CounterLabel { get; set; }
     internal int Position { get; set; }
     internal int Total { get; set; }
     internal double ProgressValue { get; set; }
@@ -381,6 +383,7 @@ internal sealed class SpectreProgressLedgerSnapshot
         int total,
         string title,
         string? target,
+        string? counterLabel,
         SpectreProgressLedgerState state,
         string? detail,
         TimeSpan duration)
@@ -390,6 +393,7 @@ internal sealed class SpectreProgressLedgerSnapshot
         Total = total;
         Title = title;
         Target = target;
+        CounterLabel = counterLabel;
         State = state;
         Detail = detail;
         Duration = duration;
@@ -400,6 +404,7 @@ internal sealed class SpectreProgressLedgerSnapshot
     internal int Total { get; }
     internal string Title { get; }
     internal string? Target { get; }
+    internal string? CounterLabel { get; }
     internal SpectreProgressLedgerState State { get; }
     internal string? Detail { get; }
     internal TimeSpan Duration { get; }

--- a/PowerForge.ConsoleShared/SpectreProgressPresentation.cs
+++ b/PowerForge.ConsoleShared/SpectreProgressPresentation.cs
@@ -61,7 +61,7 @@ internal sealed class SpectreProgressPresentation
         if (item is null) throw new ArgumentNullException(nameof(item));
 
         var ordinal = item.Position > 0 && item.Total > 0
-            ? FormatOrdinal(item.Position, item.Total)
+            ? ProgressCounterFormatter.Format(item.CounterLabel, item.Position, item.Total)
             : string.Empty;
         var idWidth = ordinal.Length;
         var detailSuffix = string.IsNullOrWhiteSpace(detail) ? string.Empty : $" — {detail}";
@@ -173,14 +173,6 @@ internal sealed class SpectreProgressPresentation
         if (viewportWidth >= 100) return 14;
         if (viewportWidth >= 80) return 12;
         return 10;
-    }
-
-    private static string FormatOrdinal(int position, int total)
-    {
-        var safeTotal = Math.Max(1, total);
-        var digits = Math.Max(2, safeTotal.ToString().Length);
-        var format = new string('0', digits);
-        return $"{Math.Max(0, position).ToString(format)}/{safeTotal.ToString(format)}";
     }
 
     private static string PadOrEllipsis(string input, int width)

--- a/PowerForge.ConsoleShared/SpectreProgressViewport.cs
+++ b/PowerForge.ConsoleShared/SpectreProgressViewport.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
@@ -25,13 +26,30 @@ internal static class SpectreProgressViewport
             return renderable;
 
         var activeIndex = FindActiveIndex(tasks);
+        return ProjectAtIndex(renderable, tasks, maximumRows, activeIndex);
+    }
+
+    internal static IRenderable ProjectAtIndex(
+        IRenderable renderable,
+        IReadOnlyList<ProgressTask> tasks,
+        int maximumRows,
+        int focusIndex)
+    {
+        if (renderable is null) throw new ArgumentNullException(nameof(renderable));
+        if (tasks is null) throw new ArgumentNullException(nameof(tasks));
+
+        maximumRows = Math.Max(1, maximumRows);
+        if (tasks.Count <= maximumRows)
+            return renderable;
+
+        focusIndex = Math.Max(0, Math.Min(tasks.Count - 1, focusIndex));
         var startIndex = Math.Min(
             tasks.Count - maximumRows,
-            Math.Max(0, activeIndex - maximumRows + 1));
+            Math.Max(0, focusIndex - maximumRows + 1));
         return new WindowedRenderable(renderable, startIndex, maximumRows, tasks.Count);
     }
 
-    private static int FindActiveIndex(IReadOnlyList<ProgressTask> tasks)
+    internal static int FindActiveIndex(IReadOnlyList<ProgressTask> tasks)
     {
         for (var index = tasks.Count - 1; index >= 0; index--)
         {
@@ -99,6 +117,48 @@ internal static class SpectreProgressViewport
                 if (lineIndex < selected.Length - 1)
                     yield return Segment.LineBreak;
             }
+        }
+    }
+}
+
+/// <summary>
+/// Keeps a live progress viewport focused on the furthest work reached. A brief
+/// gap between adjacent tasks must not jump back to an older concurrent task.
+/// </summary>
+internal sealed class SpectreProgressViewportState
+{
+    private int _furthestFocusIndex = -1;
+
+    internal IRenderable Project(
+        IRenderable renderable,
+        IReadOnlyList<ProgressTask> tasks,
+        int maximumRows)
+    {
+        if (renderable is null) throw new ArgumentNullException(nameof(renderable));
+        if (tasks is null) throw new ArgumentNullException(nameof(tasks));
+        if (tasks.Count == 0)
+            return renderable;
+
+        var activeIndex = SpectreProgressViewport.FindActiveIndex(tasks);
+        AdvanceFocus(activeIndex);
+        var focusIndex = Math.Min(Volatile.Read(ref _furthestFocusIndex), tasks.Count - 1);
+        return SpectreProgressViewport.ProjectAtIndex(
+            renderable,
+            tasks,
+            maximumRows,
+            focusIndex);
+    }
+
+    private void AdvanceFocus(int candidate)
+    {
+        var observed = Volatile.Read(ref _furthestFocusIndex);
+        while (candidate > observed)
+        {
+            var actual = Interlocked.CompareExchange(ref _furthestFocusIndex, candidate, observed);
+            if (actual == observed)
+                return;
+
+            observed = actual;
         }
     }
 }

--- a/PowerForge.ConsoleShared/SpectreProjectBuildConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectreProjectBuildConsoleUi.cs
@@ -138,6 +138,7 @@ internal static class SpectreProjectBuildConsoleUi
         private readonly ProgressContext _context;
         private readonly IReadOnlyDictionary<ProjectBuildProgressPhase, ProgressTask> _tasks;
         private readonly HashSet<ProjectBuildProgressPhase> _failed = new();
+        private readonly Dictionary<ProjectBuildProgressPhase, (int Completed, int Total)> _phaseCounts = new();
         private readonly SpectreProgressLedger _ledger;
 
         public SpectreProjectBuildProgressReporter(
@@ -152,6 +153,7 @@ internal static class SpectreProjectBuildConsoleUi
         public void PhaseStarted(ProjectBuildProgressPhase phase, int totalItems, string? detail = null)
         {
             if (!_tasks.TryGetValue(phase, out var task)) return;
+            RememberCount(phase, 0, totalItems);
             if (!task.IsStarted) task.StartTask();
             task.Value = 0;
             task.Description = BuildLabel(phase, detail, 0, totalItems, "cyan");
@@ -160,6 +162,7 @@ internal static class SpectreProjectBuildConsoleUi
         public void PhaseUpdated(ProjectBuildProgressPhase phase, int completedItems, int totalItems, string? detail = null)
         {
             if (!_tasks.TryGetValue(phase, out var task)) return;
+            RememberCount(phase, completedItems, totalItems);
             if (!task.IsStarted) task.StartTask();
             var total = Math.Max(1, totalItems);
             task.Value = Math.Min(100, Math.Max(0, completedItems) * 100d / total);
@@ -169,8 +172,9 @@ internal static class SpectreProjectBuildConsoleUi
         public void PhaseCompleted(ProjectBuildProgressPhase phase, string? detail = null)
         {
             if (!_tasks.TryGetValue(phase, out var task)) return;
+            var count = GetTerminalCount(phase, completed: true);
             if (!task.IsStarted) task.StartTask();
-            task.Description = BuildLabel(phase, detail, null, null, "green", "✓");
+            task.Description = BuildLabel(phase, detail, count.Completed, count.Total, "green", "✓");
             task.Value = 100;
             task.StopTask();
         }
@@ -179,8 +183,9 @@ internal static class SpectreProjectBuildConsoleUi
         {
             if (!_tasks.TryGetValue(phase, out var task)) return;
             _failed.Add(phase);
+            var count = GetTerminalCount(phase, completed: false);
             if (!task.IsStarted) task.StartTask();
-            task.Description = BuildLabel(phase, detail, null, null, "red", "x");
+            task.Description = BuildLabel(phase, detail, count.Completed, count.Total, "red", "x");
             task.Value = 100;
             task.StopTask();
         }
@@ -236,6 +241,31 @@ internal static class SpectreProjectBuildConsoleUi
                 _ledger.GetSnapshots(),
                 "Project build details");
 
+        private void RememberCount(
+            ProjectBuildProgressPhase phase,
+            int completed,
+            int total)
+        {
+            if (total <= 0) {
+                return;
+            }
+
+            _phaseCounts[phase] = (Math.Min(Math.Max(0, completed), total), total);
+        }
+
+        private (int? Completed, int? Total) GetTerminalCount(
+            ProjectBuildProgressPhase phase,
+            bool completed)
+        {
+            if (!_phaseCounts.TryGetValue(phase, out var count)) {
+                return (null, null);
+            }
+
+            return completed
+                ? (count.Total, count.Total)
+                : (count.Completed, count.Total);
+        }
+
         private static SpectreProgressLedgerItem ToLedgerItem(ProjectBuildProgressItem item)
             => new()
             {
@@ -245,6 +275,7 @@ internal static class SpectreProjectBuildConsoleUi
                 GroupOrder = (int)item.Phase,
                 Title = item.Title,
                 Kind = item.Kind,
+                CounterLabel = ProgressCounterFormatter.GetProjectBuildScope(item.Phase),
                 Position = item.Position,
                 Total = item.Total,
                 Duration = item.Duration
@@ -260,10 +291,13 @@ internal static class SpectreProjectBuildConsoleUi
         {
             var prefix = string.IsNullOrWhiteSpace(status) ? string.Empty : status + " ";
             var count = completed.HasValue && total.GetValueOrDefault() > 0
-                ? $" {completed}/{total}"
+                ? ProgressCounterFormatter.Format(
+                    ProgressCounterFormatter.GetProjectBuildScope(phase),
+                    completed.GetValueOrDefault(),
+                    total.GetValueOrDefault()) + " — "
                 : string.Empty;
             var suffix = string.IsNullOrWhiteSpace(detail) ? string.Empty : $" — {detail}";
-            return $"[{color}]{Markup.Escape(prefix + GetPhaseName(phase) + count + suffix)}[/]";
+            return $"[{color}]{Markup.Escape(prefix + count + GetPhaseName(phase) + suffix)}[/]";
         }
     }
 }

--- a/PowerForge.PowerShell/Services/ModulePipelineGitHubReleaseProgressAdapter.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineGitHubReleaseProgressAdapter.cs
@@ -30,7 +30,7 @@ internal sealed class ModulePipelineGitHubReleaseProgressAdapter : IGitHubReleas
         var fileName = string.IsNullOrWhiteSpace(progress.FileName)
             ? Path.GetFileName(progress.FilePath)
             : progress.FileName;
-        var detail = $"{Math.Max(1, progress.Position)}/{Math.Max(1, progress.TotalAssets)} {fileName}";
+        var detail = $"{ProgressCounterFormatter.Format("Asset", progress.Position, progress.TotalAssets)} {fileName}";
         if (progress.TotalBytes > 0)
         {
             detail += $" — {DotNetRepositoryReleaseService.FormatBytes(Math.Max(0, progress.BytesTransferred))} / " +

--- a/PowerForge.Tests/ModulePipelineExecutionSessionTests.cs
+++ b/PowerForge.Tests/ModulePipelineExecutionSessionTests.cs
@@ -146,7 +146,7 @@ public sealed class ModulePipelineExecutionSessionTests
             Assert.Equal(step!.Key, update.Key);
             Assert.Equal(50, update.Value);
             Assert.Equal(400, update.Maximum);
-            Assert.Contains("1/2 one.zip", update.Detail, StringComparison.Ordinal);
+            Assert.Contains("Asset 01/02 one.zip", update.Detail, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/PowerForgeReleaseProgressAdaptersTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseProgressAdaptersTests.cs
@@ -22,14 +22,35 @@ public sealed class PowerForgeReleaseProgressAdaptersTests
             update =>
             {
                 Assert.Equal(PowerForgeReleaseProgressItemState.Started, update.State);
-                Assert.Contains("0/4", update.Detail, StringComparison.Ordinal);
+                Assert.Contains("Project 00/04", update.Detail, StringComparison.Ordinal);
             },
             update =>
             {
                 Assert.Equal(PowerForgeReleaseProgressItemState.Started, update.State);
-                Assert.Contains("2/4", update.Detail, StringComparison.Ordinal);
+                Assert.Contains("Project 02/04", update.Detail, StringComparison.Ordinal);
             },
-            update => Assert.Equal(PowerForgeReleaseProgressItemState.Completed, update.State));
+            update =>
+            {
+                Assert.Equal(PowerForgeReleaseProgressItemState.Completed, update.State);
+                Assert.Contains("Project 04/04", update.Detail, StringComparison.Ordinal);
+            });
+    }
+
+    [Fact]
+    public void ProjectBuildAdapter_PreservesLastCountWhenPhaseFails()
+    {
+        var release = new RecordingReleaseProgress();
+        var adapter = new ProjectBuildReleaseProgressAdapter(
+            release,
+            PowerForgeReleaseProgressPhase.Packages);
+
+        adapter.PhaseStarted(ProjectBuildProgressPhase.PackageBuild, 4, "Packing Alpha");
+        adapter.PhaseUpdated(ProjectBuildProgressPhase.PackageBuild, 2, 4, "Packing Beta");
+        adapter.PhaseFailed(ProjectBuildProgressPhase.PackageBuild, "Packing failed");
+
+        var failure = release.Updates[^1];
+        Assert.Equal(PowerForgeReleaseProgressItemState.Failed, failure.State);
+        Assert.Contains("Project 02/04", failure.Detail, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/PowerForge.Tests/ProjectBuildProgressLedgerTests.cs
+++ b/PowerForge.Tests/ProjectBuildProgressLedgerTests.cs
@@ -143,6 +143,7 @@ public sealed class ProjectBuildProgressLedgerTests
                     GroupOrder = 1,
                     Title = "Pack artefact",
                     Target = "Unpacked",
+                    CounterLabel = "Module",
                     Kind = ModulePipelineStepKind.Artefact.ToString(),
                     Position = 1,
                     Total = 2
@@ -154,7 +155,7 @@ public sealed class ProjectBuildProgressLedgerTests
             tasks => finalTaskDescriptions = tasks.Select(task => task.Description).ToArray());
 
         var description = Assert.Single(finalTaskDescriptions!);
-        Assert.StartsWith("01/02 Pack artefact", description, StringComparison.Ordinal);
+        Assert.StartsWith("Module 01/02 Pack artefact", description, StringComparison.Ordinal);
         Assert.Contains("packing", description, StringComparison.Ordinal);
         Assert.EndsWith("Unpacked", description, StringComparison.Ordinal);
         Assert.Contains("PK", writer.ToString(), StringComparison.Ordinal);
@@ -230,15 +231,39 @@ public sealed class ProjectBuildProgressLedgerTests
 
         Assert.True(result.Success);
         var output = writer.ToString();
-        var first = output.LastIndexOf("01/03 Stage to staging", StringComparison.Ordinal);
-        var second = output.LastIndexOf("02/03 Pack artefact", StringComparison.Ordinal);
-        var third = output.LastIndexOf("03/03 Publish", StringComparison.Ordinal);
+        var first = output.LastIndexOf("Module 01/03 Stage to staging", StringComparison.Ordinal);
+        var second = output.LastIndexOf("Module 02/03 Pack artefact", StringComparison.Ordinal);
+        var third = output.LastIndexOf("Module 03/03 Publish", StringComparison.Ordinal);
         Assert.True(first >= 0, output);
         Assert.True(second > first, output);
         Assert.True(third > second, output);
         Assert.Contains("Unpacked (Local)", output, StringComparison.Ordinal);
         Assert.Contains("PowerShellGallery", output, StringComparison.Ordinal);
+        Assert.Contains("Phase 01/01", output, StringComparison.Ordinal);
     }
+
+    [Theory]
+    [InlineData(1, 9, "01/09")]
+    [InlineData(1, 24, "01/24")]
+    [InlineData(20, 24, "20/24")]
+    [InlineData(1, 100, "001/100")]
+    public void ProgressCounterFormatter_UsesOneStableWidthPerScope(
+        int position,
+        int total,
+        string expected)
+        => Assert.Equal(expected, ProgressCounterFormatter.Format(position, total));
+
+    [Theory]
+    [InlineData(ProjectBuildProgressPhase.Plan, "Step")]
+    [InlineData(ProjectBuildProgressPhase.Versioning, "Project")]
+    [InlineData(ProjectBuildProgressPhase.PackageBuild, "Project")]
+    [InlineData(ProjectBuildProgressPhase.PackageSigning, "Package")]
+    [InlineData(ProjectBuildProgressPhase.NuGetPublish, "Package")]
+    [InlineData(ProjectBuildProgressPhase.GitHubPublish, "Release")]
+    public void ProjectBuildCounterScope_MatchesTheCountedResource(
+        ProjectBuildProgressPhase phase,
+        string expected)
+        => Assert.Equal(expected, ProgressCounterFormatter.GetProjectBuildScope(phase));
 
     [Fact]
     public void StandaloneConsole_WritesDetailedLedgerAfterSuccess()
@@ -280,6 +305,45 @@ public sealed class ProjectBuildProgressLedgerTests
         Assert.Contains("Project build details", output, StringComparison.Ordinal);
         Assert.Contains("Sample.Project", output, StringComparison.Ordinal);
         Assert.Contains("00:02.000", output, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(true, "Project 06/06")]
+    [InlineData(false, "Project 05/06")]
+    public void StandaloneConsole_PreservesExplicitCounterInTerminalPhaseState(
+        bool success,
+        string expectedCounter)
+    {
+        using var writer = new StringWriter();
+        var console = CreateConsole(writer, height: 12);
+
+        var result = SpectreProjectBuildConsoleUi.RunInteractive(
+            console,
+            new ProjectBuildConsolePlan
+            {
+                ConfigPath = "project.build.json",
+                RootPath = "repository",
+                Build = true
+            },
+            progress =>
+            {
+                progress.PhaseStarted(ProjectBuildProgressPhase.PackageBuild, 6, "packing");
+                progress.PhaseUpdated(ProjectBuildProgressPhase.PackageBuild, 5, 6, "packing");
+                if (success) {
+                    progress.PhaseCompleted(ProjectBuildProgressPhase.PackageBuild, "complete");
+                }
+                else {
+                    progress.PhaseFailed(ProjectBuildProgressPhase.PackageBuild, "failed");
+                }
+
+                return new ProjectBuildWorkflowResult
+                {
+                    Result = new ProjectBuildResult { Success = success }
+                };
+            });
+
+        Assert.Equal(success, result.Result.Success);
+        Assert.Contains(expectedCounter, writer.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/PowerForge.Tests/SpectreBuildProgressColumnsTests.cs
+++ b/PowerForge.Tests/SpectreBuildProgressColumnsTests.cs
@@ -82,6 +82,29 @@ public sealed class SpectreBuildProgressColumnsTests
         Assert.EndsWith("PowerShellGallery", targetedLabel, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("Module", 17, 18, "Module 17/18")]
+    [InlineData("Tool", 1, 10, "Tool 01/10")]
+    [InlineData("Project", 1, 6, "Project 01/06")]
+    [InlineData("Asset", 20, 24, "Asset 20/24")]
+    public void Presentation_MakesEveryCounterScopeExplicit(
+        string scope,
+        int position,
+        int total,
+        string expected)
+    {
+        var presentation = new SpectreProgressPresentation(viewportWidth: 140, unicode: false);
+        var item = new SpectreProgressLedgerItem
+        {
+            Title = "Work item",
+            CounterLabel = scope,
+            Position = position,
+            Total = total
+        };
+
+        Assert.StartsWith(expected, presentation.BuildLabel(item, null), StringComparison.Ordinal);
+    }
+
     [Fact]
     public void Run_WritesCompletedProgressFrameAfterLiveDisplayCloses()
     {
@@ -144,6 +167,55 @@ public sealed class SpectreBuildProgressColumnsTests
         Assert.DoesNotContain("Task.04", output, StringComparison.Ordinal);
         AssertOrdered(output, "Task.05", "Task.06", "Task.07", "Task.08", "Task.09");
         Assert.DoesNotContain("Task.10", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ViewportState_DoesNotJumpBackBetweenAdjacentUploadRows()
+    {
+        var tasks = Enumerable.Range(1, 30)
+            .Select(index => new ProgressTask(
+                index,
+                index <= 18 ? $"Module {index:00}/18" : $"Asset {index - 18:00}/12",
+                maxValue: 1,
+                autoStart: false,
+                TimeProvider.System))
+            .ToArray();
+        var viewport = new SpectreProgressViewportState();
+
+        tasks[16].StartTask();
+        tasks[24].StartTask();
+        var uploadFrame = RenderViewport(viewport, tasks, maximumRows: 6);
+
+        tasks[24].Value = 1;
+        tasks[24].StopTask();
+        var betweenUploadsFrame = RenderViewport(viewport, tasks, maximumRows: 6);
+
+        tasks[25].StartTask();
+        var nextUploadFrame = RenderViewport(viewport, tasks, maximumRows: 6);
+
+        Assert.Contains("Asset 07/12", uploadFrame, StringComparison.Ordinal);
+        Assert.DoesNotContain("Module 17/18", betweenUploadsFrame, StringComparison.Ordinal);
+        Assert.Contains("Asset 07/12", betweenUploadsFrame, StringComparison.Ordinal);
+        Assert.Contains("Asset 08/12", nextUploadFrame, StringComparison.Ordinal);
+    }
+
+    private static string RenderViewport(
+        SpectreProgressViewportState viewport,
+        IReadOnlyList<ProgressTask> tasks,
+        int maximumRows)
+    {
+        var rows = new Rows(tasks.Select(task => (IRenderable)new Text(task.Description)));
+        var projected = viewport.Project(rows, tasks, maximumRows);
+        using var writer = new StringWriter();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new TerminalConsoleOutput(writer),
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Interactive = InteractionSupport.Yes
+        });
+        console.Write(projected);
+        return writer.ToString();
     }
 
     private static void AssertOrdered(string output, params string[] values)

--- a/PowerForge/InternalsVisibleTo.cs
+++ b/PowerForge/InternalsVisibleTo.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("PowerForge.Tests")]
 [assembly: InternalsVisibleTo("PowerForge.Net472SmokeTests")]
 [assembly: InternalsVisibleTo("PowerForge.Cli")]
+[assembly: InternalsVisibleTo("PowerForge.ConsoleShared")]
 [assembly: InternalsVisibleTo("PowerForge.PowerShell")]
 [assembly: InternalsVisibleTo("PowerForge.Web")]
 [assembly: InternalsVisibleTo("PowerForgeStudio.Tests")]

--- a/PowerForge/ProgressCounterFormatter.cs
+++ b/PowerForge/ProgressCounterFormatter.cs
@@ -1,0 +1,38 @@
+using System.Globalization;
+
+namespace PowerForge;
+
+/// <summary>Formats stable, explicitly scoped progress counters.</summary>
+internal static class ProgressCounterFormatter
+{
+    internal static string GetProjectBuildScope(ProjectBuildProgressPhase phase)
+        => phase switch
+        {
+            ProjectBuildProgressPhase.Versioning => "Project",
+            ProjectBuildProgressPhase.PackageBuild => "Project",
+            ProjectBuildProgressPhase.PackageSigning => "Package",
+            ProjectBuildProgressPhase.NuGetPublish => "Package",
+            ProjectBuildProgressPhase.GitHubPublish => "Release",
+            _ => "Step"
+        };
+
+    internal static string Format(int position, int total)
+    {
+        var safeTotal = Math.Max(1, total);
+        var digits = Math.Max(2, safeTotal.ToString(CultureInfo.InvariantCulture).Length);
+        var format = new string('0', digits);
+        return $"{Math.Max(0, position).ToString(format, CultureInfo.InvariantCulture)}/" +
+               safeTotal.ToString(format, CultureInfo.InvariantCulture);
+    }
+
+    internal static string Format(string? scope, int position, int total)
+    {
+        var counter = Format(position, total);
+        if (string.IsNullOrWhiteSpace(scope)) {
+            return counter;
+        }
+
+        var normalizedScope = scope!.Trim();
+        return $"{normalizedScope} {counter}";
+    }
+}

--- a/PowerForge/Services/PowerForgeReleaseProgressAdapters.cs
+++ b/PowerForge/Services/PowerForgeReleaseProgressAdapters.cs
@@ -6,6 +6,7 @@ internal sealed class ProjectBuildReleaseProgressAdapter : IProjectBuildProgress
     private readonly PowerForgeReleaseProgressPhase _releasePhase;
     private readonly Dictionary<ProjectBuildProgressPhase, PowerForgeReleaseProgressItem> _items = new();
     private readonly Dictionary<string, PowerForgeReleaseProgressItem> _projectItems = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<ProjectBuildProgressPhase, (int Completed, int Total)> _phaseCounts = new();
 
     internal ProjectBuildReleaseProgressAdapter(
         IPowerForgeReleaseProgressReporterV2 release,
@@ -17,8 +18,9 @@ internal sealed class ProjectBuildReleaseProgressAdapter : IProjectBuildProgress
 
     public void PhaseStarted(ProjectBuildProgressPhase phase, int totalItems, string? detail = null)
     {
+        RememberCount(phase, 0, totalItems);
         var item = GetOrCreate(phase);
-        _release.ItemUpdated(item, PowerForgeReleaseProgressItemState.Started, WithCount(detail, 0, totalItems));
+        _release.ItemUpdated(item, PowerForgeReleaseProgressItemState.Started, WithCount(phase, detail, 0, totalItems));
     }
 
     public void PhaseUpdated(
@@ -27,18 +29,31 @@ internal sealed class ProjectBuildReleaseProgressAdapter : IProjectBuildProgress
         int totalItems,
         string? detail = null)
     {
+        RememberCount(phase, completedItems, totalItems);
         var item = GetOrCreate(phase);
         _release.ItemUpdated(
             item,
             PowerForgeReleaseProgressItemState.Started,
-            WithCount(detail, completedItems, totalItems));
+            WithCount(phase, detail, completedItems, totalItems));
     }
 
     public void PhaseCompleted(ProjectBuildProgressPhase phase, string? detail = null)
-        => _release.ItemUpdated(GetOrCreate(phase), PowerForgeReleaseProgressItemState.Completed, detail);
+    {
+        var count = GetTerminalCount(phase, completed: true);
+        _release.ItemUpdated(
+            GetOrCreate(phase),
+            PowerForgeReleaseProgressItemState.Completed,
+            WithCount(phase, detail, count.Completed, count.Total));
+    }
 
     public void PhaseFailed(ProjectBuildProgressPhase phase, string? detail = null)
-        => _release.ItemUpdated(GetOrCreate(phase), PowerForgeReleaseProgressItemState.Failed, detail);
+    {
+        var count = GetTerminalCount(phase, completed: false);
+        _release.ItemUpdated(
+            GetOrCreate(phase),
+            PowerForgeReleaseProgressItemState.Failed,
+            WithCount(phase, detail, count.Completed, count.Total));
+    }
 
     public void ItemsPlanned(
         ProjectBuildProgressPhase phase,
@@ -129,12 +144,42 @@ internal sealed class ProjectBuildReleaseProgressAdapter : IProjectBuildProgress
             _ => phase.ToString()
         };
 
-    private static string? WithCount(string? detail, int completed, int total)
+    private void RememberCount(
+        ProjectBuildProgressPhase phase,
+        int completed,
+        int total)
+    {
+        if (total <= 0) {
+            return;
+        }
+
+        _phaseCounts[phase] = (Math.Min(Math.Max(0, completed), total), total);
+    }
+
+    private (int Completed, int Total) GetTerminalCount(
+        ProjectBuildProgressPhase phase,
+        bool completed)
+    {
+        if (!_phaseCounts.TryGetValue(phase, out var count)) {
+            return (0, 0);
+        }
+
+        return completed ? (count.Total, count.Total) : count;
+    }
+
+    private static string? WithCount(
+        ProjectBuildProgressPhase phase,
+        string? detail,
+        int completed,
+        int total)
     {
         if (total <= 0)
             return detail;
 
-        var count = $"{Math.Max(0, completed)}/{total}";
+        var count = ProgressCounterFormatter.Format(
+            ProgressCounterFormatter.GetProjectBuildScope(phase),
+            completed,
+            total);
         return string.IsNullOrWhiteSpace(detail) ? count : $"{count} — {detail}";
     }
 }


### PR DESCRIPTION
## Summary

- keep the live progress viewport on the furthest release work reached instead of jumping back to older concurrent rows between sequential uploads
- make every counter explicit and stable with semantic scopes such as Phase, Module, Tool, Project, Package, Release, and Asset
- preserve counters when phases complete or fail, including shared release adapters and final detail ledgers

## User-visible behavior

A short terminal now remains on Asset 20/24 during the gap before Asset 21/24 starts. It no longer flashes back to Module 17/18. Counters retain fixed width and meaning throughout their lifecycle.

## Validation

- 42 focused progress and release contract tests pass
- full Release solution build succeeds for net472, net8.0, and net10.0 with zero warnings and errors
- synthetic six-row terminal sequence inspected across active upload, between-upload gap, and next upload
- one independent local review plus one targeted confirmation completed; all findings addressed