### PR TITLE
Fix AsyncPSCmdlet pipeline-stop propagation

### DIFF
--- a/PSPublishModule/Cmdlets/AsyncPSCmdlet.Execution.cs
+++ b/PSPublishModule/Cmdlets/AsyncPSCmdlet.Execution.cs
@@ -483,6 +483,7 @@ public abstract partial class AsyncPSCmdlet
                         if (Volatile.Read(ref deferPipeDisposal) != 0)
                         {
                             ClearPipes();
+                            DeactivateHook();
                             DisposePipeOnce();
                         }
                     }
@@ -539,9 +540,9 @@ public abstract partial class AsyncPSCmdlet
                 if (blockTask.IsCompleted)
                 {
                     ClearPipes();
+                    DeactivateHook();
                     DisposePipeOnce();
                 }
-                DeactivateHook();
             }
 
             if (pipelineException is OperationCanceledException && stopRequested)

--- a/PowerForge.Tests/AsyncPSCmdletTestCommands.cs
+++ b/PowerForge.Tests/AsyncPSCmdletTestCommands.cs
@@ -327,11 +327,15 @@ public sealed class TestAsyncCancellationWriteCommand : AsyncPSCmdlet
 {
     private static ManualResetEventSlim _started = new();
     private static ManualResetEventSlim _writeAttempted = new();
+    private static TaskCompletionSource<bool> _allowWrite = CreateAllowWriteSource();
 
     public static ManualResetEventSlim Started => _started;
     public static ManualResetEventSlim WriteAttempted => _writeAttempted;
 
     public static Exception? BackgroundWriteException { get; private set; }
+
+    public static void AllowWrite()
+        => _allowWrite.TrySetResult(true);
 
     public static void Reset()
     {
@@ -339,6 +343,7 @@ public sealed class TestAsyncCancellationWriteCommand : AsyncPSCmdlet
         _writeAttempted.Dispose();
         _started = new ManualResetEventSlim();
         _writeAttempted = new ManualResetEventSlim();
+        _allowWrite = CreateAllowWriteSource();
         BackgroundWriteException = null;
     }
 
@@ -351,6 +356,7 @@ public sealed class TestAsyncCancellationWriteCommand : AsyncPSCmdlet
         }
         catch (OperationCanceledException) when (CancelToken.IsCancellationRequested)
         {
+            await _allowWrite.Task;
             try
             {
                 WriteProgress(new ProgressRecord(1, "cancelled", "finishing"));
@@ -366,6 +372,9 @@ public sealed class TestAsyncCancellationWriteCommand : AsyncPSCmdlet
             }
         }
     }
+
+    private static TaskCompletionSource<bool> CreateAllowWriteSource()
+        => new(TaskCreationOptions.RunContinuationsAsynchronously);
 }
 
 [Cmdlet(VerbsDiagnostic.Test, "AsyncCapturedCancellationWrite")]

--- a/PowerForge.Tests/AsyncPSCmdletTests.cs
+++ b/PowerForge.Tests/AsyncPSCmdletTests.cs
@@ -363,7 +363,14 @@ public sealed partial class AsyncPSCmdletTests
             "The asynchronous cmdlet did not start in time.");
 
         powerShell.Stop();
-        Assert.Throws<PipelineStoppedException>(() => powerShell.EndInvoke(invocation));
+        try
+        {
+            Assert.Throws<PipelineStoppedException>(() => powerShell.EndInvoke(invocation));
+        }
+        finally
+        {
+            TestAsyncCancellationWriteCommand.AllowWrite();
+        }
         Assert.True(
             TestAsyncCancellationWriteCommand.WriteAttempted.Wait(TimeSpan.FromSeconds(5)),
             "The background hook did not observe the stop in time.");


### PR DESCRIPTION
## What changed

- keep the active async hook identity alive until its task completes after a pipeline stop
- preserve PipelineStoppedException for direct hook stream writes made during cancellation cleanup
- make the regression test deterministic while retaining silent drop behavior for captured callbacks

Fixes #693

## Validation

- 56 AsyncPSCmdlet tests
- regression stress: 25/25 passes
- PSPublishModule builds: net472, net8.0, net10.0
- net472 smoke tests: 4/4
- packaged module tests in PowerShell 7 and Windows PowerShell 5.1: 43/43 plus 47/47 in each host
- independent concurrency/lifetime review: no P0-P3 findings