### PR TITLE
Surface nested package release progress

### DIFF
--- a/PowerForge.ConsoleShared/SpectreModulePipelineConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectreModulePipelineConsoleUi.cs
@@ -218,13 +218,13 @@ internal static class SpectreModulePipelineConsoleUi
         return new SpectreProgressLedgerItem
         {
             Key = item.Key,
-            GroupKey = PowerForgeReleaseProgressPhase.Module.ToString(),
-            GroupTitle = "Build PowerShell module",
-            GroupOrder = (int)PowerForgeReleaseProgressPhase.Module,
+            GroupKey = item.GroupKey ?? item.Phase.ToString(),
+            GroupTitle = item.GroupTitle ?? GetGroupTitle(item.Phase),
+            GroupOrder = ((int)item.Phase * 100) + (item.GroupOrder ?? 0),
             Title = item.Title,
             Kind = item.Kind,
             Target = item.Target,
-            CounterLabel = "Module",
+            CounterLabel = item.CounterLabel ?? GetCounterLabel(item),
             Position = item.Position,
             Total = item.Total
         };
@@ -237,7 +237,26 @@ internal static class SpectreModulePipelineConsoleUi
         return interactive ? ConsoleView.Standard : ConsoleView.Ansi;
     }
 
-    private sealed class SpectrePipelineProgressReporter : IModulePipelineProgressReporterV3
+    private static string GetGroupTitle(PowerForgeReleaseProgressPhase phase)
+        => phase == PowerForgeReleaseProgressPhase.Packages
+            ? "Build and publish NuGet packages"
+            : "Build PowerShell module";
+
+    private static string GetCounterLabel(PowerForgeReleaseProgressItem item)
+    {
+        if (item.Phase != PowerForgeReleaseProgressPhase.Packages)
+            return "Module";
+
+        return item.Kind switch
+        {
+            nameof(ProjectBuildProgressPhase.PackageSigning) => "Package",
+            nameof(ProjectBuildProgressPhase.NuGetPublish) => "Package",
+            "GitHubAsset" => "Asset",
+            _ => "Project"
+        };
+    }
+
+    private sealed class SpectrePipelineProgressReporter : IModulePipelineProgressReporterV4
     {
         private readonly SpectreProgressLedger _ledger;
         private readonly IReadOnlyDictionary<string, SpectreProgressLedgerItem> _items;
@@ -270,6 +289,39 @@ internal static class SpectreModulePipelineConsoleUi
             item.ProgressValue = Math.Max(0, value);
             item.ProgressMaximum = Math.Max(0, maximum);
             _ledger.Update(item, SpectreProgressLedgerState.Started, detail);
+        }
+
+        public void ItemsPlanned(
+            PowerForgeReleaseProgressPhase phase,
+            IReadOnlyList<PowerForgeReleaseProgressItem> items)
+        {
+            if (items is null || items.Count == 0)
+                return;
+
+            _ledger.Plan(items
+                .Where(static item => item is not null)
+                .Select(ToLedgerItem));
+        }
+
+        public void ItemUpdated(
+            PowerForgeReleaseProgressItem item,
+            PowerForgeReleaseProgressItemState state,
+            string? detail = null)
+        {
+            if (item is null)
+                return;
+
+            _ledger.Update(
+                ToLedgerItem(item),
+                state switch
+                {
+                    PowerForgeReleaseProgressItemState.Started => SpectreProgressLedgerState.Started,
+                    PowerForgeReleaseProgressItemState.Completed => SpectreProgressLedgerState.Completed,
+                    PowerForgeReleaseProgressItemState.Failed => SpectreProgressLedgerState.Failed,
+                    PowerForgeReleaseProgressItemState.Skipped => SpectreProgressLedgerState.Skipped,
+                    _ => SpectreProgressLedgerState.Planned
+                },
+                detail);
         }
 
         private void Update(

--- a/PowerForge.ConsoleShared/SpectrePowerForgeReleaseConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectrePowerForgeReleaseConsoleUi.cs
@@ -130,7 +130,13 @@ internal static class SpectrePowerForgeReleaseConsoleUi
         var runModule = !hasTargetAwareSelection &&
                         spec.Module is not null &&
                         (!request.PackagesOnly && !request.ToolsOnly || request.ModuleOnly);
-        var runPackages = spec.Packages is not null && !request.ModuleOnly && !request.ToolsOnly;
+        var moduleIncludesPackages = runModule &&
+                                     spec.Module?.IncludesPackages == true &&
+                                     !request.PlanOnly &&
+                                     !request.ValidateOnly;
+        var runPackages = (spec.Packages is not null || moduleIncludesPackages) &&
+                          !request.ModuleOnly &&
+                          !request.ToolsOnly;
         if (hasTargetAwareSelection)
             runPackages = false;
         var runTools = spec.Tools is not null && !request.ModuleOnly && !request.PackagesOnly;
@@ -283,7 +289,16 @@ internal static class SpectrePowerForgeReleaseConsoleUi
                 .Select(ToLedgerItem));
 
             if (_tasks.TryGetValue(phase, out var phaseTask))
+            {
+                if (!phaseTask.IsStarted)
+                {
+                    phaseTask.StartTask();
+                    _presentation.MarkStarted(phaseTask, phase.ToString());
+                    phaseTask.Value = 5;
+                }
+
                 phaseTask.Description = Label(phase, $"{CountItems(phase)} detailed step(s)");
+            }
         }
 
         public void ItemUpdated(
@@ -314,6 +329,14 @@ internal static class SpectrePowerForgeReleaseConsoleUi
             foreach (var entry in _tasks)
             {
                 if (entry.Value.IsFinished || _failed.Contains(entry.Key)) continue;
+                if (success &&
+                    _ledger.GetItemCount(entry.Key.ToString()) > 0 &&
+                    _ledger.GetCompletionRatio(entry.Key.ToString()) >= 1d)
+                {
+                    PhaseCompleted(entry.Key, $"{CountItems(entry.Key)} detailed step(s) completed");
+                    continue;
+                }
+
                 if (entry.Value.IsStarted && !success)
                 {
                     PhaseFailed(entry.Key, "workflow stopped");
@@ -367,13 +390,13 @@ internal static class SpectrePowerForgeReleaseConsoleUi
             => new()
             {
                 Key = $"{item.Phase}:{item.Key}",
-                GroupKey = item.Phase.ToString(),
-                GroupTitle = _phaseNames[item.Phase],
-                GroupOrder = (int)item.Phase,
+                GroupKey = item.GroupKey ?? item.Phase.ToString(),
+                GroupTitle = item.GroupTitle ?? _phaseNames[item.Phase],
+                GroupOrder = ((int)item.Phase * 100) + (item.GroupOrder ?? 0),
                 Title = item.Title,
                 Kind = item.Kind,
                 Target = item.Target,
-                CounterLabel = GetCounterLabel(item.Phase),
+                CounterLabel = item.CounterLabel ?? GetCounterLabel(item),
                 Position = item.Position,
                 Total = item.Total,
                 ProgressValue = item.ProgressValue,
@@ -381,8 +404,16 @@ internal static class SpectrePowerForgeReleaseConsoleUi
                 Duration = item.Duration
             };
 
-        private static string GetCounterLabel(PowerForgeReleaseProgressPhase phase)
-            => phase switch
+        private static string GetCounterLabel(PowerForgeReleaseProgressItem item)
+        {
+            if (item.Phase == PowerForgeReleaseProgressPhase.Packages &&
+                (string.Equals(item.Kind, ProjectBuildProgressPhase.PackageSigning.ToString(), StringComparison.Ordinal) ||
+                 string.Equals(item.Kind, ProjectBuildProgressPhase.NuGetPublish.ToString(), StringComparison.Ordinal)))
+            {
+                return "Package";
+            }
+
+            return item.Phase switch
             {
                 PowerForgeReleaseProgressPhase.Versioning => "Version",
                 PowerForgeReleaseProgressPhase.Module => "Module",
@@ -391,5 +422,6 @@ internal static class SpectrePowerForgeReleaseConsoleUi
                 PowerForgeReleaseProgressPhase.GitHub => "Asset",
                 _ => "Item"
             };
+        }
     }
 }

--- a/PowerForge.ConsoleShared/SpectreProgressLedger.cs
+++ b/PowerForge.ConsoleShared/SpectreProgressLedger.cs
@@ -85,7 +85,7 @@ internal sealed class SpectreProgressLedger
         lock (_sync)
         {
             var entries = _entries.Values
-                .Where(entry => string.Equals(entry.Item.GroupKey, groupKey, StringComparison.OrdinalIgnoreCase))
+                .Where(entry => BelongsToGroup(entry.Item.GroupKey, groupKey))
                 .ToArray();
             if (entries.Length == 0)
                 return 0;
@@ -98,8 +98,7 @@ internal sealed class SpectreProgressLedger
     {
         lock (_sync)
         {
-            return _entries.Values.Count(entry =>
-                string.Equals(entry.Item.GroupKey, groupKey, StringComparison.OrdinalIgnoreCase));
+            return _entries.Values.Count(entry => BelongsToGroup(entry.Item.GroupKey, groupKey));
         }
     }
 
@@ -159,7 +158,7 @@ internal sealed class SpectreProgressLedger
         {
             return _entries.Values
                 .OrderBy(entry => entry.Item.GroupOrder)
-                .ThenBy(entry => entry.Item.Position <= 0 ? int.MaxValue : entry.Item.Position)
+                .ThenBy(entry => entry.Item.Position <= 0 ? int.MinValue : entry.Item.Position)
                 .ThenBy(entry => entry.Item.Title, StringComparer.OrdinalIgnoreCase)
                 .Select(entry => new SpectreProgressLedgerSnapshot(
                     entry.Item.GroupTitle,
@@ -175,6 +174,10 @@ internal sealed class SpectreProgressLedger
                 .ToArray();
         }
     }
+
+    private static bool BelongsToGroup(string candidate, string groupKey)
+        => string.Equals(candidate, groupKey, StringComparison.OrdinalIgnoreCase) ||
+           candidate.StartsWith(groupKey + ":", StringComparison.OrdinalIgnoreCase);
 
     internal static void WriteLedger(
         IAnsiConsole console,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -183,7 +183,8 @@ public sealed partial class ModulePipelineRunner
                 configPath,
                 destination,
                 remotePublishAttempted,
-                coordinatedReleaseCheckpointActive);
+                coordinatedReleaseCheckpointActive,
+                session.CreateProjectBuildProgressReporter(step));
             session.Done(step);
             return true;
         }
@@ -230,7 +231,8 @@ public sealed partial class ModulePipelineRunner
                 configPath,
                 destination,
                 remotePublishAttempted,
-                coordinatedReleaseCheckpointActive);
+                coordinatedReleaseCheckpointActive,
+                session.CreateProjectBuildProgressReporter(step));
             session.Done(step);
             return true;
         }
@@ -310,7 +312,8 @@ public sealed partial class ModulePipelineRunner
         string configPath,
         PackageBuildPublishDestination destination,
         Action remotePublishAttempted,
-        bool coordinatedReleaseCheckpointActive)
+        bool coordinatedReleaseCheckpointActive,
+        IProjectBuildProgressReporter? progress)
     {
         var release = existing.Result.Release
             ?? throw new InvalidOperationException($"Cannot reuse package build result for {destination}; the earlier package build did not include a release result.");
@@ -326,7 +329,8 @@ public sealed partial class ModulePipelineRunner
                     configuration,
                     configPath,
                     existing.RootPath,
-                    remotePublishAttempted);
+                    remotePublishAttempted,
+                    progress);
                 break;
             case PackageBuildPublishDestination.GitHub:
                 PublishExistingGitHubRelease(
@@ -335,7 +339,8 @@ public sealed partial class ModulePipelineRunner
                     configuration,
                     configPath,
                     remotePublishAttempted,
-                    coordinatedReleaseCheckpointActive);
+                    coordinatedReleaseCheckpointActive,
+                    progress);
                 break;
         }
     }
@@ -345,7 +350,8 @@ public sealed partial class ModulePipelineRunner
         ProjectBuildConfiguration configuration,
         string configPath,
         string repositoryRoot,
-        Action remotePublishAttempted)
+        Action remotePublishAttempted,
+        IProjectBuildProgressReporter? progress)
     {
         var configDirectory = Path.GetDirectoryName(configPath);
         if (string.IsNullOrWhiteSpace(configDirectory))
@@ -380,7 +386,8 @@ public sealed partial class ModulePipelineRunner
             configuration.SkipDuplicate ?? true,
             configuration.PublishFailFast ?? true,
             suppressCompanionSymbols: !(configuration.IncludeSymbols ?? false) || publishSymbolsSeparately,
-            remotePublishAttempted: remotePublishAttempted);
+            remotePublishAttempted: remotePublishAttempted,
+            progress: progress);
 
         ApplyPublishedNuGetArtifactOutcomes(
             release,
@@ -464,7 +471,8 @@ public sealed partial class ModulePipelineRunner
         ProjectBuildConfiguration configuration,
         string configPath,
         Action remotePublishAttempted,
-        bool coordinatedReleaseCheckpointActive)
+        bool coordinatedReleaseCheckpointActive,
+        IProjectBuildProgressReporter? progress)
     {
         var configDirectory = Path.GetDirectoryName(configPath);
         if (string.IsNullOrWhiteSpace(configDirectory))
@@ -503,7 +511,8 @@ public sealed partial class ModulePipelineRunner
                 GitHubTagConflictPolicy = NormalizeOptional(configuration.GitHubTagConflictPolicy),
                 PublishFailFast = configuration.PublishFailFast ?? true
             },
-            release);
+            release,
+            progress);
 
         existing.Result.GitHub.AddRange(summary.Results);
         existing.Result.Success = summary.Success;
@@ -531,6 +540,7 @@ public sealed partial class ModulePipelineRunner
                 state,
                 segment,
                 mode,
+                session.CreateProjectBuildProgressReporter(step),
                 useDuplicateTolerantNuGetRetry,
                 remotePublishAttempted,
                 coordinatedReleaseCheckpointActive);
@@ -581,6 +591,7 @@ public sealed partial class ModulePipelineRunner
                 state,
                 segment,
                 mode,
+                session.CreateProjectBuildProgressReporter(step),
                 useDuplicateTolerantNuGetRetry,
                 remotePublishAttempted,
                 coordinatedReleaseCheckpointActive);
@@ -657,6 +668,7 @@ public sealed partial class ModulePipelineRunner
         ModulePipelineRunState state,
         ConfigurationProjectBuildSegment segment,
         PackageBuildExecutionMode mode,
+        IProjectBuildProgressReporter? progress,
         bool useDuplicateTolerantNuGetRetry = false,
         Action? remotePublishAttempted = null,
         bool coordinatedReleaseCheckpointActive = false)
@@ -708,7 +720,8 @@ public sealed partial class ModulePipelineRunner
                 ? null
                 : plan.Release?.Configuration?.PrimaryProject,
             RemotePublishAttempted = remotePublishAttempted,
-            CoordinatedReleaseCheckpointActive = coordinatedReleaseCheckpointActive
+            CoordinatedReleaseCheckpointActive = coordinatedReleaseCheckpointActive,
+            Progress = progress
         };
 
         _logger.Info($"Running package project build ({DescribePackageBuildMode(mode)}): {configPath}");
@@ -720,6 +733,7 @@ public sealed partial class ModulePipelineRunner
         ModulePipelineRunState state,
         ConfigurationPackageBuildSegment segment,
         PackageBuildExecutionMode mode,
+        IProjectBuildProgressReporter? progress,
         bool useDuplicateTolerantNuGetRetry = false,
         Action? remotePublishAttempted = null,
         bool coordinatedReleaseCheckpointActive = false)
@@ -768,7 +782,8 @@ public sealed partial class ModulePipelineRunner
                 ? null
                 : plan.Release?.Configuration?.PrimaryProject,
             RemotePublishAttempted = remotePublishAttempted,
-            CoordinatedReleaseCheckpointActive = coordinatedReleaseCheckpointActive
+            CoordinatedReleaseCheckpointActive = coordinatedReleaseCheckpointActive,
+            Progress = progress
         };
 
         _logger.Info($"Running inline package build ({DescribePackageBuildMode(mode)}).");

--- a/PowerForge.Tests/ModuleBuildHostServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildHostServiceTests.cs
@@ -532,6 +532,19 @@ public sealed class ModuleBuildHostServiceTests
             {
                 Items = new[] { item }
             });
+            var packageItem = new PowerForgeReleaseProgressItem
+            {
+                Phase = PowerForgeReleaseProgressPhase.Packages,
+                Key = "package:publish:one",
+                Title = "Sample.1.0.0.nupkg",
+                Kind = nameof(ProjectBuildProgressPhase.NuGetPublish),
+                Position = 1,
+                Total = 1
+            };
+            var packagePlanned = JsonSerializer.Serialize(new ModulePipelineProgressProtocolMessage
+            {
+                Items = new[] { packageItem }
+            });
             var completed = JsonSerializer.Serialize(new ModulePipelineProgressProtocolMessage
             {
                 Item = item,
@@ -540,6 +553,9 @@ public sealed class ModuleBuildHostServiceTests
             request.OutputLineReceived!(
                 "##powerforge-module-progress-v1##" +
                 Convert.ToBase64String(Encoding.UTF8.GetBytes(planned)));
+            request.OutputLineReceived!(
+                "##powerforge-module-progress-v1##" +
+                Convert.ToBase64String(Encoding.UTF8.GetBytes(packagePlanned)));
             request.OutputLineReceived!(
                 "##powerforge-module-progress-v1##" +
                 Convert.ToBase64String(Encoding.UTF8.GetBytes(completed)));
@@ -561,9 +577,13 @@ public sealed class ModuleBuildHostServiceTests
         Assert.NotNull(captured);
         Assert.Equal("1", captured!.EnvironmentVariables![ModulePipelineProgressProtocol.EnvironmentVariable]);
         Assert.NotNull(captured.OutputLineReceived);
-        var plannedItem = Assert.Single(progress.Planned);
+        Assert.Equal(2, progress.Planned.Count);
+        var plannedItem = Assert.Single(progress.Planned, item => item.Phase == PowerForgeReleaseProgressPhase.Module);
         Assert.Equal("build:stage", plannedItem.Key);
         Assert.Equal("staging", plannedItem.Target);
+        Assert.Single(progress.Planned, item => item.Phase == PowerForgeReleaseProgressPhase.Packages);
+        Assert.Contains(PowerForgeReleaseProgressPhase.Module, progress.PlannedPhases);
+        Assert.Contains(PowerForgeReleaseProgressPhase.Packages, progress.PlannedPhases);
         var update = Assert.Single(progress.Updates);
         Assert.Equal(PowerForgeReleaseProgressItemState.Completed, update.State);
     }
@@ -618,6 +638,8 @@ public sealed class ModuleBuildHostServiceTests
     {
         public List<PowerForgeReleaseProgressItem> Planned { get; } = new();
 
+        public List<PowerForgeReleaseProgressPhase> PlannedPhases { get; } = new();
+
         public List<(PowerForgeReleaseProgressItem Item, PowerForgeReleaseProgressItemState State)> Updates { get; } = new();
 
         public void PhaseStarted(PowerForgeReleaseProgressPhase phase, int totalItems, string? detail = null) { }
@@ -629,7 +651,10 @@ public sealed class ModuleBuildHostServiceTests
         public void ItemsPlanned(
             PowerForgeReleaseProgressPhase phase,
             IReadOnlyList<PowerForgeReleaseProgressItem> items)
-            => Planned.AddRange(items);
+        {
+            PlannedPhases.Add(phase);
+            Planned.AddRange(items);
+        }
 
         public void ItemUpdated(
             PowerForgeReleaseProgressItem item,

--- a/PowerForge.Tests/ModuleBuildWorkflowServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildWorkflowServiceTests.cs
@@ -229,6 +229,21 @@ public sealed class ModuleBuildWorkflowServiceTests
                 }
             });
         var steps = ModulePipelineStep.Create(plan);
+        var transported = ModulePipelineProgressItemFactory.Create(plan);
+        var packageLane = Assert.Single(
+            transported,
+            item => item.Kind == ModulePipelineStepKind.PackageBuild.ToString());
+        Assert.Equal(PowerForgeReleaseProgressPhase.Packages, packageLane.Phase);
+        Assert.Equal(1, packageLane.Position);
+        Assert.Equal(1, packageLane.Total);
+        var moduleItems = transported
+            .Where(item => item.Phase == PowerForgeReleaseProgressPhase.Module)
+            .ToArray();
+        Assert.NotEmpty(moduleItems);
+        Assert.Equal(
+            Enumerable.Range(1, moduleItems.Length),
+            moduleItems.Select(item => item.Position));
+        Assert.All(moduleItems, item => Assert.Equal(moduleItems.Length, item.Total));
 
         SpectreModulePipelineConsoleUi.RunInteractive(
             console,
@@ -236,6 +251,32 @@ public sealed class ModuleBuildWorkflowServiceTests
             "powerforge.json",
             progress =>
             {
+                var detailed = Assert.IsAssignableFrom<IModulePipelineProgressReporterV4>(progress);
+                var packageItems = new[]
+                {
+                    new PowerForgeReleaseProgressItem
+                    {
+                        Phase = PowerForgeReleaseProgressPhase.Packages,
+                        Key = "package:publish:one",
+                        Title = "Sample.Core.1.0.0.nupkg",
+                        Kind = nameof(ProjectBuildProgressPhase.NuGetPublish),
+                        Position = 1,
+                        Total = 2
+                    },
+                    new PowerForgeReleaseProgressItem
+                    {
+                        Phase = PowerForgeReleaseProgressPhase.Packages,
+                        Key = "package:publish:two",
+                        Title = "Sample.Syntax.1.0.0.nupkg",
+                        Kind = nameof(ProjectBuildProgressPhase.NuGetPublish),
+                        Position = 2,
+                        Total = 2
+                    }
+                };
+                detailed.ItemsPlanned(PowerForgeReleaseProgressPhase.Packages, packageItems);
+                foreach (var item in packageItems)
+                    detailed.ItemUpdated(item, PowerForgeReleaseProgressItemState.Completed, "published");
+
                 foreach (var step in steps)
                 {
                     progress.StepStarting(step);
@@ -251,6 +292,9 @@ public sealed class ModuleBuildWorkflowServiceTests
         Assert.Contains("Packages → Module", output, StringComparison.Ordinal);
         Assert.Contains("NuGet → PowerShell Gallery → GitHub", output, StringComparison.Ordinal);
         Assert.Contains("Build and publish NuGet packages (SamplePackages)", output, StringComparison.Ordinal);
+        Assert.Contains("Package 01/02 Sample.Core.1.0.0.nupkg", output, StringComparison.Ordinal);
+        Assert.Contains("Package 02/02 Sample.Syntax.1.0.0.nupkg", output, StringComparison.Ordinal);
+        Assert.Contains("published", output, StringComparison.Ordinal);
         Assert.Contains("Module artefacts", output, StringComparison.Ordinal);
         Assert.Contains("Module publishes", output, StringComparison.Ordinal);
         Assert.Contains("Coordinated steps", output, StringComparison.Ordinal);

--- a/PowerForge.Tests/ModulePipelinePackageBuildTests.cs
+++ b/PowerForge.Tests/ModulePipelinePackageBuildTests.cs
@@ -30,6 +30,18 @@ public sealed partial class ModulePipelinePackageBuildTests
                 packageBuildExecutor: (request, configuration, configPath) =>
                 {
                     calls.Add(new PackageBuildCall(request, configuration, configPath));
+                    var detailed = Assert.IsAssignableFrom<IProjectBuildProgressReporterV2>(request.Progress);
+                    var item = new ProjectBuildProgressItem
+                    {
+                        Phase = ProjectBuildProgressPhase.PackageBuild,
+                        Key = "sample",
+                        Title = configPath ?? request.ConfigPath,
+                        Kind = ProjectBuildProgressPhase.PackageBuild.ToString(),
+                        Position = 1,
+                        Total = 1
+                    };
+                    detailed.ItemsPlanned(ProjectBuildProgressPhase.PackageBuild, [item]);
+                    detailed.ItemUpdated(item, ProjectBuildProgressItemState.Completed, "1 package");
                     return new ProjectBuildHostExecutionResult
                     {
                         Success = true,
@@ -106,6 +118,17 @@ public sealed partial class ModulePipelinePackageBuildTests
             Assert.True(inlineConfiguration.UseGitHubPackages);
             Assert.Equal("EvotecIT", inlineConfiguration.GitHubPackagesOwner);
             Assert.False(inlineConfiguration.GitHubIncludeProjectNameInTag);
+            Assert.Equal(2, reporter.NestedPlanned.Count(item =>
+                item.Kind == ProjectBuildProgressPhase.PackageBuild.ToString()));
+            Assert.Equal(2, reporter.NestedPlanned
+                .Where(item => item.Kind == ProjectBuildProgressPhase.PackageBuild.ToString())
+                .Select(item => item.Key)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Count());
+            Assert.All(reporter.NestedPlanned, item =>
+                Assert.Equal(PowerForgeReleaseProgressPhase.Packages, item.Phase));
+            Assert.Equal(2, reporter.NestedUpdates.Count(update =>
+                update.State == PowerForgeReleaseProgressItemState.Completed));
 
             var projectPackageIndex = reporter.StartedKeys.IndexOf("package:project:01");
             var inlinePackageIndex = reporter.StartedKeys.IndexOf("package:inline:01");
@@ -115,6 +138,26 @@ public sealed partial class ModulePipelinePackageBuildTests
             Assert.True(stageIndex >= 0);
             Assert.True(projectPackageIndex < stageIndex);
             Assert.True(inlinePackageIndex < stageIndex);
+
+            var parentStep = ModulePipelineStep.Create(plan)
+                .First(step => step.Kind == ModulePipelineStepKind.PackageBuild);
+            var throwingAdapter = new ModulePipelineNestedProgressAdapter(
+                new ThrowingNestedProgressReporter(),
+                parentStep);
+            var nestedItem = new PowerForgeReleaseProgressItem
+            {
+                Phase = PowerForgeReleaseProgressPhase.Packages,
+                Key = "project:sample",
+                Title = "Sample",
+                Position = 1,
+                Total = 1
+            };
+            var progressException = Record.Exception(() =>
+            {
+                throwingAdapter.ItemsPlanned(PowerForgeReleaseProgressPhase.Packages, [nestedItem]);
+                throwingAdapter.ItemUpdated(nestedItem, PowerForgeReleaseProgressItemState.Completed, "complete");
+            });
+            Assert.Null(progressException);
         }
         finally
         {
@@ -1603,10 +1646,12 @@ public sealed partial class ModulePipelinePackageBuildTests
         ProjectBuildConfiguration? Configuration,
         string? ConfigPath);
 
-    private sealed class RecordingProgressReporter : IModulePipelineProgressReporter
+    private sealed class RecordingProgressReporter : IModulePipelineProgressReporterV4
     {
         public List<string> StartedKeys { get; } = new();
         public List<string> FailedKeys { get; } = new();
+        public List<PowerForgeReleaseProgressItem> NestedPlanned { get; } = new();
+        public List<(PowerForgeReleaseProgressItem Item, PowerForgeReleaseProgressItemState State)> NestedUpdates { get; } = new();
 
         public void StepStarting(ModulePipelineStep step)
         {
@@ -1621,5 +1666,48 @@ public sealed partial class ModulePipelinePackageBuildTests
         {
             FailedKeys.Add(step.Key);
         }
+
+        public void StepSkipped(ModulePipelineStep step)
+        {
+        }
+
+        public void StepProgress(ModulePipelineStep step, double value, double maximum, string? detail = null)
+        {
+        }
+
+        public void ItemsPlanned(
+            PowerForgeReleaseProgressPhase phase,
+            IReadOnlyList<PowerForgeReleaseProgressItem> items)
+        {
+            NestedPlanned.AddRange(items);
+        }
+
+        public void ItemUpdated(
+            PowerForgeReleaseProgressItem item,
+            PowerForgeReleaseProgressItemState state,
+            string? detail = null)
+        {
+            NestedUpdates.Add((item, state));
+        }
+    }
+
+    private sealed class ThrowingNestedProgressReporter : IModulePipelineProgressReporterV4
+    {
+        public void StepStarting(ModulePipelineStep step) { }
+        public void StepCompleted(ModulePipelineStep step) { }
+        public void StepFailed(ModulePipelineStep step, Exception error) { }
+        public void StepSkipped(ModulePipelineStep step) { }
+        public void StepProgress(ModulePipelineStep step, double value, double maximum, string? detail = null) { }
+
+        public void ItemsPlanned(
+            PowerForgeReleaseProgressPhase phase,
+            IReadOnlyList<PowerForgeReleaseProgressItem> items)
+            => throw new InvalidOperationException("Progress host unavailable.");
+
+        public void ItemUpdated(
+            PowerForgeReleaseProgressItem item,
+            PowerForgeReleaseProgressItemState state,
+            string? detail = null)
+            => throw new InvalidOperationException("Progress host unavailable.");
     }
 }

--- a/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
+++ b/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
@@ -5,6 +5,59 @@ namespace PowerForge.Tests;
 public sealed class NuGetPackagePublishServiceTests
 {
     [Fact]
+    public void ExecutePackages_ReportsEveryPublishedPackageAsDurableWork()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "pf-nuget-publish-progress-" + Guid.NewGuid().ToString("N")));
+        try
+        {
+            var packages = new[]
+            {
+                Path.Combine(root.FullName, "Sample.Core.1.0.0.nupkg"),
+                Path.Combine(root.FullName, "Sample.Syntax.1.0.0.nupkg")
+            };
+            foreach (var package in packages)
+                File.WriteAllText(package, "package");
+
+            var progress = new RecordingProjectBuildProgress();
+            var service = new NuGetPackagePublishService(
+                new NullLogger(),
+                _ => new DotNetRepositoryReleaseService.PackagePushResult
+                {
+                    Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Published
+                });
+
+            var result = service.ExecutePackages(
+                packages,
+                "key",
+                "https://api.nuget.org/v3/index.json",
+                skipDuplicate: true,
+                progress: progress);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(
+                new[] { "Sample.Core.1.0.0.nupkg", "Sample.Syntax.1.0.0.nupkg" },
+                progress.Planned.Select(item => item.Title));
+            Assert.All(progress.Planned, item =>
+                Assert.Equal(ProjectBuildProgressPhase.NuGetPublish, item.Phase));
+            Assert.Equal(2, progress.Updates.Count(update =>
+                update.State == ProjectBuildProgressItemState.Started));
+            Assert.Equal(2, progress.Updates.Count(update =>
+                update.State == ProjectBuildProgressItemState.Completed &&
+                update.Detail == "published"));
+            Assert.All(
+                progress.Updates.Where(update => update.State == ProjectBuildProgressItemState.Completed),
+                update => Assert.NotNull(update.Item.Duration));
+            Assert.Contains(ProjectBuildProgressPhase.NuGetPublish, progress.CompletedPhases);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void Execute_in_plan_mode_reports_packages_as_published()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-nuget-publish-" + Guid.NewGuid().ToString("N")));
@@ -433,5 +486,38 @@ public sealed class NuGetPackagePublishServiceTests
         {
             try { root.Delete(recursive: true); } catch { }
         }
+    }
+
+    private sealed class RecordingProjectBuildProgress : IProjectBuildProgressReporterV2
+    {
+        public List<ProjectBuildProgressItem> Planned { get; } = new();
+        public List<(ProjectBuildProgressItem Item, ProjectBuildProgressItemState State, string? Detail)> Updates { get; } = new();
+        public List<ProjectBuildProgressPhase> CompletedPhases { get; } = new();
+
+        public void PhaseStarted(ProjectBuildProgressPhase phase, int totalItems, string? detail = null)
+        {
+        }
+
+        public void PhaseUpdated(ProjectBuildProgressPhase phase, int completedItems, int totalItems, string? detail = null)
+        {
+        }
+
+        public void PhaseCompleted(ProjectBuildProgressPhase phase, string? detail = null)
+            => CompletedPhases.Add(phase);
+
+        public void PhaseFailed(ProjectBuildProgressPhase phase, string? detail = null)
+        {
+        }
+
+        public void ItemsPlanned(
+            ProjectBuildProgressPhase phase,
+            IReadOnlyList<ProjectBuildProgressItem> items)
+            => Planned.AddRange(items);
+
+        public void ItemUpdated(
+            ProjectBuildProgressItem item,
+            ProjectBuildProgressItemState state,
+            string? detail = null)
+            => Updates.Add((item, state, detail));
     }
 }

--- a/PowerForge.Tests/PowerForgeReleaseProgressAdaptersTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseProgressAdaptersTests.cs
@@ -3,6 +3,29 @@ namespace PowerForge.Tests;
 public sealed class PowerForgeReleaseProgressAdaptersTests
 {
     [Fact]
+    public void ProjectBuildAdapter_DerivesNestedGroupsFromTheOwningReleasePhase()
+    {
+        var release = new RecordingReleaseProgress();
+        var adapter = new ProjectBuildReleaseProgressAdapter(
+            release,
+            PowerForgeReleaseProgressPhase.Versioning);
+        var item = new ProjectBuildProgressItem
+        {
+            Phase = ProjectBuildProgressPhase.Versioning,
+            Key = "ProjectA",
+            Title = "ProjectA",
+            Position = 1,
+            Total = 1
+        };
+
+        adapter.ItemsPlanned(ProjectBuildProgressPhase.Versioning, [item]);
+
+        var planned = Assert.Single(release.Planned);
+        Assert.Equal("Versioning:Versioning", planned.GroupKey);
+        Assert.StartsWith(PowerForgeReleaseProgressPhase.Versioning.ToString(), planned.GroupKey, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ProjectBuildAdapter_ForwardsExistingPhaseContractAsDetailedReleaseItems()
     {
         var release = new RecordingReleaseProgress();
@@ -174,6 +197,89 @@ public sealed class PowerForgeReleaseProgressAdaptersTests
                 Assert.Contains("/", update.Detail, StringComparison.Ordinal);
             },
             update => Assert.Equal(PowerForgeReleaseProgressItemState.Completed, update.State));
+    }
+
+    [Fact]
+    public void ProjectGitHubAdapter_ForwardsAssetsThroughThePackageLane()
+    {
+        var release = new RecordingReleaseProgress();
+        var project = new ProjectBuildReleaseProgressAdapter(
+            release,
+            PowerForgeReleaseProgressPhase.Packages);
+        var assetPath = Path.Combine(Path.GetTempPath(), "Sample.1.0.0.zip");
+        var adapter = new ProjectBuildGitHubProgressAdapter(project, [assetPath]);
+
+        adapter.Report(new GitHubReleaseAssetProgress
+        {
+            FilePath = assetPath,
+            FileName = "Sample.1.0.0.zip",
+            Position = 1,
+            TotalAssets = 1,
+            State = GitHubReleaseAssetProgressState.Uploading,
+            BytesTransferred = 512,
+            TotalBytes = 1024
+        });
+        adapter.Report(new GitHubReleaseAssetProgress
+        {
+            FilePath = assetPath,
+            FileName = "Sample.1.0.0.zip",
+            Position = 1,
+            TotalAssets = 1,
+            State = GitHubReleaseAssetProgressState.Uploaded,
+            BytesTransferred = 1024,
+            TotalBytes = 1024
+        });
+
+        var item = Assert.Single(release.Planned);
+        Assert.Equal(PowerForgeReleaseProgressPhase.Packages, item.Phase);
+        Assert.Equal("GitHubAsset", item.Kind);
+        Assert.Equal("Sample.1.0.0.zip", item.Title);
+        Assert.Collection(
+            release.Updates,
+            update =>
+            {
+                Assert.Equal(PowerForgeReleaseProgressItemState.Started, update.State);
+                Assert.Contains("512 B / 1 KB", update.Detail, StringComparison.Ordinal);
+            },
+            update => Assert.Equal(PowerForgeReleaseProgressItemState.Completed, update.State));
+    }
+
+    [Fact]
+    public void ProjectGitHubAdapter_UsesOneGlobalSequenceForSameNamedAssets()
+    {
+        var release = new RecordingReleaseProgress();
+        var project = new ProjectBuildReleaseProgressAdapter(
+            release,
+            PowerForgeReleaseProgressPhase.Packages);
+        var firstPath = Path.Combine(Path.GetTempPath(), "ProjectA", "Package.zip");
+        var secondPath = Path.Combine(Path.GetTempPath(), "ProjectB", "Package.zip");
+        var adapter = new ProjectBuildGitHubProgressAdapter(project, [firstPath, secondPath]);
+
+        foreach (var path in new[] { firstPath, secondPath })
+        {
+            adapter.Report(new GitHubReleaseAssetProgress
+            {
+                FilePath = path,
+                FileName = "Package.zip",
+                Position = 1,
+                TotalAssets = 1,
+                State = GitHubReleaseAssetProgressState.Uploaded
+            });
+        }
+
+        Assert.Collection(
+            release.Planned,
+            first =>
+            {
+                Assert.Equal(1, first.Position);
+                Assert.Equal(2, first.Total);
+            },
+            second =>
+            {
+                Assert.Equal(2, second.Position);
+                Assert.Equal(2, second.Total);
+            });
+        Assert.Equal(2, release.Planned.Select(static item => item.Key).Distinct(StringComparer.Ordinal).Count());
     }
 
     private sealed class RecordingReleaseProgress : IPowerForgeReleaseProgressReporterV2

--- a/PowerForge.Tests/ProjectBuildGitHubPublisherTests.cs
+++ b/PowerForge.Tests/ProjectBuildGitHubPublisherTests.cs
@@ -8,11 +8,21 @@ public sealed class ProjectBuildGitHubPublisherTests
     public void Publish_per_project_builds_project_tags_and_collects_results()
     {
         var requests = new List<GitHubReleasePublishRequest>();
+        var progress = new RecordingProjectProgress();
         var publisher = new ProjectBuildGitHubPublisher(
             new NullLogger(),
             request =>
             {
                 requests.Add(request);
+                var assetPath = Assert.Single(request.AssetFilePaths!);
+                request.Progress?.Report(new GitHubReleaseAssetProgress
+                {
+                    FilePath = assetPath,
+                    FileName = Path.GetFileName(assetPath),
+                    Position = 1,
+                    TotalAssets = 1,
+                    State = GitHubReleaseAssetProgressState.Uploaded
+                });
                 return new GitHubReleasePublishResult
                 {
                     Succeeded = true,
@@ -26,8 +36,10 @@ public sealed class ProjectBuildGitHubPublisherTests
 
         try
         {
-            var assetA = Path.Combine(root.FullName, "ProjectA.1.2.3.zip");
-            var assetB = Path.Combine(root.FullName, "ProjectB.2.0.0.zip");
+            var projectAPath = Directory.CreateDirectory(Path.Combine(root.FullName, "ProjectA"));
+            var projectBPath = Directory.CreateDirectory(Path.Combine(root.FullName, "ProjectB"));
+            var assetA = Path.Combine(projectAPath.FullName, "Package.zip");
+            var assetB = Path.Combine(projectBPath.FullName, "Package.zip");
             File.WriteAllText(assetA, "a");
             File.WriteAllText(assetB, "b");
 
@@ -39,6 +51,7 @@ public sealed class ProjectBuildGitHubPublisherTests
                 ReleaseMode = "PerProject",
                 TagTemplate = "{Project}-v{Version}",
                 ReleaseName = "{Project} {Version}",
+                Progress = progress,
                 Release = new DotNetRepositoryReleaseResult
                 {
                     Success = true,
@@ -81,10 +94,36 @@ public sealed class ProjectBuildGitHubPublisherTests
                     Assert.Single(second.AssetFilePaths!);
                     Assert.Equal(assetB, second.AssetFilePaths![0]);
                 });
+            Assert.Collection(
+                progress.Items,
+                first =>
+                {
+                    Assert.Equal(1, first.Position);
+                    Assert.Equal(2, first.Total);
+                },
+                second =>
+                {
+                    Assert.Equal(2, second.Position);
+                    Assert.Equal(2, second.Total);
+                });
+            Assert.Equal(2, progress.Items.Select(static item => item.Key).Distinct(StringComparer.Ordinal).Count());
         }
         finally
         {
             try { root.Delete(recursive: true); } catch { }
         }
+    }
+
+    private sealed class RecordingProjectProgress : IProjectBuildProgressReporterV2
+    {
+        internal List<ProjectBuildProgressItem> Items { get; } = new();
+
+        public void PhaseStarted(ProjectBuildProgressPhase phase, int totalItems, string? detail = null) { }
+        public void PhaseUpdated(ProjectBuildProgressPhase phase, int completedItems, int totalItems, string? detail = null) { }
+        public void PhaseCompleted(ProjectBuildProgressPhase phase, string? detail = null) { }
+        public void PhaseFailed(ProjectBuildProgressPhase phase, string? detail = null) { }
+        public void ItemsPlanned(ProjectBuildProgressPhase phase, IReadOnlyList<ProjectBuildProgressItem> items)
+            => Items.AddRange(items);
+        public void ItemUpdated(ProjectBuildProgressItem item, ProjectBuildProgressItemState state, string? detail = null) { }
     }
 }

--- a/PowerForge.Tests/ProjectBuildProgressLedgerTests.cs
+++ b/PowerForge.Tests/ProjectBuildProgressLedgerTests.cs
@@ -249,6 +249,126 @@ public sealed class ProjectBuildProgressLedgerTests
         Assert.DoesNotContain("x Phase", output, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void UnifiedReleaseConsole_CompletesModuleOwnedPackageLaneFromDetailedItems()
+    {
+        using var writer = new StringWriter();
+        var console = CreateConsole(writer, height: 20);
+        var spec = new PowerForgeReleaseSpec
+        {
+            Module = new PowerForgeModuleReleaseOptions
+            {
+                ModuleName = "SampleProgress",
+                ModuleVersion = "1.0.0",
+                IncludesPackages = true
+            }
+        };
+        var request = new PowerForgeReleaseRequest
+        {
+            ConfigPath = "release.json"
+        };
+        var package = new PowerForgeReleaseProgressItem
+        {
+            Phase = PowerForgeReleaseProgressPhase.Packages,
+            Key = "module:package:Sample.Core.1.0.0.nupkg",
+            Title = "Sample.Core.1.0.0.nupkg",
+            Kind = ProjectBuildProgressPhase.NuGetPublish.ToString(),
+            Position = 1,
+            Total = 1
+        };
+
+        var result = SpectrePowerForgeReleaseConsoleUi.RunInteractive(
+            console,
+            spec,
+            request,
+            progress =>
+            {
+                var detailed = Assert.IsAssignableFrom<IPowerForgeReleaseProgressReporterV2>(progress);
+                progress.PhaseStarted(PowerForgeReleaseProgressPhase.Module, 1);
+                progress.PhaseCompleted(PowerForgeReleaseProgressPhase.Module, "complete");
+                detailed.ItemsPlanned(PowerForgeReleaseProgressPhase.Packages, [package]);
+                detailed.ItemUpdated(package, PowerForgeReleaseProgressItemState.Started, "publishing");
+                detailed.ItemUpdated(package, PowerForgeReleaseProgressItemState.Completed, "published");
+                return new PowerForgeReleaseResult { Success = true };
+            });
+
+        Assert.True(result.Success);
+        var output = writer.ToString();
+        Assert.Contains("Package 01/01 Sample.Core.1.0.0.nupkg", output, StringComparison.Ordinal);
+        Assert.Contains("published", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("Build NuGet packages - not required", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void UnifiedReleaseConsole_KeepsNestedPackageStagesOrderedAndLocallyCounted()
+    {
+        using var writer = new StringWriter();
+        var console = CreateConsole(writer, height: 24);
+        var spec = new PowerForgeReleaseSpec
+        {
+            Module = new PowerForgeModuleReleaseOptions
+            {
+                ModuleName = "SampleProgress",
+                ModuleVersion = "1.0.0",
+                IncludesPackages = true
+            }
+        };
+
+        var result = SpectrePowerForgeReleaseConsoleUi.RunInteractive(
+            console,
+            spec,
+            new PowerForgeReleaseRequest { ConfigPath = "release.json" },
+            progress =>
+            {
+                var detailed = Assert.IsAssignableFrom<IPowerForgeReleaseProgressReporterV2>(progress);
+                var project = new ProjectBuildReleaseProgressAdapter(
+                    detailed,
+                    PowerForgeReleaseProgressPhase.Packages);
+                foreach (var phase in new[]
+                         {
+                             ProjectBuildProgressPhase.Versioning,
+                             ProjectBuildProgressPhase.PackageBuild,
+                             ProjectBuildProgressPhase.PackageSigning,
+                             ProjectBuildProgressPhase.NuGetPublish,
+                             ProjectBuildProgressPhase.GitHubPublish
+                         })
+                {
+                    var counter = phase is ProjectBuildProgressPhase.PackageSigning or ProjectBuildProgressPhase.NuGetPublish
+                        ? "Package"
+                        : phase == ProjectBuildProgressPhase.GitHubPublish ? "Asset" : "Project";
+                    var item = new ProjectBuildProgressItem
+                    {
+                        Phase = phase,
+                        Key = $"{phase}:one",
+                        Title = $"{phase} item",
+                        Kind = phase == ProjectBuildProgressPhase.GitHubPublish ? "GitHubAsset" : phase.ToString(),
+                        Position = 1,
+                        Total = 2
+                    };
+                    project.ItemsPlanned(phase, [item]);
+                    project.ItemUpdated(item, ProjectBuildProgressItemState.Completed, $"{counter} complete");
+                }
+
+                return new PowerForgeReleaseResult { Success = true };
+            });
+
+        Assert.True(result.Success);
+        var output = writer.ToString();
+        var version = output.LastIndexOf("Resolve project versions", StringComparison.Ordinal);
+        var build = output.LastIndexOf("Build packages and archives", StringComparison.Ordinal);
+        var sign = output.LastIndexOf("Sign NuGet packages", StringComparison.Ordinal);
+        var publish = output.LastIndexOf("Publish NuGet packages", StringComparison.Ordinal);
+        var github = output.LastIndexOf("Publish project GitHub release", StringComparison.Ordinal);
+        Assert.True(version >= 0, output);
+        Assert.True(build > version, output);
+        Assert.True(sign > build, output);
+        Assert.True(publish > sign, output);
+        Assert.True(github > publish, output);
+        Assert.Contains("Project 01/02 Versioning item", output, StringComparison.Ordinal);
+        Assert.Contains("Package 01/02 PackageSigning item", output, StringComparison.Ordinal);
+        Assert.Contains("Asset 01/02 GitHubPublish item", output, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData(1, 9, "01/09")]
     [InlineData(1, 24, "01/24")]
@@ -439,15 +559,31 @@ public sealed class ProjectBuildProgressLedgerTests
                 progress);
 
             Assert.True(result.Success, result.ErrorMessage);
+            var versionItems = progress.Planned
+                .Where(item => item.Phase == ProjectBuildProgressPhase.Versioning)
+                .ToArray();
+            var packageItems = progress.Planned
+                .Where(item => item.Phase == ProjectBuildProgressPhase.PackageBuild)
+                .ToArray();
             Assert.Equal(
                 new[] { "Sample.First", "Sample.Second" },
-                progress.Planned.Select(item => item.Title).OrderBy(title => title, StringComparer.Ordinal));
-            Assert.Equal(new[] { 1, 2 }, progress.Planned.Select(item => item.Position).OrderBy(position => position));
-            Assert.All(progress.Planned, item => Assert.Equal(2, item.Total));
-            Assert.Equal(2, progress.Updates.Count(update => update.State == ProjectBuildProgressItemState.Started));
-            Assert.Equal(2, progress.Updates.Count(update => update.State == ProjectBuildProgressItemState.Completed));
+                packageItems.Select(item => item.Title).OrderBy(title => title, StringComparer.Ordinal));
+            Assert.Equal(new[] { 1, 2 }, packageItems.Select(item => item.Position).OrderBy(position => position));
+            Assert.All(packageItems, item => Assert.Equal(2, item.Total));
+            Assert.Equal(2, versionItems.Length);
+            Assert.All(versionItems, versionItem => Assert.Contains(progress.Updates, update =>
+                update.Item.Key == versionItem.Key &&
+                update.State == ProjectBuildProgressItemState.Completed));
+            Assert.Equal(2, progress.Updates.Count(update =>
+                update.Item.Phase == ProjectBuildProgressPhase.PackageBuild &&
+                update.State == ProjectBuildProgressItemState.Started));
+            Assert.Equal(2, progress.Updates.Count(update =>
+                update.Item.Phase == ProjectBuildProgressPhase.PackageBuild &&
+                update.State == ProjectBuildProgressItemState.Completed));
             Assert.All(
-                progress.Updates.Where(update => update.State == ProjectBuildProgressItemState.Completed),
+                progress.Updates.Where(update =>
+                    update.Item.Phase == ProjectBuildProgressPhase.PackageBuild &&
+                    update.State == ProjectBuildProgressItemState.Completed),
                 update =>
                 {
                     Assert.NotNull(update.Item.Duration);
@@ -461,6 +597,71 @@ public sealed class ProjectBuildProgressLedgerTests
         finally
         {
             try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Execute_ReportsEverySignedPackageAsDurableWork()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            WriteProject(root.FullName, "Sample.Signed");
+            var progress = new RecordingProjectBuildProgress();
+            DotNetRepositoryReleaseService.PackageSigningHandler signer = (
+                IReadOnlyList<string> packages,
+                DotNetRepositoryReleaseSpec spec,
+                string sha256,
+                out string error) =>
+            {
+                error = string.Empty;
+                return packages.Count > 0;
+            };
+            var service = new DotNetRepositoryReleaseService(
+                new NullLogger(),
+                signer,
+                (_, _) => "ABCDEF");
+
+            var result = service.Execute(
+                new DotNetRepositoryReleaseSpec
+                {
+                    RootPath = root.FullName,
+                    Configuration = "Release",
+                    OutputPath = Path.Combine(root.FullName, "packages"),
+                    Pack = true,
+                    Publish = false,
+                    UpdateVersions = false,
+                    CreateReleaseZip = false,
+                    CertificateThumbprint = "ABC123",
+                    SignAssemblies = false,
+                    SignPackages = true
+                },
+                signAssemblies: null,
+                validateAssemblySigning: null,
+                progress);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            var signingItems = progress.Planned
+                .Where(item => item.Phase == ProjectBuildProgressPhase.PackageSigning)
+                .ToArray();
+            var signingItem = Assert.Single(signingItems);
+            Assert.EndsWith(".nupkg", signingItem.Title, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(progress.Updates, update =>
+                update.Item.Key == signingItem.Key &&
+                update.State == ProjectBuildProgressItemState.Started &&
+                update.Detail == "signing");
+            var completed = Assert.Single(progress.Updates, update =>
+                update.Item.Key == signingItem.Key &&
+                update.State == ProjectBuildProgressItemState.Completed);
+            Assert.Equal("signed", completed.Detail);
+            Assert.NotNull(completed.Item.Duration);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
         }
     }
 
@@ -494,12 +695,15 @@ public sealed class ProjectBuildProgressLedgerTests
                 progress);
 
             Assert.True(result.Success, result.ErrorMessage);
-            var firstTerminal = progress.Updates.FindIndex(update =>
+            var packageUpdates = progress.Updates
+                .Where(update => update.Item.Phase == ProjectBuildProgressPhase.PackageBuild)
+                .ToList();
+            var firstTerminal = packageUpdates.FindIndex(update =>
                 update.State is ProjectBuildProgressItemState.Completed or ProjectBuildProgressItemState.Failed);
-            Assert.Equal(2, progress.Updates.Take(firstTerminal).Count(update =>
+            Assert.Equal(2, packageUpdates.Take(firstTerminal).Count(update =>
                 update.State == ProjectBuildProgressItemState.Started &&
                 update.Detail == "building in MSBuild batch"));
-            Assert.Equal(2, progress.Updates.Take(firstTerminal).Count(update =>
+            Assert.Equal(2, packageUpdates.Take(firstTerminal).Count(update =>
                 update.State == ProjectBuildProgressItemState.Started &&
                 update.Detail == "MSBuild batch complete; awaiting package collection" &&
                 update.Item.Duration > TimeSpan.Zero));

--- a/PowerForge.Tests/ProjectBuildWorkflowServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildWorkflowServiceTests.cs
@@ -41,9 +41,10 @@ public sealed class ProjectBuildWorkflowServiceTests
             progress.Events);
     }
 
-    private sealed class RecordingProjectBuildProgress : IProjectBuildProgressReporter
+    private sealed class RecordingProjectBuildProgress : IProjectBuildProgressReporterV2
     {
         public List<string> Events { get; } = new();
+        public List<ProjectBuildProgressItem> Items { get; } = new();
 
         public void PhaseStarted(ProjectBuildProgressPhase phase, int totalItems, string? detail = null)
             => Events.Add($"start:{phase}:{totalItems}");
@@ -56,6 +57,12 @@ public sealed class ProjectBuildWorkflowServiceTests
 
         public void PhaseFailed(ProjectBuildProgressPhase phase, string? detail = null)
             => Events.Add($"fail:{phase}");
+
+        public void ItemsPlanned(ProjectBuildProgressPhase phase, IReadOnlyList<ProjectBuildProgressItem> items)
+            => Items.AddRange(items);
+
+        public void ItemUpdated(ProjectBuildProgressItem item, ProjectBuildProgressItemState state, string? detail = null)
+            => Events.Add($"item:{item.Phase}:{item.Title}:{state}");
     }
 
     [Fact]
@@ -103,6 +110,7 @@ public sealed class ProjectBuildWorkflowServiceTests
         var remotePublishAttempts = 0;
         var remoteAttemptRecordedBeforePublish = false;
         var logger = new RecordingLogger();
+        var progress = new RecordingProjectBuildProgress();
         var service = new ProjectBuildWorkflowService(
             logger,
             executeRelease: spec =>
@@ -141,6 +149,18 @@ public sealed class ProjectBuildWorkflowServiceTests
                 Assert.Equal("EvotecIT", request.Owner);
                 Assert.Equal("PSPublishModule", request.Repository);
                 Assert.Equal("token", request.Token);
+                var detailed = Assert.IsAssignableFrom<IProjectBuildProgressReporterV2>(request.Progress);
+                var asset = new ProjectBuildProgressItem
+                {
+                    Phase = ProjectBuildProgressPhase.GitHubPublish,
+                    Key = "github:1:ProjectA.1.2.3.zip",
+                    Title = "ProjectA.1.2.3.zip",
+                    Kind = "GitHubAsset",
+                    Position = 1,
+                    Total = 1
+                };
+                detailed.ItemsPlanned(ProjectBuildProgressPhase.GitHubPublish, [asset]);
+                detailed.ItemUpdated(asset, ProjectBuildProgressItemState.Completed, "uploaded");
                 return new ProjectBuildGitHubPublishSummary
                 {
                     Success = true,
@@ -177,7 +197,8 @@ public sealed class ProjectBuildWorkflowServiceTests
                 Spec = new DotNetRepositoryReleaseSpec { RootPath = Directory.GetCurrentDirectory(), PublishFailFast = true }
             },
             executeBuild: true,
-            remotePublishAttempted: () => remotePublishAttempts++);
+            remotePublishAttempted: () => remotePublishAttempts++,
+            progress: progress);
 
         Assert.Equal(2, callIndex);
         Assert.Equal(1, remotePublishAttempts);
@@ -186,6 +207,9 @@ public sealed class ProjectBuildWorkflowServiceTests
         Assert.Single(workflow.Result.GitHub);
         Assert.NotNull(workflow.GitHubPublishSummary);
         Assert.Equal("v1.2.3", workflow.GitHubPublishSummary!.SummaryTag);
+        var asset = Assert.Single(progress.Items, item => item.Kind == "GitHubAsset");
+        Assert.Equal("ProjectA.1.2.3.zip", asset.Title);
+        Assert.Contains("item:GitHubPublish:ProjectA.1.2.3.zip:Completed", progress.Events);
         Assert.Contains(logger.SuccessMessages, message => message.Contains("Project build plan prepared in", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(logger.SuccessMessages, message => message.Contains("Project build release execution completed in", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(logger.SuccessMessages, message => message.Contains("GitHub publish completed in", StringComparison.OrdinalIgnoreCase));

--- a/PowerForge/Models/PowerForgeReleaseProgress.cs
+++ b/PowerForge/Models/PowerForgeReleaseProgress.cs
@@ -61,6 +61,18 @@ public sealed class PowerForgeReleaseProgressItem
     /// <summary>Optional semantic destination or artifact target shown separately from the action title.</summary>
     public string? Target { get; set; }
 
+    /// <summary>Optional presentation group key used to keep nested workflow stages distinct.</summary>
+    public string? GroupKey { get; set; }
+
+    /// <summary>Optional presentation group title used for nested workflow history.</summary>
+    public string? GroupTitle { get; set; }
+
+    /// <summary>Optional order within the owning release phase.</summary>
+    public int? GroupOrder { get; set; }
+
+    /// <summary>Optional counter label such as Project, Package, or Asset.</summary>
+    public string? CounterLabel { get; set; }
+
     /// <summary>One-based position in the owning plan.</summary>
     public int Position { get; set; }
 

--- a/PowerForge/Models/ProjectBuildGitHubPublishRequest.cs
+++ b/PowerForge/Models/ProjectBuildGitHubPublishRequest.cs
@@ -5,6 +5,8 @@ namespace PowerForge;
 /// </summary>
 public sealed class ProjectBuildGitHubPublishRequest
 {
+    internal IProjectBuildProgressReporterV2? Progress { get; set; }
+
     /// <summary>Repository owner.</summary>
     public string Owner { get; set; } = string.Empty;
 

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -259,10 +259,14 @@ public sealed partial class DotNetRepositoryReleaseService
 
             PrepareReleaseVersionFloor(packable, expectedGlobal, expectedMap, spec);
             var alignedVersions = ResolveAlignedPackageVersions(packable, expectedGlobal, expectedMap, spec);
+            var detailedProgress = progress as IProjectBuildProgressReporterV2;
+            var versionItems = CreateVersionProgressItems(packable, detailedProgress);
             progress?.PhaseStarted(ProjectBuildProgressPhase.Versioning, packable.Length, "Resolving project versions");
             var versionProgress = 0;
             foreach (var project in packable)
             {
+                var versionItem = versionItems[project];
+                detailedProgress?.ItemUpdated(versionItem, ProjectBuildProgressItemState.Started, "resolving version");
                 progress?.PhaseUpdated(ProjectBuildProgressPhase.Versioning, versionProgress, packable.Length, project.ProjectName);
                 var expectedVersion = ResolveExpectedVersion(
                     project.ProjectName,
@@ -301,6 +305,7 @@ public sealed partial class DotNetRepositoryReleaseService
                     project.ErrorMessage = $"Version resolution failed: {ex.Message}";
                     _logger.Warn($"{project.ProjectName}: {project.ErrorMessage}");
                     result.Success = false;
+                    detailedProgress?.ItemUpdated(versionItem, ProjectBuildProgressItemState.Failed, project.ErrorMessage);
                     versionProgress++;
                     progress?.PhaseUpdated(ProjectBuildProgressPhase.Versioning, versionProgress, packable.Length, project.ProjectName);
                     continue;
@@ -313,6 +318,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         : resolutionWarning;
                     _logger.Warn($"{project.ProjectName}: {project.ErrorMessage}");
                     result.Success = false;
+                    detailedProgress?.ItemUpdated(versionItem, ProjectBuildProgressItemState.Failed, project.ErrorMessage);
                     versionProgress++;
                     progress?.PhaseUpdated(ProjectBuildProgressPhase.Versioning, versionProgress, packable.Length, project.ProjectName);
                     continue;
@@ -342,6 +348,7 @@ public sealed partial class DotNetRepositoryReleaseService
                 project.NewVersion = resolvedVersion;
                 if (spec.WhatIf || !shouldUpdateProjectVersion)
                 {
+                    detailedProgress?.ItemUpdated(versionItem, ProjectBuildProgressItemState.Completed, resolvedVersion);
                     versionProgress++;
                     progress?.PhaseUpdated(ProjectBuildProgressPhase.Versioning, versionProgress, packable.Length, project.ProjectName);
                     continue;
@@ -364,6 +371,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         _logger.Info($"{project.ProjectName}: version unchanged ({project.OldVersion}).");
                 }
 
+                detailedProgress?.ItemUpdated(versionItem, ProjectBuildProgressItemState.Completed, resolvedVersion);
                 versionProgress++;
                 progress?.PhaseUpdated(ProjectBuildProgressPhase.Versioning, versionProgress, packable.Length, project.ProjectName);
             }
@@ -375,7 +383,6 @@ public sealed partial class DotNetRepositoryReleaseService
             if (spec.Pack)
             {
                 progress?.PhaseStarted(ProjectBuildProgressPhase.PackageBuild, packable.Length, "Building and packing projects");
-                var detailedProgress = progress as IProjectBuildProgressReporterV2;
                 var packageProgressItems = CreatePackageProgressItems(packable, detailedProgress);
                 var packageWatches = new Dictionary<DotNetRepositoryProjectResult, Stopwatch>();
                 DotNetPackResult? batchPackResult = null;
@@ -588,182 +595,18 @@ public sealed partial class DotNetRepositoryReleaseService
                 else
                     progress?.PhaseCompleted(ProjectBuildProgressPhase.PackageBuild, $"{packable.Sum(project => project.Packages.Count)} package(s) produced");
 
-                if (!spec.WhatIf && signNuGetPackages && signingSha256 is not null)
+                if (!spec.WhatIf &&
+                    signNuGetPackages &&
+                    signingSha256 is not null &&
+                    ExecutePackageSigning(spec, result, packable, signingSha256, progress, detailedProgress))
                 {
-                    var packagesToSign = packable
-                        .Where(project => string.IsNullOrWhiteSpace(project.ErrorMessage))
-                        .SelectMany(project => project.Packages.Concat(project.SymbolPackages))
-                        .Where(package => !string.IsNullOrWhiteSpace(package))
-                        .Distinct(StringComparer.OrdinalIgnoreCase)
-                        .ToArray();
-
-                    if (packagesToSign.Length > 0)
-                    {
-                        progress?.PhaseStarted(ProjectBuildProgressPhase.PackageSigning, packagesToSign.Length, "Signing NuGet packages");
-                        _logger.Info($"Signing {packagesToSign.Length} NuGet package(s)...");
-                        var signingWatch = Stopwatch.StartNew();
-                        if (!_signPackages(packagesToSign, spec, signingSha256, out var signError))
-                        {
-                            signingWatch.Stop();
-                            result.ErrorMessage = signError;
-                            _logger.Warn(signError);
-                            result.Success = false;
-                            MarkPackageSigningFailure(packable, packagesToSign, signError);
-                            progress?.PhaseFailed(ProjectBuildProgressPhase.PackageSigning, signError);
-                            if (spec.PublishFailFast)
-                                return result;
-                        }
-                        else
-                        {
-                            signingWatch.Stop();
-                            _logger.Success($"Signed {packagesToSign.Length} NuGet package(s) in {FormatDuration(signingWatch.Elapsed)}.");
-                            progress?.PhaseCompleted(ProjectBuildProgressPhase.PackageSigning, $"{packagesToSign.Length} package(s) signed");
-                        }
-                    }
+                    return result;
                 }
             }
 
-            if (spec.Publish)
+            if (spec.Publish && ExecuteNuGetPublishing(spec, result, packable, root, progress, detailedProgress))
             {
-                var preflight = ValidatePublishPreflight(packable, spec);
-                if (!preflight.Success)
-                {
-                    result.Success = false;
-                    result.ErrorMessage = preflight.ErrorMessage;
-                    return result;
-                }
-
-                if (string.IsNullOrWhiteSpace(spec.PublishApiKey))
-                {
-                    result.Success = false;
-                    result.ErrorMessage = "PublishApiKey is required when Publish is enabled.";
-                    return result;
-                }
-
-                var source = string.IsNullOrWhiteSpace(spec.PublishSource)
-                    ? "https://api.nuget.org/v3/index.json"
-                    : spec.PublishSource!.Trim();
-                result.PublishSource = source;
-
-                var orderedProjects = SortProjectsForPublish(packable);
-                var publishSymbolsSeparately = spec.IncludeSymbols && IsLocalPublishSource(source);
-                var packages = GetPackagesForPublish(orderedProjects, publishSymbolsSeparately).ToArray();
-
-                var packageLookup = orderedProjects
-                    .SelectMany(p => (publishSymbolsSeparately
-                            ? p.Packages.Concat(p.SymbolPackages)
-                            : p.Packages)
-                        .Select(pkg => new { Package = pkg, Project = p }))
-                    .GroupBy(x => x.Package, StringComparer.OrdinalIgnoreCase)
-                    .ToDictionary(g => g.Key, g => g.First().Project, StringComparer.OrdinalIgnoreCase);
-
-                var publishWatch = Stopwatch.StartNew();
-                progress?.PhaseStarted(ProjectBuildProgressPhase.NuGetPublish, packages.Length, "Publishing package artifacts");
-                var publishProgress = 0;
-                foreach (var pkg in packages)
-                {
-                    progress?.PhaseUpdated(ProjectBuildProgressPhase.NuGetPublish, publishProgress, packages.Length, Path.GetFileName(pkg));
-                    packageLookup.TryGetValue(pkg, out var project);
-                    var publishedArtifacts = GetPublishedArtifacts(
-                        project,
-                        pkg,
-                        includeCompanionSymbols: !publishSymbolsSeparately);
-                    if (spec.WhatIf)
-                    {
-                        result.PublishedPackages.AddRange(publishedArtifacts);
-                        continue;
-                    }
-
-                    if (publishSymbolsSeparately &&
-                        !CanPublishSymbolPackage(
-                            pkg,
-                            (IEnumerable<string>?)project?.Packages ?? Array.Empty<string>(),
-                            primaryPackage =>
-                                result.PublishedPackages.Contains(primaryPackage, StringComparer.OrdinalIgnoreCase) ||
-                                result.SkippedDuplicatePackages.Contains(primaryPackage, StringComparer.OrdinalIgnoreCase),
-                            out var primaryPackage))
-                    {
-                        var blockedResult = CreateBlockedCompanionResult(pkg, primaryPackage);
-                        result.Success = false;
-                        result.FailedPackages.Add(pkg);
-                        _logger.Warn(blockedResult.Message!);
-                        if (project is not null && string.IsNullOrWhiteSpace(project.ErrorMessage))
-                            project.ErrorMessage = blockedResult.Message;
-                        if (spec.PublishFailFast)
-                        {
-                            result.ErrorMessage = blockedResult.Message;
-                            return result;
-                        }
-
-                        continue;
-                    }
-
-                    _logger.Info($"Publishing {Path.GetFileName(pkg)}...");
-                    var packagePublishWatch = Stopwatch.StartNew();
-                    spec.RemotePublishAttempted?.Invoke();
-                    var pushResult = PushPackage(
-                        pkg,
-                        spec.PublishApiKey!,
-                        source,
-                        spec.SkipDuplicate,
-                        suppressCompanionSymbols: !spec.IncludeSymbols || publishSymbolsSeparately,
-                        workingDirectory: root);
-                    packagePublishWatch.Stop();
-                    var artifactOutcomes = ClassifyPublishedArtifacts(
-                        publishedArtifacts,
-                        pushResult,
-                        spec.SkipDuplicate);
-                    foreach (var artifact in publishedArtifacts)
-                    {
-                        switch (artifactOutcomes[artifact])
-                        {
-                            case PackagePushOutcome.SkippedDuplicate:
-                                result.SkippedDuplicatePackages.Add(artifact);
-                                _logger.Info($"Skipped duplicate {Path.GetFileName(artifact)} in {FormatDuration(packagePublishWatch.Elapsed)}; package already exists in the feed.");
-                                break;
-                            case PackagePushOutcome.Published:
-                                result.PublishedPackages.Add(artifact);
-                                _logger.Success($"Published {Path.GetFileName(artifact)} in {FormatDuration(packagePublishWatch.Elapsed)}.");
-                                break;
-                            default:
-                                result.FailedPackages.Add(artifact);
-                                _logger.Warn($"NuGet push failed for {artifact} after {FormatDuration(packagePublishWatch.Elapsed)}: {pushResult.Message}");
-                                break;
-                        }
-                    }
-
-                    var failedArtifacts = publishedArtifacts
-                        .Where(artifact => artifactOutcomes[artifact] == PackagePushOutcome.Failed)
-                        .ToArray();
-                    if (failedArtifacts.Length > 0)
-                    {
-                        result.Success = false;
-                        var error = pushResult.Message;
-                        if (project is not null && string.IsNullOrWhiteSpace(project.ErrorMessage))
-                            project.ErrorMessage = $"Publish failed for {string.Join(", ", failedArtifacts.Select(Path.GetFileName))}: {error}";
-                        if (spec.PublishFailFast)
-                        {
-                            if (string.IsNullOrWhiteSpace(result.ErrorMessage))
-                                result.ErrorMessage = $"Publish failed for {string.Join(", ", failedArtifacts.Select(Path.GetFileName))}.";
-                            return result;
-                        }
-                    }
-                    publishProgress++;
-                }
-                publishWatch.Stop();
-                var publishSummary = spec.WhatIf
-                    ? $"NuGet publish plan prepared in {FormatDuration(publishWatch.Elapsed)} ({result.PublishedPackages.Count} package artifact(s) would be published)."
-                    : $"NuGet publish phase completed in {FormatDuration(publishWatch.Elapsed)} ({result.PublishedPackages.Count} published, {result.SkippedDuplicatePackages.Count} skipped duplicate, {result.FailedPackages.Count} failed).";
-                if (result.FailedPackages.Count == 0)
-                {
-                    _logger.Success(publishSummary);
-                    progress?.PhaseCompleted(ProjectBuildProgressPhase.NuGetPublish, publishSummary);
-                }
-                else
-                {
-                    _logger.Warn(publishSummary);
-                    progress?.PhaseFailed(ProjectBuildProgressPhase.NuGetPublish, publishSummary);
-                }
+                return result;
             }
 
             if (result.ResolvedVersionsByProject.Count > 0)

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PackagePublication.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PackagePublication.cs
@@ -1,0 +1,254 @@
+using System.Diagnostics;
+
+namespace PowerForge;
+
+public sealed partial class DotNetRepositoryReleaseService
+{
+    private bool ExecutePackageSigning(
+        DotNetRepositoryReleaseSpec spec,
+        DotNetRepositoryReleaseResult result,
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        string signingCertificateSha256,
+        IProjectBuildProgressReporter? progress,
+        IProjectBuildProgressReporterV2? detailedProgress)
+    {
+        var packages = projects
+            .Where(project => string.IsNullOrWhiteSpace(project.ErrorMessage))
+            .SelectMany(project => project.Packages.Concat(project.SymbolPackages))
+            .Where(package => !string.IsNullOrWhiteSpace(package))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (packages.Length == 0)
+            return false;
+
+        var items = CreateArtifactProgressItems(
+            packages,
+            ProjectBuildProgressPhase.PackageSigning,
+            detailedProgress);
+        progress?.PhaseStarted(ProjectBuildProgressPhase.PackageSigning, packages.Length, "Signing NuGet packages");
+        foreach (var package in packages)
+        {
+            UpdateArtifactProgress(
+                detailedProgress,
+                items[package],
+                ProjectBuildProgressItemState.Started,
+                "signing");
+        }
+
+        _logger.Info($"Signing {packages.Length} NuGet package(s)...");
+        var watch = Stopwatch.StartNew();
+        if (!_signPackages(packages, spec, signingCertificateSha256, out var error))
+        {
+            watch.Stop();
+            result.ErrorMessage = error;
+            result.Success = false;
+            MarkPackageSigningFailure(projects, packages, error);
+            _logger.Warn(error);
+            foreach (var package in packages)
+            {
+                UpdateArtifactProgress(
+                    detailedProgress,
+                    items[package],
+                    ProjectBuildProgressItemState.Failed,
+                    error,
+                    watch.Elapsed);
+            }
+
+            progress?.PhaseFailed(ProjectBuildProgressPhase.PackageSigning, error);
+            return spec.PublishFailFast;
+        }
+
+        watch.Stop();
+        _logger.Success($"Signed {packages.Length} NuGet package(s) in {FormatDuration(watch.Elapsed)}.");
+        foreach (var package in packages)
+        {
+            UpdateArtifactProgress(
+                detailedProgress,
+                items[package],
+                ProjectBuildProgressItemState.Completed,
+                "signed",
+                watch.Elapsed);
+        }
+
+        progress?.PhaseCompleted(ProjectBuildProgressPhase.PackageSigning, $"{packages.Length} package(s) signed");
+        return false;
+    }
+
+    private bool ExecuteNuGetPublishing(
+        DotNetRepositoryReleaseSpec spec,
+        DotNetRepositoryReleaseResult result,
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        string root,
+        IProjectBuildProgressReporter? progress,
+        IProjectBuildProgressReporterV2? detailedProgress)
+    {
+        var preflight = ValidatePublishPreflight(projects, spec);
+        if (!preflight.Success)
+        {
+            result.Success = false;
+            result.ErrorMessage = preflight.ErrorMessage;
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(spec.PublishApiKey))
+        {
+            result.Success = false;
+            result.ErrorMessage = "PublishApiKey is required when Publish is enabled.";
+            return true;
+        }
+
+        var source = string.IsNullOrWhiteSpace(spec.PublishSource)
+            ? "https://api.nuget.org/v3/index.json"
+            : spec.PublishSource!.Trim();
+        result.PublishSource = source;
+
+        var orderedProjects = SortProjectsForPublish(projects);
+        var publishSymbolsSeparately = spec.IncludeSymbols && IsLocalPublishSource(source);
+        var packages = GetPackagesForPublish(orderedProjects, publishSymbolsSeparately).ToArray();
+        var packageLookup = orderedProjects
+            .SelectMany(project => (publishSymbolsSeparately
+                    ? project.Packages.Concat(project.SymbolPackages)
+                    : project.Packages)
+                .Select(package => new { Package = package, Project = project }))
+            .GroupBy(entry => entry.Package, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First().Project, StringComparer.OrdinalIgnoreCase);
+
+        var watch = Stopwatch.StartNew();
+        var items = CreateArtifactProgressItems(
+            packages,
+            ProjectBuildProgressPhase.NuGetPublish,
+            detailedProgress);
+        progress?.PhaseStarted(ProjectBuildProgressPhase.NuGetPublish, packages.Length, "Publishing package artifacts");
+        var completed = 0;
+        foreach (var package in packages)
+        {
+            var item = items[package];
+            UpdateArtifactProgress(
+                detailedProgress,
+                item,
+                ProjectBuildProgressItemState.Started,
+                spec.WhatIf ? "planning publish" : "publishing");
+            progress?.PhaseUpdated(ProjectBuildProgressPhase.NuGetPublish, completed, packages.Length, Path.GetFileName(package));
+            packageLookup.TryGetValue(package, out var project);
+            var artifacts = GetPublishedArtifacts(
+                project,
+                package,
+                includeCompanionSymbols: !publishSymbolsSeparately);
+            if (spec.WhatIf)
+            {
+                result.PublishedPackages.AddRange(artifacts);
+                UpdateArtifactProgress(detailedProgress, item, ProjectBuildProgressItemState.Completed, "would publish");
+                completed++;
+                continue;
+            }
+
+            if (publishSymbolsSeparately &&
+                !CanPublishSymbolPackage(
+                    package,
+                    (IEnumerable<string>?)project?.Packages ?? Array.Empty<string>(),
+                    primaryPackage =>
+                        result.PublishedPackages.Contains(primaryPackage, StringComparer.OrdinalIgnoreCase) ||
+                        result.SkippedDuplicatePackages.Contains(primaryPackage, StringComparer.OrdinalIgnoreCase),
+                    out var primaryPackage))
+            {
+                var blocked = CreateBlockedCompanionResult(package, primaryPackage);
+                result.Success = false;
+                result.FailedPackages.Add(package);
+                _logger.Warn(blocked.Message!);
+                if (project is not null && string.IsNullOrWhiteSpace(project.ErrorMessage))
+                    project.ErrorMessage = blocked.Message;
+                UpdateArtifactProgress(detailedProgress, item, ProjectBuildProgressItemState.Failed, blocked.Message);
+                completed++;
+                if (spec.PublishFailFast)
+                {
+                    result.ErrorMessage = blocked.Message;
+                    return true;
+                }
+
+                continue;
+            }
+
+            _logger.Info($"Publishing {Path.GetFileName(package)}...");
+            var packageWatch = Stopwatch.StartNew();
+            spec.RemotePublishAttempted?.Invoke();
+            var pushResult = PushPackage(
+                package,
+                spec.PublishApiKey!,
+                source,
+                spec.SkipDuplicate,
+                suppressCompanionSymbols: !spec.IncludeSymbols || publishSymbolsSeparately,
+                workingDirectory: root);
+            packageWatch.Stop();
+            var outcomes = ClassifyPublishedArtifacts(artifacts, pushResult, spec.SkipDuplicate);
+            foreach (var artifact in artifacts)
+            {
+                switch (outcomes[artifact])
+                {
+                    case PackagePushOutcome.SkippedDuplicate:
+                        result.SkippedDuplicatePackages.Add(artifact);
+                        _logger.Info($"Skipped duplicate {Path.GetFileName(artifact)} in {FormatDuration(packageWatch.Elapsed)}; package already exists in the feed.");
+                        break;
+                    case PackagePushOutcome.Published:
+                        result.PublishedPackages.Add(artifact);
+                        _logger.Success($"Published {Path.GetFileName(artifact)} in {FormatDuration(packageWatch.Elapsed)}.");
+                        break;
+                    default:
+                        result.FailedPackages.Add(artifact);
+                        _logger.Warn($"NuGet push failed for {artifact} after {FormatDuration(packageWatch.Elapsed)}: {pushResult.Message}");
+                        break;
+                }
+            }
+
+            var failures = artifacts
+                .Where(artifact => outcomes[artifact] == PackagePushOutcome.Failed)
+                .ToArray();
+            if (failures.Length > 0)
+            {
+                UpdateArtifactProgress(
+                    detailedProgress,
+                    item,
+                    ProjectBuildProgressItemState.Failed,
+                    pushResult.Message,
+                    packageWatch.Elapsed);
+                result.Success = false;
+                if (project is not null && string.IsNullOrWhiteSpace(project.ErrorMessage))
+                    project.ErrorMessage = $"Publish failed for {string.Join(", ", failures.Select(Path.GetFileName))}: {pushResult.Message}";
+                if (spec.PublishFailFast)
+                {
+                    if (string.IsNullOrWhiteSpace(result.ErrorMessage))
+                        result.ErrorMessage = $"Publish failed for {string.Join(", ", failures.Select(Path.GetFileName))}.";
+                    return true;
+                }
+            }
+            else
+            {
+                var skipped = artifacts.All(artifact => outcomes[artifact] == PackagePushOutcome.SkippedDuplicate);
+                UpdateArtifactProgress(
+                    detailedProgress,
+                    item,
+                    ProjectBuildProgressItemState.Completed,
+                    skipped ? "already existed" : "published",
+                    packageWatch.Elapsed);
+            }
+
+            completed++;
+        }
+
+        watch.Stop();
+        var summary = spec.WhatIf
+            ? $"NuGet publish plan prepared in {FormatDuration(watch.Elapsed)} ({result.PublishedPackages.Count} package artifact(s) would be published)."
+            : $"NuGet publish phase completed in {FormatDuration(watch.Elapsed)} ({result.PublishedPackages.Count} published, {result.SkippedDuplicatePackages.Count} skipped duplicate, {result.FailedPackages.Count} failed).";
+        if (result.FailedPackages.Count == 0)
+        {
+            _logger.Success(summary);
+            progress?.PhaseCompleted(ProjectBuildProgressPhase.NuGetPublish, summary);
+        }
+        else
+        {
+            _logger.Warn(summary);
+            progress?.PhaseFailed(ProjectBuildProgressPhase.NuGetPublish, summary);
+        }
+
+        return false;
+    }
+}

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Progress.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Progress.cs
@@ -4,6 +4,68 @@ namespace PowerForge;
 
 public sealed partial class DotNetRepositoryReleaseService
 {
+    private static Dictionary<DotNetRepositoryProjectResult, ProjectBuildProgressItem> CreateVersionProgressItems(
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        IProjectBuildProgressReporterV2? progress)
+    {
+        var items = projects
+            .Select((project, index) => new
+            {
+                Project = project,
+                Item = new ProjectBuildProgressItem
+                {
+                    Phase = ProjectBuildProgressPhase.Versioning,
+                    Key = $"version:{project.ProjectName}",
+                    Title = project.ProjectName,
+                    Kind = nameof(ProjectBuildProgressPhase.Versioning),
+                    Position = index + 1,
+                    Total = projects.Count
+                }
+            })
+            .ToDictionary(entry => entry.Project, entry => entry.Item);
+        progress?.ItemsPlanned(
+            ProjectBuildProgressPhase.Versioning,
+            items.Values.OrderBy(item => item.Position).ToArray());
+        return items;
+    }
+
+    private static Dictionary<string, ProjectBuildProgressItem> CreateArtifactProgressItems(
+        IReadOnlyList<string> paths,
+        ProjectBuildProgressPhase phase,
+        IProjectBuildProgressReporterV2? progress)
+    {
+        var items = paths
+            .Select((path, index) => new
+            {
+                Path = path,
+                Item = new ProjectBuildProgressItem
+                {
+                    Phase = phase,
+                    Key = $"{phase}:{index + 1}:{Path.GetFileName(path)}",
+                    Title = Path.GetFileName(path),
+                    Kind = phase.ToString(),
+                    Position = index + 1,
+                    Total = paths.Count
+                }
+            })
+            .ToDictionary(entry => entry.Path, entry => entry.Item, StringComparer.OrdinalIgnoreCase);
+        progress?.ItemsPlanned(
+            phase,
+            items.Values.OrderBy(item => item.Position).ToArray());
+        return items;
+    }
+
+    private static void UpdateArtifactProgress(
+        IProjectBuildProgressReporterV2? progress,
+        ProjectBuildProgressItem item,
+        ProjectBuildProgressItemState state,
+        string? detail = null,
+        TimeSpan? duration = null)
+    {
+        item.Duration = duration;
+        progress?.ItemUpdated(item, state, detail);
+    }
+
     private static Dictionary<DotNetRepositoryProjectResult, ProjectBuildProgressItem> CreatePackageProgressItems(
         IReadOnlyList<DotNetRepositoryProjectResult> projects,
         IProjectBuildProgressReporterV2? progress)

--- a/PowerForge/Services/IModulePipelineProgressReporter.cs
+++ b/PowerForge/Services/IModulePipelineProgressReporter.cs
@@ -34,3 +34,21 @@ public interface IModulePipelineProgressReporterV3 : IModulePipelineProgressRepo
     /// <summary>Updates the current and maximum values for a running step.</summary>
     void StepProgress(ModulePipelineStep step, double value, double maximum, string? detail = null);
 }
+
+/// <summary>
+/// Optional extension for hosts that render durable work items produced by a nested
+/// project/package workflow inside a module pipeline step.
+/// </summary>
+public interface IModulePipelineProgressReporterV4 : IModulePipelineProgressReporterV3
+{
+    /// <summary>Registers nested work items in their owning release phase.</summary>
+    void ItemsPlanned(
+        PowerForgeReleaseProgressPhase phase,
+        IReadOnlyList<PowerForgeReleaseProgressItem> items);
+
+    /// <summary>Updates one nested work item.</summary>
+    void ItemUpdated(
+        PowerForgeReleaseProgressItem item,
+        PowerForgeReleaseProgressItemState state,
+        string? detail = null);
+}

--- a/PowerForge/Services/ModuleBuildHostService.cs
+++ b/PowerForge/Services/ModuleBuildHostService.cs
@@ -157,7 +157,10 @@ public sealed class ModuleBuildHostService
             return null;
 
         if (message.Items is { Length: > 0 })
-            progress.ItemsPlanned(PowerForgeReleaseProgressPhase.Module, message.Items);
+        {
+            foreach (var group in message.Items.GroupBy(item => item.Phase))
+                progress.ItemsPlanned(group.Key, group.ToArray());
+        }
 
         if (message.Item is not null && message.State.HasValue)
             progress.ItemUpdated(message.Item, message.State.Value, message.Detail);

--- a/PowerForge/Services/ModulePipelineExecutionSession.cs
+++ b/PowerForge/Services/ModulePipelineExecutionSession.cs
@@ -7,6 +7,7 @@ internal sealed class ModulePipelineExecutionSession
 {
     private readonly IModulePipelineProgressReporterV2? _reporterV2;
     private readonly IModulePipelineProgressReporterV3? _reporterV3;
+    private readonly IModulePipelineProgressReporterV4? _reporterV4;
     private readonly HashSet<string> _startedKeys;
     private readonly Dictionary<string, ModulePipelineStep> _stepsByKey;
     private readonly Dictionary<ConfigurationArtefactSegment, ModulePipelineStep> _artefactSteps;
@@ -24,6 +25,7 @@ internal sealed class ModulePipelineExecutionSession
         Reporter = reporter ?? NullModulePipelineProgressReporter.Instance;
         _reporterV2 = Reporter as IModulePipelineProgressReporterV2;
         _reporterV3 = Reporter as IModulePipelineProgressReporterV3;
+        _reporterV4 = Reporter as IModulePipelineProgressReporterV4;
         _startedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         _stepsByKey = Steps
             .Where(static step => !string.IsNullOrWhiteSpace(step.Key))
@@ -159,6 +161,17 @@ internal sealed class ModulePipelineExecutionSession
     {
         if (step is null || _reporterV3 is null) return;
         try { _reporterV3.StepProgress(step, value, maximum, detail); } catch { }
+    }
+
+    internal IProjectBuildProgressReporter? CreateProjectBuildProgressReporter(ModulePipelineStep? step)
+    {
+        if (step is null || _reporterV4 is null)
+            return null;
+
+        var nested = new ModulePipelineNestedProgressAdapter(_reporterV4, step);
+        return new ProjectBuildReleaseProgressAdapter(
+            nested,
+            PowerForgeReleaseProgressPhase.Packages);
     }
 
     internal void Fail(ModulePipelineStep? step, Exception error)

--- a/PowerForge/Services/ModulePipelineNestedProgressAdapter.cs
+++ b/PowerForge/Services/ModulePipelineNestedProgressAdapter.cs
@@ -1,0 +1,115 @@
+namespace PowerForge;
+
+/// <summary>
+/// Bridges a nested project/package workflow into a module pipeline progress host
+/// while keeping every lane's item keys independent.
+/// </summary>
+internal sealed class ModulePipelineNestedProgressAdapter : IPowerForgeReleaseProgressReporterV2
+{
+    private readonly IModulePipelineProgressReporterV4 _reporter;
+    private readonly string _keyPrefix;
+    private readonly Dictionary<string, PowerForgeReleaseProgressItem> _items =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    internal ModulePipelineNestedProgressAdapter(
+        IModulePipelineProgressReporterV4 reporter,
+        ModulePipelineStep parentStep)
+    {
+        _reporter = reporter ?? throw new ArgumentNullException(nameof(reporter));
+        if (parentStep is null) throw new ArgumentNullException(nameof(parentStep));
+        _keyPrefix = string.IsNullOrWhiteSpace(parentStep.Key)
+            ? "package-lane"
+            : parentStep.Key;
+    }
+
+    public void PhaseStarted(PowerForgeReleaseProgressPhase phase, int totalItems, string? detail = null)
+    {
+    }
+
+    public void PhaseCompleted(PowerForgeReleaseProgressPhase phase, string? detail = null)
+    {
+    }
+
+    public void PhaseFailed(PowerForgeReleaseProgressPhase phase, string? detail = null)
+    {
+    }
+
+    public void ItemsPlanned(
+        PowerForgeReleaseProgressPhase phase,
+        IReadOnlyList<PowerForgeReleaseProgressItem> items)
+    {
+        if (items is null || items.Count == 0)
+            return;
+
+        var mapped = items
+            .Where(static item => item is not null)
+            .Select(Map)
+            .ToArray();
+        if (mapped.Length == 0)
+            return;
+
+        try
+        {
+            _reporter.ItemsPlanned(phase, mapped);
+        }
+        catch
+        {
+            // Progress is observational and must never change the build result.
+        }
+    }
+
+    public void ItemUpdated(
+        PowerForgeReleaseProgressItem item,
+        PowerForgeReleaseProgressItemState state,
+        string? detail = null)
+    {
+        if (item is null)
+            return;
+
+        try
+        {
+            _reporter.ItemUpdated(Map(item), state, detail);
+        }
+        catch
+        {
+            // Progress is observational and must never change the build result.
+        }
+    }
+
+    private PowerForgeReleaseProgressItem Map(PowerForgeReleaseProgressItem item)
+    {
+        var sourceKey = $"{item.Phase}:{item.Key}";
+        if (_items.TryGetValue(sourceKey, out var mapped))
+        {
+            CopyMutableValues(item, mapped);
+            return mapped;
+        }
+
+        mapped = new PowerForgeReleaseProgressItem
+        {
+            Phase = item.Phase,
+            Key = $"{_keyPrefix}:{item.Key}",
+            Title = item.Title,
+            Kind = item.Kind,
+            Target = item.Target,
+            GroupKey = item.GroupKey,
+            GroupTitle = item.GroupTitle,
+            GroupOrder = item.GroupOrder,
+            CounterLabel = item.CounterLabel,
+            Position = item.Position,
+            Total = item.Total
+        };
+        CopyMutableValues(item, mapped);
+        _items[sourceKey] = mapped;
+        return mapped;
+    }
+
+    private static void CopyMutableValues(
+        PowerForgeReleaseProgressItem source,
+        PowerForgeReleaseProgressItem target)
+    {
+        target.ProgressValue = source.ProgressValue;
+        target.ProgressMaximum = source.ProgressMaximum;
+        target.Duration = source.Duration;
+    }
+}

--- a/PowerForge/Services/ModulePipelineProgressItemFactory.cs
+++ b/PowerForge/Services/ModulePipelineProgressItemFactory.cs
@@ -15,27 +15,47 @@ internal static class ModulePipelineProgressItemFactory
         if (plan is null) throw new ArgumentNullException(nameof(plan));
 
         var steps = ModulePipelineStep.Create(plan);
-        return steps
-            .Select((step, index) => CreateItem(step, plan, index + 1, steps.Length))
-            .ToArray();
+        var totals = steps
+            .GroupBy(GetPhase)
+            .ToDictionary(group => group.Key, group => group.Count());
+        var positions = new Dictionary<PowerForgeReleaseProgressPhase, int>();
+        return steps.Select(step =>
+        {
+            var phase = GetPhase(step);
+            positions.TryGetValue(phase, out var position);
+            position++;
+            positions[phase] = position;
+            return CreateItem(step, plan, phase, position, totals[phase]);
+        }).ToArray();
     }
 
     private static PowerForgeReleaseProgressItem CreateItem(
         ModulePipelineStep step,
         ModulePipelinePlan plan,
+        PowerForgeReleaseProgressPhase phase,
         int position,
         int total)
     {
         var presentation = ModulePipelineStepPresentation.Create(step, plan);
+        var packageLane = phase == PowerForgeReleaseProgressPhase.Packages;
         return new PowerForgeReleaseProgressItem
         {
-            Phase = PowerForgeReleaseProgressPhase.Module,
+            Phase = phase,
             Key = step.Key,
             Title = presentation.Title,
             Kind = presentation.Kind.ToString(),
             Target = presentation.Target,
+            GroupKey = packageLane ? "Packages:Lanes" : null,
+            GroupTitle = packageLane ? "Package workflows" : null,
+            GroupOrder = packageLane ? 0 : null,
+            CounterLabel = packageLane ? "Lane" : null,
             Position = position,
             Total = total
         };
     }
+
+    private static PowerForgeReleaseProgressPhase GetPhase(ModulePipelineStep step)
+        => step.Kind == ModulePipelineStepKind.PackageBuild
+            ? PowerForgeReleaseProgressPhase.Packages
+            : PowerForgeReleaseProgressPhase.Module;
 }

--- a/PowerForge/Services/ModulePipelineProgressProtocol.cs
+++ b/PowerForge/Services/ModulePipelineProgressProtocol.cs
@@ -56,7 +56,7 @@ internal static class ModulePipelineProgressProtocol
         Console.WriteLine(Prefix + payload);
     }
 
-    private sealed class ProtocolReporter : IModulePipelineProgressReporterV3
+    private sealed class ProtocolReporter : IModulePipelineProgressReporterV4
     {
         private readonly IReadOnlyDictionary<string, PowerForgeReleaseProgressItem> _items;
 
@@ -87,6 +87,35 @@ internal static class ModulePipelineProgressProtocol
             item.ProgressValue = Math.Max(0, value);
             item.ProgressMaximum = Math.Max(0, maximum);
             Update(step, PowerForgeReleaseProgressItemState.Started, detail);
+        }
+
+        public void ItemsPlanned(
+            PowerForgeReleaseProgressPhase phase,
+            IReadOnlyList<PowerForgeReleaseProgressItem> items)
+        {
+            if (items is null || items.Count == 0)
+                return;
+
+            Write(new ModulePipelineProgressProtocolMessage
+            {
+                Items = items.Where(static item => item is not null).ToArray()
+            });
+        }
+
+        public void ItemUpdated(
+            PowerForgeReleaseProgressItem item,
+            PowerForgeReleaseProgressItemState state,
+            string? detail = null)
+        {
+            if (item is null)
+                return;
+
+            Write(new ModulePipelineProgressProtocolMessage
+            {
+                Item = item,
+                State = state,
+                Detail = detail
+            });
         }
 
         private void Update(

--- a/PowerForge/Services/NuGetPackagePublishService.cs
+++ b/PowerForge/Services/NuGetPackagePublishService.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using System.Diagnostics;
 
 namespace PowerForge;
 
@@ -117,7 +118,8 @@ internal sealed class NuGetPackagePublishService
         bool skipDuplicate,
         bool publishFailFast = true,
         bool suppressCompanionSymbols = false,
-        Action? remotePublishAttempted = null)
+        Action? remotePublishAttempted = null,
+        IProjectBuildProgressReporter? progress = null)
     {
         if (packages is null)
             throw new ArgumentNullException(nameof(packages));
@@ -136,16 +138,59 @@ internal sealed class NuGetPackagePublishService
             return result;
         }
 
+        var detailedProgress = progress as IProjectBuildProgressReporterV2;
+        var progressItems = packagePaths
+            .Select((path, index) => new
+            {
+                Path = path,
+                Item = new ProjectBuildProgressItem
+                {
+                    Phase = ProjectBuildProgressPhase.NuGetPublish,
+                    Key = $"publish:{index + 1}:{Path.GetFileName(path)}",
+                    Title = Path.GetFileName(path),
+                    Kind = ProjectBuildProgressPhase.NuGetPublish.ToString(),
+                    Position = index + 1,
+                    Total = packagePaths.Length
+                }
+            })
+            .ToDictionary(entry => entry.Path, entry => entry.Item, StringComparer.OrdinalIgnoreCase);
+        detailedProgress?.ItemsPlanned(
+            ProjectBuildProgressPhase.NuGetPublish,
+            progressItems.Values.OrderBy(item => item.Position).ToArray());
+        progress?.PhaseStarted(
+            ProjectBuildProgressPhase.NuGetPublish,
+            packagePaths.Length,
+            "Publishing existing package artifacts");
+        var completed = 0;
+
         foreach (var package in packagePaths)
         {
+            var item = progressItems[package];
+            var watch = Stopwatch.StartNew();
+            detailedProgress?.ItemUpdated(item, ProjectBuildProgressItemState.Started, "publishing");
+            progress?.PhaseUpdated(
+                ProjectBuildProgressPhase.NuGetPublish,
+                completed,
+                packagePaths.Length,
+                Path.GetFileName(package));
             if (!File.Exists(package))
             {
+                watch.Stop();
                 result.Success = false;
                 result.FailedItems.Add(package);
                 if (string.IsNullOrWhiteSpace(result.ErrorMessage))
                     result.ErrorMessage = $"Package '{package}' not found.";
+                item.Duration = watch.Elapsed;
+                detailedProgress?.ItemUpdated(
+                    item,
+                    ProjectBuildProgressItemState.Failed,
+                    result.ErrorMessage);
+                completed++;
                 if (publishFailFast)
+                {
+                    progress?.PhaseFailed(ProjectBuildProgressPhase.NuGetPublish, result.ErrorMessage);
                     return result;
+                }
                 continue;
             }
 
@@ -158,6 +203,7 @@ internal sealed class NuGetPackagePublishService
                          primaryResult.Outcome == DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate),
                     out var primaryPackage))
             {
+                watch.Stop();
                 var blockedResult = DotNetRepositoryReleaseService.CreateBlockedCompanionResult(
                     package,
                     primaryPackage);
@@ -166,8 +212,17 @@ internal sealed class NuGetPackagePublishService
                 result.PackagePushResults[package] = blockedResult;
                 if (string.IsNullOrWhiteSpace(result.ErrorMessage))
                     result.ErrorMessage = blockedResult.Message;
+                item.Duration = watch.Elapsed;
+                detailedProgress?.ItemUpdated(
+                    item,
+                    ProjectBuildProgressItemState.Failed,
+                    blockedResult.Message);
+                completed++;
                 if (publishFailFast)
+                {
+                    progress?.PhaseFailed(ProjectBuildProgressPhase.NuGetPublish, blockedResult.Message);
                     return result;
+                }
                 continue;
             }
 
@@ -186,19 +241,27 @@ internal sealed class NuGetPackagePublishService
                     Message = "Push handler returned no result."
                 };
             result.PackagePushResults[package] = pushResult;
+            watch.Stop();
+            item.Duration = watch.Elapsed;
 
             switch (pushResult.Outcome)
             {
                 case DotNetRepositoryReleaseService.PackagePushOutcome.Published:
                     result.PublishedItems.Add(package);
+                    detailedProgress?.ItemUpdated(item, ProjectBuildProgressItemState.Completed, "published");
                     break;
                 case DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate:
                     result.PublishedItems.Add(package);
                     result.SkippedDuplicateItems.Add(package);
+                    detailedProgress?.ItemUpdated(item, ProjectBuildProgressItemState.Completed, "already existed");
                     break;
                 default:
                     result.Success = false;
                     result.FailedItems.Add(package);
+                    detailedProgress?.ItemUpdated(
+                        item,
+                        ProjectBuildProgressItemState.Failed,
+                        pushResult.Message);
                     _logger.Verbose($"dotnet nuget push failed for {package}.");
                     if (pushResult.Message is string message && message.Length > 0)
                     {
@@ -207,9 +270,28 @@ internal sealed class NuGetPackagePublishService
                             result.ErrorMessage = message;
                     }
                     if (publishFailFast)
+                    {
+                        progress?.PhaseFailed(
+                            ProjectBuildProgressPhase.NuGetPublish,
+                            result.ErrorMessage ?? $"Failed to publish {Path.GetFileName(package)}.");
                         return result;
+                    }
                     break;
             }
+            completed++;
+        }
+
+        if (result.Success)
+        {
+            progress?.PhaseCompleted(
+                ProjectBuildProgressPhase.NuGetPublish,
+                $"{completed} package(s) processed");
+        }
+        else
+        {
+            progress?.PhaseFailed(
+                ProjectBuildProgressPhase.NuGetPublish,
+                result.ErrorMessage ?? $"{result.FailedItems.Count} package(s) failed");
         }
 
         return result;

--- a/PowerForge/Services/PowerForgeReleaseProgressAdapters.cs
+++ b/PowerForge/Services/PowerForgeReleaseProgressAdapters.cs
@@ -102,7 +102,11 @@ internal sealed class ProjectBuildReleaseProgressAdapter : IProjectBuildProgress
             Phase = _releasePhase,
             Key = $"project:{phase}",
             Title = GetTitle(phase),
-            Kind = phase.ToString()
+            Kind = phase.ToString(),
+            GroupKey = GetGroupKey(phase),
+            GroupTitle = GetTitle(phase),
+            GroupOrder = GetGroupOrder(phase),
+            CounterLabel = GetCounterLabel(phase)
         };
         _items[phase] = item;
         _release.ItemsPlanned(_releasePhase, new[] { item });
@@ -124,6 +128,10 @@ internal sealed class ProjectBuildReleaseProgressAdapter : IProjectBuildProgress
             Key = key,
             Title = item.Title,
             Kind = item.Kind,
+            GroupKey = GetGroupKey(item.Phase),
+            GroupTitle = GetTitle(item.Phase),
+            GroupOrder = GetGroupOrder(item.Phase),
+            CounterLabel = GetCounterLabel(item.Phase),
             Position = item.Position,
             Total = item.Total,
             Duration = item.Duration
@@ -142,6 +150,30 @@ internal sealed class ProjectBuildReleaseProgressAdapter : IProjectBuildProgress
             ProjectBuildProgressPhase.NuGetPublish => "Publish NuGet packages",
             ProjectBuildProgressPhase.GitHubPublish => "Publish project GitHub release",
             _ => phase.ToString()
+        };
+
+    private string GetGroupKey(ProjectBuildProgressPhase phase)
+        => $"{_releasePhase}:{phase}";
+
+    private static int GetGroupOrder(ProjectBuildProgressPhase phase)
+        => phase switch
+        {
+            ProjectBuildProgressPhase.Plan => 10,
+            ProjectBuildProgressPhase.Versioning => 20,
+            ProjectBuildProgressPhase.PackageBuild => 30,
+            ProjectBuildProgressPhase.PackageSigning => 40,
+            ProjectBuildProgressPhase.NuGetPublish => 50,
+            ProjectBuildProgressPhase.GitHubPublish => 60,
+            _ => 90
+        };
+
+    private static string GetCounterLabel(ProjectBuildProgressPhase phase)
+        => phase switch
+        {
+            ProjectBuildProgressPhase.PackageSigning => "Package",
+            ProjectBuildProgressPhase.NuGetPublish => "Package",
+            ProjectBuildProgressPhase.GitHubPublish => "Asset",
+            _ => "Project"
         };
 
     private void RememberCount(

--- a/PowerForge/Services/ProjectBuildGitHubProgressAdapter.cs
+++ b/PowerForge/Services/ProjectBuildGitHubProgressAdapter.cs
@@ -1,0 +1,134 @@
+namespace PowerForge;
+
+/// <summary>
+/// Maps GitHub asset transfer progress into the project-build detailed progress contract.
+/// </summary>
+internal sealed class ProjectBuildGitHubProgressAdapter : IGitHubReleaseProgressReporter
+{
+    private readonly IProjectBuildProgressReporterV2 _progress;
+    private readonly IReadOnlyDictionary<string, AssetPlanItem> _plan;
+    private readonly Dictionary<string, ProjectBuildProgressItem> _items =
+        new(StringComparer.Ordinal);
+
+    internal ProjectBuildGitHubProgressAdapter(
+        IProjectBuildProgressReporterV2 progress,
+        IReadOnlyList<string> assetPaths)
+    {
+        _progress = progress ?? throw new ArgumentNullException(nameof(progress));
+        if (assetPaths is null) throw new ArgumentNullException(nameof(assetPaths));
+
+        var plan = new Dictionary<string, AssetPlanItem>(StringComparer.Ordinal);
+        foreach (var path in assetPaths.Where(static path => !string.IsNullOrWhiteSpace(path)))
+        {
+            var identity = GetIdentity(path);
+            if (plan.ContainsKey(identity))
+                continue;
+
+            plan[identity] = new AssetPlanItem(plan.Count + 1, identity);
+        }
+
+        var total = plan.Count;
+        _plan = plan.ToDictionary(
+            static pair => pair.Key,
+            pair => new AssetPlanItem(pair.Value.Position, pair.Value.Identity, total),
+            StringComparer.Ordinal);
+    }
+
+    public void Report(GitHubReleaseAssetProgress progress)
+    {
+        if (progress is null)
+            return;
+
+        var item = GetOrCreate(progress);
+        _progress.ItemUpdated(
+            item,
+            progress.State switch
+            {
+                GitHubReleaseAssetProgressState.Replacing => ProjectBuildProgressItemState.Started,
+                GitHubReleaseAssetProgressState.Uploading => ProjectBuildProgressItemState.Started,
+                GitHubReleaseAssetProgressState.Uploaded => ProjectBuildProgressItemState.Completed,
+                GitHubReleaseAssetProgressState.Skipped => ProjectBuildProgressItemState.Skipped,
+                GitHubReleaseAssetProgressState.Failed => ProjectBuildProgressItemState.Failed,
+                _ => ProjectBuildProgressItemState.Planned
+            },
+            BuildDetail(progress));
+    }
+
+    private ProjectBuildProgressItem GetOrCreate(GitHubReleaseAssetProgress progress)
+    {
+        var identity = GetIdentity(string.IsNullOrWhiteSpace(progress.FilePath)
+            ? progress.FileName
+            : progress.FilePath);
+        var key = identity;
+        if (_items.TryGetValue(key, out var item))
+            return item;
+
+        var planned = _plan.TryGetValue(identity, out var planItem)
+            ? planItem
+            : new AssetPlanItem(_items.Count + 1, identity, Math.Max(_plan.Count, _items.Count + 1));
+
+        item = new ProjectBuildProgressItem
+        {
+            Phase = ProjectBuildProgressPhase.GitHubPublish,
+            Key = $"github:{planned.Position}:{planned.Identity}",
+            Title = progress.FileName,
+            Kind = "GitHubAsset",
+            Position = planned.Position,
+            Total = planned.Total
+        };
+        _items[key] = item;
+        _progress.ItemsPlanned(ProjectBuildProgressPhase.GitHubPublish, [item]);
+        return item;
+    }
+
+    private static string? BuildDetail(GitHubReleaseAssetProgress progress)
+    {
+        if (!string.IsNullOrWhiteSpace(progress.Detail))
+            return progress.Detail;
+        if (progress.TotalBytes <= 0)
+            return null;
+
+        return $"{FormatBytes(progress.BytesTransferred)} / {FormatBytes(progress.TotalBytes)}";
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes < 1024)
+            return $"{Math.Max(0, bytes)} B";
+
+        var value = Math.Max(0, bytes) / 1024d;
+        if (value < 1024)
+            return $"{value:0.##} KB";
+
+        return $"{value / 1024d:0.##} MB";
+    }
+
+    private static string GetIdentity(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return string.Empty;
+
+        try
+        {
+            return Path.GetFullPath(path);
+        }
+        catch
+        {
+            return path.Trim();
+        }
+    }
+
+    private readonly struct AssetPlanItem
+    {
+        internal AssetPlanItem(int position, string identity, int total = 0)
+        {
+            Position = position;
+            Identity = identity;
+            Total = total;
+        }
+
+        internal int Position { get; }
+        internal string Identity { get; }
+        internal int Total { get; }
+    }
+}

--- a/PowerForge/Services/ProjectBuildGitHubPublisher.cs
+++ b/PowerForge/Services/ProjectBuildGitHubPublisher.cs
@@ -131,6 +131,10 @@ public sealed class ProjectBuildGitHubPublisher
         var timestampToken = nowLocal.ToString("yyyyMMddHHmmss");
         var utcTimestampToken = nowUtc.ToString("yyyyMMddHHmmss");
         var repoName = request.Repository.Trim();
+        var assetPaths = GetPlannedAssetPaths(request.Release);
+        var assetProgress = request.Progress is null
+            ? null
+            : new ProjectBuildGitHubProgressAdapter(request.Progress, assetPaths);
 
         if (perProject)
         {
@@ -145,7 +149,8 @@ public sealed class ProjectBuildGitHubPublisher
                 dateTimeToken,
                 utcDateTimeToken,
                 timestampToken,
-                utcTimestampToken);
+                utcTimestampToken,
+                assetProgress);
         }
         else
         {
@@ -160,7 +165,8 @@ public sealed class ProjectBuildGitHubPublisher
                 dateTimeToken,
                 utcDateTimeToken,
                 timestampToken,
-                utcTimestampToken);
+                utcTimestampToken,
+                assetProgress);
         }
 
         if (summary.ErrorMessage is null)
@@ -180,7 +186,8 @@ public sealed class ProjectBuildGitHubPublisher
         string dateTimeToken,
         string utcDateTimeToken,
         string timestampToken,
-        string utcTimestampToken)
+        string utcTimestampToken,
+        IGitHubReleaseProgressReporter? progress)
     {
         foreach (var project in request.Release.Projects)
         {
@@ -239,7 +246,8 @@ public sealed class ProjectBuildGitHubPublisher
                 releaseName,
                 new[] { project.ReleaseZipPath! },
                 reuseExistingReleaseOnConflict,
-                result);
+                result,
+                progress);
 
             summary.Results.Add(result);
             if (!result.Success)
@@ -263,7 +271,8 @@ public sealed class ProjectBuildGitHubPublisher
         string dateTimeToken,
         string utcDateTimeToken,
         string timestampToken,
-        string utcTimestampToken)
+        string utcTimestampToken,
+        IGitHubReleaseProgressReporter? progress)
     {
         var assets = request.Release.Projects
             .Where(project => project.IsPackable && !string.IsNullOrWhiteSpace(project.ReleaseZipPath) && File.Exists(project.ReleaseZipPath))
@@ -313,7 +322,8 @@ public sealed class ProjectBuildGitHubPublisher
             releaseName,
             assets,
             reuseExistingReleaseOnConflict,
-            publishResult);
+            publishResult,
+            progress);
 
         foreach (var project in request.Release.Projects.Where(project => project.IsPackable))
         {
@@ -340,7 +350,8 @@ public sealed class ProjectBuildGitHubPublisher
         string releaseName,
         IReadOnlyList<string> assets,
         bool reuseExistingReleaseOnConflict,
-        ProjectBuildGitHubResult result)
+        ProjectBuildGitHubResult result,
+        IGitHubReleaseProgressReporter? progress)
     {
         try
         {
@@ -354,7 +365,8 @@ public sealed class ProjectBuildGitHubPublisher
                 GenerateReleaseNotes = request.GenerateReleaseNotes,
                 IsPreRelease = request.IsPreRelease,
                 ReuseExistingReleaseOnConflict = reuseExistingReleaseOnConflict,
-                AssetFilePaths = assets
+                AssetFilePaths = assets,
+                Progress = progress
             });
 
             result.Success = publishResult.Succeeded;
@@ -371,6 +383,13 @@ public sealed class ProjectBuildGitHubPublisher
             result.ErrorMessage = ex.Message;
         }
     }
+
+    private static string[] GetPlannedAssetPaths(DotNetRepositoryReleaseResult release)
+        => release.Projects
+            .Where(static project => project.IsPackable && !string.IsNullOrWhiteSpace(project.ReleaseZipPath))
+            .Select(static project => project.ReleaseZipPath!)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
 
     private void WriteGitHubPublishNotes(string? tag, GitHubReleasePublishResult result)
     {

--- a/PowerForge/Services/ProjectBuildPublishHostService.cs
+++ b/PowerForge/Services/ProjectBuildPublishHostService.cs
@@ -126,6 +126,16 @@ public sealed class ProjectBuildPublishHostService
     /// Publishes GitHub releases for the provided project release plan using shared PowerForge logic.
     /// </summary>
     public ProjectBuildGitHubPublishSummary PublishGitHub(ProjectBuildPublishHostConfiguration configuration, DotNetRepositoryReleaseResult release)
+        => PublishGitHub(configuration, release, progress: null);
+
+    /// <summary>
+    /// Publishes GitHub releases and reports durable per-asset progress when a detailed
+    /// project-build reporter is supplied.
+    /// </summary>
+    public ProjectBuildGitHubPublishSummary PublishGitHub(
+        ProjectBuildPublishHostConfiguration configuration,
+        DotNetRepositoryReleaseResult release,
+        IProjectBuildProgressReporter? progress)
     {
         FrameworkCompatibility.NotNull(configuration, nameof(configuration));
         FrameworkCompatibility.NotNull(release, nameof(release));
@@ -144,7 +154,8 @@ public sealed class ProjectBuildPublishHostService
             TagTemplate = configuration.GitHubTagTemplate,
             PrimaryProject = configuration.GitHubPrimaryProject,
             TagConflictPolicy = configuration.GitHubTagConflictPolicy,
-            PublishFailFast = configuration.PublishFailFast
+            PublishFailFast = configuration.PublishFailFast,
+            Progress = progress as IProjectBuildProgressReporterV2
         };
 
         return (_publishGitHub ?? (publishRequest => new ProjectBuildGitHubPublisher(_logger).Publish(publishRequest)))(request);

--- a/PowerForge/Services/ProjectBuildWorkflowService.cs
+++ b/PowerForge/Services/ProjectBuildWorkflowService.cs
@@ -197,7 +197,8 @@ internal sealed class ProjectBuildWorkflowService
             TagName = config.GitHubTagName,
             TagTemplate = config.GitHubTagTemplate,
             PrimaryProject = config.GitHubPrimaryProject,
-            TagConflictPolicy = config.GitHubTagConflictPolicy
+            TagConflictPolicy = config.GitHubTagConflictPolicy,
+            Progress = progress as IProjectBuildProgressReporterV2
         });
         gitHubWatch.Stop();
         if (publishSummary.Success)


### PR DESCRIPTION
## What changed

- surfaces nested project planning, version resolution, package build, signing, NuGet publish, and GitHub upload work in module and unified release consoles
- keeps each stage in a durable ordered group with explicit Project, Package, Lane, and Asset counters
- uses one global GitHub asset sequence across per-project releases, including repeated file names
- keeps progress reporting observational so a console/reporter failure cannot change a successful build result
- reports reused package publication paths instead of hiding already-built artifacts

## Why

Module builds that also owned NuGet projects previously looked module-only and collapsed package work into a single lane. This made long builds appear stuck and allowed counters to reset between nested release routes.

## Compatibility

Existing high-level progress reporters continue to work. The richer grouping metadata and nested reporter contract are optional extensions used by current PowerForge hosts.

## Validation

- multi-target Release solution build: zero warnings and zero errors
- 126 focused progress, workflow, package, and GitHub publication tests
- nonpublishing ImagePlayground build selected one unified version and produced both NuGet projects plus module artifacts
- rendered console coverage verifies version, build, sign, publish, and GitHub stage order