### PR TITLE
Isolate credentials from pull request website pipelines

### DIFF
--- a/.github/workflows/powerforge-website-ci.yml
+++ b/.github/workflows/powerforge-website-ci.yml
@@ -93,7 +93,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  website-ci:
+  website-ci-untrusted:
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
     uses: ./.github/workflows/powerforge-website-run.yml
     with:
       website_root: ${{ inputs.website_root }}
@@ -113,6 +114,35 @@ jobs:
       powerforge_web_tag: ${{ inputs.powerforge_web_tag }}
       pipeline_mode: ci
       credential_mode: none
+      use_playwright_cache: true
+      validate_pages_artifact: ${{ inputs.validate_pages_artifact }}
+      pages_artifact_path: ${{ inputs.pages_artifact_path }}
+
+  website-ci-trusted:
+    if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+    uses: ./.github/workflows/powerforge-website-run.yml
+    with:
+      website_root: ${{ inputs.website_root }}
+      pipeline_config: ${{ inputs.pipeline_config }}
+      engine_mode: ${{ inputs.engine_mode }}
+      runner_labels_json: ${{ inputs.runner_labels_json }}
+      timeout_minutes: ${{ inputs.timeout_minutes }}
+      dotnet_version: ${{ inputs.dotnet_version }}
+      dotnet_workloads: ${{ inputs.dotnet_workloads }}
+      report_artifact_name: ${{ inputs.report_artifact_name }}
+      powerforge_lock_path: ${{ inputs.powerforge_lock_path }}
+      powerforge_repository: ${{ inputs.powerforge_repository }}
+      powerforge_ref: ${{ inputs.powerforge_ref }}
+      powerforge_repository_override: ${{ inputs.powerforge_repository_override }}
+      powerforge_ref_override: ${{ inputs.powerforge_ref_override }}
+      powerforge_tool_lock_path: ${{ inputs.powerforge_tool_lock_path }}
+      powerforge_web_tag: ${{ inputs.powerforge_web_tag }}
+      pipeline_mode: ci
+      credential_mode: standard
       use_playwright_cache: true
       validate_pages_artifact: ${{ inputs.validate_pages_artifact }}
       pages_artifact_path: ${{ inputs.pages_artifact_path }}

--- a/.github/workflows/powerforge-website-ci.yml
+++ b/.github/workflows/powerforge-website-ci.yml
@@ -84,7 +84,6 @@ permissions:
   # The generated quality preset performs a read-only artifact cleanup preview.
   actions: read
   contents: read
-  packages: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -113,6 +112,7 @@ jobs:
       powerforge_tool_lock_path: ${{ inputs.powerforge_tool_lock_path }}
       powerforge_web_tag: ${{ inputs.powerforge_web_tag }}
       pipeline_mode: ci
+      credential_mode: none
       use_playwright_cache: true
       validate_pages_artifact: ${{ inputs.validate_pages_artifact }}
       pages_artifact_path: ${{ inputs.pages_artifact_path }}

--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -93,6 +93,11 @@ on:
         required: false
         type: string
         default: "ci"
+      credential_mode:
+        description: Credential exposure policy for the caller-controlled website pipeline. Use none for untrusted pull requests.
+        required: false
+        type: string
+        default: "standard"
       use_playwright_cache:
         required: false
         type: boolean
@@ -157,10 +162,20 @@ jobs:
       BUN_INSTALL_CACHE_DIR: ${{ github.workspace }}/.cache/powerforge-runner/bun-install-cache
       NPM_CONFIG_CACHE: ${{ github.workspace }}/.cache/powerforge-runner/npm-cache
     steps:
+      - name: Validate credential mode
+        shell: pwsh
+        env:
+          POWERFORGE_CREDENTIAL_MODE: ${{ inputs.credential_mode }}
+        run: |
+          if ($env:POWERFORGE_CREDENTIAL_MODE -notin @('none', 'standard')) {
+            throw "Unsupported credential_mode '$env:POWERFORGE_CREDENTIAL_MODE'. Expected none or standard."
+          }
+
       - name: Checkout website
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ github.token }}
+          persist-credentials: ${{ inputs.credential_mode != 'none' }}
           # workflow_call can otherwise default to refs/pull/<n>/merge, which is not available in some repos.
           ref: ${{ inputs.source_ref || github.event.pull_request.head.sha || github.sha }}
 
@@ -212,6 +227,7 @@ jobs:
           ref: ${{ steps.workflow_source.outputs.ref }}
           path: ./.powerforge-runner
           token: ${{ github.token }}
+          persist-credentials: ${{ inputs.credential_mode != 'none' }}
           fetch-depth: 1
 
       - name: Setup .NET
@@ -277,14 +293,14 @@ jobs:
         shell: pwsh
         env:
           NUGET_PACKAGES: ${{ runner.temp }}/powerforge-website-nuget-packages
-          GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_PACKAGES_TOKEN: ${{ secrets.repository_read_token || github.token }}
-          LICENSING_PACKAGES_TOKEN: ${{ secrets.repository_read_token || github.token }}
-          LICENSING_PACKAGES_USERNAME: ${{ github.repository_owner }}
-          INDEXNOW_KEY: ${{ secrets.indexnow_key }}
-          POWERFORGE_REPOSITORY_TOKEN: ${{ secrets.repository_read_token }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}
-          CLOUDFLARE_ZONE_ID: ${{ secrets.cloudflare_zone_id }}
+          GITHUB_TOKEN: ${{ inputs.credential_mode != 'none' && github.token || '' }}
+          GITHUB_PACKAGES_TOKEN: ${{ inputs.credential_mode != 'none' && (secrets.repository_read_token || github.token) || '' }}
+          LICENSING_PACKAGES_TOKEN: ${{ inputs.credential_mode != 'none' && (secrets.repository_read_token || github.token) || '' }}
+          LICENSING_PACKAGES_USERNAME: ${{ inputs.credential_mode != 'none' && github.repository_owner || '' }}
+          INDEXNOW_KEY: ${{ inputs.credential_mode != 'none' && secrets.indexnow_key || '' }}
+          POWERFORGE_REPOSITORY_TOKEN: ${{ inputs.credential_mode != 'none' && secrets.repository_read_token || '' }}
+          CLOUDFLARE_API_TOKEN: ${{ inputs.credential_mode != 'none' && secrets.cloudflare_api_token || '' }}
+          CLOUDFLARE_ZONE_ID: ${{ inputs.credential_mode != 'none' && secrets.cloudflare_zone_id || '' }}
           POWERFORGE_RUNNER_RESULT_PATH: ${{ runner.temp }}/powerforge-website-runner-result.json
         run: |
           $runnerArgs = @(

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerServicePackageTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerServicePackageTests.cs
@@ -146,6 +146,12 @@ public sealed class DotNetPublishPipelineRunnerServicePackageTests
             Assert.Contains("[switch]$PreserveExistingServiceBinPath", installContent, StringComparison.Ordinal);
             Assert.Contains("Set-CommandLineOption", installContent, StringComparison.Ordinal);
             Assert.Contains("$preservedBinaryPathName", installContent, StringComparison.Ordinal);
+            Assert.Contains("[string]$BackupPath", installContent, StringComparison.Ordinal);
+            Assert.Contains("Get-Content -LiteralPath $BackupPath", installContent, StringComparison.Ordinal);
+            Assert.Contains("command line backup is required", installContent, StringComparison.Ordinal);
+            Assert.Contains("Get-CimInstance -ClassName Win32_Service", installContent, StringComparison.Ordinal);
+            Assert.Contains("Invoke-CimMethod -InputObject $service -MethodName Change", installContent, StringComparison.Ordinal);
+            Assert.DoesNotContain("sc.exe delete", installContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("--config", installContent, StringComparison.Ordinal);
             Assert.DoesNotContain("{{", installContent, StringComparison.Ordinal);
 

--- a/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
@@ -18,7 +18,7 @@ public sealed class GitHubWebsiteRunWorkflowTests
     }
 
     [Fact]
-    public void WebsiteCiWorkflow_ShouldDisablePackagePermissionAndPipelineCredentials()
+    public void WebsiteCiWorkflow_ShouldSeparateUntrustedAndTrustedCredentialBoundaries()
     {
         var repoRoot = FindRepoRoot();
         var workflowPath = Path.Combine(repoRoot, ".github", "workflows", "powerforge-website-ci.yml");
@@ -26,8 +26,19 @@ public sealed class GitHubWebsiteRunWorkflowTests
         var workflowYaml = File.ReadAllText(workflowPath);
 
         Assert.NotNull(new YamlDotNet.Serialization.DeserializerBuilder().Build().Deserialize<object>(workflowYaml));
-        Assert.DoesNotContain("packages: read", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("website-ci-untrusted:", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("credential_mode: none", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("website-ci-trusted:", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("packages: read", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("credential_mode: standard", workflowYaml, StringComparison.Ordinal);
+
+        string untrustedJob = workflowYaml[
+            workflowYaml.IndexOf("  website-ci-untrusted:", StringComparison.Ordinal)..
+            workflowYaml.IndexOf("  website-ci-trusted:", StringComparison.Ordinal)];
+        Assert.DoesNotContain("packages: read", untrustedJob, StringComparison.Ordinal);
+        Assert.DoesNotContain("secrets:", untrustedJob, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -121,7 +132,7 @@ public sealed class GitHubWebsiteRunWorkflowTests
     }
 
     [Theory]
-    [InlineData("powerforge-website-ci.yml", 1)]
+    [InlineData("powerforge-website-ci.yml", 2)]
     [InlineData("powerforge-website-deploy.yml", 2)]
     [InlineData("powerforge-website-maintenance.yml", 1)]
     public void WebsiteWorkflows_ShouldForwardRequestedDotNetWorkloads(string workflowFileName, int expectedForwardCount)

--- a/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
@@ -3,7 +3,6 @@ namespace PowerForge.Tests;
 public sealed class GitHubWebsiteRunWorkflowTests
 {
     [Theory]
-    [InlineData("powerforge-website-ci.yml")]
     [InlineData("powerforge-website-deploy.yml")]
     [InlineData("powerforge-website-maintenance.yml")]
     public void WebsiteWorkflows_ShouldAllowGitHubPackagesRestore(string workflowFileName)
@@ -16,6 +15,19 @@ public sealed class GitHubWebsiteRunWorkflowTests
         var workflowYaml = File.ReadAllText(workflowPath);
 
         Assert.Contains("packages: read", workflowYaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WebsiteCiWorkflow_ShouldDisablePackagePermissionAndPipelineCredentials()
+    {
+        var repoRoot = FindRepoRoot();
+        var workflowPath = Path.Combine(repoRoot, ".github", "workflows", "powerforge-website-ci.yml");
+
+        var workflowYaml = File.ReadAllText(workflowPath);
+
+        Assert.NotNull(new YamlDotNet.Serialization.DeserializerBuilder().Build().Deserialize<object>(workflowYaml));
+        Assert.DoesNotContain("packages: read", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("credential_mode: none", workflowYaml, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -45,7 +57,7 @@ public sealed class GitHubWebsiteRunWorkflowTests
     }
 
     [Fact]
-    public void WebsiteRunWorkflow_ShouldExposeGitHubPackagesCredentialsToConsumerRestore()
+    public void WebsiteRunWorkflow_ShouldExposeCredentialsOnlyInStandardMode()
     {
         var repoRoot = FindRepoRoot();
         var workflowPath = Path.Combine(repoRoot, ".github", "workflows", "powerforge-website-run.yml");
@@ -54,9 +66,41 @@ public sealed class GitHubWebsiteRunWorkflowTests
 
         var workflowYaml = File.ReadAllText(workflowPath);
 
-        Assert.Contains("GITHUB_PACKAGES_TOKEN: ${{ secrets.repository_read_token || github.token }}", workflowYaml, StringComparison.Ordinal);
-        Assert.Contains("LICENSING_PACKAGES_TOKEN: ${{ secrets.repository_read_token || github.token }}", workflowYaml, StringComparison.Ordinal);
-        Assert.Contains("LICENSING_PACKAGES_USERNAME: ${{ github.repository_owner }}", workflowYaml, StringComparison.Ordinal);
+        Assert.NotNull(new YamlDotNet.Serialization.DeserializerBuilder().Build().Deserialize<object>(workflowYaml));
+        Assert.Contains("credential_mode:", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("persist-credentials: ${{ inputs.credential_mode != 'none' }}", workflowYaml, StringComparison.Ordinal);
+        Assert.Equal(
+            2,
+            workflowYaml.Split('\n').Count(static line =>
+                line.Trim().Equals(
+                    "persist-credentials: ${{ inputs.credential_mode != 'none' }}",
+                    StringComparison.Ordinal)));
+        Assert.Contains("GITHUB_TOKEN: ${{ inputs.credential_mode != 'none' && github.token || '' }}", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("GITHUB_PACKAGES_TOKEN: ${{ inputs.credential_mode != 'none' && (secrets.repository_read_token || github.token) || '' }}", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("LICENSING_PACKAGES_TOKEN: ${{ inputs.credential_mode != 'none' && (secrets.repository_read_token || github.token) || '' }}", workflowYaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("GITHUB_ENV", workflowYaml, StringComparison.Ordinal);
+
+        string pipelineStep = workflowYaml[
+            workflowYaml.IndexOf("      - name: Run website pipeline", StringComparison.Ordinal)..
+            workflowYaml.IndexOf("      - name: Resolve actual PowerForge engine provenance", StringComparison.Ordinal)];
+        Assert.All(
+            pipelineStep.Split('\n').Where(static line => line.Contains("TOKEN:", StringComparison.Ordinal)),
+            static line => Assert.Contains("inputs.credential_mode != 'none'", line, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void WebsiteRunWorkflow_ShouldValidateCredentialModeBeforeCheckout()
+    {
+        var repoRoot = FindRepoRoot();
+        var workflowPath = Path.Combine(repoRoot, ".github", "workflows", "powerforge-website-run.yml");
+        var workflowYaml = File.ReadAllText(workflowPath);
+
+        int validationOffset = workflowYaml.IndexOf("      - name: Validate credential mode", StringComparison.Ordinal);
+        int checkoutOffset = workflowYaml.IndexOf("      - name: Checkout website", StringComparison.Ordinal);
+
+        Assert.True(validationOffset >= 0);
+        Assert.True(checkoutOffset > validationOffset);
+        Assert.Contains("-notin @('none', 'standard')", workflowYaml, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -143,6 +143,7 @@ public sealed class PowerForgeInstallerAuthoringTests
     public void EmitSource_ModelsScriptServiceInstallWithImagePathPreservation()
     {
         var definition = CreateMonitoringInstaller();
+        definition.Product.MajorUpgradeSchedule = PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute;
         definition.Components.Add(new PowerForgeInstallerFileComponent
         {
             Id = "InstallServiceScriptComponent",
@@ -156,9 +157,9 @@ public sealed class PowerForgeInstallerAuthoringTests
         service.ScriptInstall = new PowerForgeInstallerServiceScriptInstall
         {
             Command = "\"powershell.exe\" -NoP -EP Bypass -File \"[INSTALLFOLDER]Install-Service.ps1\" -ConfigPath \"[ProgramDataMonitoring]TestimoX.Monitoring.json\" -ServiceName \"TestimoX.Monitoring\"",
-            UpgradeCommand = "\"powershell.exe\" -NoP -EP Bypass -File \"[INSTALLFOLDER]Install-Service.ps1\" -ConfigPath \"[ProgramDataMonitoring]TestimoX.Monitoring.json\" -ServiceName \"TestimoX.Monitoring\" -BackupPath \"[TempFolder]tmx-svc.txt\" -PreserveExistingServiceBinPath -UpgradeMode",
+            UpgradeCommand = "\"powershell.exe\" -NoP -EP Bypass -File \"[INSTALLFOLDER]Install-Service.ps1\" -ConfigPath \"[ProgramDataMonitoring]TestimoX.Monitoring.json\" -ServiceName \"TestimoX.Monitoring\" -BackupPath \"[WindowsFolder]Installer\\tmx-svc-[ProductCode].txt\" -PreserveExistingServiceBinPath -UpgradeMode",
             BackupExistingImagePath = true,
-            BackupPath = "[TempFolder]tmx-svc.txt",
+            BackupPath = "[WindowsFolder]Installer\\tmx-svc-[ProductCode].txt",
             StopServiceForUpgrade = true,
             StopDelaySeconds = 30
         };
@@ -184,15 +185,41 @@ public sealed class PowerForgeInstallerAuthoringTests
             (string?)e.Attribute("Remove") == "uninstall"));
         Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
             (string?)e.Attribute("Id") == "ServiceComponent.SetBackupCommand" &&
-            (string?)e.Attribute("Property") == "WixQuietExecCmdLine" &&
+            (string?)e.Attribute("Property") == "ServiceComponent.BackupImagePath" &&
             ((string?)e.Attribute("Value"))?.Contains("powershell.exe -nop -c", StringComparison.Ordinal) == true &&
             ((string?)e.Attribute("Value"))?.Contains("Name -eq 'TestimoX.Monitoring'", StringComparison.Ordinal) == true &&
-            ((string?)e.Attribute("Value"))?.Contains("$b='[TempFolder]tmx-svc.txt'", StringComparison.Ordinal) == true &&
+            ((string?)e.Attribute("Value"))?.Contains("$b='[WindowsFolder]Installer\\tmx-svc-[ProductCode].txt'", StringComparison.Ordinal) == true &&
             ((string?)e.Attribute("Value"))?.Contains("gwmi win32_service", StringComparison.Ordinal) == true &&
             ((string?)e.Attribute("Value"))?.Contains("PathName", StringComparison.Ordinal) == true &&
-            ((string?)e.Attribute("Value"))?.Contains("WriteAllText", StringComparison.Ordinal) == true &&
-            ((string?)e.Attribute("Value"))?.Contains("WriteAllText($b", StringComparison.Ordinal) == true &&
+            ((string?)e.Attribute("Value"))?.Contains("Out-File $b -NoN -NoC -ea Stop", StringComparison.Ordinal) == true &&
             ((string?)e.Attribute("Value"))?.Length <= 255));
+        Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "ServiceComponent.BackupImagePath" &&
+            (string?)e.Attribute("Execute") == "deferred" &&
+            (string?)e.Attribute("Impersonate") == "no" &&
+            (string?)e.Attribute("HideTarget") == "yes"));
+        Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "ServiceComponent.SetRollbackCommand" &&
+            (string?)e.Attribute("Property") == "ServiceComponent.RollbackImagePath" &&
+            ((string?)e.Attribute("Value"))?.Contains("sc.exe config", StringComparison.Ordinal) == true &&
+            ((string?)e.Attribute("Value"))?.Contains("sc.exe create", StringComparison.Ordinal) == true &&
+            ((string?)e.Attribute("Value"))?.Contains("if(!$?){exit 1};rm $b", StringComparison.Ordinal) == true &&
+            ((string?)e.Attribute("Value"))?.Contains("rm $b -ea 0", StringComparison.Ordinal) == true &&
+            ((string?)e.Attribute("Value"))?.Length <= 255));
+        Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "ServiceComponent.RollbackImagePath" &&
+            (string?)e.Attribute("Execute") == "rollback" &&
+            (string?)e.Attribute("Impersonate") == "no" &&
+            (string?)e.Attribute("HideTarget") == "yes"));
+        Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "ServiceComponent.SetCleanupCommand" &&
+            (string?)e.Attribute("Property") == "ServiceComponent.CleanupImagePath" &&
+            ((string?)e.Attribute("Value"))?.Contains("rm '[WindowsFolder]Installer\\tmx-svc-[ProductCode].txt'", StringComparison.Ordinal) == true));
+        Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "ServiceComponent.CleanupImagePath" &&
+            (string?)e.Attribute("Execute") == "commit" &&
+            (string?)e.Attribute("Impersonate") == "no" &&
+            (string?)e.Attribute("HideTarget") == "yes"));
         Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
             (string?)e.Attribute("Id") == "ServiceComponent.SetStopService" &&
             ((string?)e.Attribute("Value"))?.Contains("exit /b 0", StringComparison.Ordinal) == true));
@@ -212,6 +239,8 @@ public sealed class PowerForgeInstallerAuthoringTests
             .Select(e => (string?)e.Attribute("Action"))
             .ToArray();
         Assert.Contains("ServiceComponent.BackupImagePath", sequenceActions);
+        Assert.Contains("ServiceComponent.RollbackImagePath", sequenceActions);
+        Assert.Contains("ServiceComponent.CleanupImagePath", sequenceActions);
         Assert.Contains("ServiceComponent.SetStopService", sequenceActions);
         Assert.Contains("ServiceComponent.StopService", sequenceActions);
         Assert.Contains("ServiceComponent.SetInstallServiceUpgrade", sequenceActions);
@@ -227,13 +256,28 @@ public sealed class PowerForgeInstallerAuthoringTests
             (string?)e.Attribute("Before") == "ServiceComponent.BackupImagePath"));
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
             (string?)e.Attribute("Action") == "ServiceComponent.BackupImagePath" &&
+            (string?)e.Attribute("Before") == "ServiceComponent.SetRollbackCommand"));
+        Assert.NotNull(sequenceRows.SingleOrDefault(e =>
+            (string?)e.Attribute("Action") == "ServiceComponent.SetRollbackCommand" &&
+            (string?)e.Attribute("Before") == "ServiceComponent.RollbackImagePath"));
+        Assert.NotNull(sequenceRows.SingleOrDefault(e =>
+            (string?)e.Attribute("Action") == "ServiceComponent.RollbackImagePath" &&
             (string?)e.Attribute("Before") == "ServiceComponent.SetStopService"));
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
             (string?)e.Attribute("Action") == "ServiceComponent.SetStopService" &&
             (string?)e.Attribute("Before") == "ServiceComponent.StopService"));
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
             (string?)e.Attribute("Action") == "ServiceComponent.StopService" &&
-            (string?)e.Attribute("Before") == "RemoveExistingProducts"));
+            (string?)e.Attribute("Before") == "InstallFiles"));
+        Assert.NotNull(sequenceRows.SingleOrDefault(e =>
+            (string?)e.Attribute("Action") == "ServiceComponent.InstallService" &&
+            (string?)e.Attribute("Before") == "ServiceComponent.SetCleanupCommand"));
+        Assert.NotNull(sequenceRows.SingleOrDefault(e =>
+            (string?)e.Attribute("Action") == "ServiceComponent.SetCleanupCommand" &&
+            (string?)e.Attribute("Before") == "ServiceComponent.CleanupImagePath"));
+        Assert.NotNull(sequenceRows.SingleOrDefault(e =>
+            (string?)e.Attribute("Action") == "ServiceComponent.CleanupImagePath" &&
+            (string?)e.Attribute("Before") == "InstallFinalize"));
     }
 
     [Fact]
@@ -325,6 +369,7 @@ public sealed class PowerForgeInstallerAuthoringTests
     public void EmitSource_ScriptInstallCanOwnServiceUninstallWithoutServiceControl()
     {
         var definition = CreateMonitoringInstaller();
+        definition.Product.MajorUpgradeSchedule = PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute;
         var service = definition.Components.OfType<PowerForgeInstallerServiceComponent>().Single();
         service.ScriptInstall = new PowerForgeInstallerServiceScriptInstall
         {
@@ -516,11 +561,14 @@ public sealed class PowerForgeInstallerAuthoringTests
         AddScriptService(
             definition,
             "ServiceComponentWithVeryLongSharedPrefixForTenantAlpha",
-            "[TempFolder]alpha-service.txt");
+            "[WindowsFolder]Installer\\a-[ProductCode].txt");
         AddScriptService(
             definition,
             "ServiceComponentWithVeryLongSharedPrefixForTenantBeta",
-            "[TempFolder]beta-service.txt");
+            "[WindowsFolder]Installer\\b-[ProductCode].txt");
+        var services = definition.Components.OfType<PowerForgeInstallerServiceComponent>().ToArray();
+        services[0].ServiceName = "TenantAlpha";
+        services[1].ServiceName = "TenantBeta";
 
         var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
         var doc = XDocument.Parse(xml);
@@ -533,7 +581,8 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.Equal(actionIds.Length, actionIds.Distinct(StringComparer.Ordinal).Count());
 
         string[] quietExecSetterIds = doc.Descendants(Wix + "CustomAction")
-            .Where(e => (string?)e.Attribute("Property") == "WixQuietExecCmdLine")
+            .Where(e => ((string?)e.Attribute("Property"))?.EndsWith("BackupImagePath", StringComparison.Ordinal) == true ||
+                        (string?)e.Attribute("Property") == "WixQuietExecCmdLine")
             .Select(e => (string?)e.Attribute("Id"))
             .Where(id => !string.IsNullOrWhiteSpace(id))
             .Select(id => id!)
@@ -586,21 +635,21 @@ public sealed class PowerForgeInstallerAuthoringTests
         var doc = XDocument.Parse(xml);
 
         string[] backupCommands = doc.Descendants(Wix + "CustomAction")
-            .Where(e => (string?)e.Attribute("Property") == "WixQuietExecCmdLine")
             .Select(e => (string?)e.Attribute("Value"))
             .Where(value => value?.Contains("gwmi win32_service", StringComparison.Ordinal) == true)
             .Select(value => value!)
             .ToArray();
         Assert.Contains(backupCommands, command =>
-            command.Contains("[TempFolder]powerforge-ServiceOne-service-binpath.txt", StringComparison.Ordinal));
+            command.Contains("[WindowsFolder]Installer\\[ProductCode]-ServiceOne.pfb", StringComparison.Ordinal));
         Assert.Contains(backupCommands, command =>
-            command.Contains("[TempFolder]powerforge-ServiceTwo-service-binpath.txt", StringComparison.Ordinal));
+            command.Contains("[WindowsFolder]Installer\\[ProductCode]-ServiceTwo.pfb", StringComparison.Ordinal));
     }
 
     [Fact]
-    public void EmitSource_ScriptServiceBackupUsesEnvironmentForRuntimeExpandedPath()
+    public void EmitSource_ScriptServiceBackupUsesProtectedRuntimeExpandedPath()
     {
         var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Product.MajorUpgradeSchedule = PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute;
         definition.Components.Clear();
         definition.Components.Add(new PowerForgeInstallerServiceComponent
         {
@@ -613,7 +662,7 @@ public sealed class PowerForgeInstallerAuthoringTests
             {
                 Command = "\"powershell.exe\" -NoP -EP Bypass -File \"[INSTALLFOLDER]Install-Service.ps1\"",
                 BackupExistingImagePath = true,
-                BackupPath = "[TempFolder]O'Connor\\service.txt"
+                BackupPath = "[WindowsFolder]Installer\\OConnor-[ProductCode]-service.txt"
             }
         });
 
@@ -624,17 +673,73 @@ public sealed class PowerForgeInstallerAuthoringTests
             .Where(e => (string?)e.Attribute("Id") == "ServiceComponent.SetBackupCommand")
             .Select(e => (string?)e.Attribute("Value"))
             .Single(value => !string.IsNullOrWhiteSpace(value))!;
-        Assert.Contains("$b='[TempFolder]O''Connor\\service.txt'", command, StringComparison.Ordinal);
-        Assert.Contains("[IO.File]::WriteAllText($b", command, StringComparison.Ordinal);
-        Assert.Contains("[IO.File]::Delete($b)", command, StringComparison.Ordinal);
-        Assert.DoesNotContain("WriteAllText('[TempFolder]O''Connor", command, StringComparison.Ordinal);
+        Assert.Contains("$b='[WindowsFolder]Installer\\OConnor-[ProductCode]-service.txt'", command, StringComparison.Ordinal);
+        Assert.Contains("Out-File $b -NoN -NoC -ea Stop", command, StringComparison.Ordinal);
+        Assert.Contains("rm $b -ea 0", command, StringComparison.Ordinal);
         Assert.True(command.Length <= 255, $"Backup custom action target is {command.Length} characters.");
+    }
+
+    [Theory]
+    [InlineData(PowerForgeInstallerMajorUpgradeSchedule.AfterInstallValidate)]
+    [InlineData(PowerForgeInstallerMajorUpgradeSchedule.AfterInstallInitialize)]
+    public void EmitSource_RejectsImagePathBackupOutsideElevatedExecuteTransaction(
+        PowerForgeInstallerMajorUpgradeSchedule schedule)
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Product.MajorUpgradeSchedule = schedule;
+        definition.Components.Clear();
+        AddScriptService(definition, "ServiceComponent");
+        definition.Product.MajorUpgradeSchedule = schedule;
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+
+        Assert.Contains("requires a major-upgrade schedule at or after AfterInstallExecute", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("[TempFolder]service-[ProductCode].txt")]
+    [InlineData("[WindowsFolder]Temp\\service-[ProductCode].txt")]
+    [InlineData("[WindowsFolder]Installer\\service.txt")]
+    [InlineData("[WindowsFolder]Installer\\nested\\service-[ProductCode].txt")]
+    [InlineData("[WindowsFolder]Installer\\[EVIL]-[ProductCode].txt")]
+    public void EmitSource_RejectsUnprotectedOrPredictableImagePathBackup(string backupPath)
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Product.MajorUpgradeSchedule = PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute;
+        definition.Components.Clear();
+        AddScriptService(definition, "ServiceComponent", backupPath);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+
+        Assert.Contains("must be a direct child of '[WindowsFolder]Installer\\', include '[ProductCode]', and contain only safe filename literals", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitSource_RejectsUnsafeServiceNameExpansionInImagePathBackup()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Product.MajorUpgradeSchedule = PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute;
+        definition.Components.Clear();
+        AddScriptService(
+            definition,
+            "ServiceComponent",
+            "[WindowsFolder]Installer\\[ProductCode]-{serviceName}.pfb");
+        var service = definition.Components.OfType<PowerForgeInstallerServiceComponent>().Single();
+        service.ServiceName = "Unsafe'Name";
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+
+        Assert.Contains("resolves to an unsafe file name", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
     public void EmitSource_RejectsBackupCommandThatExceedsMsiTargetLimit()
     {
         var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Product.MajorUpgradeSchedule = PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute;
         definition.Components.Clear();
         definition.Components.Add(new PowerForgeInstallerServiceComponent
         {
@@ -648,7 +753,7 @@ public sealed class PowerForgeInstallerAuthoringTests
             {
                 Command = "powershell.exe -File install.ps1",
                 BackupExistingImagePath = true,
-                BackupPath = "[TempFolder]" + new string('B', 72) + ".txt"
+                BackupPath = "[WindowsFolder]Installer\\[ProductCode]-" + new string('B', 72) + ".txt"
             }
         });
 
@@ -696,6 +801,7 @@ public sealed class PowerForgeInstallerAuthoringTests
     public void EmitSource_GatesUpgradePrepActionsWithScriptInstallCondition()
     {
         var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Product.MajorUpgradeSchedule = PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute;
         definition.Components.Clear();
         definition.Components.Add(new PowerForgeInstallerServiceComponent
         {
@@ -721,11 +827,13 @@ public sealed class PowerForgeInstallerAuthoringTests
             .Where(e =>
                 string.Equals((string?)e.Attribute("Action"), "ConditionalService.SetBackupCommand", StringComparison.Ordinal) ||
                 string.Equals((string?)e.Attribute("Action"), "ConditionalService.BackupImagePath", StringComparison.Ordinal) ||
+                string.Equals((string?)e.Attribute("Action"), "ConditionalService.SetRollbackCommand", StringComparison.Ordinal) ||
+                string.Equals((string?)e.Attribute("Action"), "ConditionalService.RollbackImagePath", StringComparison.Ordinal) ||
                 string.Equals((string?)e.Attribute("Action"), "ConditionalService.SetStopService", StringComparison.Ordinal) ||
                 string.Equals((string?)e.Attribute("Action"), "ConditionalService.StopService", StringComparison.Ordinal))
             .ToArray();
 
-        Assert.Equal(4, upgradePrepRows.Length);
+        Assert.Equal(6, upgradePrepRows.Length);
         Assert.All(upgradePrepRows, row =>
         {
             var condition = (string?)row.Attribute("Condition");
@@ -735,8 +843,6 @@ public sealed class PowerForgeInstallerAuthoringTests
     }
 
     [Theory]
-    [InlineData(PowerForgeInstallerMajorUpgradeSchedule.AfterInstallValidate, "RemoveExistingProducts")]
-    [InlineData(PowerForgeInstallerMajorUpgradeSchedule.AfterInstallInitialize, "RemoveExistingProducts")]
     [InlineData(PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute, "InstallFiles")]
     [InlineData(PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecuteAgain, "InstallFiles")]
     [InlineData(PowerForgeInstallerMajorUpgradeSchedule.AfterInstallFinalize, "InstallFiles")]
@@ -756,7 +862,9 @@ public sealed class PowerForgeInstallerAuthoringTests
             .ToDictionary(row => (string)row.Attribute("Action")!, StringComparer.Ordinal);
 
         Assert.Equal("ServiceComponent.BackupImagePath", (string?)rows["ServiceComponent.SetBackupCommand"].Attribute("Before"));
-        Assert.Equal("ServiceComponent.SetStopService", (string?)rows["ServiceComponent.BackupImagePath"].Attribute("Before"));
+        Assert.Equal("ServiceComponent.SetRollbackCommand", (string?)rows["ServiceComponent.BackupImagePath"].Attribute("Before"));
+        Assert.Equal("ServiceComponent.RollbackImagePath", (string?)rows["ServiceComponent.SetRollbackCommand"].Attribute("Before"));
+        Assert.Equal("ServiceComponent.SetStopService", (string?)rows["ServiceComponent.RollbackImagePath"].Attribute("Before"));
         Assert.Equal("ServiceComponent.StopService", (string?)rows["ServiceComponent.SetStopService"].Attribute("Before"));
         Assert.Equal(expectedAnchor, (string?)rows["ServiceComponent.StopService"].Attribute("Before"));
     }
@@ -2386,6 +2494,7 @@ public sealed class PowerForgeInstallerAuthoringTests
         string componentId,
         string? backupPath = null)
     {
+        definition.Product.MajorUpgradeSchedule = PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute;
         definition.Components.Add(new PowerForgeInstallerServiceComponent
         {
             Id = componentId,
@@ -2397,7 +2506,7 @@ public sealed class PowerForgeInstallerAuthoringTests
             {
                 Command = "\"powershell.exe\" -NoP -EP Bypass -File \"[INSTALLFOLDER]Install-Service.ps1\"",
                 BackupExistingImagePath = true,
-                BackupPath = backupPath ?? "[TempFolder]powerforge-{serviceId}-service-binpath.txt",
+                BackupPath = backupPath ?? "[WindowsFolder]Installer\\[ProductCode]-{serviceId}.pfb",
                 StopServiceForUpgrade = true
             }
         });

--- a/PowerForge.Tests/WebSiteScaffolderTests.cs
+++ b/PowerForge.Tests/WebSiteScaffolderTests.cs
@@ -81,6 +81,10 @@ public class WebSiteScaffolderTests
             Assert.Contains("POWERFORGE_LOCK_PATH: ./.powerforge/engine-lock.json", workflow, StringComparison.Ordinal);
             Assert.Contains("actions: read", workflow, StringComparison.Ordinal);
             Assert.Contains("packages: read", workflow, StringComparison.Ordinal);
+            Assert.Contains("verify-site-untrusted:", workflow, StringComparison.Ordinal);
+            Assert.Contains("if: ${{ github.event_name == 'pull_request' }}", workflow, StringComparison.Ordinal);
+            Assert.Contains("verify-site-trusted:", workflow, StringComparison.Ordinal);
+            Assert.Contains("if: ${{ github.event_name != 'pull_request' }}", workflow, StringComparison.Ordinal);
             Assert.Contains("uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@main", workflow, StringComparison.Ordinal);
             Assert.Contains("website_root: .", workflow, StringComparison.Ordinal);
             Assert.Contains("pipeline_config: pipeline.json", workflow, StringComparison.Ordinal);
@@ -88,6 +92,11 @@ public class WebSiteScaffolderTests
             Assert.Contains("powerforge_repository_override: ${{ vars.POWERFORGE_REPOSITORY }}", workflow, StringComparison.Ordinal);
             Assert.Contains("powerforge_ref_override: ${{ vars.POWERFORGE_REF }}", workflow, StringComparison.Ordinal);
             Assert.Contains("secrets: inherit", workflow, StringComparison.Ordinal);
+            string untrustedJob = workflow[
+                workflow.IndexOf("  verify-site-untrusted:", StringComparison.Ordinal)..
+                workflow.IndexOf("  verify-site-trusted:", StringComparison.Ordinal)];
+            Assert.DoesNotContain("packages: read", untrustedJob, StringComparison.Ordinal);
+            Assert.DoesNotContain("secrets: inherit", untrustedJob, StringComparison.Ordinal);
             Assert.Contains("concurrency:", workflow, StringComparison.Ordinal);
 
             var maintenanceWorkflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "website-maintenance.yml"));

--- a/PowerForge.Web/Services/WebSiteScaffolder.cs
+++ b/PowerForge.Web/Services/WebSiteScaffolder.cs
@@ -1069,7 +1069,6 @@ on:
 permissions:
   actions: read
   contents: read
-  packages: read
 
 concurrency:
   group: website-ci-${{ github.ref }}
@@ -1079,7 +1078,25 @@ env:
   POWERFORGE_LOCK_PATH: ./.powerforge/engine-lock.json
 
 jobs:
-  verify-site:
+  verify-site-untrusted:
+    if: ${{ github.event_name == 'pull_request' }}
+    permissions:
+      actions: read
+      contents: read
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@main
+    with:
+      website_root: .
+      pipeline_config: pipeline.json
+      powerforge_lock_path: ./.powerforge/engine-lock.json
+      powerforge_repository_override: ${{ vars.POWERFORGE_REPOSITORY }}
+      powerforge_ref_override: ${{ vars.POWERFORGE_REF }}
+
+  verify-site-trusted:
+    if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      actions: read
+      contents: read
+      packages: read
     uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@main
     with:
       website_root: .

--- a/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
+++ b/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
@@ -746,9 +746,11 @@ public sealed class PowerForgeInstallerServiceScriptInstall
     public bool BackupExistingImagePath { get; set; }
 
     /// <summary>
-    /// Backup file path used for the existing service ImagePath. Supports <c>{serviceId}</c> and <c>{serviceName}</c> tokens.
+    /// Protected backup file path used for the existing service ImagePath. The path must be under
+    /// <c>[WindowsFolder]Installer</c>, include <c>[ProductCode]</c>, and may use <c>{serviceId}</c> and
+    /// <c>{serviceName}</c> tokens.
     /// </summary>
-    public string BackupPath { get; set; } = "[TempFolder]powerforge-{serviceId}-service-binpath.txt";
+    public string BackupPath { get; set; } = "[WindowsFolder]Installer\\[ProductCode]-{serviceId}.pfb";
 
     /// <summary>
     /// Stops the existing service during an upgrade before the old product is removed.

--- a/PowerForge/Scripts/DotNetPublish/Install-Service.Template.ps1
+++ b/PowerForge/Scripts/DotNetPublish/Install-Service.Template.ps1
@@ -50,11 +50,18 @@ if (-not [string]::IsNullOrWhiteSpace($arguments)) {
     $binaryPathName += ' ' + $arguments
 }
 
-if ($UpgradeMode -and $PreserveExistingServiceBinPath -and -not [string]::IsNullOrWhiteSpace($BackupPath) -and (Test-Path -LiteralPath $BackupPath)) {
-    $preservedBinaryPathName = (Get-Content -LiteralPath $BackupPath -Raw).Trim()
-    if (-not [string]::IsNullOrWhiteSpace($preservedBinaryPathName)) {
-        $binaryPathName = $preservedBinaryPathName
+$existing = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+if ($UpgradeMode -and $PreserveExistingServiceBinPath) {
+    if ([string]::IsNullOrWhiteSpace($BackupPath) -or -not (Test-Path -LiteralPath $BackupPath -PathType Leaf)) {
+        throw 'The existing service command line backup is required for this upgrade.'
     }
+
+    $preservedBinaryPathName = (Get-Content -LiteralPath $BackupPath -Raw).Trim()
+    if ([string]::IsNullOrWhiteSpace($preservedBinaryPathName)) {
+        throw 'The existing service command line backup is empty.'
+    }
+
+    $binaryPathName = $preservedBinaryPathName
 }
 
 if (-not [string]::IsNullOrWhiteSpace($ConfigPath)) {
@@ -70,15 +77,6 @@ if (-not [string]::IsNullOrWhiteSpace($ServiceName)) {
     $binaryPathName = Set-CommandLineOption -CommandLine $binaryPathName -Name '--service-name' -Value $ServiceName
 }
 
-$existing = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
-if ($existing) {
-    if ($existing.Status -ne 'Stopped') {
-        Stop-Service -Name $serviceName -Force -ErrorAction SilentlyContinue
-    }
-    & sc.exe delete $serviceName | Out-Null
-    Start-Sleep -Seconds 1
-}
-
 $newServiceParams = @{
     Name           = $ServiceName
     BinaryPathName = $binaryPathName
@@ -87,9 +85,12 @@ $newServiceParams = @{
     StartupType    = 'Automatic'
 }
 
+$credential = $null
+$servicePassword = $Password
 if (-not [string]::IsNullOrWhiteSpace($Account) -and $Account -ne 'LocalSystem') {
     if ([string]::IsNullOrWhiteSpace($Password)) {
         $credential = Get-Credential -UserName $Account -Message 'Enter password for service account'
+        $servicePassword = $credential.GetNetworkCredential().Password
     } else {
         $securePassword = ConvertTo-SecureString -String $Password -AsPlainText -Force
         $credential = [pscredential]::new($Account, $securePassword)
@@ -97,7 +98,38 @@ if (-not [string]::IsNullOrWhiteSpace($Account) -and $Account -ne 'LocalSystem')
     $newServiceParams.Credential = $credential
 }
 
-New-Service @newServiceParams | Out-Null
+if ($existing) {
+    if ($existing.Status -ne 'Stopped') {
+        Stop-Service -Name $ServiceName -Force -ErrorAction SilentlyContinue
+    }
+
+    $service = Get-CimInstance -ClassName Win32_Service |
+        Where-Object Name -EQ $ServiceName |
+        Select-Object -First 1
+    if ($null -eq $service) {
+        throw "Unable to resolve existing service '$ServiceName' for an in-place update."
+    }
+
+    $changeArguments = @{
+        PathName    = $binaryPathName
+        DisplayName = $DisplayName
+        StartMode   = 'Automatic'
+        StartName   = $Account
+    }
+    if (-not [string]::IsNullOrWhiteSpace($servicePassword)) {
+        $changeArguments.StartPassword = $servicePassword
+    }
+
+    $changeResult = Invoke-CimMethod -InputObject $service -MethodName Change -Arguments $changeArguments
+    if ($null -eq $changeResult -or $changeResult.ReturnValue -ne 0) {
+        $returnValue = if ($null -eq $changeResult) { 'unknown' } else { $changeResult.ReturnValue }
+        throw "Failed to update existing service '$ServiceName' (Win32_Service.Change=$returnValue)."
+    }
+
+    Set-Service -Name $ServiceName -DisplayName $DisplayName -Description $Description -StartupType Automatic
+} else {
+    New-Service @newServiceParams | Out-Null
+}
 
 if ($Start) {
     Start-Service -Name $ServiceName

--- a/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
+++ b/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
@@ -18,6 +18,14 @@ internal static class PowerForgeInstallerDefinitionValidator
         "^[A-Z_][A-Z0-9_]*$",
         RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
+    private static readonly Regex InstallerBackupFilePattern = new(
+        @"^(?:[A-Za-z0-9._ -]|\[ProductCode\]|\{serviceId\}|\{serviceName\})+$",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex InstallerBackupResolvedFilePattern = new(
+        "^[A-Za-z0-9._ -]+$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
     private static readonly string[] DialogReservedControlIds =
     {
         "Back",
@@ -275,7 +283,7 @@ internal static class PowerForgeInstallerDefinitionValidator
                 Require(service.ControlStop, $"service component '{service.Id}' ControlStop");
                 Require(service.ControlRemove, $"service component '{service.Id}' ControlRemove");
                 ValidateServiceCredentialProperties(service);
-                ValidateServiceScriptInstall(service);
+                ValidateServiceScriptInstall(definition.Product, service);
             }
             else if (component is PowerForgeInstallerRemoveFolderComponent removeFolder)
             {
@@ -299,7 +307,9 @@ internal static class PowerForgeInstallerDefinitionValidator
         }
     }
 
-    private static void ValidateServiceScriptInstall(PowerForgeInstallerServiceComponent service)
+    private static void ValidateServiceScriptInstall(
+        PowerForgeInstallerProduct product,
+        PowerForgeInstallerServiceComponent service)
     {
         var script = service.ScriptInstall;
         if (script is null)
@@ -323,13 +333,50 @@ internal static class PowerForgeInstallerDefinitionValidator
         }
 
         if (script.BackupExistingImagePath)
+        {
             Require(script.BackupPath, $"service component '{service.Id}' ScriptInstall.BackupPath");
+            if (product.MajorUpgradeSchedule is PowerForgeInstallerMajorUpgradeSchedule.AfterInstallValidate or
+                PowerForgeInstallerMajorUpgradeSchedule.AfterInstallInitialize)
+            {
+                throw new InvalidOperationException(
+                    $"Service component '{service.Id}' ScriptInstall.BackupExistingImagePath requires a major-upgrade schedule at or after AfterInstallExecute so the backup runs elevated inside the execute transaction.");
+            }
+
+            string backupPath = script.BackupPath.Trim();
+            const string protectedBackupRoot = "[WindowsFolder]Installer\\";
+            string backupFileName = backupPath.StartsWith(protectedBackupRoot, StringComparison.OrdinalIgnoreCase)
+                ? backupPath.Substring(protectedBackupRoot.Length)
+                : string.Empty;
+            if (string.IsNullOrWhiteSpace(backupFileName) ||
+                !InstallerBackupFilePattern.IsMatch(backupFileName) ||
+                backupFileName.IndexOf("[ProductCode]", StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Service component '{service.Id}' ScriptInstall.BackupPath must be a direct child of '[WindowsFolder]Installer\\', include '[ProductCode]', and contain only safe filename literals plus '{{serviceId}}' or '{{serviceName}}'.");
+            }
+
+            string resolvedBackupFileName = ReplaceBackupFileToken(backupFileName, "[ProductCode]", "PRODUCTCODE");
+            resolvedBackupFileName = ReplaceBackupFileToken(resolvedBackupFileName, "{serviceId}", service.Id);
+            resolvedBackupFileName = ReplaceBackupFileToken(resolvedBackupFileName, "{serviceName}", service.ServiceName);
+            if (!InstallerBackupResolvedFilePattern.IsMatch(resolvedBackupFileName))
+            {
+                throw new InvalidOperationException(
+                    $"Service component '{service.Id}' ScriptInstall.BackupPath resolves to an unsafe file name. Service ids and names used in backup tokens may contain only letters, digits, spaces, '.', '_', and '-'.");
+            }
+        }
         if (script.StopDelaySeconds < 0)
         {
             throw new InvalidOperationException(
                 $"Service component '{service.Id}' ScriptInstall.StopDelaySeconds must be greater than or equal to 0.");
         }
     }
+
+    private static string ReplaceBackupFileToken(string value, string token, string replacement)
+        => Regex.Replace(
+            value,
+            Regex.Escape(token),
+            _ => replacement,
+            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static void ValidateServiceCredentialProperties(PowerForgeInstallerServiceComponent service)
     {

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
@@ -50,6 +50,10 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         var ids = BuildIds(service.Id);
         yield return ids.BackupImagePathId;
         yield return ids.SetBackupCommandId;
+        yield return ids.RollbackImagePathId;
+        yield return ids.SetRollbackCommandId;
+        yield return ids.CleanupImagePathId;
+        yield return ids.SetCleanupCommandId;
         yield return ids.SetStopServiceId;
         yield return ids.StopServiceId;
         yield return ids.InstallServiceId;
@@ -94,8 +98,21 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
 
         if (script.BackupExistingImagePath)
         {
-            actions.Add(CreateSetQuietExecCommand(ids.SetBackupCommandId, BuildBackupCommand(service, resolvedBackupPath)));
-            actions.Add(CreateQuietExecAction(ids.BackupImagePathId, execute: "immediate"));
+            actions.Add(CreateSetInstallCommand(
+                ids.SetBackupCommandId,
+                ids.BackupImagePathId,
+                BuildBackupCommand(service, resolvedBackupPath)));
+            actions.Add(CreateQuietExecAction(ids.BackupImagePathId, execute: "deferred", hideTarget: true));
+            actions.Add(CreateSetInstallCommand(
+                ids.SetRollbackCommandId,
+                ids.RollbackImagePathId,
+                BuildRollbackCommand(service, resolvedBackupPath)));
+            actions.Add(CreateQuietExecAction(ids.RollbackImagePathId, execute: "rollback", hideTarget: true));
+            actions.Add(CreateSetInstallCommand(
+                ids.SetCleanupCommandId,
+                ids.CleanupImagePathId,
+                BuildCleanupCommand(service, resolvedBackupPath)));
+            actions.Add(CreateQuietExecAction(ids.CleanupImagePathId, execute: "commit", hideTarget: true));
         }
 
         if (script.StopServiceForUpgrade)
@@ -141,6 +158,8 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         {
             upgradePreparationActions.Add(new UpgradePreparationAction(ids.SetBackupCommandId, upgradeCondition));
             upgradePreparationActions.Add(new UpgradePreparationAction(ids.BackupImagePathId, upgradeCondition));
+            upgradePreparationActions.Add(new UpgradePreparationAction(ids.SetRollbackCommandId, upgradeCondition));
+            upgradePreparationActions.Add(new UpgradePreparationAction(ids.RollbackImagePathId, upgradeCondition));
         }
 
         if (script.StopServiceForUpgrade)
@@ -180,8 +199,22 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         sequence.Add(new XElement(
             WixNamespace + "Custom",
             new XAttribute("Action", ids.InstallServiceId),
-            new XAttribute("Before", "InstallFinalize"),
+            new XAttribute("Before", script.BackupExistingImagePath ? ids.SetCleanupCommandId : "InstallFinalize"),
             new XAttribute("Condition", script.Condition)));
+
+        if (script.BackupExistingImagePath)
+        {
+            sequence.Add(new XElement(
+                WixNamespace + "Custom",
+                new XAttribute("Action", ids.SetCleanupCommandId),
+                new XAttribute("Before", ids.CleanupImagePathId),
+                new XAttribute("Condition", upgradeCondition)));
+            sequence.Add(new XElement(
+                WixNamespace + "Custom",
+                new XAttribute("Action", ids.CleanupImagePathId),
+                new XAttribute("Before", "InstallFinalize"),
+                new XAttribute("Condition", upgradeCondition)));
+        }
     }
 
     private static void AddUpgradePreparationSequenceRows(
@@ -234,7 +267,7 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
             new XAttribute("DllEntry", "WixQuietExec"),
             new XAttribute("Execute", execute),
             new XAttribute("Return", "check"));
-        if (string.Equals(execute, "deferred", StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(execute, "immediate", StringComparison.OrdinalIgnoreCase))
             element.Add(new XAttribute("Impersonate", "no"));
         if (hideTarget)
             element.Add(new XAttribute("HideTarget", "yes"));
@@ -272,16 +305,44 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         string serviceName = EscapePowerShellSingleQuoted(service.ServiceName);
         string backup = EscapePowerShellSingleQuoted(backupPath);
         string command = "$b='" + backup +
-                         "';$p=(gwmi win32_service|? Name -eq '" + serviceName +
-                         "').PathName;if($p){[IO.File]::WriteAllText($b,$p)}" +
-                         "else{[IO.File]::Delete($b)}";
+                         "';rm $b -ea 0;$p=(gwmi win32_service|? Name -eq '" + serviceName +
+                         "').PathName;if($p){$p|Out-File $b -NoN -NoC -ea Stop}";
+        return BuildPowerShellCommand(service, "backup", command);
+    }
+
+    private static string BuildRollbackCommand(
+        PowerForgeInstallerServiceComponent service,
+        string backupPath)
+    {
+        string serviceName = EscapePowerShellSingleQuoted(service.ServiceName);
+        string backup = EscapePowerShellSingleQuoted(backupPath);
+        string command = "$b='" + backup +
+                         "';$n='" + serviceName +
+                         "';$p=gc -Raw $b;&sc.exe config $n binPath= $p>$null;" +
+                         "if(!$?){&sc.exe create $n binPath= $p>$null};if(!$?){exit 1};rm $b -ea 0";
+        return BuildPowerShellCommand(service, "rollback", command);
+    }
+
+    private static string BuildCleanupCommand(
+        PowerForgeInstallerServiceComponent service,
+        string backupPath)
+    {
+        string backup = EscapePowerShellSingleQuoted(backupPath);
+        return BuildPowerShellCommand(service, "cleanup", "rm '" + backup + "' -ea 0");
+    }
+
+    private static string BuildPowerShellCommand(
+        PowerForgeInstallerServiceComponent service,
+        string purpose,
+        string command)
+    {
         string result = "powershell.exe -nop -c \"" +
                         EscapeCommandDoubleQuoted(command) +
                         "\"";
         if (result.Length > 255)
         {
             throw new InvalidOperationException(
-                $"Service '{service.ServiceName}' backup command is {result.Length} characters; " +
+                $"Service '{service.ServiceName}' {purpose} command is {result.Length} characters; " +
                 "WiX CustomAction.Target supports at most 255. Shorten ServiceName or ScriptInstall.BackupPath.");
         }
 
@@ -310,6 +371,10 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         return new ServiceScriptActionIds(
             BuildActionId(prefix, "BackupImagePath"),
             BuildActionId(prefix, "SetBackupCommand"),
+            BuildActionId(prefix, "RollbackImagePath"),
+            BuildActionId(prefix, "SetRollbackCommand"),
+            BuildActionId(prefix, "CleanupImagePath"),
+            BuildActionId(prefix, "SetCleanupCommand"),
             BuildActionId(prefix, "SetStopService"),
             BuildActionId(prefix, "StopService"),
             BuildActionId(prefix, "InstallService"),
@@ -376,6 +441,10 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         internal ServiceScriptActionIds(
             string backupImagePathId,
             string setBackupCommandId,
+            string rollbackImagePathId,
+            string setRollbackCommandId,
+            string cleanupImagePathId,
+            string setCleanupCommandId,
             string setStopServiceId,
             string stopServiceId,
             string installServiceId,
@@ -387,6 +456,10 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         {
             BackupImagePathId = backupImagePathId;
             SetBackupCommandId = setBackupCommandId;
+            RollbackImagePathId = rollbackImagePathId;
+            SetRollbackCommandId = setRollbackCommandId;
+            CleanupImagePathId = cleanupImagePathId;
+            SetCleanupCommandId = setCleanupCommandId;
             SetStopServiceId = setStopServiceId;
             StopServiceId = stopServiceId;
             InstallServiceId = installServiceId;
@@ -399,6 +472,10 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
 
         internal string BackupImagePathId { get; }
         internal string SetBackupCommandId { get; }
+        internal string RollbackImagePathId { get; }
+        internal string SetRollbackCommandId { get; }
+        internal string CleanupImagePathId { get; }
+        internal string SetCleanupCommandId { get; }
         internal string SetStopServiceId { get; }
         internal string StopServiceId { get; }
         internal string InstallServiceId { get; }


### PR DESCRIPTION
## Summary

- add an explicit credential mode to the reusable website runner
- run pull request website pipelines with empty credential variables, non-persistent checkout authentication, no inherited secrets, and no package permission
- preserve package access and existing credential behavior for trusted push, manual, deployment, and maintenance runs
- generate separate untrusted and trusted website CI jobs so new sites inherit the same boundary
- protect service-upgrade ImagePath handoff in the elevated Windows Installer transaction, with a product-unique file under the protected installer directory
- update existing services in place and add rollback/commit actions so failed upgrades restore the prior command line and successful upgrades remove transient state
- reject unsafe backup paths, arbitrary MSI-property expansion, unsafe token values, and upgrade schedules that cannot provide the required elevated transaction boundary

This closes the reusable workflow and shared MSI owner gaps found while hardening [TestimoX #876](https://github.com/EvotecIT/TestimoX/pull/876). TestimoX pins this exact commit before its security changes are considered settled.

## Validation

- reusable workflow and website scaffolder contracts: 22 passed
- installer authoring and generated service-package contracts: 95 passed
- PowerForge builds for net472, net8.0, and net10.0 with 0 warnings and 0 errors