### PR TITLE
Fix transient package freshness locks

### DIFF
--- a/PowerForge.Tests/DotNetRepositoryReleaseFreshBuildTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseFreshBuildTests.cs
@@ -2,12 +2,106 @@ using System.Diagnostics;
 using System.IO.Compression;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 
 namespace PowerForge.Tests;
 
 public sealed class DotNetRepositoryReleaseFreshBuildTests
 {
+    [Fact]
+    public async Task FreshnessCleanup_RetriesTransientWindowsOutputLock()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        FileStream? lockStream = null;
+        try
+        {
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Locked"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.Locked.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var outputPath = Path.Combine(projectDirectory.FullName, "bin", "Release", "net8.0", "Sample.Locked.dll");
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+            File.WriteAllText(outputPath, "locked-output");
+            var heldStream = new FileStream(outputPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            lockStream = heldStream;
+
+            var releaseLock = Task.Run(async () =>
+            {
+                await Task.Delay(180);
+                heldStream.Dispose();
+                lockStream = null;
+            });
+
+            var success = DotNetRepositoryReleaseService.TryRemoveStalePrimaryPackageOutputs(
+                new DotNetRepositoryProjectResult
+                {
+                    ProjectName = "Sample.Locked",
+                    CsprojPath = projectPath
+                },
+                "Release",
+                new NullLogger(),
+                out var removedFileCount,
+                out _,
+                out var duration,
+                out var error);
+
+            await releaseLock;
+
+            Assert.True(success, error);
+            Assert.Equal(1, removedFileCount);
+            Assert.False(File.Exists(outputPath));
+            Assert.True(duration >= TimeSpan.FromMilliseconds(100));
+        }
+        finally
+        {
+            lockStream?.Dispose();
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void FreshnessCleanup_BoundsPersistentWindowsOutputLock()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var outputPath = Path.Combine(root.FullName, "PowerForge.Web.Cli.dll");
+            File.WriteAllText(outputPath, "locked-output");
+
+            using var lockStream = new FileStream(outputPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var success = DotNetRepositoryReleaseService.TryDeleteFreshnessOutput(
+                outputPath,
+                TimeSpan.FromMilliseconds(120),
+                out var attempts,
+                out var duration,
+                out var error);
+
+            Assert.False(success);
+            Assert.True(attempts > 1);
+            Assert.True(duration >= TimeSpan.FromMilliseconds(100));
+            Assert.True(duration < TimeSpan.FromSeconds(1));
+            Assert.IsAssignableFrom<IOException>(error);
+            Assert.True(File.Exists(outputPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     [Fact]
     public void FreshnessCleanup_RemovesOnlyPrimaryAssembliesFromSelectedConfigurationOutputs()
     {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.FreshPackageOutputs.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.FreshPackageOutputs.cs
@@ -4,12 +4,15 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Xml.Linq;
 
 namespace PowerForge;
 
 public sealed partial class DotNetRepositoryReleaseService
 {
+    private static readonly TimeSpan FreshnessCleanupRetryWindow = TimeSpan.FromSeconds(5);
+
     /// <summary>
     /// Removes only primary project assemblies that could survive in an obsolete
     /// framework/RID output or intermediate directory. Removing the intermediate
@@ -32,6 +35,8 @@ public sealed partial class DotNetRepositoryReleaseService
 
         try
         {
+            var retriedFileCount = 0;
+            var retryWaitDuration = TimeSpan.Zero;
             var projectDirectory = Path.GetDirectoryName(project.CsprojPath) ?? string.Empty;
             var primaryFileNames = ResolvePrimaryAssemblyFileNamesForCleanup(project)
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
@@ -86,7 +91,24 @@ public sealed partial class DotNetRepositoryReleaseService
                     if (!primaryFileNames.Contains(Path.GetFileName(path)))
                         continue;
 
-                    File.Delete(path);
+                    if (!TryDeleteFreshnessOutput(
+                            path,
+                            FreshnessCleanupRetryWindow,
+                            out var deleteAttempts,
+                            out var deleteDuration,
+                            out var deleteError))
+                    {
+                        throw new IOException(
+                            $"Primary output remained locked or unavailable after {deleteAttempts} delete attempt(s) over {FormatDuration(deleteDuration)}: '{path}'. " +
+                            "Close the process using this build output and retry.",
+                            deleteError);
+                    }
+
+                    if (deleteAttempts > 1)
+                    {
+                        retriedFileCount++;
+                        retryWaitDuration += deleteDuration;
+                    }
                     removedFileCount++;
                     if (intermediateRootSet.Any(root => IsPathWithinRoot(path, root)))
                         removedIntermediatePrimaryOutput = true;
@@ -95,6 +117,11 @@ public sealed partial class DotNetRepositoryReleaseService
 
             watch.Stop();
             duration = watch.Elapsed;
+            if (retriedFileCount > 0)
+            {
+                logger.Warn(
+                    $"{project.ProjectName}: freshness cleanup waited {FormatDuration(retryWaitDuration)} for {retriedFileCount} transiently locked primary output(s).");
+            }
             var message = $"{project.ProjectName}: freshness cleanup removed {removedFileCount} stale primary output(s) from {searchRoots.Length} scoped root(s) in {FormatDuration(duration)}.";
             if (removedFileCount > 0)
                 logger.Success(message);
@@ -109,6 +136,48 @@ public sealed partial class DotNetRepositoryReleaseService
             error = $"Freshness cleanup failed for {project.ProjectName} after removing {removedFileCount} file(s). {ex.Message}";
             logger.Error(error);
             return false;
+        }
+    }
+
+    internal static bool TryDeleteFreshnessOutput(
+        string path,
+        TimeSpan retryWindow,
+        out int attempts,
+        out TimeSpan duration,
+        out Exception? error)
+    {
+        var watch = Stopwatch.StartNew();
+        attempts = 0;
+        error = null;
+        var delayMilliseconds = 40;
+        var boundedRetryWindow = retryWindow < TimeSpan.Zero ? TimeSpan.Zero : retryWindow;
+
+        while (true)
+        {
+            attempts++;
+            try
+            {
+                File.Delete(path);
+                watch.Stop();
+                duration = watch.Elapsed;
+                error = null;
+                return true;
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                error = ex;
+                if (watch.Elapsed >= boundedRetryWindow)
+                {
+                    watch.Stop();
+                    duration = watch.Elapsed;
+                    return false;
+                }
+
+                var remaining = boundedRetryWindow - watch.Elapsed;
+                var delay = TimeSpan.FromMilliseconds(Math.Min(delayMilliseconds, Math.Max(1, remaining.TotalMilliseconds)));
+                Thread.Sleep(delay);
+                delayMilliseconds = Math.Min(delayMilliseconds * 2, 400);
+            }
         }
     }
 


### PR DESCRIPTION
## What changed

PowerForge now tolerates short Windows file-lock handoffs while removing stale primary outputs before NuGet package builds.

- retries transient `IOException` and `UnauthorizedAccessException` failures with bounded backoff
- records when a release had to wait for transiently locked outputs
- keeps persistent locks fail-closed with the exact path, attempt count, elapsed time, and remediation guidance
- covers both a released transient lock and a permanently held lock

This prevents a successful executable matrix from being followed by an immediate package failure when Windows, an antivirus scanner, or a just-finished build briefly retains `PowerForge.Web.Cli.dll`.

## Validation

- focused freshness cleanup suite: 25/25
- full Release solution build: 0 warnings and 0 errors
- complete `Build-Project.ps1 -RunMode Build`: `Success=True` through module, 10 executable outputs, and six NuGet projects at unified version 3.0.97
- independent read-only release-path review: no P0-P3 findings

No package or release was published during validation.