### PR TITLE
Limit signing to final package outputs

### DIFF
--- a/PSPublishModule/Cmdlets/InvokeDotNetReleaseBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeDotNetReleaseBuildCommand.cs
@@ -56,6 +56,14 @@ public sealed class InvokeDotNetReleaseBuildCommand : PSCmdlet
     [Parameter]
     public string TimeStampServer { get; set; } = "http://timestamp.digicert.com";
 
+    /// <summary>Explicitly replaces existing Authenticode assembly signatures.</summary>
+    [Parameter]
+    public SwitchParameter OverwriteSignedAssemblies { get; set; }
+
+    /// <summary>Explicitly replaces existing NuGet package signatures.</summary>
+    [Parameter]
+    public SwitchParameter OverwriteSignedPackages { get; set; }
+
     /// <summary>When enabled, also packs all project dependencies that have their own .csproj files.</summary>
     [Parameter]
     public SwitchParameter PackDependencies { get; set; }
@@ -95,6 +103,8 @@ public sealed class InvokeDotNetReleaseBuildCommand : PSCmdlet
                 CertificateThumbprint = CertificateThumbprint,
                 LocalStore = mappedStore,
                 TimeStampServer = TimeStampServer,
+                OverwriteSignedAssemblies = OverwriteSignedAssemblies.IsPresent,
+                OverwriteSignedPackages = OverwriteSignedPackages.IsPresent,
                 PackDependencies = PackDependencies.IsPresent
             };
 

--- a/PSPublishModule/Cmdlets/InvokeDotNetRepositoryReleaseCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeDotNetRepositoryReleaseCommand.cs
@@ -120,9 +120,17 @@ public sealed class InvokeDotNetRepositoryReleaseCommand : PSCmdlet
     [Parameter]
     public SwitchParameter SignDependencyAssemblies { get; set; }
 
+    /// <summary>Explicitly replaces existing Authenticode assembly signatures.</summary>
+    [Parameter]
+    public SwitchParameter OverwriteSignedAssemblies { get; set; }
+
     /// <summary>Skip signing generated NuGet packages.</summary>
     [Parameter]
     public SwitchParameter SkipPackageSigning { get; set; }
+
+    /// <summary>Explicitly replaces existing NuGet package signatures.</summary>
+    [Parameter]
+    public SwitchParameter OverwriteSignedPackages { get; set; }
 
     /// <summary>Skip dotnet pack step.</summary>
     [Parameter]
@@ -209,6 +217,8 @@ public sealed class InvokeDotNetRepositoryReleaseCommand : PSCmdlet
             SignAssemblies = SkipAssemblySigning.IsPresent ? false : null,
             SignDependencyAssemblies = SignDependencyAssemblies.IsPresent,
             SignPackages = SkipPackageSigning.IsPresent ? false : null,
+            OverwriteSignedAssemblies = OverwriteSignedAssemblies.IsPresent,
+            OverwriteSignedPackages = OverwriteSignedPackages.IsPresent,
             SkipPack = SkipPack.IsPresent,
             IncludeSymbols = IncludeSymbols.IsPresent,
             Publish = Publish.IsPresent,

--- a/PSPublishModule/Cmdlets/NewConfigurationDotNetSignCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationDotNetSignCommand.cs
@@ -21,6 +21,18 @@ public sealed class NewConfigurationDotNetSignCommand : PSCmdlet
     public SwitchParameter Enabled { get; set; }
 
     /// <summary>
+    /// Includes DLL files when signing publish or bundle outputs.
+    /// </summary>
+    [Parameter]
+    public SwitchParameter IncludeDlls { get; set; }
+
+    /// <summary>
+    /// Explicitly replaces existing signatures instead of preserving already signed files.
+    /// </summary>
+    [Parameter]
+    public SwitchParameter OverwriteSigned { get; set; }
+
+    /// <summary>
     /// Optional path to signtool.exe.
     /// </summary>
     [Parameter]
@@ -88,6 +100,8 @@ public sealed class NewConfigurationDotNetSignCommand : PSCmdlet
         WriteObject(new DotNetPublishSignOptions
         {
             Enabled = Enabled.IsPresent,
+            IncludeDlls = IncludeDlls.IsPresent,
+            OverwriteSigned = OverwriteSigned.IsPresent,
             ToolPath = ToolPath,
             OnMissingTool = OnMissingTool,
             OnSignFailure = OnSignFailure,

--- a/PSPublishModule/Cmdlets/NewConfigurationPackageBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationPackageBuildCommand.cs
@@ -79,6 +79,14 @@ public sealed class NewConfigurationProjectBuildCommand : PSCmdlet
     [Parameter]
     public SwitchParameter SignPackages { get; set; }
 
+    /// <summary>Whether existing Authenticode assembly signatures may be replaced.</summary>
+    [Parameter]
+    public SwitchParameter OverwriteSignedAssemblies { get; set; }
+
+    /// <summary>Whether existing NuGet package signatures may be replaced.</summary>
+    [Parameter]
+    public SwitchParameter OverwriteSignedPackages { get; set; }
+
     /// <summary>Additional project-build JSON overrides for less common fields.</summary>
     [Parameter]
     public IDictionary? Options { get; set; }
@@ -105,6 +113,8 @@ public sealed class NewConfigurationProjectBuildCommand : PSCmdlet
                 SignAssemblies = BoundSwitch(nameof(SignAssemblies), SignAssemblies),
                 SignDependencyAssemblies = BoundSwitch(nameof(SignDependencyAssemblies), SignDependencyAssemblies),
                 SignPackages = BoundSwitch(nameof(SignPackages), SignPackages),
+                OverwriteSignedAssemblies = BoundSwitch(nameof(OverwriteSignedAssemblies), OverwriteSignedAssemblies),
+                OverwriteSignedPackages = BoundSwitch(nameof(OverwriteSignedPackages), OverwriteSignedPackages),
                 Options = PackageBuildConfiguration.ToObjectDictionary(Options)
             }
         });
@@ -268,6 +278,12 @@ public sealed class NewConfigurationPackageBuildCommand : PSCmdlet
     /// <summary>Whether generated NuGet packages should be signed.</summary>
     [Parameter] public SwitchParameter SignPackages { get; set; }
 
+    /// <summary>Whether existing Authenticode assembly signatures may be replaced.</summary>
+    [Parameter] public SwitchParameter OverwriteSignedAssemblies { get; set; }
+
+    /// <summary>Whether existing NuGet package signatures may be replaced.</summary>
+    [Parameter] public SwitchParameter OverwriteSignedPackages { get; set; }
+
     /// <summary>NuGet version lookup credential user name.</summary>
     [Parameter] public string? NugetCredentialUserName { get; set; }
 
@@ -377,6 +393,8 @@ public sealed class NewConfigurationPackageBuildCommand : PSCmdlet
                 SignAssemblies = BoundSwitch(nameof(SignAssemblies), SignAssemblies),
                 SignDependencyAssemblies = BoundSwitch(nameof(SignDependencyAssemblies), SignDependencyAssemblies),
                 SignPackages = BoundSwitch(nameof(SignPackages), SignPackages),
+                OverwriteSignedAssemblies = BoundSwitch(nameof(OverwriteSignedAssemblies), OverwriteSignedAssemblies),
+                OverwriteSignedPackages = BoundSwitch(nameof(OverwriteSignedPackages), OverwriteSignedPackages),
                 NugetCredentialUserName = Normalize(NugetCredentialUserName),
                 NugetCredentialSecret = NugetCredentialSecret,
                 NugetCredentialSecretFilePath = Normalize(NugetCredentialSecretFilePath),

--- a/PSPublishModule/Cmdlets/NewConfigurationProjectSigningCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationProjectSigningCommand.cs
@@ -77,6 +77,12 @@ public sealed class NewConfigurationProjectSigningCommand : PSCmdlet
     public string? KeyContainer { get; set; }
 
     /// <summary>
+    /// Explicitly replaces existing signatures instead of preserving already signed files.
+    /// </summary>
+    [Parameter]
+    public SwitchParameter OverwriteSigned { get; set; }
+
+    /// <summary>
     /// Emits a <see cref="ConfigurationProjectSigning"/> object.
     /// </summary>
     protected override void ProcessRecord()
@@ -93,7 +99,8 @@ public sealed class NewConfigurationProjectSigningCommand : PSCmdlet
             Description = NormalizeNullable(Description),
             Url = NormalizeNullable(Url),
             Csp = NormalizeNullable(Csp),
-            KeyContainer = NormalizeNullable(KeyContainer)
+            KeyContainer = NormalizeNullable(KeyContainer),
+            OverwriteSigned = OverwriteSigned.IsPresent
         });
     }
 

--- a/PowerForge.PowerShell/Services/AuthenticodeSigningService.cs
+++ b/PowerForge.PowerShell/Services/AuthenticodeSigningService.cs
@@ -185,39 +185,45 @@ public sealed class AuthenticodeSigningService
 
     private IReadOnlyList<PSObject> SignWithWindowsAuthenticode(string[] files, AuthenticodeSignRequest request)
     {
-        var unsignedFiles = GetUnsignedFiles("Get-AuthenticodeSignature", files);
-        if (unsignedFiles.Length == 0)
+        var filesToSign = request.OverwriteSigned
+            ? files
+            : GetUnsignedFiles("Get-AuthenticodeSignature", files);
+        if (filesToSign.Length == 0)
             return Array.Empty<PSObject>();
 
-        foreach (var file in unsignedFiles)
+        foreach (var file in filesToSign)
             _logger.Verbose($"Signing file: {file}");
 
         return InvokeMany("Set-AuthenticodeSignature", ps =>
         {
-            ps.AddParameter("FilePath", unsignedFiles);
+            ps.AddParameter("FilePath", filesToSign);
             ps.AddParameter("Certificate", request.Certificate);
             ps.AddParameter("TimestampServer", request.TimeStampServer);
             ps.AddParameter("IncludeChain", request.WindowsIncludeChain);
             ps.AddParameter("HashAlgorithm", request.HashAlgorithm);
+            if (request.OverwriteSigned) ps.AddParameter("Force");
         });
     }
 
     private IReadOnlyList<PSObject> SignWithOpenAuthenticode(string[] files, AuthenticodeSignRequest request)
     {
-        var unsignedFiles = GetUnsignedFiles("Get-OpenAuthenticodeSignature", files);
-        if (unsignedFiles.Length == 0)
+        var filesToSign = request.OverwriteSigned
+            ? files
+            : GetUnsignedFiles("Get-OpenAuthenticodeSignature", files);
+        if (filesToSign.Length == 0)
             return Array.Empty<PSObject>();
 
-        foreach (var file in unsignedFiles)
+        foreach (var file in filesToSign)
             _logger.Verbose($"Signing file: {file}");
 
         return InvokeMany("Set-OpenAuthenticodeSignature", ps =>
         {
-            ps.AddParameter("FilePath", unsignedFiles);
+            ps.AddParameter("FilePath", filesToSign);
             ps.AddParameter("Certificate", request.Certificate);
             ps.AddParameter("TimeStampServer", request.TimeStampServer);
             ps.AddParameter("IncludeChain", request.NonWindowsIncludeChain);
             ps.AddParameter("HashAlgorithm", request.HashAlgorithm);
+            if (request.OverwriteSigned) ps.AddParameter("Force");
         });
     }
 

--- a/PowerForge.PowerShell/Services/DotNetAssemblySigningCallbackFactory.cs
+++ b/PowerForge.PowerShell/Services/DotNetAssemblySigningCallbackFactory.cs
@@ -61,7 +61,8 @@ public static class DotNetAssemblySigningCallbackFactory
                 TimeStampServer = req.TimeStampServer,
                 HashAlgorithm = "SHA256",
                 WindowsIncludeChain = "All",
-                NonWindowsIncludeChain = "WholeChain"
+                NonWindowsIncludeChain = "WholeChain",
+                OverwriteSigned = req.OverwriteSigned
             });
         };
     }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.FormattingSigningDelivery.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.FormattingSigningDelivery.cs
@@ -106,7 +106,10 @@ public sealed partial class ModulePipelineRunner
     private ModuleSigningResult SignBuiltModuleOutput(
         string moduleName,
         string rootPath,
-        SigningOptionsConfiguration? signing)
+        SigningOptionsConfiguration? signing,
+        InformationConfiguration? information,
+        DeliveryOptionsConfiguration? delivery,
+        bool includeScriptFolders)
     {
         if (string.IsNullOrWhiteSpace(rootPath))
             throw new ArgumentException("Root path is required.", nameof(rootPath));
@@ -136,9 +139,14 @@ public sealed partial class ModulePipelineRunner
                 "Configure CertificateThumbprint, CertificatePFXPath, or CertificatePFXBase64 before enabling delivery/module signing.");
         }
 
+        var packageFilePaths = ArtefactBuilder.ResolveModulePackageSourceFiles(
+            rootPath,
+            information,
+            delivery,
+            includeScriptFolders);
         var include = BuildSigningIncludePatterns(signing);
-        var exclude = BuildSigningExcludeSubstrings(signing);
-        return _hostedOperations.SignModuleOutput(moduleName, rootPath, include, exclude, signing);
+        var exclude = BuildSigningExcludeSubstrings(signing, delivery);
+        return _hostedOperations.SignModuleOutput(moduleName, rootPath, packageFilePaths, include, exclude, signing);
     }
 
     internal static string[] BuildSigningIncludePatterns(SigningOptionsConfiguration signing)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Phases.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Phases.cs
@@ -292,7 +292,10 @@ public sealed partial class ModulePipelineRunner
                 state.SigningResult = SignBuiltModuleOutput(
                     moduleName: plan.ModuleName,
                     rootPath: buildResult.StagingPath,
-                    signing: plan.Signing);
+                    signing: plan.Signing,
+                    information: plan.Information,
+                    delivery: plan.Delivery,
+                    includeScriptFolders: !state.PackageWithoutScriptFolders);
                 session.Done(session.SignStep);
             }
             catch (Exception ex)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseFingerprint.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseFingerprint.cs
@@ -433,6 +433,8 @@ public sealed partial class ModulePipelineRunner
             configuration.SignAssemblies?.ToString(),
             configuration.SignDependencyAssemblies?.ToString(),
             configuration.SignPackages?.ToString(),
+            configuration.OverwriteSignedAssemblies?.ToString(),
+            configuration.OverwriteSignedPackages?.ToString(),
             configuration.GitHubUsername,
             configuration.GitHubRepositoryName,
             configuration.GitHubIsPreRelease.ToString(),

--- a/PowerForge.PowerShell/Services/PowerShellModulePipelineHostedOperations.cs
+++ b/PowerForge.PowerShell/Services/PowerShellModulePipelineHostedOperations.cs
@@ -240,13 +240,16 @@ internal sealed class PowerShellModulePipelineHostedOperations :
     public ModuleSigningResult SignModuleOutput(
         string moduleName,
         string rootPath,
+        string[] packageFilePaths,
         string[] includePatterns,
         string[] excludeSubstrings,
         SigningOptionsConfiguration signing)
     {
-        var args = new List<string>(8)
+        var packageFileListPath = WriteTemporaryLineFile(packageFilePaths);
+        var args = new List<string>(9)
         {
             rootPath,
+            packageFileListPath,
             EncodeLines(includePatterns),
             EncodeLines(excludeSubstrings),
             signing.CertificateThumbprint ?? string.Empty,
@@ -257,7 +260,15 @@ internal sealed class PowerShellModulePipelineHostedOperations :
         };
 
         var script = EmbeddedScripts.Load("Scripts/Signing/Sign-Module.ps1");
-        var result = RunScript(script, args, TimeSpan.FromMinutes(10), preferPwsh: true);
+        PowerShellRunResult result;
+        try
+        {
+            result = RunScript(script, args, TimeSpan.FromMinutes(10), preferPwsh: true);
+        }
+        finally
+        {
+            try { File.Delete(packageFileListPath); } catch { /* best effort */ }
+        }
         var summary = TryExtractSigningSummary(result.StdOut);
 
         if (result.ExitCode != 0 || (summary?.Failed ?? 0) > 0)
@@ -292,6 +303,20 @@ internal sealed class PowerShellModulePipelineHostedOperations :
         }
 
         return summary;
+    }
+
+    private static string WriteTemporaryLineFile(IEnumerable<string> lines)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "PowerForge", "modulepipeline");
+        Directory.CreateDirectory(tempDir);
+        var path = Path.Combine(tempDir, $"modulepackage_{Guid.NewGuid():N}.txt");
+        File.WriteAllLines(
+            path,
+            (lines ?? Array.Empty<string>())
+                .Where(static line => !string.IsNullOrWhiteSpace(line))
+                .Distinct(StringComparer.OrdinalIgnoreCase),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        return path;
     }
 
     private static string EncodeImportModules(IEnumerable<ImportModuleEntry> modules)

--- a/PowerForge.Tests/DotNetNuGetClientTests.cs
+++ b/PowerForge.Tests/DotNetNuGetClientTests.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using PowerForge;
 
 namespace PowerForge.Tests;
@@ -302,8 +303,7 @@ public sealed class DotNetNuGetClientTests
                 "--certificate-store-name",
                 "My",
                 "--timestamper",
-                "http://timestamp.digicert.com",
-                "--overwrite"
+                "http://timestamp.digicert.com"
             ],
             captured!.Arguments);
         Assert.True(result.Succeeded);
@@ -327,7 +327,8 @@ public sealed class DotNetNuGetClientTests
             },
             certificateFingerprint: "ABC123",
             certificateStoreLocation: "CurrentUser",
-            timeStampServer: "http://timestamp.digicert.com"));
+            timeStampServer: "http://timestamp.digicert.com",
+            overwrite: true));
 
         Assert.NotNull(captured);
         Assert.Equal(
@@ -348,6 +349,42 @@ public sealed class DotNetNuGetClientTests
             ],
             captured!.Arguments);
         Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task SignPackageAsync_DefaultPreservesAlreadySignedPackage()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var packagePath = Path.Combine(root.FullName, "Test.1.0.0.nupkg");
+            using (var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create))
+            {
+                archive.CreateEntry("Test.nuspec");
+                archive.CreateEntry(".signature.p7s");
+            }
+
+            var calls = 0;
+            var client = new DotNetNuGetClient(new StubProcessRunner(request =>
+            {
+                calls++;
+                return new ProcessRunResult(0, string.Empty, string.Empty, request.FileName, TimeSpan.Zero, timedOut: false);
+            }));
+
+            var result = await client.SignPackageAsync(new DotNetNuGetSignRequest(
+                packagePath,
+                certificateFingerprint: "ABC123",
+                certificateStoreLocation: "CurrentUser",
+                timeStampServer: "http://timestamp.digicert.com"));
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(0, calls);
+            Assert.Contains("Preserved 1 already signed", result.StdOut, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
     }
 
     private sealed class StubProcessRunner : IProcessRunner

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerBundleTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerBundleTests.cs
@@ -161,6 +161,7 @@ public sealed class DotNetPublishPipelineRunnerBundleTests
                 {
                     Enabled = true,
                     IncludeDlls = true,
+                    OverwriteSigned = true,
                     Thumbprint = "ABC123",
                     TimestampUrl = "http://timestamp.example"
                 }
@@ -177,7 +178,8 @@ public sealed class DotNetPublishPipelineRunnerBundleTests
                         SignPatterns = new[] { " **/*.ps1 ", "**/*.dll" },
                         SignOverrides = new DotNetPublishSignPatch
                         {
-                            Description = "TierBridge Package"
+                            Description = "TierBridge Package",
+                            OverwriteSigned = false
                         }
                     }
                 }
@@ -191,6 +193,7 @@ public sealed class DotNetPublishPipelineRunnerBundleTests
             Assert.NotNull(postProcess.Sign);
             Assert.True(postProcess.Sign!.Enabled);
             Assert.True(postProcess.Sign.IncludeDlls);
+            Assert.False(postProcess.Sign.OverwriteSigned);
             Assert.Equal("ABC123", postProcess.Sign.Thumbprint);
             Assert.Equal("http://timestamp.example", postProcess.Sign.TimestampUrl);
             Assert.Equal("TierBridge Package", postProcess.Sign.Description);

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.Signing.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.Signing.cs
@@ -1,0 +1,198 @@
+using System.Reflection;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class DotNetPublishPipelineRunnerHardeningTests
+{
+    [Theory]
+    [InlineData(unchecked((int)0x800B0100), true)]
+    [InlineData(unchecked((int)0x800B0001), true)]
+    [InlineData(unchecked((int)0x800B0003), true)]
+    [InlineData(unchecked((int)0x800B0109), false)]
+    [InlineData(unchecked((int)0x80096010), false)]
+    [InlineData(0, false)]
+    public void AuthenticodeSignaturePresence_DistinguishesMissingFromInvalidSignatures(int status, bool expectedNoSignature)
+        => Assert.Equal(expectedNoSignature, WindowsAuthenticodeSignatureInspector.IsNoSignatureStatus(status));
+
+    [Fact]
+    public void TrySignOutput_WhenMissingToolAndPolicyFail_Throws()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var outputDir = Directory.CreateDirectory(Path.Combine(root, "out")).FullName;
+            File.WriteAllText(Path.Combine(outputDir, "app.exe"), "dummy");
+            var sign = new DotNetPublishSignOptions
+            {
+                Enabled = true,
+                ToolPath = "definitely-not-a-real-signtool.exe",
+                OnMissingTool = DotNetPublishPolicyMode.Fail,
+                OnSignFailure = DotNetPublishPolicyMode.Fail
+            };
+
+            var ex = Assert.Throws<TargetInvocationException>(() =>
+                GetTrySignOutputMethod().Invoke(
+                    new DotNetPublishPipelineRunner(new NullLogger()),
+                    new object[] { outputDir, sign }));
+            Assert.IsType<InvalidOperationException>(ex.InnerException);
+            Assert.True(
+                ex.InnerException!.Message.Contains("Signing requested", StringComparison.OrdinalIgnoreCase)
+                || ex.InnerException.Message.Contains("Signing failed", StringComparison.OrdinalIgnoreCase),
+                $"Unexpected message: {ex.InnerException.Message}");
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Theory]
+    [InlineData(false, 1)]
+    [InlineData(true, 2)]
+    public void TrySignOutput_SelectsExpectedPublishFiles(bool includeDlls, int expectedTargets)
+    {
+        if (!DotNetPublishPipelineRunner.IsWindows())
+            return;
+
+        var root = CreateTempRoot();
+        try
+        {
+            var outputDir = Directory.CreateDirectory(Path.Combine(root, "out")).FullName;
+            File.WriteAllText(Path.Combine(outputDir, "app.exe"), "dummy");
+            File.WriteAllText(Path.Combine(outputDir, "lib.dll"), "dummy");
+            var logger = new CollectingLogger();
+            var sign = new DotNetPublishSignOptions
+            {
+                Enabled = true,
+                IncludeDlls = includeDlls,
+                ToolPath = Path.Combine(Environment.SystemDirectory, "cmd.exe"),
+                OnMissingTool = DotNetPublishPolicyMode.Fail,
+                OnSignFailure = DotNetPublishPolicyMode.Skip
+            };
+
+            _ = GetTrySignOutputMethod().Invoke(
+                new DotNetPublishPipelineRunner(logger),
+                new object[] { outputDir, sign });
+
+            Assert.Contains(
+                logger.InfoMessages,
+                message => message.Contains($"Signing {expectedTargets} file(s)", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void TrySignOutput_DefaultPreservesExistingValidSignature()
+    {
+        if (!DotNetPublishPipelineRunner.IsWindows())
+            return;
+
+        var root = CreateTempRoot();
+        try
+        {
+            var outputDir = Directory.CreateDirectory(Path.Combine(root, "out")).FullName;
+            var executable = Path.Combine(outputDir, "app.exe");
+            File.WriteAllText(executable, "dummy");
+            var requests = new List<ProcessRunRequest>();
+            var processRunner = new StubProcessRunner(request =>
+            {
+                requests.Add(request);
+                return new ProcessRunResult(0, string.Empty, string.Empty, request.FileName, TimeSpan.Zero, timedOut: false);
+            });
+            var sign = new DotNetPublishSignOptions
+            {
+                Enabled = true,
+                ToolPath = Path.Combine(Environment.SystemDirectory, "cmd.exe"),
+                OnMissingTool = DotNetPublishPolicyMode.Fail,
+                OnSignFailure = DotNetPublishPolicyMode.Fail
+            };
+
+            var signedCount = Assert.IsType<int>(GetTrySignOutputMethod().Invoke(
+                new DotNetPublishPipelineRunner(new NullLogger(), processRunner, _ => true),
+                new object[] { outputDir, sign }));
+
+            Assert.Equal(1, signedCount);
+            Assert.Empty(requests);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void TrySignOutput_OverwriteOptInSkipsExistingSignatureCheck()
+    {
+        if (!DotNetPublishPipelineRunner.IsWindows())
+            return;
+
+        var root = CreateTempRoot();
+        try
+        {
+            var outputDir = Directory.CreateDirectory(Path.Combine(root, "out")).FullName;
+            File.WriteAllText(Path.Combine(outputDir, "app.exe"), "dummy");
+            var requests = new List<ProcessRunRequest>();
+            var processRunner = new StubProcessRunner(request =>
+            {
+                requests.Add(request);
+                return new ProcessRunResult(0, string.Empty, string.Empty, request.FileName, TimeSpan.Zero, timedOut: false);
+            });
+            var sign = new DotNetPublishSignOptions
+            {
+                Enabled = true,
+                OverwriteSigned = true,
+                ToolPath = Path.Combine(Environment.SystemDirectory, "cmd.exe"),
+                OnMissingTool = DotNetPublishPolicyMode.Fail,
+                OnSignFailure = DotNetPublishPolicyMode.Fail
+            };
+
+            var signedCount = Assert.IsType<int>(GetTrySignOutputMethod().Invoke(
+                new DotNetPublishPipelineRunner(new NullLogger(), processRunner, _ => true),
+                new object[] { outputDir, sign }));
+
+            Assert.Equal(1, signedCount);
+            Assert.Equal("sign", Assert.Single(requests).Arguments[0]);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void TrySignOutput_WhenDllOnlyAndIncludeDllsDisabled_HonorsFailurePolicy()
+    {
+        if (!DotNetPublishPipelineRunner.IsWindows())
+            return;
+
+        var root = CreateTempRoot();
+        try
+        {
+            var outputDir = Directory.CreateDirectory(Path.Combine(root, "out")).FullName;
+            File.WriteAllText(Path.Combine(outputDir, "lib.dll"), "dummy");
+            var sign = new DotNetPublishSignOptions
+            {
+                Enabled = true,
+                ToolPath = Path.Combine(Environment.SystemDirectory, "cmd.exe"),
+                OnMissingTool = DotNetPublishPolicyMode.Fail,
+                OnSignFailure = DotNetPublishPolicyMode.Fail
+            };
+
+            var ex = Assert.Throws<TargetInvocationException>(() =>
+                GetTrySignOutputMethod().Invoke(
+                    new DotNetPublishPipelineRunner(new NullLogger()),
+                    new object[] { outputDir, sign }));
+            Assert.IsType<InvalidOperationException>(ex.InnerException);
+            Assert.Contains("no matching files were found", ex.InnerException!.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("IncludeDlls=true", ex.InnerException.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+}

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace PowerForge.Tests;
 
-public sealed class DotNetPublishPipelineRunnerHardeningTests
+public sealed partial class DotNetPublishPipelineRunnerHardeningTests
 {
     [Fact]
     public void BuildMsBuildPropertyArgs_EscapesListAndAssignmentSeparators()
@@ -353,142 +353,6 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
             var json = File.ReadAllText(manifestJson);
             Assert.DoesNotContain("\"Kind\": 2", json, StringComparison.Ordinal);
             Assert.DoesNotContain("\"Style\": 1", json, StringComparison.Ordinal);
-        }
-        finally
-        {
-            TryDelete(root);
-        }
-    }
-
-    [Fact]
-    public void TrySignOutput_WhenMissingToolAndPolicyFail_Throws()
-    {
-        var root = CreateTempRoot();
-        try
-        {
-            var outputDir = Directory.CreateDirectory(Path.Combine(root, "out")).FullName;
-            File.WriteAllText(Path.Combine(outputDir, "app.exe"), "dummy");
-
-            var sign = new DotNetPublishSignOptions
-            {
-                Enabled = true,
-                ToolPath = "definitely-not-a-real-signtool.exe",
-                OnMissingTool = DotNetPublishPolicyMode.Fail,
-                OnSignFailure = DotNetPublishPolicyMode.Fail
-            };
-
-            var runner = new DotNetPublishPipelineRunner(new NullLogger());
-            var method = GetTrySignOutputMethod();
-
-            var ex = Assert.Throws<TargetInvocationException>(() => method!.Invoke(runner, new object[] { outputDir, sign }));
-            Assert.IsType<InvalidOperationException>(ex.InnerException);
-            Assert.True(
-                ex.InnerException!.Message.Contains("Signing requested", StringComparison.OrdinalIgnoreCase)
-                || ex.InnerException!.Message.Contains("Signing failed", StringComparison.OrdinalIgnoreCase),
-                $"Unexpected message: {ex.InnerException!.Message}");
-        }
-        finally
-        {
-            TryDelete(root);
-        }
-    }
-
-    [Fact]
-    public void TrySignOutput_DefaultsToExecutablesOnly()
-    {
-        if (!DotNetPublishPipelineRunner.IsWindows())
-            return;
-
-        var root = CreateTempRoot();
-        try
-        {
-            var outputDir = Directory.CreateDirectory(Path.Combine(root, "out")).FullName;
-            File.WriteAllText(Path.Combine(outputDir, "app.exe"), "dummy");
-            File.WriteAllText(Path.Combine(outputDir, "lib.dll"), "dummy");
-
-            var logger = new CollectingLogger();
-            var sign = new DotNetPublishSignOptions
-            {
-                Enabled = true,
-                ToolPath = Path.Combine(Environment.SystemDirectory, "cmd.exe"),
-                OnMissingTool = DotNetPublishPolicyMode.Fail,
-                OnSignFailure = DotNetPublishPolicyMode.Skip
-            };
-
-            var runner = new DotNetPublishPipelineRunner(logger);
-            var method = GetTrySignOutputMethod();
-
-            _ = method!.Invoke(runner, new object[] { outputDir, sign });
-            Assert.Contains(logger.InfoMessages, message => message.Contains("Signing 1 file(s)", StringComparison.OrdinalIgnoreCase));
-        }
-        finally
-        {
-            TryDelete(root);
-        }
-    }
-
-    [Fact]
-    public void TrySignOutput_IncludeDllsSignsExecutablesAndLibraries()
-    {
-        if (!DotNetPublishPipelineRunner.IsWindows())
-            return;
-
-        var root = CreateTempRoot();
-        try
-        {
-            var outputDir = Directory.CreateDirectory(Path.Combine(root, "out")).FullName;
-            File.WriteAllText(Path.Combine(outputDir, "app.exe"), "dummy");
-            File.WriteAllText(Path.Combine(outputDir, "lib.dll"), "dummy");
-
-            var logger = new CollectingLogger();
-            var sign = new DotNetPublishSignOptions
-            {
-                Enabled = true,
-                IncludeDlls = true,
-                ToolPath = Path.Combine(Environment.SystemDirectory, "cmd.exe"),
-                OnMissingTool = DotNetPublishPolicyMode.Fail,
-                OnSignFailure = DotNetPublishPolicyMode.Skip
-            };
-
-            var runner = new DotNetPublishPipelineRunner(logger);
-            var method = GetTrySignOutputMethod();
-
-            _ = method!.Invoke(runner, new object[] { outputDir, sign });
-            Assert.Contains(logger.InfoMessages, message => message.Contains("Signing 2 file(s)", StringComparison.OrdinalIgnoreCase));
-        }
-        finally
-        {
-            TryDelete(root);
-        }
-    }
-
-    [Fact]
-    public void TrySignOutput_WhenDllOnlyAndIncludeDllsDisabled_HonorsFailurePolicy()
-    {
-        if (!DotNetPublishPipelineRunner.IsWindows())
-            return;
-
-        var root = CreateTempRoot();
-        try
-        {
-            var outputDir = Directory.CreateDirectory(Path.Combine(root, "out")).FullName;
-            File.WriteAllText(Path.Combine(outputDir, "lib.dll"), "dummy");
-
-            var sign = new DotNetPublishSignOptions
-            {
-                Enabled = true,
-                ToolPath = Path.Combine(Environment.SystemDirectory, "cmd.exe"),
-                OnMissingTool = DotNetPublishPolicyMode.Fail,
-                OnSignFailure = DotNetPublishPolicyMode.Fail
-            };
-
-            var runner = new DotNetPublishPipelineRunner(new NullLogger());
-            var method = GetTrySignOutputMethod();
-
-            var ex = Assert.Throws<TargetInvocationException>(() => method.Invoke(runner, new object[] { outputDir, sign }));
-            Assert.IsType<InvalidOperationException>(ex.InnerException);
-            Assert.Contains("no matching files were found", ex.InnerException!.Message, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("IncludeDlls=true", ex.InnerException.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {
@@ -1264,5 +1128,16 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
         public void Warn(string message) { }
         public void Error(string message) { }
         public void Verbose(string message) { }
+    }
+
+    private sealed class StubProcessRunner : IProcessRunner
+    {
+        private readonly Func<ProcessRunRequest, ProcessRunResult> _execute;
+
+        public StubProcessRunner(Func<ProcessRunRequest, ProcessRunResult> execute)
+            => _execute = execute;
+
+        public Task<ProcessRunResult> RunAsync(ProcessRunRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(_execute(request));
     }
 }

--- a/PowerForge.Tests/DotNetRepositoryReleasePreparationServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleasePreparationServiceTests.cs
@@ -34,6 +34,8 @@ public sealed class DotNetRepositoryReleasePreparationServiceTests
                 TimeStampServer = "http://timestamp.test",
                 SignAssemblies = false,
                 SignPackages = false,
+                OverwriteSignedAssemblies = true,
+                OverwriteSignedPackages = true,
                 IncludeSymbols = true,
                 Publish = true,
                 PublishFailFast = true,
@@ -54,6 +56,8 @@ public sealed class DotNetRepositoryReleasePreparationServiceTests
             Assert.Equal(PowerForge.CertificateStoreLocation.LocalMachine, context.Spec.CertificateStore);
             Assert.False(context.Spec.SignAssemblies);
             Assert.False(context.Spec.SignPackages);
+            Assert.True(context.Spec.OverwriteSignedAssemblies);
+            Assert.True(context.Spec.OverwriteSignedPackages);
             Assert.True(context.Spec.IncludeSymbols);
             Assert.Equal("Debug", context.Spec.Configuration);
             Assert.True(context.Spec.Publish);

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -635,6 +635,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
                 CreateReleaseZip = false,
                 CertificateThumbprint = "ABC123",
                 SignAssemblies = true,
+                OverwriteSignedAssemblies = true,
                 SignPackages = false
             };
 
@@ -643,6 +644,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
                 request =>
                 {
                     Assert.Equal("ABC123", request.CertificateThumbprint);
+                    Assert.True(request.OverwriteSigned);
                     var filePaths = Assert.IsType<string[]>(request.FilePaths);
                     signedAssemblies += filePaths.Count(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase));
                     Assert.Contains(filePaths, path => path.EndsWith(Path.Combine("Shared", "bin", "Release", "net8.0", "Shared.dll"), StringComparison.OrdinalIgnoreCase));
@@ -711,6 +713,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
                     signingCalls++;
                     Assert.Equal(CertificateStoreLocation.CurrentUser, request.LocalStore);
                     Assert.Equal("ABC123", request.CertificateThumbprint);
+                    Assert.False(request.OverwriteSigned);
                     Assert.Contains("Sample.Package.dll", request.IncludePatterns);
                     Assert.Contains("Sample.Package.exe", request.IncludePatterns);
                     Assert.DoesNotContain("*.dll", request.IncludePatterns);

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -2049,6 +2049,7 @@ public sealed class ModulePipelineHostedOperationsTests
     public void SignModuleOutput_UsesInjectedPowerShellRunner()
     {
         var requests = new List<PowerShellRunRequest>();
+        string[] packageFiles = Array.Empty<string>();
         var summary = new ModuleSigningResult
         {
             TotalMatched = 1,
@@ -2062,6 +2063,7 @@ public sealed class ModulePipelineHostedOperationsTests
         var runner = new RecordingPowerShellRunner(request =>
         {
             requests.Add(request);
+            packageFiles = File.ReadAllLines(request.Arguments[1]);
             return new PowerShellRunResult(0, stdout, string.Empty, "pwsh");
         });
 
@@ -2069,6 +2071,7 @@ public sealed class ModulePipelineHostedOperationsTests
         var result = operations.SignModuleOutput(
             moduleName: "TestModule",
             rootPath: @"C:\Temp\TestModule",
+            packageFilePaths: new[] { @"C:\Temp\TestModule\TestModule.psm1" },
             includePatterns: new[] { "*.psm1" },
             excludeSubstrings: Array.Empty<string>(),
             signing: new SigningOptionsConfiguration());
@@ -2076,6 +2079,7 @@ public sealed class ModulePipelineHostedOperationsTests
         var request = Assert.Single(requests);
         Assert.Equal(PowerShellInvocationMode.File, request.InvocationMode);
         Assert.True(request.PreferPwsh);
+        Assert.Equal(new[] { @"C:\Temp\TestModule\TestModule.psm1" }, packageFiles);
         Assert.Equal(1, result.SignedNew);
     }
 
@@ -2096,6 +2100,33 @@ public sealed class ModulePipelineHostedOperationsTests
 
         Assert.Contains("[AllowEmptyCollection()]", script, StringComparison.Ordinal);
         Assert.Contains("Add-FailedFile -List $failedFiles", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SigningScript_ExclusionsMatchPackageRelativePathSegments()
+    {
+        var script = EmbeddedScripts.Load("Scripts/Signing/Sign-Module.ps1");
+        var ast = System.Management.Automation.Language.Parser.ParseInput(script, out _, out var parseErrors);
+        Assert.Empty(parseErrors);
+        var function = ast.Find(
+            node => node is System.Management.Automation.Language.FunctionDefinitionAst definition &&
+                    definition.Name.Equals("Test-ExcludedPackagePath", StringComparison.Ordinal),
+            searchNestedScriptBlocks: true);
+        Assert.NotNull(function);
+
+        using var powerShell = System.Management.Automation.PowerShell.Create();
+        powerShell.AddScript(function!.Extent.Text + "\n" + """
+            Test-ExcludedPackagePath -relativePath 'PowerInfoblox.psm1' -exclusions @('Modules')
+            Test-ExcludedPackagePath -relativePath 'InternalModules/tool.exe' -exclusions @('Modules')
+            Test-ExcludedPackagePath -relativePath 'Modules/dependency.dll' -exclusions @('Modules')
+            Test-ExcludedPackagePath -relativePath 'InternalModules/tool.exe' -exclusions @('Internal')
+            Test-ExcludedPackagePath -relativePath 'Assets/tool.exe' -exclusions @('Assets')
+            """);
+
+        var results = powerShell.Invoke().Select(result => Assert.IsType<bool>(result.BaseObject)).ToArray();
+
+        Assert.Empty(powerShell.Streams.Error);
+        Assert.Equal(new[] { false, false, true, false, true }, results);
     }
 
     [Fact]
@@ -2755,6 +2786,7 @@ public sealed class ModulePipelineHostedOperationsTests
         public ModuleSigningResult SignModuleOutput(
             string moduleName,
             string rootPath,
+            string[] packageFilePaths,
             string[] includePatterns,
             string[] excludeSubstrings,
             SigningOptionsConfiguration signing)

--- a/PowerForge.Tests/ModulePipelineManifestRefreshTests.cs
+++ b/PowerForge.Tests/ModulePipelineManifestRefreshTests.cs
@@ -637,6 +637,7 @@ public sealed class ModulePipelineManifestRefreshTests
         public ModuleSigningResult SignModuleOutput(
             string moduleName,
             string rootPath,
+            string[] packageFilePaths,
             string[] includePatterns,
             string[] excludeSubstrings,
             SigningOptionsConfiguration signing)

--- a/PowerForge.Tests/ModulePipelineMissingAnalysisServiceTests.cs
+++ b/PowerForge.Tests/ModulePipelineMissingAnalysisServiceTests.cs
@@ -256,6 +256,7 @@ public sealed class ModulePipelineMissingAnalysisServiceTests
         public ModuleSigningResult SignModuleOutput(
             string moduleName,
             string rootPath,
+            string[] packageFilePaths,
             string[] includePatterns,
             string[] excludeSubstrings,
             SigningOptionsConfiguration signing)

--- a/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.Signing.cs
+++ b/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.Signing.cs
@@ -1,0 +1,208 @@
+using System.Reflection;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class ModulePipelineScriptExecutionSeamTests
+{
+    [Fact]
+    public void SignBuiltModuleOutput_UsesInjectedHostedOperations()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var hostedOperations = new FakeHostedOperations
+        {
+            NextSigningResult = new ModuleSigningResult { SignedNew = 2, Attempted = 2 }
+        };
+
+        try
+        {
+            WriteSigningFixture(root.FullName, "TestModule");
+            var runner = CreateRunner(hostedOperations);
+
+            var result = InvokeSignBuiltModuleOutput(
+                runner,
+                "TestModule",
+                root.FullName,
+                new SigningOptionsConfiguration
+                {
+                    CertificateThumbprint = "ABC123",
+                    IncludeInternals = false
+                },
+                includeScriptFolders: false);
+
+            Assert.Same(hostedOperations.NextSigningResult, result);
+            Assert.Equal(1, hostedOperations.SignCalls);
+            Assert.Contains("*.ps1", hostedOperations.LastIncludePatterns, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("Modules", hostedOperations.LastExcludePatterns, StringComparer.OrdinalIgnoreCase);
+            AssertPackageFiles(
+                root.FullName,
+                hostedOperations.LastPackageFilePaths,
+                "TestModule.psd1",
+                "TestModule.psm1",
+                Path.Combine("Lib", "Default", "Binary.dll"));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void SignBuiltModuleOutput_IncludesPackagedScriptFoldersForUnmergedModule()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteSigningFixture(root.FullName, moduleName);
+            var hostedOperations = new FakeHostedOperations();
+
+            _ = InvokeSignBuiltModuleOutput(
+                CreateRunner(hostedOperations),
+                moduleName,
+                root.FullName,
+                new SigningOptionsConfiguration { CertificateThumbprint = "ABC123" },
+                includeScriptFolders: true);
+
+            AssertPackageFiles(
+                root.FullName,
+                hostedOperations.LastPackageFilePaths,
+                "TestModule.psd1",
+                "TestModule.psm1",
+                Path.Combine("Lib", "Default", "Binary.dll"),
+                Path.Combine("Public", "Get-Test.ps1"));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void SignBuiltModuleOutput_CustomInternalsRemainPackagedButHonorSigningOptOut()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteSigningFixture(root.FullName, moduleName);
+            WriteInternalTool(root.FullName);
+            var hostedOperations = new FakeHostedOperations();
+
+            _ = InvokeSignBuiltModuleOutput(
+                CreateRunner(hostedOperations),
+                moduleName,
+                root.FullName,
+                new SigningOptionsConfiguration
+                {
+                    CertificateThumbprint = "ABC123",
+                    IncludeExe = true,
+                    IncludeInternals = false
+                },
+                includeScriptFolders: false,
+                delivery: CreateDelivery());
+
+            AssertPackageFiles(
+                root.FullName,
+                hostedOperations.LastPackageFilePaths,
+                "TestModule.psd1",
+                "TestModule.psm1",
+                Path.Combine("Lib", "Default", "Binary.dll"),
+                Path.Combine("Payload", "Tools", "helper.exe"));
+            Assert.Contains("Payload", hostedOperations.LastExcludePatterns, StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void SignBuiltModuleOutput_CustomInternalsSigningOptInRemovesDeliveryExclusion()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteSigningFixture(root.FullName, moduleName);
+            WriteInternalTool(root.FullName);
+            var hostedOperations = new FakeHostedOperations();
+
+            _ = InvokeSignBuiltModuleOutput(
+                CreateRunner(hostedOperations),
+                moduleName,
+                root.FullName,
+                new SigningOptionsConfiguration
+                {
+                    CertificateThumbprint = "ABC123",
+                    IncludeExe = true,
+                    IncludeInternals = true
+                },
+                includeScriptFolders: false,
+                delivery: CreateDelivery());
+
+            Assert.DoesNotContain("Payload", hostedOperations.LastExcludePatterns, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains(
+                hostedOperations.LastPackageFilePaths,
+                path => path.EndsWith(Path.Combine("Payload", "Tools", "helper.exe"), StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    private static ModulePipelineRunner CreateRunner(FakeHostedOperations hostedOperations)
+        => new(
+            new NullLogger(),
+            new ThrowingPowerShellRunner(),
+            new FakeMetadataProvider(),
+            hostedOperations);
+
+    private static DeliveryOptionsConfiguration CreateDelivery()
+        => new() { Enable = true, InternalsPath = "Payload" };
+
+    private static void WriteInternalTool(string rootPath)
+    {
+        Directory.CreateDirectory(Path.Combine(rootPath, "Payload", "Tools"));
+        File.WriteAllText(Path.Combine(rootPath, "Payload", "Tools", "helper.exe"), "binary");
+    }
+
+    private static ModuleSigningResult InvokeSignBuiltModuleOutput(
+        ModulePipelineRunner runner,
+        string moduleName,
+        string rootPath,
+        SigningOptionsConfiguration signing,
+        bool includeScriptFolders,
+        DeliveryOptionsConfiguration? delivery = null)
+    {
+        var method = typeof(ModulePipelineRunner).GetMethod("SignBuiltModuleOutput", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.True(method is not null, "SignBuiltModuleOutput method signature may have changed.");
+        return (ModuleSigningResult)method!.Invoke(
+            runner,
+            new object?[] { moduleName, rootPath, signing, null, delivery, includeScriptFolders })!;
+    }
+
+    private static void WriteSigningFixture(string rootPath, string moduleName)
+    {
+        WriteMinimalModule(rootPath, moduleName, "1.0.0");
+        Directory.CreateDirectory(Path.Combine(rootPath, "Lib", "Default"));
+        File.WriteAllText(Path.Combine(rootPath, "Lib", "Default", "Binary.dll"), "binary");
+        Directory.CreateDirectory(Path.Combine(rootPath, "Public"));
+        File.WriteAllText(Path.Combine(rootPath, "Public", "Get-Test.ps1"), "function Get-Test { }");
+        Directory.CreateDirectory(Path.Combine(rootPath, "Docs"));
+        File.WriteAllText(Path.Combine(rootPath, "Docs", "BuildOnly.ps1"), "throw 'not packaged'");
+    }
+
+    private static void AssertPackageFiles(string rootPath, string[] actualPaths, params string[] expectedRelativePaths)
+    {
+        var expected = expectedRelativePaths
+            .Select(path => Path.GetFullPath(Path.Combine(rootPath, path)))
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var actual = actualPaths
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        Assert.Equal(expected, actual);
+    }
+}

--- a/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.cs
+++ b/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace PowerForge.Tests;
 
-public sealed class ModulePipelineScriptExecutionSeamTests
+public sealed partial class ModulePipelineScriptExecutionSeamTests
 {
     [Fact]
     public void RunImportModules_UsesInjectedHostedOperations()
@@ -76,40 +76,6 @@ public sealed class ModulePipelineScriptExecutionSeamTests
         {
             try { root.Delete(recursive: true); } catch { /* best effort */ }
         }
-    }
-
-    [Fact]
-    public void SignBuiltModuleOutput_UsesInjectedHostedOperations()
-    {
-        var hostedOperations = new FakeHostedOperations
-        {
-            NextSigningResult = new ModuleSigningResult
-            {
-                SignedNew = 2,
-                Attempted = 2
-            }
-        };
-
-        var runner = new ModulePipelineRunner(
-            new NullLogger(),
-            new ThrowingPowerShellRunner(),
-            new FakeMetadataProvider(),
-            hostedOperations);
-
-        var result = InvokeSignBuiltModuleOutput(
-            runner,
-            "TestModule",
-            Path.GetTempPath(),
-            new SigningOptionsConfiguration
-            {
-                CertificateThumbprint = "ABC123",
-                IncludeInternals = false
-            });
-
-        Assert.Same(hostedOperations.NextSigningResult, result);
-        Assert.Equal(1, hostedOperations.SignCalls);
-        Assert.Contains("*.ps1", hostedOperations.LastIncludePatterns, StringComparer.OrdinalIgnoreCase);
-        Assert.Contains("Modules", hostedOperations.LastExcludePatterns, StringComparer.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -569,17 +535,6 @@ public sealed class ModulePipelineScriptExecutionSeamTests
         method!.Invoke(runner, new object?[] { plan, buildResult });
     }
 
-    private static ModuleSigningResult InvokeSignBuiltModuleOutput(
-        ModulePipelineRunner runner,
-        string moduleName,
-        string rootPath,
-        SigningOptionsConfiguration signing)
-    {
-        var method = typeof(ModulePipelineRunner).GetMethod("SignBuiltModuleOutput", BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.True(method is not null, "SignBuiltModuleOutput method signature may have changed.");
-        return (ModuleSigningResult)method!.Invoke(runner, new object?[] { moduleName, rootPath, signing })!;
-    }
-
     private sealed class FakeMetadataProvider : IModuleDependencyMetadataProvider
     {
         public IReadOnlyDictionary<string, InstalledModuleMetadata> GetLatestInstalledModules(IReadOnlyList<string> names)
@@ -610,6 +565,7 @@ public sealed class ModulePipelineScriptExecutionSeamTests
         public ImportModuleEntry[] LastImportModules { get; private set; } = Array.Empty<ImportModuleEntry>();
         public ModuleImportValidationTarget[] LastTargets { get; private set; } = Array.Empty<ModuleImportValidationTarget>();
         public int SignCalls { get; private set; }
+        public string[] LastPackageFilePaths { get; private set; } = Array.Empty<string>();
         public string[] LastIncludePatterns { get; private set; } = Array.Empty<string>();
         public string[] LastExcludePatterns { get; private set; } = Array.Empty<string>();
         public ModuleSigningResult NextSigningResult { get; set; } = new();
@@ -717,12 +673,14 @@ public sealed class ModulePipelineScriptExecutionSeamTests
         public ModuleSigningResult SignModuleOutput(
             string moduleName,
             string rootPath,
+            string[] packageFilePaths,
             string[] includePatterns,
             string[] excludeSubstrings,
             SigningOptionsConfiguration signing)
         {
             OperationOrder.Add("Sign");
             SignCalls++;
+            LastPackageFilePaths = packageFilePaths ?? Array.Empty<string>();
             LastIncludePatterns = includePatterns ?? Array.Empty<string>();
             LastExcludePatterns = excludeSubstrings ?? Array.Empty<string>();
             return NextSigningResult;

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
@@ -1496,6 +1496,7 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
         public ModuleSigningResult SignModuleOutput(
             string moduleName,
             string rootPath,
+            string[] packageFilePaths,
             string[] includePatterns,
             string[] excludeSubstrings,
             SigningOptionsConfiguration signing)

--- a/PowerForge.Tests/ModulePublisherPackagingTests.cs
+++ b/PowerForge.Tests/ModulePublisherPackagingTests.cs
@@ -103,6 +103,36 @@ public sealed class ModulePublisherPackagingTests
         }
     }
 
+    [Fact]
+    public void PrepareModulePackageForRepositoryPublish_PreservesSelectedEmptyDirectories()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        string? publishPath = null;
+
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteStagingFixture(root.FullName, moduleName);
+            Directory.CreateDirectory(Path.Combine(root.FullName, "Lib", "Empty", "Nested"));
+            Directory.CreateDirectory(Path.Combine(root.FullName, "Public", "Empty", "Nested"));
+
+            publishPath = ModulePublisher.PrepareModulePackageForRepositoryPublish(
+                stagingPath: root.FullName,
+                moduleName: moduleName,
+                information: null,
+                delivery: null,
+                includeScriptFolders: true);
+
+            Assert.True(Directory.Exists(Path.Combine(publishPath!, "Lib", "Empty", "Nested")));
+            Assert.True(Directory.Exists(Path.Combine(publishPath!, "Public", "Empty", "Nested")));
+        }
+        finally
+        {
+            ModulePublisher.CleanupTemporaryPublishPath(publishPath);
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
     private static void WriteStagingFixture(string stagingRoot, string moduleName)
     {
         Directory.CreateDirectory(stagingRoot);

--- a/PowerForge.Tests/PowerForgeProjectCmdletTests.cs
+++ b/PowerForge.Tests/PowerForgeProjectCmdletTests.cs
@@ -112,6 +112,8 @@ public sealed class PowerForgeProjectCmdletTests
             .AddParameter("ProvideLocalNuGetFeed")
             .AddParameter("Build")
             .AddParameter("IncludeSymbols")
+            .AddParameter("OverwriteSignedAssemblies")
+            .AddParameter("OverwriteSignedPackages")
             .AddParameter("PublishNuget", false)
             .AddParameter("PublishGitHub", false)
             .AddParameter("CreateReleaseZip", false)
@@ -129,6 +131,8 @@ public sealed class PowerForgeProjectCmdletTests
         Assert.True(segment.Configuration.Enabled);
         Assert.True(segment.Configuration.Build);
         Assert.True(segment.Configuration.IncludeSymbols);
+        Assert.True(segment.Configuration.OverwriteSignedAssemblies);
+        Assert.True(segment.Configuration.OverwriteSignedPackages);
         Assert.False(segment.Configuration.PublishNuget);
         Assert.False(segment.Configuration.PublishGitHub);
         Assert.False(segment.Configuration.CreateReleaseZip);
@@ -154,6 +158,8 @@ public sealed class PowerForgeProjectCmdletTests
             .AddParameter("AlignPackageVersions")
             .AddParameter("BuildBeforeModule")
             .AddParameter("IncludeSymbols")
+            .AddParameter("OverwriteSignedAssemblies")
+            .AddParameter("OverwriteSignedPackages")
             .AddParameter("PublishNuget", false)
             .AddParameter("UseGitHubPackages")
             .AddParameter("GitHubPackagesOwner", "EvotecIT")
@@ -168,6 +174,8 @@ public sealed class PowerForgeProjectCmdletTests
         Assert.True(segment.Configuration.AlignPackageVersions);
         Assert.True(segment.Configuration.BuildBeforeModule);
         Assert.True(segment.Configuration.IncludeSymbols);
+        Assert.True(segment.Configuration.OverwriteSignedAssemblies);
+        Assert.True(segment.Configuration.OverwriteSignedPackages);
         Assert.False(segment.Configuration.PublishNuget);
         Assert.True(segment.Configuration.UseGitHubPackages);
         Assert.Equal("EvotecIT", segment.Configuration.GitHubPackagesOwner);

--- a/PowerForge.Tests/PowerForgeProjectDslMapperTests.cs
+++ b/PowerForge.Tests/PowerForgeProjectDslMapperTests.cs
@@ -27,7 +27,8 @@ public sealed class PowerForgeProjectDslMapperTests
             {
                 Mode = ConfigurationProjectSigningMode.OnDemand,
                 Thumbprint = "ABC123",
-                Description = "IntelligenceX Chat"
+                Description = "IntelligenceX Chat",
+                OverwriteSigned = true
             },
             Output = new ConfigurationProjectOutput
             {
@@ -83,6 +84,7 @@ public sealed class PowerForgeProjectDslMapperTests
         Assert.NotNull(target.Publish.Sign);
         Assert.False(target.Publish.Sign!.Enabled);
         Assert.Equal("ABC123", target.Publish.Sign.Thumbprint);
+        Assert.True(target.Publish.Sign.OverwriteSigned);
 
         var bundle = spec.Tools.DotNetPublish.Bundles[0];
         Assert.Equal("ChatApp", bundle.PrepareFromTarget);
@@ -94,6 +96,7 @@ public sealed class PowerForgeProjectDslMapperTests
         Assert.Equal(bundle.Id, installer.PrepareFromBundleId);
         Assert.NotNull(installer.Sign);
         Assert.False(installer.Sign!.Enabled);
+        Assert.True(installer.Sign.OverwriteSigned);
 
         Assert.True(request.ToolsOnly);
         Assert.Equal("Release", request.Configuration);

--- a/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
@@ -128,6 +128,8 @@ public sealed class ProjectBuildPreparationServiceTests
                 Configuration = "Debug",
                 PackStrategy = "MSBuild",
                 IncludeSymbols = true,
+                OverwriteSignedAssemblies = true,
+                OverwriteSignedPackages = true,
                 PublishNuget = true,
                 PublishGitHub = true
             };
@@ -148,6 +150,8 @@ public sealed class ProjectBuildPreparationServiceTests
             Assert.Equal("Debug", context.Spec.Configuration);
             Assert.Equal(DotNetRepositoryPackStrategy.MSBuild, context.Spec.PackStrategy);
             Assert.True(context.Spec.IncludeSymbols);
+            Assert.True(context.Spec.OverwriteSignedAssemblies);
+            Assert.True(context.Spec.OverwriteSignedPackages);
         }
         finally
         {

--- a/PowerForge/Abstractions/IModulePipelineHostedOperations.cs
+++ b/PowerForge/Abstractions/IModulePipelineHostedOperations.cs
@@ -56,6 +56,7 @@ internal interface IModulePipelineHostedOperations
     ModuleSigningResult SignModuleOutput(
         string moduleName,
         string rootPath,
+        string[] packageFilePaths,
         string[] includePatterns,
         string[] excludeSubstrings,
         SigningOptionsConfiguration signing);

--- a/PowerForge/Models/AuthenticodeSignRequest.cs
+++ b/PowerForge/Models/AuthenticodeSignRequest.cs
@@ -25,4 +25,7 @@ public sealed class AuthenticodeSignRequest
 
     /// <summary>Non-Windows include-chain argument for Set-OpenAuthenticodeSignature.</summary>
     public string NonWindowsIncludeChain { get; set; } = "WholeChain";
+
+    /// <summary>Explicitly replaces existing Authenticode signatures. Defaults to false.</summary>
+    public bool OverwriteSigned { get; set; }
 }

--- a/PowerForge/Models/Configuration/ConfigurationPackageBuildSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationPackageBuildSegment.cs
@@ -65,6 +65,12 @@ public sealed class ProjectBuildConfigurationReference
     /// <summary>Whether generated NuGet packages should be signed, overriding the referenced JSON when set.</summary>
     public bool? SignPackages { get; set; }
 
+    /// <summary>Whether existing Authenticode assembly signatures may be replaced.</summary>
+    public bool? OverwriteSignedAssemblies { get; set; }
+
+    /// <summary>Whether existing NuGet package signatures may be replaced.</summary>
+    public bool? OverwriteSignedPackages { get; set; }
+
     /// <summary>Additional project-build JSON overrides for less common fields.</summary>
     public Dictionary<string, object?>? Options { get; set; }
 }
@@ -220,6 +226,12 @@ public sealed class PackageBuildConfiguration
 
     /// <summary>Whether generated NuGet packages should be signed.</summary>
     public bool? SignPackages { get; set; }
+
+    /// <summary>Whether existing Authenticode assembly signatures may be replaced.</summary>
+    public bool? OverwriteSignedAssemblies { get; set; }
+
+    /// <summary>Whether existing NuGet package signatures may be replaced.</summary>
+    public bool? OverwriteSignedPackages { get; set; }
 
     /// <summary>NuGet version lookup credential user name.</summary>
     public string? NugetCredentialUserName { get; set; }

--- a/PowerForge/Models/DotNet/DotNetNuGetSignRequest.cs
+++ b/PowerForge/Models/DotNet/DotNetNuGetSignRequest.cs
@@ -13,7 +13,7 @@ public sealed class DotNetNuGetSignRequest
     /// <param name="certificateStoreLocation">Certificate store location.</param>
     /// <param name="timeStampServer">Timestamp server URL.</param>
     /// <param name="certificateStoreName">Certificate store name. Defaults to <c>My</c>.</param>
-    /// <param name="overwrite">When true, passes <c>--overwrite</c>.</param>
+    /// <param name="overwrite">When true, explicitly replaces existing package signatures. Defaults to false.</param>
     /// <param name="workingDirectory">Optional working directory override.</param>
     /// <param name="timeout">Optional timeout override.</param>
     public DotNetNuGetSignRequest(
@@ -22,7 +22,7 @@ public sealed class DotNetNuGetSignRequest
         string certificateStoreLocation,
         string timeStampServer,
         string certificateStoreName = "My",
-        bool overwrite = true,
+        bool overwrite = false,
         string? workingDirectory = null,
         TimeSpan? timeout = null)
         : this(
@@ -45,7 +45,7 @@ public sealed class DotNetNuGetSignRequest
     /// <param name="certificateStoreLocation">Certificate store location.</param>
     /// <param name="timeStampServer">Timestamp server URL.</param>
     /// <param name="certificateStoreName">Certificate store name. Defaults to <c>My</c>.</param>
-    /// <param name="overwrite">When true, passes <c>--overwrite</c>.</param>
+    /// <param name="overwrite">When true, explicitly replaces existing package signatures. Defaults to false.</param>
     /// <param name="workingDirectory">Optional working directory override.</param>
     /// <param name="timeout">Optional timeout override.</param>
     public DotNetNuGetSignRequest(
@@ -54,7 +54,7 @@ public sealed class DotNetNuGetSignRequest
         string certificateStoreLocation,
         string timeStampServer,
         string certificateStoreName = "My",
-        bool overwrite = true,
+        bool overwrite = false,
         string? workingDirectory = null,
         TimeSpan? timeout = null)
     {

--- a/PowerForge/Models/DotNetPublish/DotNetPublishTarget.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishTarget.cs
@@ -179,6 +179,9 @@ public sealed class DotNetPublishSignOptions
     /// <summary>Opts into signing *.dll files in addition to executables.</summary>
     public bool IncludeDlls { get; set; }
 
+    /// <summary>Explicitly replaces existing signatures instead of preserving already signed files.</summary>
+    public bool OverwriteSigned { get; set; }
+
     /// <summary>Optional path to signtool.exe (defaults to "signtool.exe").</summary>
     public string? ToolPath { get; set; } = "signtool.exe";
 
@@ -227,6 +230,9 @@ public sealed class DotNetPublishSignPatch
 
     /// <summary>Optional include-DLLs override. Set <c>false</c> to explicitly disable DLL signing even if the base profile enables it.</summary>
     public bool? IncludeDlls { get; set; }
+
+    /// <summary>Optional existing-signature overwrite override.</summary>
+    public bool? OverwriteSigned { get; set; }
 
     /// <summary>Optional path to signtool.exe override.</summary>
     public string? ToolPath { get; set; }

--- a/PowerForge/Models/DotNetReleaseBuildAssemblySigningRequest.cs
+++ b/PowerForge/Models/DotNetReleaseBuildAssemblySigningRequest.cs
@@ -22,4 +22,7 @@ public sealed class DotNetReleaseBuildAssemblySigningRequest
 
     /// <summary>Explicit files to sign. When set, signing services can use these instead of enumerating <see cref="ReleasePath"/>.</summary>
     public string[]? FilePaths { get; set; }
+
+    /// <summary>Explicitly replaces existing Authenticode signatures. Defaults to false.</summary>
+    public bool OverwriteSigned { get; set; }
 }

--- a/PowerForge/Models/DotNetReleaseBuildSpec.cs
+++ b/PowerForge/Models/DotNetReleaseBuildSpec.cs
@@ -20,6 +20,12 @@ public sealed class DotNetReleaseBuildSpec
     /// <summary>Timestamp server URL used while signing.</summary>
     public string TimeStampServer { get; set; } = "http://timestamp.digicert.com";
 
+    /// <summary>Explicitly replaces existing Authenticode assembly signatures. Defaults to false.</summary>
+    public bool OverwriteSignedAssemblies { get; set; }
+
+    /// <summary>Explicitly replaces existing NuGet package signatures. Defaults to false.</summary>
+    public bool OverwriteSignedPackages { get; set; }
+
     /// <summary>When enabled, also packs all project dependencies that have their own .csproj files.</summary>
     public bool PackDependencies { get; set; }
 
@@ -29,4 +35,3 @@ public sealed class DotNetReleaseBuildSpec
     /// <summary>Patterns used to select which assemblies should be signed.</summary>
     public string[] AssemblyIncludePatterns { get; set; } = { "*.dll" };
 }
-

--- a/PowerForge/Models/DotNetRepositoryReleasePreparationRequest.cs
+++ b/PowerForge/Models/DotNetRepositoryReleasePreparationRequest.cs
@@ -28,6 +28,8 @@ internal sealed class DotNetRepositoryReleasePreparationRequest
     public bool? SignAssemblies { get; set; }
     public bool? SignDependencyAssemblies { get; set; }
     public bool? SignPackages { get; set; }
+    public bool OverwriteSignedAssemblies { get; set; }
+    public bool OverwriteSignedPackages { get; set; }
     public bool SkipPack { get; set; }
     public bool IncludeSymbols { get; set; }
     public bool Publish { get; set; }

--- a/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
@@ -108,8 +108,14 @@ public sealed class DotNetRepositoryReleaseSpec
     /// <summary>When true, assembly signing also signs copied dependency assemblies from build outputs.</summary>
     public bool SignDependencyAssemblies { get; set; }
 
+    /// <summary>Explicitly replaces existing Authenticode assembly signatures. Defaults to false.</summary>
+    public bool OverwriteSignedAssemblies { get; set; }
+
     /// <summary>When true and a certificate is configured, signs generated NuGet packages.</summary>
     public bool SignPackages { get; set; } = true;
+
+    /// <summary>Explicitly replaces existing NuGet package signatures. Defaults to false.</summary>
+    public bool OverwriteSignedPackages { get; set; }
 
     /// <summary>When true, publishes packages with dotnet nuget push.</summary>
     public bool Publish { get; set; }

--- a/PowerForge/Models/PowerForgeProjectDsl.cs
+++ b/PowerForge/Models/PowerForgeProjectDsl.cs
@@ -172,6 +172,11 @@ public sealed class ConfigurationProjectSigning
     /// Optional key container name.
     /// </summary>
     public string? KeyContainer { get; set; }
+
+    /// <summary>
+    /// Explicitly replaces existing signatures instead of preserving already signed files.
+    /// </summary>
+    public bool OverwriteSigned { get; set; }
 }
 
 /// <summary>

--- a/PowerForge/Models/ProjectBuildConfiguration.cs
+++ b/PowerForge/Models/ProjectBuildConfiguration.cs
@@ -47,6 +47,8 @@ internal sealed class ProjectBuildConfiguration
     public bool? SignAssemblies { get; set; }
     public bool? SignDependencyAssemblies { get; set; }
     public bool? SignPackages { get; set; }
+    public bool? OverwriteSignedAssemblies { get; set; }
+    public bool? OverwriteSignedPackages { get; set; }
     public string? NugetCredentialUserName { get; set; }
     public string? NugetCredentialSecret { get; set; }
     public string? NugetCredentialSecretFilePath { get; set; }

--- a/PowerForge/Scripts/Signing/Sign-Module.ps1
+++ b/PowerForge/Scripts/Signing/Sign-Module.ps1
@@ -1,5 +1,6 @@
 ﻿param(
   [string]$RootPath,
+  [string]$PackageFileListPath,
   [string]$IncludeB64,
   [string]$ExcludeB64,
   [string]$Thumbprint,
@@ -16,6 +17,37 @@ function DecodeLines([string]$b64) {
   if ([string]::IsNullOrWhiteSpace($b64)) { return @() }
   $text = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($b64))
   return $text -split "`n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | ForEach-Object { $_.Trim() }
+}
+
+function Test-ExcludedPackagePath([string]$relativePath, [string[]]$exclusions) {
+  if ([string]::IsNullOrWhiteSpace($relativePath) -or -not $exclusions -or $exclusions.Count -eq 0) {
+    return $false
+  }
+
+  $normalizedPath = $relativePath.Replace('\', '/').Trim('/')
+  $segments = @($normalizedPath -split '/' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+  foreach ($entry in $exclusions) {
+    if ([string]::IsNullOrWhiteSpace($entry)) { continue }
+    $normalizedExclusion = $entry.Trim().Trim('"').Replace('\', '/').Trim('/')
+    if ([string]::IsNullOrWhiteSpace($normalizedExclusion)) { continue }
+
+    if ($normalizedExclusion.Contains('/')) {
+      $wrappedPath = '/' + $normalizedPath + '/'
+      $wrappedExclusion = '/' + $normalizedExclusion + '/'
+      if ($wrappedPath.IndexOf($wrappedExclusion, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+        return $true
+      }
+      continue
+    }
+
+    foreach ($segment in $segments) {
+      if ($segment.Equals($normalizedExclusion, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $true
+      }
+    }
+  }
+
+  return $false
 }
 
 function EmitError([string]$msg) {
@@ -105,9 +137,12 @@ try {
   if ([string]::IsNullOrWhiteSpace($RootPath)) { throw "RootPath is required." }
   if (-not (Test-Path -LiteralPath $RootPath)) { throw "RootPath not found: $RootPath" }
   $root = (Resolve-Path -LiteralPath $RootPath).Path
+  if ([string]::IsNullOrWhiteSpace($PackageFileListPath)) { throw "PackageFileListPath is required." }
+  if (-not (Test-Path -LiteralPath $PackageFileListPath -PathType Leaf)) { throw "Package file list not found: $PackageFileListPath" }
 
   $include = DecodeLines $IncludeB64
   $exclude = DecodeLines $ExcludeB64
+  $packageFiles = @(Get-Content -LiteralPath $PackageFileListPath -ErrorAction Stop | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
   $overwrite = -not [string]::IsNullOrWhiteSpace($OverwriteSigned) -and $OverwriteSigned -eq '1'
 
   if (-not $include -or $include.Count -eq 0) {
@@ -149,28 +184,54 @@ try {
 
   $thisTp = ($cert.Thumbprint -replace '\s','').ToUpperInvariant()
 
-  # Enumerate files (include patterns, then apply exclude substrings)
-  $files = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
-  foreach ($pat in $include) {
-    if ([string]::IsNullOrWhiteSpace($pat)) { continue }
-    Get-ChildItem -LiteralPath $root -Recurse -File -Filter $pat -ErrorAction SilentlyContinue |
-      ForEach-Object { [void]$files.Add($_.FullName) }
+  # Select signable files only from the final module package file set.
+  $pathComparison = if ([System.IO.Path]::DirectorySeparatorChar -eq '\') {
+    [System.StringComparison]::OrdinalIgnoreCase
+  } else {
+    [System.StringComparison]::Ordinal
+  }
+  $pathComparer = if ([System.IO.Path]::DirectorySeparatorChar -eq '\') {
+    [System.StringComparer]::OrdinalIgnoreCase
+  } else {
+    [System.StringComparer]::Ordinal
+  }
+  $files = New-Object 'System.Collections.Generic.HashSet[string]' ($pathComparer)
+  $rootPrefix = $root.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+  foreach ($candidate in $packageFiles) {
+    $candidatePath = if ([System.IO.Path]::IsPathRooted($candidate)) {
+      [System.IO.Path]::GetFullPath($candidate)
+    } else {
+      [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($root, $candidate))
+    }
+
+    if (-not $candidatePath.StartsWith($rootPrefix, $pathComparison)) {
+      throw "Packaged signing candidate is outside RootPath: $candidatePath"
+    }
+    if (-not [System.IO.File]::Exists($candidatePath)) {
+      throw "Packaged signing candidate was not found: $candidatePath"
+    }
+
+    $name = [System.IO.Path]::GetFileName($candidatePath)
+    foreach ($pat in $include) {
+      if ([string]::IsNullOrWhiteSpace($pat)) { continue }
+      if ($name -like $pat) {
+        [void]$files.Add($candidatePath)
+        break
+      }
+    }
   }
 
   $all = @($files)
   if ($exclude -and $exclude.Count -gt 0) {
     $all = $all | Where-Object {
       $p = [string]$_
-      foreach ($x in $exclude) {
-        if ([string]::IsNullOrWhiteSpace($x)) { continue }
-        if ($p.IndexOf($x, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) { return $false }
-      }
-      return $true
+      $relativePath = $p.Substring($rootPrefix.Length)
+      return -not (Test-ExcludedPackagePath -relativePath $relativePath -exclusions $exclude)
     }
   }
 
   if (-not $all -or $all.Count -eq 0) {
-    throw "No files matched for signing under '$root'."
+    throw "No packaged files matched for signing under '$root'."
   }
 
   $ts = 'http://timestamp.digicert.com'

--- a/PowerForge/Services/ArtefactBuilder.Packaging.cs
+++ b/PowerForge/Services/ArtefactBuilder.Packaging.cs
@@ -61,6 +61,16 @@ public sealed partial class ArtefactBuilder
         };
     }
 
+    internal static string[] ResolveModulePackageSourceFiles(
+        string stagingRoot,
+        InformationConfiguration? information,
+        DeliveryOptionsConfiguration? delivery,
+        bool includeScriptFolders = true)
+    {
+        var include = ResolvePackagingInformation(information, delivery, includeScriptFolders);
+        return EnumerateModulePackageFiles(stagingRoot, include);
+    }
+
     private static string[] MergeDeliveryIncludeAll(string[] includeAll, DeliveryOptionsConfiguration? delivery)
     {
         if (delivery?.Enable != true)
@@ -99,66 +109,138 @@ public sealed partial class ArtefactBuilder
     private static void CopyModulePackage(string stagingRoot, string destinationModuleRoot, PackagingInformation include)
     {
         var src = Path.GetFullPath(stagingRoot);
-        if (!Directory.Exists(src)) throw new DirectoryNotFoundException($"Staging directory not found: {src}");
 
         if (Directory.Exists(destinationModuleRoot))
             Directory.Delete(destinationModuleRoot, recursive: true);
         Directory.CreateDirectory(destinationModuleRoot);
+        CreatePackageDirectoryStructure(src, destinationModuleRoot, include);
+
+        foreach (var file in EnumerateModulePackageFiles(src, include))
+        {
+            var relativePath = ComputeRelativePath(src, file);
+            var destinationPath = Path.Combine(destinationModuleRoot, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+            File.Copy(file, destinationPath, overwrite: true);
+        }
+    }
+
+    private static void CreatePackageDirectoryStructure(
+        string stagingRoot,
+        string destinationModuleRoot,
+        PackagingInformation include)
+    {
+        foreach (var dirName in include.IncludeAll)
+        {
+            if (string.IsNullOrWhiteSpace(dirName)) continue;
+            var sourceDir = Path.Combine(stagingRoot, dirName);
+            if (!Directory.Exists(sourceDir)) continue;
+            CreateDirectoryTree(sourceDir, Path.Combine(destinationModuleRoot, dirName), Array.Empty<string>());
+        }
+
+        foreach (var dirName in include.IncludePS1)
+        {
+            if (string.IsNullOrWhiteSpace(dirName)) continue;
+            var sourceDir = Path.Combine(stagingRoot, dirName);
+            if (!Directory.Exists(sourceDir)) continue;
+            CreateDirectoryTree(
+                sourceDir,
+                Path.Combine(destinationModuleRoot, dirName),
+                include.ExcludeFromPackage ?? Array.Empty<string>());
+        }
+    }
+
+    private static void CreateDirectoryTree(
+        string sourceRoot,
+        string destinationRoot,
+        string[] excludedDirectoryPatterns)
+    {
+        Directory.CreateDirectory(destinationRoot);
+        var stack = new Stack<string>();
+        stack.Push(Path.GetFullPath(sourceRoot));
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            foreach (var directory in Directory.EnumerateDirectories(current, "*", SearchOption.TopDirectoryOnly))
+            {
+                var name = Path.GetFileName(directory);
+                if (string.IsNullOrWhiteSpace(name) || WildcardAnyMatch(name, excludedDirectoryPatterns))
+                    continue;
+
+                var relativePath = ComputeRelativePath(sourceRoot, directory);
+                Directory.CreateDirectory(Path.Combine(destinationRoot, relativePath));
+                stack.Push(directory);
+            }
+        }
+    }
+
+    private static string[] EnumerateModulePackageFiles(string stagingRoot, PackagingInformation include)
+    {
+        var src = Path.GetFullPath(stagingRoot);
+        if (!Directory.Exists(src)) throw new DirectoryNotFoundException($"Staging directory not found: {src}");
 
         var excludes = include.ExcludeFromPackage ?? Array.Empty<string>();
+        var files = new List<string>();
+        var seen = new HashSet<string>(CreateCurrentFileSystemPathComparer());
 
-        bool IsExcludedName(string name)
-            => WildcardAnyMatch(name, excludes);
+        void AddFile(string file)
+        {
+            var fullPath = Path.GetFullPath(file);
+            if (seen.Add(fullPath))
+                files.Add(fullPath);
+        }
 
-        // 1) Root files
         foreach (var file in Directory.EnumerateFiles(src, "*", SearchOption.TopDirectoryOnly))
         {
             var name = Path.GetFileName(file);
-            if (string.IsNullOrWhiteSpace(name) || IsExcludedName(name)) continue;
+            if (string.IsNullOrWhiteSpace(name) || WildcardAnyMatch(name, excludes)) continue;
             if (!WildcardAnyMatch(name, include.IncludeRoot)) continue;
-            File.Copy(file, Path.Combine(destinationModuleRoot, name), overwrite: true);
+            AddFile(file);
         }
 
-        // 2) IncludeAll directories
         foreach (var dirName in include.IncludeAll)
         {
             if (string.IsNullOrWhiteSpace(dirName)) continue;
             var dir = Path.Combine(src, dirName);
             if (!Directory.Exists(dir)) continue;
 
-            CopyDirectoryFiltered(
+            AddDirectoryFiles(
                 dir,
-                Path.Combine(destinationModuleRoot, dirName),
                 include.ExcludeFromPackage ?? Array.Empty<string>(),
                 includeOnlyPs1: false,
-                excludeDirectories: false);
+                excludeDirectories: false,
+                AddFile);
         }
 
-        // 3) IncludePS1 directories
         foreach (var dirName in include.IncludePS1)
         {
             if (string.IsNullOrWhiteSpace(dirName)) continue;
             var dir = Path.Combine(src, dirName);
             if (!Directory.Exists(dir)) continue;
 
-            CopyDirectoryFiltered(
+            AddDirectoryFiles(
                 dir,
-                Path.Combine(destinationModuleRoot, dirName),
                 include.ExcludeFromPackage ?? Array.Empty<string>(),
                 includeOnlyPs1: true,
-                excludeDirectories: true);
+                excludeDirectories: true,
+                AddFile);
         }
+
+        return files.ToArray();
     }
 
-    private static void CopyDirectoryFiltered(
+    private static StringComparer CreateCurrentFileSystemPathComparer()
+        => Path.DirectorySeparatorChar == '\\'
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+
+    private static void AddDirectoryFiles(
         string sourceDir,
-        string destDir,
         string[] excludeNamePatterns,
         bool includeOnlyPs1,
-        bool excludeDirectories)
+        bool excludeDirectories,
+        Action<string> addFile)
     {
         var sourceFull = Path.GetFullPath(sourceDir);
-        Directory.CreateDirectory(destDir);
 
         var stack = new Stack<string>();
         stack.Push(sourceFull);
@@ -166,18 +248,13 @@ public sealed partial class ArtefactBuilder
         while (stack.Count > 0)
         {
             var current = stack.Pop();
-            var rel = ComputeRelativePath(sourceFull, current);
-            var targetDir = string.IsNullOrEmpty(rel) || rel == "." ? destDir : Path.Combine(destDir, rel);
-            Directory.CreateDirectory(targetDir);
 
             foreach (var file in Directory.EnumerateFiles(current, "*", SearchOption.TopDirectoryOnly))
             {
                 var name = Path.GetFileName(file);
                 if (string.IsNullOrWhiteSpace(name) || WildcardAnyMatch(name, excludeNamePatterns)) continue;
                 if (includeOnlyPs1 && !name.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase)) continue;
-
-                var destFile = Path.Combine(targetDir, name);
-                File.Copy(file, destFile, overwrite: true);
+                addFile(file);
             }
 
             foreach (var dir in Directory.EnumerateDirectories(current, "*", SearchOption.TopDirectoryOnly))

--- a/PowerForge/Services/DotNetNuGetClient.cs
+++ b/PowerForge/Services/DotNetNuGetClient.cs
@@ -1,3 +1,5 @@
+using System.IO.Compression;
+
 namespace PowerForge;
 
 /// <summary>
@@ -108,11 +110,29 @@ public sealed class DotNetNuGetClient
         if (string.IsNullOrWhiteSpace(request.TimeStampServer))
             throw new ArgumentException("TimeStampServer is required.", nameof(request));
 
+        var packagePaths = request.Overwrite
+            ? request.PackagePaths
+            : request.PackagePaths
+                .Where(path => !HasNuGetSignature(path, request.WorkingDirectory))
+                .ToArray();
+        var skippedSignedPackages = request.PackagePaths.Length - packagePaths.Length;
+        if (packagePaths.Length == 0)
+        {
+            return new DotNetNuGetSignResult(
+                exitCode: 0,
+                stdOut: $"Preserved {skippedSignedPackages} already signed NuGet package(s).",
+                stdErr: string.Empty,
+                executable: _dotNetExecutable,
+                duration: TimeSpan.Zero,
+                timedOut: false,
+                errorMessage: null);
+        }
+
         var arguments = new List<string> {
             "nuget",
             "sign"
         };
-        arguments.AddRange(request.PackagePaths);
+        arguments.AddRange(packagePaths);
         arguments.AddRange(new[]
         {
             "--certificate-fingerprint",
@@ -136,9 +156,18 @@ public sealed class DotNetNuGetClient
                 request.Timeout ?? _defaultTimeout),
             cancellationToken).ConfigureAwait(false);
 
+        var preservationMessage = skippedSignedPackages > 0
+            ? $"Preserved {skippedSignedPackages} already signed NuGet package(s)."
+            : null;
+        var stdOut = string.IsNullOrWhiteSpace(preservationMessage)
+            ? processResult.StdOut
+            : string.IsNullOrWhiteSpace(processResult.StdOut)
+                ? preservationMessage!
+                : processResult.StdOut.TrimEnd() + Environment.NewLine + preservationMessage;
+
         return new DotNetNuGetSignResult(
             processResult.ExitCode,
-            processResult.StdOut,
+            stdOut,
             processResult.StdErr,
             processResult.Executable,
             processResult.Duration,
@@ -146,6 +175,31 @@ public sealed class DotNetNuGetClient
             processResult.ExitCode == 0 && !processResult.TimedOut
                 ? null
                 : FirstLine(processResult.StdErr) ?? FirstLine(processResult.StdOut) ?? $"dotnet nuget sign failed with exit code {processResult.ExitCode}.");
+    }
+
+    private static bool HasNuGetSignature(string packagePath, string? workingDirectory)
+    {
+        try
+        {
+            var baseDirectory = string.IsNullOrWhiteSpace(workingDirectory)
+                ? Environment.CurrentDirectory
+                : Path.GetFullPath(workingDirectory!);
+            var resolvedPath = Path.IsPathRooted(packagePath)
+                ? Path.GetFullPath(packagePath)
+                : Path.GetFullPath(Path.Combine(baseDirectory, packagePath));
+            if (!File.Exists(resolvedPath))
+                return false;
+
+            using var stream = File.Open(resolvedPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false);
+            return archive.Entries.Any(entry =>
+                string.Equals(entry.FullName, ".signature.p7s", StringComparison.OrdinalIgnoreCase));
+        }
+        catch
+        {
+            // Let dotnet nuget sign report missing or malformed package errors.
+            return false;
+        }
     }
 
     private static string BuildPushResponseFileContent(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.cs
@@ -91,6 +91,15 @@ public sealed partial class DotNetPublishPipelineRunner
                 continue;
             }
 
+            if (!sign.OverwriteSigned && _hasAuthenticodeSignature(file))
+            {
+                if (_logger.IsVerbose)
+                    _logger.Verbose($"Preserving existing signature: {file}");
+                signed.Add(file);
+                continue;
+            }
+
+            var timeout = TimeSpan.FromSeconds(Math.Max(1, sign.TimeoutSeconds));
             var args = new List<string> { "sign", "/fd", "SHA256" };
             if (!string.IsNullOrWhiteSpace(sign.TimestampUrl))
                 args.AddRange(new[] { "/tr", sign.TimestampUrl!, "/td", "SHA256" });
@@ -112,13 +121,11 @@ public sealed partial class DotNetPublishPipelineRunner
                 args.AddRange(new[] { "/kc", sign.KeyContainer! });
 
             args.Add(file);
-            var timeout = TimeSpan.FromSeconds(Math.Max(1, sign.TimeoutSeconds));
-            var res = RunProcessWithTimeout(
+            var res = RunSigningTool(
                 signToolPath,
                 runDir,
                 args,
-                timeout,
-                _cancellationToken.Value);
+                timeout);
             if (res.ExitCode != 0)
             {
                 var details = TailLines(res.StdErr, maxLines: 10, maxChars: 2000) ?? string.Empty;
@@ -136,6 +143,25 @@ public sealed partial class DotNetPublishPipelineRunner
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(f => f, StringComparer.OrdinalIgnoreCase)
             .ToArray();
+    }
+
+    private ProcessRunResult RunSigningTool(
+        string signToolPath,
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        TimeSpan timeout)
+    {
+        var result = _processRunner.RunAsync(
+                new ProcessRunRequest(
+                    signToolPath,
+                    workingDirectory,
+                    arguments,
+                    timeout),
+                _cancellationToken.Value)
+            .GetAwaiter()
+            .GetResult();
+        _cancellationToken.Value.ThrowIfCancellationRequested();
+        return result;
     }
 
     private void HandlePolicy(DotNetPublishPolicyMode policy, string message)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.cs
@@ -12,6 +12,7 @@ public sealed partial class DotNetPublishPipelineRunner
 {
     private readonly ILogger _logger;
     private readonly IProcessRunner _processRunner;
+    private readonly Func<string, bool> _hasAuthenticodeSignature;
     private readonly AsyncLocal<CancellationToken> _cancellationToken = new();
 
     /// <summary>
@@ -22,10 +23,14 @@ public sealed partial class DotNetPublishPipelineRunner
     {
     }
 
-    internal DotNetPublishPipelineRunner(ILogger logger, IProcessRunner processRunner)
+    internal DotNetPublishPipelineRunner(
+        ILogger logger,
+        IProcessRunner processRunner,
+        Func<string, bool>? hasAuthenticodeSignature = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _processRunner = processRunner ?? throw new ArgumentNullException(nameof(processRunner));
+        _hasAuthenticodeSignature = hasAuthenticodeSignature ?? WindowsAuthenticodeSignatureInspector.HasSignature;
     }
 
 }

--- a/PowerForge/Services/DotNetPublishSigningProfileResolver.cs
+++ b/PowerForge/Services/DotNetPublishSigningProfileResolver.cs
@@ -59,6 +59,7 @@ internal static class DotNetPublishSigningProfileResolver
         {
             Enabled = sign.Enabled,
             IncludeDlls = sign.IncludeDlls,
+            OverwriteSigned = sign.OverwriteSigned,
             ToolPath = sign.ToolPath,
             OnMissingTool = sign.OnMissingTool,
             OnSignFailure = sign.OnSignFailure,
@@ -80,6 +81,7 @@ internal static class DotNetPublishSigningProfileResolver
         {
             Enabled = signOverrides.Enabled,
             IncludeDlls = signOverrides.IncludeDlls,
+            OverwriteSigned = signOverrides.OverwriteSigned,
             ToolPath = signOverrides.ToolPath,
             OnMissingTool = signOverrides.OnMissingTool,
             OnSignFailure = signOverrides.OnSignFailure,
@@ -105,6 +107,8 @@ internal static class DotNetPublishSigningProfileResolver
             sign.Enabled = patch.Enabled.Value;
         if (patch.IncludeDlls.HasValue)
             sign.IncludeDlls = patch.IncludeDlls.Value;
+        if (patch.OverwriteSigned.HasValue)
+            sign.OverwriteSigned = patch.OverwriteSigned.Value;
         if (patch.OnMissingTool.HasValue)
             sign.OnMissingTool = patch.OnMissingTool.Value;
         if (patch.OnSignFailure.HasValue)

--- a/PowerForge/Services/DotNetReleaseBuildService.cs
+++ b/PowerForge/Services/DotNetReleaseBuildService.cs
@@ -119,6 +119,7 @@ public sealed class DotNetReleaseBuildService
                     LocalStore = spec.LocalStore,
                     CertificateThumbprint = spec.CertificateThumbprint!.Trim(),
                     TimeStampServer = timeStampServer,
+                    OverwriteSigned = spec.OverwriteSignedAssemblies,
                     IncludePatterns = spec.AssemblyIncludePatterns ?? Array.Empty<string>()
                 });
             }
@@ -137,18 +138,25 @@ public sealed class DotNetReleaseBuildService
                 return result;
             }
 
+            var allPackages = new List<string>();
+            allPackages.AddRange(Directory.EnumerateFiles(releasePath, "*.nupkg", SearchOption.AllDirectories));
+
             if (spec.PackDependencies && dependencyProjects.Length > 0)
             {
                 _logger.Verbose($"DotNetReleaseBuild - Packing {dependencyProjects.Length} dependency projects");
+                var dependencyPackages = new List<string>();
                 foreach (var depProj in dependencyProjects)
                 {
                     var depName = Path.GetFileName(depProj) ?? depProj;
                     _logger.Verbose($"DotNetReleaseBuild - Packing dependency: {depName}");
+                    var depDir = Path.GetDirectoryName(depProj) ?? csprojDir;
+                    var depRelease = Path.Combine(depDir, "bin", configuration);
+                    var existingPackages = SnapshotPackages(depRelease);
 
                     var depExit = RunProcess(
                         fileName: "dotnet",
                         arguments: $"pack {Quote(depProj)} --configuration {Quote(configuration)} --no-restore --no-build",
-                        workingDirectory: Path.GetDirectoryName(depProj) ?? csprojDir,
+                        workingDirectory: depDir,
                         out var depStdErr,
                         out var depStdOut);
                     if (depExit != 0)
@@ -156,23 +164,13 @@ public sealed class DotNetReleaseBuildService
                         _logger.Warn($"DotNetReleaseBuild - Failed to pack dependency: {depName}");
                         if (!string.IsNullOrWhiteSpace(depStdErr)) _logger.Verbose(depStdErr.Trim());
                         if (!string.IsNullOrWhiteSpace(depStdOut)) _logger.Verbose(depStdOut.Trim());
+                        continue;
                     }
-                }
-            }
 
-            var allPackages = new List<string>();
-            allPackages.AddRange(Directory.EnumerateFiles(releasePath, "*.nupkg", SearchOption.AllDirectories));
-
-            if (spec.PackDependencies)
-            {
-                foreach (var depProj in dependencyProjects)
-                {
-                    var depDir = Path.GetDirectoryName(depProj);
-                    if (string.IsNullOrWhiteSpace(depDir)) continue;
-                    var depRelease = Path.Combine(depDir, "bin", configuration);
-                    if (!Directory.Exists(depRelease)) continue;
-                    allPackages.AddRange(Directory.EnumerateFiles(depRelease, "*.nupkg", SearchOption.AllDirectories));
+                    dependencyPackages.AddRange(EnumerateCreatedOrChangedPackages(depRelease, existingPackages));
                 }
+
+                allPackages.AddRange(dependencyPackages);
             }
 
             if (!string.IsNullOrWhiteSpace(spec.CertificateThumbprint) && allPackages.Count > 0)
@@ -189,22 +187,20 @@ public sealed class DotNetReleaseBuildService
 
                 _logger.Verbose($"DotNetReleaseBuild - Using certificate SHA256: {sha256}");
 
-                foreach (var pkgPath in allPackages)
-                {
-                    var pkgName = Path.GetFileName(pkgPath) ?? pkgPath;
-                    _logger.Verbose($"DotNetReleaseBuild - Signing package: {pkgName}");
-
-                    var signExit = RunProcess(
-                        fileName: "dotnet",
-                        arguments: $"nuget sign {Quote(pkgPath)} --certificate-fingerprint {Quote(sha256)} --certificate-store-location {spec.LocalStore} --certificate-store-name My --timestamper {Quote(timeStampServer)} --overwrite",
-                        workingDirectory: csprojDir,
-                        out _,
-                        out _);
-                    if (signExit != 0)
-                        _logger.Warn($"DotNetReleaseBuild - Failed to sign {pkgPath}");
-                    else
-                        _logger.Verbose($"DotNetReleaseBuild - Successfully signed {pkgPath}");
-                }
+                var signResult = new DotNetNuGetClient()
+                    .SignPackageAsync(new DotNetNuGetSignRequest(
+                        packagePaths: allPackages,
+                        certificateFingerprint: sha256,
+                        certificateStoreLocation: spec.LocalStore.ToString(),
+                        timeStampServer: timeStampServer,
+                        overwrite: spec.OverwriteSignedPackages,
+                        workingDirectory: csprojDir))
+                    .GetAwaiter()
+                    .GetResult();
+                if (!signResult.Succeeded)
+                    _logger.Warn($"DotNetReleaseBuild - Failed to sign NuGet packages. {signResult.ErrorMessage}");
+                else
+                    _logger.Verbose($"DotNetReleaseBuild - NuGet package signing completed. {signResult.StdOut}".Trim());
             }
 
             result.Success = true;
@@ -232,6 +228,41 @@ public sealed class DotNetReleaseBuildService
 
     private static string? GetFirstElementValue(XDocument doc, string localName)
         => doc.Descendants().FirstOrDefault(e => e.Name.LocalName.Equals(localName, StringComparison.OrdinalIgnoreCase))?.Value;
+
+    private static Dictionary<string, (long Length, DateTime LastWriteUtc)> SnapshotPackages(string directory)
+    {
+        var snapshot = new Dictionary<string, (long Length, DateTime LastWriteUtc)>(StringComparer.OrdinalIgnoreCase);
+        if (!Directory.Exists(directory))
+            return snapshot;
+
+        foreach (var path in Directory.EnumerateFiles(directory, "*.nupkg", SearchOption.AllDirectories))
+        {
+            var file = new FileInfo(path);
+            snapshot[Path.GetFullPath(path)] = (file.Length, file.LastWriteTimeUtc);
+        }
+
+        return snapshot;
+    }
+
+    private static IEnumerable<string> EnumerateCreatedOrChangedPackages(
+        string directory,
+        IReadOnlyDictionary<string, (long Length, DateTime LastWriteUtc)> before)
+    {
+        if (!Directory.Exists(directory))
+            yield break;
+
+        foreach (var path in Directory.EnumerateFiles(directory, "*.nupkg", SearchOption.AllDirectories))
+        {
+            var fullPath = Path.GetFullPath(path);
+            var file = new FileInfo(fullPath);
+            if (!before.TryGetValue(fullPath, out var previous) ||
+                previous.Length != file.Length ||
+                previous.LastWriteUtc != file.LastWriteTimeUtc)
+            {
+                yield return fullPath;
+            }
+        }
+    }
 
     private static IEnumerable<string> GetProjectReferences(XDocument doc, string csprojPath)
     {

--- a/PowerForge/Services/DotNetRepositoryReleasePreparationService.cs
+++ b/PowerForge/Services/DotNetRepositoryReleasePreparationService.cs
@@ -64,6 +64,8 @@ internal sealed class DotNetRepositoryReleasePreparationService
                 SignAssemblies = ResolveSigningEnabled(request.SignAssemblies, request.CertificateThumbprint),
                 SignDependencyAssemblies = request.SignDependencyAssemblies ?? false,
                 SignPackages = ResolveSigningEnabled(request.SignPackages, request.CertificateThumbprint),
+                OverwriteSignedAssemblies = request.OverwriteSignedAssemblies,
+                OverwriteSignedPackages = request.OverwriteSignedPackages,
                 Pack = !request.SkipPack,
                 IncludeSymbols = request.IncludeSymbols,
                 Publish = request.Publish,

--- a/PowerForge/Services/DotNetRepositoryReleaseService.BatchPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.BatchPacking.cs
@@ -327,6 +327,7 @@ public sealed partial class DotNetRepositoryReleaseService
                     LocalStore = spec.CertificateStore,
                     CertificateThumbprint = spec.CertificateThumbprint!.Trim(),
                     TimeStampServer = string.IsNullOrWhiteSpace(spec.TimeStampServer) ? "http://timestamp.digicert.com" : spec.TimeStampServer!.Trim(),
+                    OverwriteSigned = spec.OverwriteSignedAssemblies,
                     IncludePatterns = Array.Empty<string>(),
                     FilePaths = filePaths
                 });

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Signing.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Signing.cs
@@ -28,7 +28,14 @@ public sealed partial class DotNetRepositoryReleaseService
             .ToArray();
         if (packagePaths.Length == 0) return true;
 
-        var exitCode = RunDotnetSign(packagePaths, sha256, store, timeStampServer, out var stdErr, out var stdOut);
+        var exitCode = RunDotnetSign(
+            packagePaths,
+            sha256,
+            store,
+            timeStampServer,
+            spec.OverwriteSignedPackages,
+            out var stdErr,
+            out var stdOut);
         if (exitCode == 0) return true;
 
         var msg = string.Join(Environment.NewLine, stdErr, stdOut).Trim();
@@ -41,6 +48,7 @@ public sealed partial class DotNetRepositoryReleaseService
         string sha256,
         string store,
         string timeStampServer,
+        bool overwriteSignedPackages,
         out string stdErr,
         out string stdOut)
     {
@@ -49,7 +57,8 @@ public sealed partial class DotNetRepositoryReleaseService
                 packagePaths: packagePaths,
                 certificateFingerprint: sha256,
                 certificateStoreLocation: store,
-                timeStampServer: timeStampServer))
+                timeStampServer: timeStampServer,
+                overwrite: overwriteSignedPackages))
             .GetAwaiter()
             .GetResult();
 

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -184,6 +184,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         LocalStore = spec.CertificateStore,
                         CertificateThumbprint = spec.CertificateThumbprint!.Trim(),
                         TimeStampServer = string.IsNullOrWhiteSpace(spec.TimeStampServer) ? "http://timestamp.digicert.com" : spec.TimeStampServer!.Trim(),
+                        OverwriteSigned = spec.OverwriteSignedAssemblies,
                         IncludePatterns = includePatterns,
                         FilePaths = signingPlan.Files
                     });

--- a/PowerForge/Services/PowerForgeProjectDslMapper.cs
+++ b/PowerForge/Services/PowerForgeProjectDslMapper.cs
@@ -198,6 +198,7 @@ internal static class PowerForgeProjectDslMapper
         return new DotNetPublishSignOptions
         {
             Enabled = signing.Mode == ConfigurationProjectSigningMode.Enabled,
+            OverwriteSigned = signing.OverwriteSigned,
             ToolPath = NormalizeNullable(signing.ToolPath) ?? "signtool.exe",
             Thumbprint = NormalizeNullable(signing.Thumbprint),
             SubjectName = NormalizeNullable(signing.SubjectName),

--- a/PowerForge/Services/ProjectBuildConfigurationAdapter.cs
+++ b/PowerForge/Services/ProjectBuildConfigurationAdapter.cs
@@ -43,6 +43,8 @@ internal static class ProjectBuildConfigurationAdapter
         Apply(target, reference.SignAssemblies, static (config, value) => config.SignAssemblies = value);
         Apply(target, reference.SignDependencyAssemblies, static (config, value) => config.SignDependencyAssemblies = value);
         Apply(target, reference.SignPackages, static (config, value) => config.SignPackages = value);
+        Apply(target, reference.OverwriteSignedAssemblies, static (config, value) => config.OverwriteSignedAssemblies = value);
+        Apply(target, reference.OverwriteSignedPackages, static (config, value) => config.OverwriteSignedPackages = value);
         return target;
     }
 

--- a/PowerForge/Services/ProjectBuildPreparationService.cs
+++ b/PowerForge/Services/ProjectBuildPreparationService.cs
@@ -117,6 +117,8 @@ internal sealed class ProjectBuildPreparationService
             SignAssemblies = ResolveSigningEnabled(config.SignAssemblies, config.CertificateThumbprint),
             SignDependencyAssemblies = config.SignDependencyAssemblies ?? false,
             SignPackages = ResolveSigningEnabled(config.SignPackages, config.CertificateThumbprint),
+            OverwriteSignedAssemblies = config.OverwriteSignedAssemblies ?? false,
+            OverwriteSignedPackages = config.OverwriteSignedPackages ?? false,
             Pack = context.Build || context.PublishNuget || context.PublishGitHub,
             CreateReleaseZip = context.CreateReleaseZip,
             Publish = context.PublishNuget,

--- a/PowerForge/Services/WindowsAuthenticodeSignatureInspector.cs
+++ b/PowerForge/Services/WindowsAuthenticodeSignatureInspector.cs
@@ -1,0 +1,116 @@
+using System.Runtime.InteropServices;
+
+namespace PowerForge;
+
+internal static class WindowsAuthenticodeSignatureInspector
+{
+    private const int TrustENoSignature = unchecked((int)0x800B0100);
+    private const int TrustEProviderUnknown = unchecked((int)0x800B0001);
+    private const int TrustESubjectFormUnknown = unchecked((int)0x800B0003);
+    private static readonly Guid GenericVerifyV2 = new("00AAC56B-CD44-11d0-8CC2-00C04FC295EE");
+
+    internal static bool HasSignature(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath) || !IsWindows())
+            return false;
+
+        var fileInfoPointer = IntPtr.Zero;
+        var trustDataPointer = IntPtr.Zero;
+        try
+        {
+            var fileInfo = new WinTrustFileInfo
+            {
+                StructSize = (uint)Marshal.SizeOf<WinTrustFileInfo>(),
+                FilePath = filePath,
+                FileHandle = IntPtr.Zero,
+                KnownSubject = IntPtr.Zero
+            };
+            fileInfoPointer = Marshal.AllocHGlobal(Marshal.SizeOf<WinTrustFileInfo>());
+            Marshal.StructureToPtr(fileInfo, fileInfoPointer, fDeleteOld: false);
+
+            var trustData = new WinTrustData
+            {
+                StructSize = (uint)Marshal.SizeOf<WinTrustData>(),
+                UiChoice = 2,
+                RevocationChecks = 0,
+                UnionChoice = 1,
+                FileInfo = fileInfoPointer,
+                StateAction = 0,
+                ProviderFlags = 0x1000,
+                UiContext = 0
+            };
+            trustDataPointer = Marshal.AllocHGlobal(Marshal.SizeOf<WinTrustData>());
+            Marshal.StructureToPtr(trustData, trustDataPointer, fDeleteOld: false);
+
+            var status = WinVerifyTrust(new IntPtr(-1), GenericVerifyV2, trustDataPointer);
+            return !IsNoSignatureStatus(status);
+        }
+        catch (DllNotFoundException)
+        {
+            return false;
+        }
+        catch (EntryPointNotFoundException)
+        {
+            return false;
+        }
+        finally
+        {
+            if (trustDataPointer != IntPtr.Zero)
+            {
+                Marshal.DestroyStructure<WinTrustData>(trustDataPointer);
+                Marshal.FreeHGlobal(trustDataPointer);
+            }
+            if (fileInfoPointer != IntPtr.Zero)
+            {
+                Marshal.DestroyStructure<WinTrustFileInfo>(fileInfoPointer);
+                Marshal.FreeHGlobal(fileInfoPointer);
+            }
+        }
+    }
+
+    internal static bool IsNoSignatureStatus(int status)
+        => status == TrustENoSignature ||
+           status == TrustEProviderUnknown ||
+           status == TrustESubjectFormUnknown;
+
+    private static bool IsWindows()
+    {
+#if NET472
+        return Environment.OSVersion.Platform == PlatformID.Win32NT;
+#else
+        return OperatingSystem.IsWindows();
+#endif
+    }
+
+    [DllImport("wintrust.dll", ExactSpelling = true, CharSet = CharSet.Unicode)]
+    private static extern int WinVerifyTrust(
+        IntPtr windowHandle,
+        [MarshalAs(UnmanagedType.LPStruct)] Guid actionId,
+        IntPtr trustData);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct WinTrustFileInfo
+    {
+        internal uint StructSize;
+        [MarshalAs(UnmanagedType.LPWStr)] internal string FilePath;
+        internal IntPtr FileHandle;
+        internal IntPtr KnownSubject;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct WinTrustData
+    {
+        internal uint StructSize;
+        internal IntPtr PolicyCallbackData;
+        internal IntPtr SipClientData;
+        internal uint UiChoice;
+        internal uint RevocationChecks;
+        internal uint UnionChoice;
+        internal IntPtr FileInfo;
+        internal uint StateAction;
+        internal IntPtr StateData;
+        internal IntPtr UrlReference;
+        internal uint ProviderFlags;
+        internal uint UiContext;
+    }
+}

--- a/Schemas/project.build.schema.json
+++ b/Schemas/project.build.schema.json
@@ -179,6 +179,14 @@
       "type": "boolean",
       "description": "When true and CertificateThumbprint is configured, signs generated NuGet packages. Defaults to true when CertificateThumbprint is set."
     },
+    "OverwriteSignedAssemblies": {
+      "type": "boolean",
+      "description": "When true, explicitly replaces existing Authenticode assembly signatures. Defaults to false."
+    },
+    "OverwriteSignedPackages": {
+      "type": "boolean",
+      "description": "When true, explicitly replaces existing NuGet package signatures. Defaults to false."
+    },
     "PublishSource": {
       "type": [
         "string",


### PR DESCRIPTION
## Summary

- derive module signing candidates from the exact final package selection, so merged modules sign the delivered `.psm1`, `.psd1`, binaries, and opted-in Internal payloads without traversing pre-merge source trees
- preserve existing Authenticode and NuGet signatures by default across module, repository-release, project-build, dotnet publish, bundle, MSI, and legacy signing paths
- expose explicit overwrite controls through the PowerShell cmdlets, project DSL/configuration models, and project-build schema while retaining packaged empty-directory behavior

## Behavior change

Merged modules no longer sign staging-only `Public` or `Private` source files. Unmerged modules still sign scripts that remain in the final package, and Internal delivery content continues to follow its signing opt-in/opt-out configuration.

Existing signatures are no longer replaced automatically. Workflows that intentionally re-sign files or packages must set the relevant `OverwriteSigned`, `OverwriteSignedAssemblies`, or `OverwriteSignedPackages` option.

## Validation

- 207 focused signing, packaging, configuration, and release tests
- full solution Release build across supported target frameworks
- .NET Framework 4.7.2 smoke suite
- PowerInfoblox final-package selection resolves only `PowerInfoblox.psd1` and `PowerInfoblox.psm1`
- independent local review plus targeted confirmation completed with no remaining findings