### PR TITLE
Add query-parameter redirect selectors

### DIFF
--- a/PowerForge.Tests/WebLinkServiceQueryRedirectTests.cs
+++ b/PowerForge.Tests/WebLinkServiceQueryRedirectTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.IO;
+using PowerForge.Web;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed class WebLinkServiceQueryRedirectTests
+{
+    [Fact]
+    public void Validate_RejectsConflictingOrUnsafeQueryParameterSelectors()
+    {
+        var dataSet = new WebLinkDataSet
+        {
+            Redirects = new[]
+            {
+                new LinkRedirectRule
+                {
+                    Id = "conflicting-query-selector",
+                    SourcePath = "/blog/",
+                    SourceQuery = "tag=powershell",
+                    SourceQueryParameter = "tag",
+                    TargetUrl = "/blog/"
+                },
+                new LinkRedirectRule
+                {
+                    Id = "unsafe-query-parameter",
+                    SourcePath = "/blog/",
+                    SourceQueryParameter = "tag|category",
+                    TargetUrl = "/blog/"
+                }
+            }
+        };
+
+        var result = WebLinkService.Validate(dataSet);
+
+        Assert.Contains(result.Issues, issue => issue.Code == "PFLINK.REDIRECT.QUERY_SELECTOR_CONFLICT");
+        Assert.Contains(result.Issues, issue => issue.Code == "PFLINK.REDIRECT.QUERY_PARAMETER");
+    }
+
+    [Fact]
+    public void ExportApache_EmitsParameterPresenceAndCanonicalHostRedirects()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-query-redirects-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var outputPath = Path.Combine(root, "links.conf");
+            var dataSet = new WebLinkDataSet
+            {
+                Redirects = new[]
+                {
+                    new LinkRedirectRule
+                    {
+                        Id = "legacy-tag-query",
+                        SourceHost = "evotec.xyz",
+                        SourcePath = "/blog/",
+                        SourceQueryParameter = "tag",
+                        MatchType = LinkRedirectMatchType.Query,
+                        TargetUrl = "https://evotec.xyz/blog/",
+                        Status = 301
+                    },
+                    new LinkRedirectRule
+                    {
+                        Id = "canonical-www-host",
+                        SourceHost = "www.evotec.xyz",
+                        SourcePath = "/",
+                        MatchType = LinkRedirectMatchType.Prefix,
+                        TargetUrl = "https://evotec.xyz/{path}",
+                        Status = 301,
+                        PreserveQuery = true,
+                        AllowExternal = true
+                    }
+                }
+            };
+
+            var validation = WebLinkService.Validate(dataSet);
+            Assert.True(validation.Success, string.Join(Environment.NewLine, Array.ConvertAll(validation.Issues, issue => issue.Message)));
+
+            var result = WebLinkService.ExportApache(dataSet, new WebLinkApacheExportOptions
+            {
+                OutputPath = outputPath
+            });
+
+            Assert.Equal(2, result.RuleCount);
+            var apache = File.ReadAllText(outputPath);
+            Assert.Contains("RewriteCond %{HTTP_HOST} ^(www\\.)?evotec\\.xyz$ [NC]", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteCond %{QUERY_STRING} (^|&)tag=[^&]*(&|$)", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteRule ^/?blog/?$ https://evotec.xyz/blog/ [R=301,L,QSD]", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteCond %{HTTP_HOST} ^www\\.evotec\\.xyz$ [NC]", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteRule ^/?(.*)$ https://evotec.xyz/$1 [R=301,L,QSA]", apache, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Validate_DetectsQueryParameterSelectorLoopsAcrossRoutes()
+    {
+        var dataSet = new WebLinkDataSet
+        {
+            Redirects = new[]
+            {
+                new LinkRedirectRule
+                {
+                    Id = "tag-to-category",
+                    SourcePath = "/blog/",
+                    SourceQueryParameter = "tag",
+                    MatchType = LinkRedirectMatchType.Query,
+                    TargetUrl = "/archive/?category=legacy"
+                },
+                new LinkRedirectRule
+                {
+                    Id = "category-to-tag",
+                    SourcePath = "/archive/",
+                    SourceQueryParameter = "category",
+                    MatchType = LinkRedirectMatchType.Query,
+                    TargetUrl = "/blog/?tag=legacy"
+                }
+            }
+        };
+
+        var result = WebLinkService.Validate(dataSet);
+
+        Assert.Contains(result.Issues, issue => issue.Code == "PFLINK.REDIRECT.LOOP");
+    }
+}

--- a/PowerForge.Web.Cli/WebLinkCommandSupport.cs
+++ b/PowerForge.Web.Cli/WebLinkCommandSupport.cs
@@ -192,7 +192,7 @@ internal static class WebLinkCommandSupport
         var dataSet = WebLinkService.Load(new WebLinkLoadOptions { RedirectsPath = redirectJsonPath });
         var lines = new List<string>
         {
-            "enabled,id,source_host,source_path,source_query,target_url,status,match_type,group,source,notes"
+            "enabled,id,source_host,source_path,source_query,source_query_parameter,target_url,status,match_type,group,source,notes"
         };
 
         foreach (var redirect in dataSet.Redirects.OrderBy(static item => item.SourceHost ?? string.Empty, StringComparer.OrdinalIgnoreCase).ThenBy(static item => item.SourcePath, StringComparer.OrdinalIgnoreCase))
@@ -203,6 +203,7 @@ internal static class WebLinkCommandSupport
                 EscapeCsv(redirect.SourceHost),
                 EscapeCsv(redirect.SourcePath),
                 EscapeCsv(redirect.SourceQuery),
+                EscapeCsv(redirect.SourceQueryParameter),
                 EscapeCsv(redirect.TargetUrl),
                 EscapeCsv(redirect.Status.ToString(CultureInfo.InvariantCulture)),
                 EscapeCsv(redirect.MatchType.ToString().ToLowerInvariant()),

--- a/PowerForge.Web/Models/LinksSpec.cs
+++ b/PowerForge.Web/Models/LinksSpec.cs
@@ -50,6 +50,8 @@ public sealed class LinkRedirectRule
     public string SourcePath { get; set; } = string.Empty;
     /// <summary>Optional exact query string match without a leading question mark.</summary>
     public string? SourceQuery { get; set; }
+    /// <summary>Optional query parameter name to match regardless of its value, ordering, or accompanying parameters.</summary>
+    public string? SourceQueryParameter { get; set; }
     /// <summary>Source matching strategy.</summary>
     public LinkRedirectMatchType MatchType { get; set; } = LinkRedirectMatchType.Exact;
     /// <summary>Absolute URL or root-relative path target; optional only for 410 Gone rules.</summary>

--- a/PowerForge.Web/Services/WebLinkService.ExportApache.cs
+++ b/PowerForge.Web/Services/WebLinkService.ExportApache.cs
@@ -37,6 +37,7 @@ public static partial class WebLinkService
             .ThenBy(static rule => rule.SourceHost ?? string.Empty, StringComparer.OrdinalIgnoreCase)
             .ThenBy(static rule => rule.SourcePath, StringComparer.OrdinalIgnoreCase)
             .ThenBy(static rule => rule.SourceQuery ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static rule => rule.SourceQueryParameter ?? string.Empty, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
         var ruleCount = 0;
@@ -108,7 +109,7 @@ public static partial class WebLinkService
                 return false;
 
             AppendHostCondition(lines, rule.SourceHost);
-            AppendQueryCondition(lines, rule.SourceQuery);
+            AppendQueryCondition(lines, rule.SourceQuery, rule.SourceQueryParameter);
             lines.Add($"RewriteRule {gonePattern} - [G,L]");
             lines.Add(string.Empty);
             return true;
@@ -122,9 +123,9 @@ public static partial class WebLinkService
             throw new InvalidOperationException($"Apache redirect target contains characters that must be URL-encoded before export: {rule.Id ?? rule.SourcePath}");
 
         AppendHostCondition(lines, rule.SourceHost);
-        AppendQueryCondition(lines, rule.SourceQuery);
+        AppendQueryCondition(lines, rule.SourceQuery, rule.SourceQueryParameter);
 
-        var hasSourceQuery = !string.IsNullOrWhiteSpace(rule.SourceQuery);
+        var hasSourceQuery = HasSourceQuerySelector(rule);
         var flags = new List<string>
         {
             $"R={ResolveStatus(rule.Status, defaultStatus: 301)}",
@@ -252,8 +253,21 @@ public static partial class WebLinkService
         lines.Add($"RewriteCond %{{HTTP_HOST}} ^{prefix}{Regex.Escape(trimmed)}$ [NC]");
     }
 
-    private static void AppendQueryCondition(List<string> lines, string? query)
+    private static void AppendQueryCondition(List<string> lines, string? query, string? queryParameter)
     {
+        if (!string.IsNullOrWhiteSpace(query) && !string.IsNullOrWhiteSpace(queryParameter))
+            throw new InvalidOperationException("Apache redirect sourceQuery and sourceQueryParameter are mutually exclusive.");
+
+        if (!string.IsNullOrWhiteSpace(queryParameter))
+        {
+            var parameter = queryParameter.Trim();
+            if (!SafeQueryParameterNameRegex.IsMatch(parameter))
+                throw new InvalidOperationException("Apache redirect sourceQueryParameter must be a URL-safe query parameter name.");
+
+            lines.Add($"RewriteCond %{{QUERY_STRING}} (^|&){Regex.Escape(parameter)}=[^&]*(&|$)");
+            return;
+        }
+
         if (string.IsNullOrWhiteSpace(query))
             return;
 

--- a/PowerForge.Web/Services/WebLinkService.QueryParameters.cs
+++ b/PowerForge.Web/Services/WebLinkService.QueryParameters.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace PowerForge.Web;
+
+/// <summary>Query-selector validation and display helpers for link-service redirects.</summary>
+public static partial class WebLinkService
+{
+    private static readonly Regex SafeQueryParameterNameRegex = new(
+        "^[a-z0-9][a-z0-9._~-]*$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static void ValidateSourceQuerySelector(LinkRedirectRule redirect, List<LinkValidationIssue> issues, string label)
+    {
+        if (!string.IsNullOrWhiteSpace(redirect.SourceQuery) &&
+            !string.IsNullOrWhiteSpace(redirect.SourceQueryParameter))
+        {
+            AddIssue(
+                issues,
+                LinkValidationSeverity.Error,
+                "PFLINK.REDIRECT.QUERY_SELECTOR_CONFLICT",
+                "Redirect sourceQuery and sourceQueryParameter are mutually exclusive.",
+                "redirect",
+                label);
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(redirect.SourceQueryParameter) &&
+            !SafeQueryParameterNameRegex.IsMatch(redirect.SourceQueryParameter.Trim()))
+        {
+            AddIssue(
+                issues,
+                LinkValidationSeverity.Error,
+                "PFLINK.REDIRECT.QUERY_PARAMETER",
+                "Redirect sourceQueryParameter must be a URL-safe query parameter name.",
+                "redirect",
+                label);
+        }
+    }
+
+    private static bool HasSourceQuerySelector(LinkRedirectRule redirect)
+        => !string.IsNullOrWhiteSpace(redirect.SourceQuery) ||
+           !string.IsNullOrWhiteSpace(redirect.SourceQueryParameter);
+
+    private static string NormalizeSourceQueryParameter(string? parameter)
+        => string.IsNullOrWhiteSpace(parameter) ? string.Empty : parameter.Trim();
+
+    private static string BuildSourceQueryDisplay(LinkRedirectRule redirect)
+    {
+        if (!string.IsNullOrWhiteSpace(redirect.SourceQuery))
+            return redirect.SourceQuery.Trim().TrimStart('?');
+
+        var parameter = NormalizeSourceQueryParameter(redirect.SourceQueryParameter);
+        return string.IsNullOrWhiteSpace(parameter) ? string.Empty : parameter + "=*";
+    }
+
+    private static IEnumerable<string> EnumerateSourceQueryParameterNames(string? query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            yield break;
+
+        foreach (var segment in query.Trim().TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var equalsIndex = segment.IndexOf('=');
+            var name = equalsIndex < 0 ? segment : segment[..equalsIndex];
+            if (!string.IsNullOrWhiteSpace(name))
+                yield return name;
+        }
+    }
+}

--- a/PowerForge.Web/Services/WebLinkService.cs
+++ b/PowerForge.Web/Services/WebLinkService.cs
@@ -326,6 +326,8 @@ public static partial class WebLinkService
             if (redirect.MatchType == LinkRedirectMatchType.Regex && IsBroadRegex(redirect.SourcePath))
                 AddIssue(issues, LinkValidationSeverity.Warning, "PFLINK.REDIRECT.REGEX_BROAD", "Regex redirect looks very broad and should be reviewed.", "redirect", label);
 
+            ValidateSourceQuerySelector(redirect, issues, label);
+
             var key = BuildRedirectKey(redirect);
             if (seen.TryGetValue(key, out var existing))
             {
@@ -409,6 +411,7 @@ public static partial class WebLinkService
     private static void ValidateRedirectGraph(LinkRedirectRule[] redirects, List<LinkValidationIssue> issues)
     {
         var map = new Dictionary<string, RedirectGraphTarget>(StringComparer.OrdinalIgnoreCase);
+        var selectorMap = new Dictionary<string, RedirectGraphTarget>(StringComparer.OrdinalIgnoreCase);
         foreach (var redirect in redirects)
         {
             if (redirect.MatchType != LinkRedirectMatchType.Exact && redirect.MatchType != LinkRedirectMatchType.Query)
@@ -417,6 +420,14 @@ public static partial class WebLinkService
                 continue;
 
             var source = NormalizeSourcePath(redirect.SourcePath);
+            var sourceQueryParameter = NormalizeSourceQueryParameter(redirect.SourceQueryParameter);
+            if (!string.IsNullOrWhiteSpace(sourceQueryParameter))
+            {
+                if (!string.IsNullOrWhiteSpace(source) && !string.IsNullOrWhiteSpace(target.Path))
+                    selectorMap[BuildRedirectGraphSelectorKey(redirect.SourceHost, source, sourceQueryParameter)] = target;
+                continue;
+            }
+
             if (string.Equals(source, target.Path, StringComparison.OrdinalIgnoreCase) &&
                 string.Equals(NormalizeRedirectGraphQuery(redirect.SourceQuery), target.Query, StringComparison.Ordinal))
             {
@@ -456,11 +467,14 @@ public static partial class WebLinkService
             foreach (var traversalHost in BuildRedirectGraphTraversalHosts(host, graphHosts))
             {
                 var current = NormalizeSourcePath(redirect.SourcePath);
-                var currentQuery = redirect.SourceQuery;
+                var sourceQueryParameter = NormalizeSourceQueryParameter(redirect.SourceQueryParameter);
+                var currentQuery = string.IsNullOrWhiteSpace(sourceQueryParameter)
+                    ? redirect.SourceQuery
+                    : sourceQueryParameter + "=*";
                 var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 var depth = 0;
                 var reported = false;
-                while (TryGetRedirectGraphTarget(map, traversalHost, current, currentQuery, out var next))
+                while (TryGetRedirectGraphTarget(map, selectorMap, traversalHost, current, currentQuery, out var next))
                 {
                     if (!visited.Add(BuildRedirectGraphKey(traversalHost, current, currentQuery)))
                     {
@@ -513,6 +527,7 @@ public static partial class WebLinkService
 
     private static bool TryGetRedirectGraphTarget(
         IReadOnlyDictionary<string, RedirectGraphTarget> map,
+        IReadOnlyDictionary<string, RedirectGraphTarget> selectorMap,
         string host,
         string path,
         string? query,
@@ -541,6 +556,18 @@ public static partial class WebLinkService
             {
                 return true;
             }
+        }
+
+        foreach (var queryParameter in EnumerateSourceQueryParameterNames(query))
+        {
+            if (!string.IsNullOrWhiteSpace(host) &&
+                selectorMap.TryGetValue(BuildRedirectGraphSelectorKey(host, path, queryParameter), out target!))
+            {
+                return true;
+            }
+
+            if (selectorMap.TryGetValue(BuildRedirectGraphSelectorKey(null, path, queryParameter), out target!))
+                return true;
         }
 
         target = default;
@@ -691,7 +718,7 @@ public static partial class WebLinkService
             RelatedId = related is null ? null : (string.IsNullOrWhiteSpace(related.Id) ? related.SourcePath : related.Id),
             SourceHost = redirect.SourceHost,
             SourcePath = redirect.SourcePath,
-            SourceQuery = redirect.SourceQuery,
+            SourceQuery = BuildSourceQueryDisplay(redirect),
             TargetUrl = redirect.TargetUrl,
             RelatedTargetUrl = related?.TargetUrl,
             NormalizedTargetUrl = normalizedTarget,
@@ -709,7 +736,8 @@ public static partial class WebLinkService
             NormalizeRedirectGraphHost(redirect.SourceHost),
             ((int)NormalizeRedirectKeyMatchType(redirect)).ToString(CultureInfo.InvariantCulture),
             BuildRedirectSourceKey(redirect),
-            BuildOrdinalKey(NormalizeRedirectGraphQuery(redirect.SourceQuery)));
+            BuildOrdinalKey(NormalizeRedirectGraphQuery(redirect.SourceQuery)),
+            BuildOrdinalKey(NormalizeSourceQueryParameter(redirect.SourceQueryParameter)));
 
     private static string BuildRedirectSourceKey(LinkRedirectRule redirect)
         => redirect.MatchType == LinkRedirectMatchType.Regex
@@ -717,12 +745,15 @@ public static partial class WebLinkService
             : NormalizeSourcePath(redirect.SourcePath);
 
     private static LinkRedirectMatchType NormalizeRedirectKeyMatchType(LinkRedirectRule redirect)
-        => redirect.MatchType == LinkRedirectMatchType.Exact && !string.IsNullOrWhiteSpace(redirect.SourceQuery)
+        => redirect.MatchType == LinkRedirectMatchType.Exact && HasSourceQuerySelector(redirect)
             ? LinkRedirectMatchType.Query
             : redirect.MatchType;
 
     private static string BuildRedirectGraphKey(string? host, string path, string? query)
         => string.Join("|", NormalizeRedirectGraphHost(host), NormalizeSourcePath(path), BuildOrdinalKey(NormalizeRedirectGraphQuery(query)));
+
+    private static string BuildRedirectGraphSelectorKey(string? host, string path, string queryParameter)
+        => string.Join("|", NormalizeRedirectGraphHost(host), NormalizeSourcePath(path), "selector", BuildOrdinalKey(NormalizeSourceQueryParameter(queryParameter)));
 
     private static string BuildOrdinalKey(string value)
         => Convert.ToHexString(Encoding.UTF8.GetBytes(value));
@@ -929,7 +960,8 @@ public static partial class WebLinkService
     {
         var host = string.IsNullOrWhiteSpace(redirect.SourceHost) ? "*" : redirect.SourceHost.Trim();
         var path = string.IsNullOrWhiteSpace(redirect.SourcePath) ? "/" : redirect.SourcePath.Trim();
-        var query = string.IsNullOrWhiteSpace(redirect.SourceQuery) ? string.Empty : "?" + redirect.SourceQuery.Trim().TrimStart('?');
+        var sourceQuery = BuildSourceQueryDisplay(redirect);
+        var query = string.IsNullOrWhiteSpace(sourceQuery) ? string.Empty : "?" + sourceQuery;
         return $"{host}{path}{query}";
     }
 


### PR DESCRIPTION
## Summary

- add `sourceQueryParameter` for redirect rules that match a query parameter name regardless of value or ordering
- export safe Apache parameter-presence conditions with query-string discard behavior
- include selector-aware duplicate, loop, chain, and review-report handling
- cover validation, Apache output, canonical-host preservation, and selector-cycle regressions

## Example

A rule with `sourceQueryParameter: tag` can canonicalize legacy WordPress URLs such as `/blog/?tag=powershell` without maintaining one redirect per tag value.

## Consumer

EvotecIT/Website consumes this commit for canonical `www` and legacy blog query redirects.