### PR TITLE
Unify coordinated release progress presentation

### DIFF
--- a/PowerForge.ConsoleShared/SpectreModulePipelineConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectreModulePipelineConsoleUi.cs
@@ -100,10 +100,16 @@ internal static class SpectreModulePipelineConsoleUi
 
         var unicode = ConsoleEncoding.ShouldRenderUnicode(console.Profile.Capabilities.Unicode);
         var versionText = BuildServices.FormatVersionWithPreRelease(plan.ResolvedVersion, plan.PreRelease);
+        var packageLaneCount = (plan.ProjectBuilds?.Length ?? 0) + (plan.PackageBuilds?.Length ?? 0);
+        var coordinatedRelease = packageLaneCount > 0 || plan.Release is not null;
 
         var title = unicode
-            ? $"🛠️ PowerForge • {plan.ModuleName} {versionText}"
-            : $"PowerForge • {plan.ModuleName} {versionText}";
+            ? coordinatedRelease
+                ? $"🛠️ PowerForge • Coordinated release • {plan.ModuleName} {versionText}"
+                : $"🛠️ PowerForge • {plan.ModuleName} {versionText}"
+            : coordinatedRelease
+                ? $"PowerForge • Coordinated release • {plan.ModuleName} {versionText}"
+                : $"PowerForge • {plan.ModuleName} {versionText}";
         console.Write(new Rule($"[yellow bold underline]{Esc(title)}[/]") { Justification = Justify.Left });
 
         var iconColWidth = unicode ? 2 : 3;
@@ -120,6 +126,22 @@ internal static class SpectreModulePipelineConsoleUi
         var cfgText = string.IsNullOrWhiteSpace(configLabel) ? "(discovered)" : configLabel;
         AddInfoRow(unicode ? "⚙️" : "CFG", "Config", Esc(cfgText));
         AddInfoRow(unicode ? "📁" : "DIR", "Project", Esc(plan.ProjectRoot));
+
+        if (coordinatedRelease)
+        {
+            var scope = packageLaneCount > 0
+                ? $"PowerShell module + {packageLaneCount} NuGet package {(packageLaneCount == 1 ? "lane" : "lanes")}"
+                : "PowerShell module";
+            AddInfoRow(unicode ? "🧭" : "SCP", "Scope", Esc(scope));
+
+            var buildOrder = plan.Release?.Configuration?.BuildOrder;
+            if (buildOrder is { Length: > 0 })
+                AddInfoRow(unicode ? "↕️" : "ORD", "Build order", Esc(FormatReleaseOrder(buildOrder)));
+
+            var publishOrder = plan.Release?.Configuration?.PublishOrder;
+            if (publishOrder is { Length: > 0 })
+                AddInfoRow(unicode ? "🚀" : "PUB", "Publish order", Esc(FormatReleaseOrder(publishOrder)));
+        }
 
         var stagingText = string.IsNullOrWhiteSpace(plan.BuildSpec.StagingPath) ? "(temp)" : plan.BuildSpec.StagingPath;
         AddInfoRow(unicode ? "🧪" : "TMP", "Staging", Esc(stagingText));
@@ -141,14 +163,27 @@ internal static class SpectreModulePipelineConsoleUi
             "Validation",
             validations.Count == 0 ? "[grey]Disabled[/]" : Esc(string.Join(", ", validations)));
 
-        AddInfoRow(unicode ? "📦" : "PKG", "Artefacts", Esc((plan.Artefacts?.Length ?? 0).ToString()));
-        AddInfoRow(unicode ? "🚀" : "PUB", "Publishes", Esc((plan.Publishes?.Length ?? 0).ToString()));
+        AddInfoRow(
+            unicode ? "📦" : "PKG",
+            coordinatedRelease ? "Module artefacts" : "Artefacts",
+            Esc((plan.Artefacts?.Length ?? 0).ToString()));
+        AddInfoRow(
+            unicode ? "🚀" : "PUB",
+            coordinatedRelease ? "Module publishes" : "Publishes",
+            Esc((plan.Publishes?.Length ?? 0).ToString()));
         AddInfoRow(unicode ? "📥" : "INS", "Install", plan.InstallEnabled ? Esc($"{plan.InstallStrategy}, keep {plan.InstallKeepVersions}") : "[grey]Disabled[/]");
 
-        AddInfoRow(unicode ? "🧭" : "STP", "Steps", Esc(steps.Length.ToString()));
+        AddInfoRow(unicode ? "🧭" : "STP", coordinatedRelease ? "Coordinated steps" : "Steps", Esc(steps.Length.ToString()));
         console.Write(info);
         console.WriteLine();
     }
+
+    private static string FormatReleaseOrder(IEnumerable<string> values)
+        => string.Join(
+            " → ",
+            values.Select(value => string.Equals(value, "PowerShellGallery", StringComparison.OrdinalIgnoreCase)
+                ? "PowerShell Gallery"
+                : value));
 
     private static string NormalizeIcon(string? icon)
     {

--- a/PowerForge.ConsoleShared/SpectrePowerForgeReleaseConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectrePowerForgeReleaseConsoleUi.cs
@@ -254,7 +254,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
         {
             if (!_tasks.TryGetValue(phase, out var task)) return;
             if (!task.IsStarted) task.StartTask();
-            task.Description = Label(phase, detail, "✓");
+            task.Description = Label(phase, detail);
             task.Value = 100;
             task.StopTask();
             _presentation.MarkTerminal(task, SpectreProgressLedgerState.Completed);
@@ -265,7 +265,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
             if (!_tasks.TryGetValue(phase, out var task)) return;
             _failed.Add(phase);
             if (!task.IsStarted) task.StartTask();
-            task.Description = Label(phase, detail, "x");
+            task.Description = Label(phase, detail);
             task.Value = 100;
             task.StopTask();
             _presentation.MarkTerminal(task, SpectreProgressLedgerState.Failed);
@@ -321,7 +321,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
                 }
 
                 entry.Value.StartTask();
-                entry.Value.Description = Label(entry.Key, success ? "not required" : "skipped after failure", "–");
+                entry.Value.Description = Label(entry.Key, success ? "not required" : "skipped after failure");
                 entry.Value.Value = 100;
                 entry.Value.StopTask();
                 _presentation.MarkTerminal(entry.Value, SpectreProgressLedgerState.Skipped);
@@ -338,11 +338,10 @@ internal static class SpectrePowerForgeReleaseConsoleUi
                 _ledger.GetSnapshots(),
                 "Unified release details");
 
-        private string Label(PowerForgeReleaseProgressPhase phase, string? detail, string? status = null)
+        private string Label(PowerForgeReleaseProgressPhase phase, string? detail)
         {
-            var prefix = string.IsNullOrWhiteSpace(status) ? string.Empty : status + " ";
             var suffix = string.IsNullOrWhiteSpace(detail) ? string.Empty : " — " + detail;
-            return prefix + _phaseCounters[phase] + " — " + _phaseNames[phase] + suffix;
+            return _phaseCounters[phase] + " — " + _phaseNames[phase] + suffix;
         }
 
         private void UpdatePhaseProgress(PowerForgeReleaseProgressPhase phase)

--- a/PowerForge.ConsoleShared/SpectreProgressLedger.cs
+++ b/PowerForge.ConsoleShared/SpectreProgressLedger.cs
@@ -166,6 +166,7 @@ internal sealed class SpectreProgressLedger
                     entry.Item.Position,
                     entry.Item.Total,
                     entry.Item.Title,
+                    entry.Item.Kind,
                     entry.Item.Target,
                     entry.Item.CounterLabel,
                     entry.State,
@@ -191,6 +192,7 @@ internal sealed class SpectreProgressLedger
             .Border(TableBorder.None)
             .HideHeaders()
             .AddColumn(new TableColumn("Status").NoWrap().Width(1))
+            .AddColumn(new TableColumn("Kind").NoWrap().Width(unicode ? 2 : 3))
             .AddColumn(new TableColumn("Item").NoWrap())
             .AddColumn(new TableColumn("Result"))
             .AddColumn(new TableColumn("Duration").RightAligned().NoWrap());
@@ -202,6 +204,7 @@ internal sealed class SpectreProgressLedger
             {
                 currentGroup = snapshot.GroupTitle;
                 table.AddRow(
+                    string.Empty,
                     string.Empty,
                     $"[grey bold]{Esc(currentGroup)}[/]",
                     string.Empty,
@@ -218,6 +221,7 @@ internal sealed class SpectreProgressLedger
                     .Where(value => !string.IsNullOrWhiteSpace(value)));
             table.AddRow(
                 $"[{color}]{icon}[/]",
+                SpectreProgressPresentation.GetKindIcon(snapshot.Kind, unicode),
                 $"[{color}]{Esc($"{ordinal} {snapshot.Title}")}[/]",
                 $"[{color}]{Esc(result)}[/]",
                 $"[deepskyblue1]{Esc(FormatDuration(snapshot.Duration))}[/]");
@@ -382,6 +386,7 @@ internal sealed class SpectreProgressLedgerSnapshot
         int position,
         int total,
         string title,
+        string? kind,
         string? target,
         string? counterLabel,
         SpectreProgressLedgerState state,
@@ -392,6 +397,7 @@ internal sealed class SpectreProgressLedgerSnapshot
         Position = position;
         Total = total;
         Title = title;
+        Kind = kind;
         Target = target;
         CounterLabel = counterLabel;
         State = state;
@@ -403,6 +409,7 @@ internal sealed class SpectreProgressLedgerSnapshot
     internal int Position { get; }
     internal int Total { get; }
     internal string Title { get; }
+    internal string? Kind { get; }
     internal string? Target { get; }
     internal string? CounterLabel { get; }
     internal SpectreProgressLedgerState State { get; }

--- a/PowerForge.ConsoleShared/SpectreProgressPresentation.cs
+++ b/PowerForge.ConsoleShared/SpectreProgressPresentation.cs
@@ -128,10 +128,20 @@ internal sealed class SpectreProgressPresentation
             return kind?.Trim().ToLowerInvariant() switch
             {
                 "module" => unicode ? "[cyan]🔨[/]" : "[cyan]BL[/]",
+                "plan" => unicode ? "[steelblue1]🧭[/]" : "[steelblue1]PL[/]",
                 "packages" => unicode ? "[magenta]📦[/]" : "[magenta]PK[/]",
-                "tools" => unicode ? "[deepskyblue1]🧰[/]" : "[deepskyblue1]TL[/]",
+                "packagesigning" or "msisign" => unicode ? "[gold3]🔏[/]" : "[gold3]SG[/]",
+                "nugetpublish" => unicode ? "[yellow]🚀[/]" : "[yellow]PB[/]",
+                "githubpublish" or "githubasset" => unicode ? "[yellow]🚀[/]" : "[yellow]GH[/]",
+                "tools" or "toolpublish" => unicode ? "[deepskyblue1]🧰[/]" : "[deepskyblue1]TL[/]",
                 "github" => unicode ? "[yellow]🚀[/]" : "[yellow]GH[/]",
                 "versioning" => unicode ? "[lightskyblue1]🏷[/]" : "[lightskyblue1]VR[/]",
+                "clean" => unicode ? "[grey]🧹[/]" : "[grey]CL[/]",
+                "restore" => unicode ? "[green]📥[/]" : "[green]RS[/]",
+                "servicelifecycle" or "commandhook" => unicode ? "[steelblue1]⚙[/]" : "[steelblue1]AC[/]",
+                "benchmarkextract" or "benchmarkgate" => unicode ? "[orange3]🧪[/]" : "[orange3]TS[/]",
+                "manifest" => unicode ? "[deepskyblue1]📝[/]" : "[deepskyblue1]DC[/]",
+                "msiprepare" or "msibuild" or "bundle" or "storepackage" => unicode ? "[magenta]📦[/]" : "[magenta]PK[/]",
                 _ => unicode ? "[grey]•[/]" : "[grey]PF[/]"
             };
         }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -931,59 +931,7 @@ public sealed partial class ModulePipelineRunner
     private static bool ShouldRunPackageBuildBeforeModule(
         ConfigurationReleaseSegment? release,
         bool buildBeforeModule)
-        => ResolveReleaseBuildOrderOverride(release) ?? buildBeforeModule;
-
-    private static bool? ResolveReleaseBuildOrderOverride(ConfigurationReleaseSegment? release)
-    {
-        var order = release?.Configuration?.BuildOrder;
-        if (order is null || order.Length == 0)
-            return null;
-
-        int? packageIndex = null;
-        int? moduleIndex = null;
-        for (var index = 0; index < order.Length; index++)
-        {
-            if (string.IsNullOrWhiteSpace(order[index]))
-                continue;
-
-            if (TryParseReleaseBuildLane(order[index], out var lane))
-            {
-                if (lane == ReleaseBuildLane.PackageBuild && packageIndex is null)
-                    packageIndex = index;
-                if (lane == ReleaseBuildLane.Module && moduleIndex is null)
-                    moduleIndex = index;
-            }
-        }
-
-        if (packageIndex is null || moduleIndex is null)
-            return null;
-
-        return packageIndex.Value < moduleIndex.Value;
-    }
-
-    private static bool TryParseReleaseBuildLane(string value, out ReleaseBuildLane lane)
-    {
-        var normalized = value.Trim().Replace("-", string.Empty).Replace("_", string.Empty);
-        if (string.Equals(normalized, "PackageBuild", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(normalized, "PackageBuilds", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(normalized, "ProjectBuild", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(normalized, "ProjectBuilds", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(normalized, "Packages", StringComparison.OrdinalIgnoreCase))
-        {
-            lane = ReleaseBuildLane.PackageBuild;
-            return true;
-        }
-
-        if (string.Equals(normalized, "Module", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(normalized, "ModuleBuild", StringComparison.OrdinalIgnoreCase))
-        {
-            lane = ReleaseBuildLane.Module;
-            return true;
-        }
-
-        lane = default;
-        return false;
-    }
+        => ModulePipelinePackageBuildOrder.ShouldRunBeforeModule(release, buildBeforeModule);
 
     private static string? NormalizeOptional(string? value)
         => string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
@@ -1115,12 +1063,6 @@ public sealed partial class ModulePipelineRunner
     {
         NuGet,
         GitHub
-    }
-
-    private enum ReleaseBuildLane
-    {
-        PackageBuild,
-        Module
     }
 
     private readonly struct ProjectBuildEffectiveActions

--- a/PowerForge.Tests/ModuleBuildWorkflowServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildWorkflowServiceTests.cs
@@ -201,6 +201,61 @@ public sealed class ModuleBuildWorkflowServiceTests
         Assert.True(install > publish, output);
     }
 
+    [Fact]
+    public void DirectModuleConsole_DescribesCoordinatedModuleAndNuGetReleaseTruthfully()
+    {
+        using var writer = new StringWriter();
+        var console = CreateConsole(writer);
+        var plan = CreatePlan(
+            projectBuilds:
+            [
+                new ConfigurationProjectBuildSegment
+                {
+                    Configuration = new ProjectBuildConfigurationReference
+                    {
+                        Name = "SamplePackages",
+                        ConfigPath = "Build/project.build.json",
+                        BuildBeforeModule = true,
+                        PublishNuget = true
+                    }
+                }
+            ],
+            release: new ConfigurationReleaseSegment
+            {
+                Configuration = new ReleaseConfiguration
+                {
+                    BuildOrder = ["Packages", "Module"],
+                    PublishOrder = ["NuGet", "PowerShellGallery", "GitHub"]
+                }
+            });
+        var steps = ModulePipelineStep.Create(plan);
+
+        SpectreModulePipelineConsoleUi.RunInteractive(
+            console,
+            plan,
+            "powerforge.json",
+            progress =>
+            {
+                foreach (var step in steps)
+                {
+                    progress.StepStarting(step);
+                    progress.StepCompleted(step);
+                }
+
+                return CreateResult(plan);
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Coordinated release", output, StringComparison.Ordinal);
+        Assert.Contains("PowerShell module + 1 NuGet package lane", output, StringComparison.Ordinal);
+        Assert.Contains("Packages → Module", output, StringComparison.Ordinal);
+        Assert.Contains("NuGet → PowerShell Gallery → GitHub", output, StringComparison.Ordinal);
+        Assert.Contains("Build and publish NuGet packages (SamplePackages)", output, StringComparison.Ordinal);
+        Assert.Contains("Module artefacts", output, StringComparison.Ordinal);
+        Assert.Contains("Module publishes", output, StringComparison.Ordinal);
+        Assert.Contains("Coordinated steps", output, StringComparison.Ordinal);
+    }
+
     private static ModuleBuildPreparedContext CreatePreparedContext()
     {
         return new ModuleBuildPreparedContext
@@ -223,7 +278,9 @@ public sealed class ModuleBuildWorkflowServiceTests
     private static ModulePipelinePlan CreatePlan(
         ConfigurationArtefactSegment[]? artefacts = null,
         ConfigurationPublishSegment[]? publishes = null,
-        bool installEnabled = false)
+        bool installEnabled = false,
+        ConfigurationProjectBuildSegment[]? projectBuilds = null,
+        ConfigurationReleaseSegment? release = null)
     {
         return new ModulePipelinePlan(
             moduleName: "SampleModule",
@@ -258,6 +315,11 @@ public sealed class ModuleBuildWorkflowServiceTests
             commandModuleDependencies: new Dictionary<string, string[]>(),
             testsAfterMerge: Array.Empty<TestConfiguration>(),
             actions: Array.Empty<ConfigurationActionSegment>(),
+            appleApps: Array.Empty<ConfigurationAppleAppSegment>(),
+            xcodeProjectVersions: Array.Empty<ConfigurationXcodeProjectVersionSegment>(),
+            projectBuilds: projectBuilds ?? Array.Empty<ConfigurationProjectBuildSegment>(),
+            packageBuilds: Array.Empty<ConfigurationPackageBuildSegment>(),
+            release: release,
             mergeModule: false,
             mergeMissing: false,
             doNotAttemptToFixRelativePaths: false,

--- a/PowerForge.Tests/ModulePipelineStepTests.cs
+++ b/PowerForge.Tests/ModulePipelineStepTests.cs
@@ -318,6 +318,82 @@ public sealed class ModulePipelineStepTests
             Assert.True(idxInline < idxStage);
             Assert.Equal(ModulePipelineStepKind.PackageBuild, steps[idxProject].Kind);
             Assert.Equal(ModulePipelineStepKind.PackageBuild, steps[idxInline].Kind);
+            Assert.Equal("Run NuGet package lane (project.build.json)", steps[idxProject].Title);
+            Assert.Equal("Run NuGet package lane (Inline)", steps[idxInline].Title);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Create_PlacesEveryPackageLaneAtItsEffectiveReleasePosition(bool overrideBeforeModule)
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var segments = new List<IConfigurationSegment>
+            {
+                new ConfigurationProjectBuildSegment
+                {
+                    Configuration = new ProjectBuildConfigurationReference
+                    {
+                        Name = "Referenced",
+                        ConfigPath = "Build/project.build.json",
+                        BuildBeforeModule = false
+                    }
+                },
+                new ConfigurationPackageBuildSegment
+                {
+                    Configuration = new PackageBuildConfiguration
+                    {
+                        Name = "Inline",
+                        BuildBeforeModule = false
+                    }
+                }
+            };
+            if (overrideBeforeModule)
+            {
+                segments.Add(new ConfigurationReleaseSegment
+                {
+                    Configuration = new ReleaseConfiguration
+                    {
+                        BuildOrder = ["Packages", "Module"]
+                    }
+                });
+            }
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0",
+                    CsprojPath = null
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = segments.ToArray()
+            };
+
+            var plan = new ModulePipelineRunner(new NullLogger()).Plan(spec);
+            var steps = ModulePipelineStep.Create(plan);
+            var packageSteps = steps.Where(step => step.Kind == ModulePipelineStepKind.PackageBuild).ToArray();
+            var stageIndex = Array.FindIndex(steps, step => step.Key == "build:stage");
+
+            Assert.Equal(2, packageSteps.Length);
+            Assert.Equal(2, packageSteps.Select(step => step.Key).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+            Assert.All(
+                packageSteps,
+                step => Assert.Equal(
+                    overrideBeforeModule,
+                    Array.IndexOf(steps, step) < stageIndex));
         }
         finally
         {

--- a/PowerForge.Tests/ProjectBuildProgressLedgerTests.cs
+++ b/PowerForge.Tests/ProjectBuildProgressLedgerTests.cs
@@ -31,6 +31,7 @@ public sealed class ProjectBuildProgressLedgerTests
                         GroupTitle = "Build packages and archives",
                         GroupOrder = 1,
                         Title = $"Project.{index:00}",
+                        Kind = ModulePipelineStepKind.PackageBuild.ToString(),
                         Position = index,
                         Total = 85
                     })
@@ -68,12 +69,16 @@ public sealed class ProjectBuildProgressLedgerTests
         Assert.All(snapshots, snapshot => Assert.Equal(SpectreProgressLedgerState.Completed, snapshot.State));
         Assert.Equal(TimeSpan.FromSeconds(1), snapshots[0].Duration);
         Assert.Equal(TimeSpan.FromSeconds(85), snapshots[^1].Duration);
+        Assert.All(snapshots, snapshot => Assert.Equal(ModulePipelineStepKind.PackageBuild.ToString(), snapshot.Kind));
 
         SpectreProgressLedger.WriteLedger(console, snapshots, "Project build details");
         var output = writer.ToString();
         Assert.Contains("Project.01", output, StringComparison.Ordinal);
         Assert.Contains("Project.85", output, StringComparison.Ordinal);
         Assert.Contains("01:25.000", output, StringComparison.Ordinal);
+        Assert.True(
+            output.Contains("📦", StringComparison.Ordinal) || output.Contains("PK", StringComparison.Ordinal),
+            output);
     }
 
     [Fact]
@@ -240,6 +245,8 @@ public sealed class ProjectBuildProgressLedgerTests
         Assert.Contains("Unpacked (Local)", output, StringComparison.Ordinal);
         Assert.Contains("PowerShellGallery", output, StringComparison.Ordinal);
         Assert.Contains("Phase 01/01", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("✓ Phase", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("x Phase", output, StringComparison.Ordinal);
     }
 
     [Theory]
@@ -264,6 +271,21 @@ public sealed class ProjectBuildProgressLedgerTests
         ProjectBuildProgressPhase phase,
         string expected)
         => Assert.Equal(expected, ProgressCounterFormatter.GetProjectBuildScope(phase));
+
+    [Theory]
+    [InlineData(nameof(ProjectBuildProgressPhase.PackageSigning), "SG")]
+    [InlineData(nameof(ProjectBuildProgressPhase.NuGetPublish), "PB")]
+    [InlineData(nameof(ProjectBuildProgressPhase.GitHubPublish), "GH")]
+    [InlineData("GitHubAsset", "GH")]
+    [InlineData("ToolPublish", "TL")]
+    [InlineData(nameof(DotNetPublishStepKind.MsiSign), "SG")]
+    [InlineData(nameof(DotNetPublishStepKind.Bundle), "PK")]
+    public void SharedKindIcons_DescribeRealReleaseAdapterKinds(string kind, string expected)
+    {
+        var rendered = SpectreProgressPresentation.GetKindIcon(kind, unicode: false);
+        Assert.Contains(expected, rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("PF", rendered, StringComparison.Ordinal);
+    }
 
     [Fact]
     public void StandaloneConsole_WritesDetailedLedgerAfterSuccess()

--- a/PowerForge/Models/ModulePipelinePackageBuildOrder.cs
+++ b/PowerForge/Models/ModulePipelinePackageBuildOrder.cs
@@ -1,0 +1,68 @@
+namespace PowerForge;
+
+/// <summary>
+/// Resolves the effective package-lane position shared by execution and progress planning.
+/// </summary>
+internal static class ModulePipelinePackageBuildOrder
+{
+    internal static bool ShouldRunBeforeModule(ConfigurationReleaseSegment? release, bool buildBeforeModule)
+        => ResolveOverride(release) ?? buildBeforeModule;
+
+    private static bool? ResolveOverride(ConfigurationReleaseSegment? release)
+    {
+        var order = release?.Configuration?.BuildOrder;
+        if (order is null || order.Length == 0)
+            return null;
+
+        int? packageIndex = null;
+        int? moduleIndex = null;
+        for (var index = 0; index < order.Length; index++)
+        {
+            if (string.IsNullOrWhiteSpace(order[index]))
+                continue;
+
+            if (!TryParseLane(order[index], out var lane))
+                continue;
+
+            if (lane == ReleaseBuildLane.PackageBuild && packageIndex is null)
+                packageIndex = index;
+            if (lane == ReleaseBuildLane.Module && moduleIndex is null)
+                moduleIndex = index;
+        }
+
+        if (packageIndex is null || moduleIndex is null)
+            return null;
+
+        return packageIndex.Value < moduleIndex.Value;
+    }
+
+    private static bool TryParseLane(string value, out ReleaseBuildLane lane)
+    {
+        var normalized = value.Trim().Replace("-", string.Empty).Replace("_", string.Empty);
+        if (string.Equals(normalized, "PackageBuild", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(normalized, "PackageBuilds", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(normalized, "ProjectBuild", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(normalized, "ProjectBuilds", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(normalized, "Packages", StringComparison.OrdinalIgnoreCase))
+        {
+            lane = ReleaseBuildLane.PackageBuild;
+            return true;
+        }
+
+        if (string.Equals(normalized, "Module", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(normalized, "ModuleBuild", StringComparison.OrdinalIgnoreCase))
+        {
+            lane = ReleaseBuildLane.Module;
+            return true;
+        }
+
+        lane = default;
+        return false;
+    }
+
+    private enum ReleaseBuildLane
+    {
+        PackageBuild,
+        Module
+    }
+}

--- a/PowerForge/Models/ModulePipelineStep.cs
+++ b/PowerForge/Models/ModulePipelineStep.cs
@@ -112,7 +112,7 @@ public sealed class ModulePipelineStep
 
         AddActionSteps(steps, plan, ModulePipelineActionStage.BeforeDependencies);
         AddActionSteps(steps, plan, ModulePipelineActionStage.AfterDependencies);
-        AddPackageBuildSteps(steps, plan);
+        AddPackageBuildSteps(steps, plan, beforeModule: true);
         AddActionSteps(steps, plan, ModulePipelineActionStage.BeforeVersioning);
         if (plan.AppleApps is { Length: > 0 })
         {
@@ -333,6 +333,7 @@ public sealed class ModulePipelineStep
             }
         }
         AddActionSteps(steps, plan, ModulePipelineActionStage.AfterArtefacts);
+        AddPackageBuildSteps(steps, plan, beforeModule: false);
 
         // 8) Publishes
         AddActionSteps(steps, plan, ModulePipelineActionStage.BeforePublish);
@@ -403,18 +404,24 @@ public sealed class ModulePipelineStep
         }
     }
 
-    private static void AddPackageBuildSteps(List<ModulePipelineStep> steps, ModulePipelinePlan plan)
+    private static void AddPackageBuildSteps(
+        List<ModulePipelineStep> steps,
+        ModulePipelinePlan plan,
+        bool beforeModule)
     {
         if (plan.ProjectBuilds is { Length: > 0 })
         {
             for (var i = 0; i < plan.ProjectBuilds.Length; i++)
             {
                 var segment = plan.ProjectBuilds[i];
-                if (segment?.Configuration?.BuildBeforeModule != true)
+                if (segment?.Configuration is null ||
+                    ModulePipelinePackageBuildOrder.ShouldRunBeforeModule(
+                        plan.Release,
+                        segment.Configuration.BuildBeforeModule) != beforeModule)
                     continue;
 
                 var name = segment.Configuration.Name;
-                var label = "Build packages";
+                var label = GetPackageLaneAction(segment.Configuration.PublishNuget);
                 if (!string.IsNullOrWhiteSpace(name))
                     label += $" ({name})";
                 else if (!string.IsNullOrWhiteSpace(segment.Configuration.ConfigPath))
@@ -433,13 +440,17 @@ public sealed class ModulePipelineStep
             for (var i = 0; i < plan.PackageBuilds.Length; i++)
             {
                 var segment = plan.PackageBuilds[i];
-                if (segment?.Configuration?.BuildBeforeModule != true)
+                if (segment?.Configuration is null ||
+                    ModulePipelinePackageBuildOrder.ShouldRunBeforeModule(
+                        plan.Release,
+                        segment.Configuration.BuildBeforeModule) != beforeModule)
                     continue;
 
                 var name = segment.Configuration.Name;
+                var action = GetPackageLaneAction(segment.Configuration.PublishNuget);
                 var label = string.IsNullOrWhiteSpace(name)
-                    ? "Build packages (inline)"
-                    : $"Build packages ({name})";
+                    ? $"{action} (inline)"
+                    : $"{action} ({name})";
 
                 steps.Add(new ModulePipelineStep(
                     kind: ModulePipelineStepKind.PackageBuild,
@@ -449,6 +460,14 @@ public sealed class ModulePipelineStep
             }
         }
     }
+
+    private static string GetPackageLaneAction(bool? publishNuget)
+        => publishNuget switch
+        {
+            true => "Build and publish NuGet packages",
+            false => "Build NuGet packages",
+            _ => "Run NuGet package lane"
+        };
 
     private static void AddExternalAssetSteps(List<ModulePipelineStep> steps, ModulePipelinePlan plan)
     {


### PR DESCRIPTION
## Summary

- present module plus NuGet work as one coordinated release instead of a module-only pipeline
- show build and publish order explicitly and label package lanes according to their actual behavior
- preserve semantic step icons in the durable release history while keeping one shared status presentation
- use one package-order resolver for both execution and the displayed plan

## User impact

A release that builds a PowerShell module and NuGet packages now describes that complete scope up front. Its detailed progress remains as rich as the module view, while Package, Project, Tool, Release, and Asset counters and icons stay truthful throughout the run.

## Validation

Focused console, pipeline-order, workflow, and progress-ledger contracts pass. The multi-target Release solution build completes with zero warnings and errors, and the coordinated console was inspected at a representative terminal width.