### PR TITLE
Retry stalled GitHub Pages deployments

### DIFF
--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -31,6 +31,7 @@ on:
         type: string
         default: '["ubuntu-latest"]'
       timeout_minutes:
+        description: Maximum deployment or post-deployment job duration. GitHub Pages retries once within this budget because deploy-pages limits each attempt to 10 minutes.
         required: false
         type: number
         default: 40
@@ -256,15 +257,22 @@ jobs:
     if: ${{ inputs.deployment_target == 'github-pages' }}
     needs: build
     runs-on: ${{ fromJson(inputs.runner_labels_json) }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url }}
     permissions:
       pages: write
       id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
+        continue-on-error: true
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+
+      - name: Retry GitHub Pages deployment
+        if: ${{ steps.deployment.outcome == 'failure' }}
+        id: deployment_retry
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
   deploy-linux:

--- a/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
@@ -152,6 +152,42 @@ public sealed class GitHubWebsiteRunWorkflowTests
     }
 
     [Fact]
+    public void WebsiteDeployWorkflow_ShouldRetryAStalledGitHubPagesDeployment()
+    {
+        var repoRoot = FindRepoRoot();
+        var workflowPath = Path.Combine(repoRoot, ".github", "workflows", "powerforge-website-deploy.yml");
+        var workflowYaml = File.ReadAllText(workflowPath);
+
+        Assert.NotNull(new YamlDotNet.Serialization.DeserializerBuilder().Build().Deserialize<object>(workflowYaml));
+
+        string pagesDeployJob = workflowYaml[
+            workflowYaml.IndexOf("  deploy:", StringComparison.Ordinal)..
+            workflowYaml.IndexOf("  deploy-linux:", StringComparison.Ordinal)];
+        string initialDeployStep = pagesDeployJob[
+            pagesDeployJob.IndexOf("      - name: Deploy to GitHub Pages", StringComparison.Ordinal)..
+            pagesDeployJob.IndexOf("      - name: Retry GitHub Pages deployment", StringComparison.Ordinal)];
+        string retryDeployStep = pagesDeployJob[
+            pagesDeployJob.IndexOf("      - name: Retry GitHub Pages deployment", StringComparison.Ordinal)..];
+
+        Assert.Contains("timeout-minutes: ${{ inputs.timeout_minutes }}", pagesDeployJob, StringComparison.Ordinal);
+        Assert.Contains("continue-on-error: true", initialDeployStep, StringComparison.Ordinal);
+        Assert.DoesNotContain("continue-on-error:", retryDeployStep, StringComparison.Ordinal);
+        Assert.Equal(
+            1,
+            pagesDeployJob.Split('\n').Count(static line =>
+                line.Trim().Equals("continue-on-error: true", StringComparison.Ordinal)));
+        Assert.Contains("if: ${{ steps.deployment.outcome == 'failure' }}", pagesDeployJob, StringComparison.Ordinal);
+        Assert.Contains(
+            "url: ${{ steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url }}",
+            pagesDeployJob,
+            StringComparison.Ordinal);
+        Assert.Equal(
+            2,
+            pagesDeployJob.Split('\n').Count(static line =>
+                line.Contains("uses: actions/deploy-pages@", StringComparison.Ordinal)));
+    }
+
+    [Fact]
     public void WebsiteRunWorkflow_ShouldResolveOptionalCallerSourceRefToExactProvenance()
     {
         var repoRoot = FindRepoRoot();


### PR DESCRIPTION
GitHub Pages deployments now retry once when the first `actions/deploy-pages` attempt fails. The retry stays inside the existing deployment timeout, and a second failure still fails the job.

This addresses deployments that remain queued until `actions/deploy-pages` reaches its hard 10-minute per-attempt limit. The published environment URL is taken from whichever attempt succeeds.

The workflow contract test covers the retry condition, the two-attempt boundary, the overall timeout, URL propagation, and the requirement that only the first attempt may continue on error.

Validation: all 24 GitHub website workflow tests pass. A fresh read-only review found no P0-P2 issues; its P3 test-contract finding was addressed before publication.
