### PR TITLE
Retry interrupted GitHub release asset uploads

### DIFF
--- a/PowerForge.Tests/GitHubReleasePublisherRetryTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherRetryTests.cs
@@ -51,6 +51,7 @@ public sealed class GitHubReleasePublisherRetryTests
             await Respond(firstUpload, "{\"message\":\"Bad Gateway\"}", 502);
 
             await Respond(await NextRequest(), "{\"message\":\"Service Unavailable\"}", 503);
+            await Respond(await NextRequest(), "[]");
 
             var secondUpload = await NextRequest();
             using (var stream = new MemoryStream())
@@ -135,6 +136,7 @@ public sealed class GitHubReleasePublisherRetryTests
                 422);
 
             var starterAsset = $$"""[{"id":88,"name":"{{assetName}}","state":"starter"}]""";
+            await Respond(await NextRequest(), "{\"message\":\"Service Unavailable\"}", 503);
             await Respond(await NextRequest(), starterAsset);
             await Respond(await NextRequest(), starterAsset);
             await Respond(await NextRequest(), string.Empty, 204);
@@ -167,12 +169,84 @@ public sealed class GitHubReleasePublisherRetryTests
                     "POST /uploads",
                     "GET /repos/EvotecIT/example/releases/42/assets",
                     "GET /repos/EvotecIT/example/releases/42/assets",
+                    "GET /repos/EvotecIT/example/releases/42/assets",
                     "DELETE /repos/EvotecIT/example/releases/assets/88",
                     "POST /uploads",
                     "GET /repos/EvotecIT/example/releases/42/assets",
                     "GET /repos/EvotecIT/example/releases/42/assets"
                 ],
                 requests);
+        }
+        finally
+        {
+            listener.Stop();
+            listener.Close();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
+    public async Task PublishRelease_RefusesToDeleteStarterThatBecameUploaded()
+    {
+        var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(assetPath, "starter-state-race");
+        var assetName = Path.GetFileName(assetPath);
+        var requests = new List<string>();
+
+        async Task<HttpListenerContext> NextRequest()
+        {
+            var context = await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            requests.Add($"{context.Request.HttpMethod} {context.Request.Url!.AbsolutePath}");
+            return context;
+        }
+
+        static async Task Respond(HttpListenerContext context, string json, int statusCode = 200)
+        {
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var server = Task.Run(async () =>
+        {
+            await Respond(
+                await NextRequest(),
+                $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""",
+                201);
+            await Respond(
+                await NextRequest(),
+                "{\"message\":\"Validation Failed\",\"errors\":[{\"resource\":\"ReleaseAsset\",\"code\":\"already_exists\",\"field\":\"name\"}]}",
+                422);
+            await Respond(await NextRequest(), $$"""[{"id":88,"name":"{{assetName}}","state":"starter"}]""");
+            await Respond(await NextRequest(), $$"""[{"id":88,"name":"{{assetName}}","state":"uploaded"}]""");
+        });
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new GitHubReleasePublisher(new NullLogger()).PublishRelease(
+                    new GitHubReleasePublishRequest
+                    {
+                        Owner = "EvotecIT",
+                        Repository = "example",
+                        Token = "token",
+                        ApiBaseUrl = apiBaseUrl,
+                        TagName = "v1.2.3",
+                        AssetFilePaths = [assetPath]
+                    }));
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Contains("changed from state 'starter' to 'uploaded'", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(requests, request => request.StartsWith("DELETE ", StringComparison.Ordinal));
         }
         finally
         {
@@ -222,6 +296,7 @@ public sealed class GitHubReleasePublisherRetryTests
                 422);
 
             var starterAsset = $$"""[{"id":88,"name":"{{assetName}}","state":"starter"}]""";
+            await Respond(await NextRequest(), "{\"message\":\"Service Unavailable\"}", 503);
             await Respond(await NextRequest(), starterAsset);
             await Respond(await NextRequest(), starterAsset);
             await Respond(await NextRequest(), string.Empty, 204);

--- a/PowerForge.Tests/GitHubReleasePublisherRetryTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherRetryTests.cs
@@ -1,0 +1,229 @@
+using PowerForge;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace PowerForge.Tests;
+
+public sealed class GitHubReleasePublisherRetryTests
+{
+    [Fact]
+    public async Task PublishRelease_RetriesTransientAssetFailureWithFreshContent()
+    {
+        var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        var expectedBytes = Encoding.UTF8.GetBytes("retry-safe-release-asset");
+        await File.WriteAllBytesAsync(assetPath, expectedBytes);
+        var receivedUploads = new List<byte[]>();
+
+        async Task<HttpListenerContext> NextRequest()
+            => await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        static async Task Respond(HttpListenerContext context, string json, int statusCode = 200)
+        {
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var assetName = Path.GetFileName(assetPath);
+        var server = Task.Run(async () =>
+        {
+            var create = await NextRequest();
+            await Respond(
+                create,
+                $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""",
+                201);
+
+            var firstUpload = await NextRequest();
+            using (var stream = new MemoryStream())
+            {
+                await firstUpload.Request.InputStream.CopyToAsync(stream);
+                receivedUploads.Add(stream.ToArray());
+            }
+            await Respond(firstUpload, "{\"message\":\"Bad Gateway\"}", 502);
+
+            await Respond(await NextRequest(), "[]");
+
+            var secondUpload = await NextRequest();
+            using (var stream = new MemoryStream())
+            {
+                await secondUpload.Request.InputStream.CopyToAsync(stream);
+                receivedUploads.Add(stream.ToArray());
+            }
+            await Respond(secondUpload, $$"""{"id":99,"name":"{{assetName}}"}""", 201);
+
+            var assets = $$"""[{"id":99,"name":"{{assetName}}"}]""";
+            await Respond(await NextRequest(), assets);
+            await Respond(await NextRequest(), assets);
+        });
+
+        try
+        {
+            var result = new GitHubReleasePublisher(new NullLogger()).PublishRelease(
+                new GitHubReleasePublishRequest
+                {
+                    Owner = "EvotecIT",
+                    Repository = "example",
+                    Token = "token",
+                    ApiBaseUrl = apiBaseUrl,
+                    TagName = "v1.2.3",
+                    AssetFilePaths = [assetPath]
+                });
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.True(result.Succeeded);
+            Assert.Equal(assetName, Assert.Single(result.UploadedAssets));
+            Assert.Equal(2, receivedUploads.Count);
+            Assert.All(receivedUploads, bytes => Assert.Equal(expectedBytes, bytes));
+        }
+        finally
+        {
+            listener.Stop();
+            listener.Close();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
+    public async Task PublishRelease_RemovesIncompleteStarterAssetBeforeRetry()
+    {
+        var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(assetPath, "starter-recovery");
+        var assetName = Path.GetFileName(assetPath);
+        var requests = new List<string>();
+
+        async Task<HttpListenerContext> NextRequest()
+        {
+            var context = await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            requests.Add($"{context.Request.HttpMethod} {context.Request.Url!.AbsolutePath}");
+            return context;
+        }
+
+        static async Task Respond(HttpListenerContext context, string json, int statusCode = 200)
+        {
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var server = Task.Run(async () =>
+        {
+            await Respond(
+                await NextRequest(),
+                $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""",
+                201);
+            await Respond(await NextRequest(), "{\"message\":\"Bad Gateway\"}", 502);
+
+            var starterAsset = $$"""[{"id":88,"name":"{{assetName}}","state":"starter"}]""";
+            await Respond(await NextRequest(), starterAsset);
+            await Respond(await NextRequest(), starterAsset);
+            await Respond(await NextRequest(), string.Empty, 204);
+
+            await Respond(await NextRequest(), $$"""{"id":99,"name":"{{assetName}}"}""", 201);
+            var uploadedAsset = $$"""[{"id":99,"name":"{{assetName}}","state":"uploaded"}]""";
+            await Respond(await NextRequest(), uploadedAsset);
+            await Respond(await NextRequest(), uploadedAsset);
+        });
+
+        try
+        {
+            var result = new GitHubReleasePublisher(new NullLogger()).PublishRelease(
+                new GitHubReleasePublishRequest
+                {
+                    Owner = "EvotecIT",
+                    Repository = "example",
+                    Token = "token",
+                    ApiBaseUrl = apiBaseUrl,
+                    TagName = "v1.2.3",
+                    AssetFilePaths = [assetPath]
+                });
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.True(result.Succeeded);
+            Assert.Equal(assetName, Assert.Single(result.UploadedAssets));
+            Assert.Equal(
+                [
+                    "POST /repos/EvotecIT/example/releases",
+                    "POST /uploads",
+                    "GET /repos/EvotecIT/example/releases/42/assets",
+                    "GET /repos/EvotecIT/example/releases/42/assets",
+                    "DELETE /repos/EvotecIT/example/releases/assets/88",
+                    "POST /uploads",
+                    "GET /repos/EvotecIT/example/releases/42/assets",
+                    "GET /repos/EvotecIT/example/releases/42/assets"
+                ],
+                requests);
+        }
+        finally
+        {
+            listener.Stop();
+            listener.Close();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
+    public void UploadRetryClassification_CoversStreamTransportFailuresButNotCancellation()
+    {
+        Assert.True(GitHubReleasePublisher.IsTransientAssetUploadException(
+            new HttpRequestException("Error while copying content to a stream."),
+            CancellationToken.None));
+        Assert.True(GitHubReleasePublisher.IsTransientAssetUploadException(
+            new IOException("connection reset"),
+            CancellationToken.None));
+        Assert.False(GitHubReleasePublisher.IsTransientAssetUploadException(
+            new InvalidOperationException("invalid response"),
+            CancellationToken.None));
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Assert.False(GitHubReleasePublisher.IsTransientAssetUploadException(
+            new TaskCanceledException("cancelled"),
+            cancellation.Token));
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.RequestTimeout, true)]
+    [InlineData((HttpStatusCode)429, true)]
+    [InlineData(HttpStatusCode.InternalServerError, true)]
+    [InlineData(HttpStatusCode.BadGateway, true)]
+    [InlineData(HttpStatusCode.ServiceUnavailable, true)]
+    [InlineData(HttpStatusCode.GatewayTimeout, true)]
+    [InlineData(HttpStatusCode.UnprocessableEntity, false)]
+    [InlineData(HttpStatusCode.BadRequest, false)]
+    public void UploadRetryClassification_RetriesOnlyTransientHttpStatuses(
+        HttpStatusCode statusCode,
+        bool expected)
+        => Assert.Equal(expected, GitHubReleasePublisher.IsTransientAssetUploadStatus(statusCode));
+
+    private static int GetAvailablePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+}

--- a/PowerForge.Tests/GitHubReleasePublisherRetryTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherRetryTests.cs
@@ -50,7 +50,7 @@ public sealed class GitHubReleasePublisherRetryTests
             }
             await Respond(firstUpload, "{\"message\":\"Bad Gateway\"}", 502);
 
-            await Respond(await NextRequest(), "[]");
+            await Respond(await NextRequest(), "{\"message\":\"Service Unavailable\"}", 503);
 
             var secondUpload = await NextRequest();
             using (var stream = new MemoryStream())
@@ -93,7 +93,7 @@ public sealed class GitHubReleasePublisherRetryTests
     }
 
     [Fact]
-    public async Task PublishRelease_RemovesIncompleteStarterAssetBeforeRetry()
+    public async Task PublishRelease_RemovesExistingStarterAssetBeforeRetry()
     {
         var listener = new HttpListener();
         var port = GetAvailablePort();
@@ -129,7 +129,10 @@ public sealed class GitHubReleasePublisherRetryTests
                 await NextRequest(),
                 $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""",
                 201);
-            await Respond(await NextRequest(), "{\"message\":\"Bad Gateway\"}", 502);
+            await Respond(
+                await NextRequest(),
+                "{\"message\":\"Validation Failed\",\"errors\":[{\"resource\":\"ReleaseAsset\",\"code\":\"already_exists\",\"field\":\"name\"}]}",
+                422);
 
             var starterAsset = $$"""[{"id":88,"name":"{{assetName}}","state":"starter"}]""";
             await Respond(await NextRequest(), starterAsset);
@@ -170,6 +173,223 @@ public sealed class GitHubReleasePublisherRetryTests
                     "GET /repos/EvotecIT/example/releases/42/assets"
                 ],
                 requests);
+        }
+        finally
+        {
+            listener.Stop();
+            listener.Close();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
+    public async Task PublishRelease_ReconcilesLateStarterAfterInterruptedUpload()
+    {
+        var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(assetPath, "late-starter-recovery");
+        var assetName = Path.GetFileName(assetPath);
+
+        async Task<HttpListenerContext> NextRequest()
+            => await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        static async Task Respond(HttpListenerContext context, string json, int statusCode = 200)
+        {
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var server = Task.Run(async () =>
+        {
+            await Respond(
+                await NextRequest(),
+                $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""",
+                201);
+            await Respond(await NextRequest(), "{\"message\":\"Bad Gateway\"}", 502);
+            await Respond(await NextRequest(), "[]");
+            await Respond(
+                await NextRequest(),
+                "{\"message\":\"Validation Failed\",\"errors\":[{\"resource\":\"ReleaseAsset\",\"code\":\"already_exists\",\"field\":\"name\"}]}",
+                422);
+
+            var starterAsset = $$"""[{"id":88,"name":"{{assetName}}","state":"starter"}]""";
+            await Respond(await NextRequest(), starterAsset);
+            await Respond(await NextRequest(), starterAsset);
+            await Respond(await NextRequest(), string.Empty, 204);
+
+            await Respond(await NextRequest(), $$"""{"id":99,"name":"{{assetName}}"}""", 201);
+            var uploadedAsset = $$"""[{"id":99,"name":"{{assetName}}","state":"uploaded"}]""";
+            await Respond(await NextRequest(), uploadedAsset);
+            await Respond(await NextRequest(), uploadedAsset);
+        });
+
+        try
+        {
+            var result = new GitHubReleasePublisher(new NullLogger()).PublishRelease(
+                new GitHubReleasePublishRequest
+                {
+                    Owner = "EvotecIT",
+                    Repository = "example",
+                    Token = "token",
+                    ApiBaseUrl = apiBaseUrl,
+                    TagName = "v1.2.3",
+                    AssetFilePaths = [assetPath]
+                });
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.True(result.Succeeded);
+            Assert.Equal(assetName, Assert.Single(result.UploadedAssets));
+        }
+        finally
+        {
+            listener.Stop();
+            listener.Close();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
+    public async Task PublishRelease_TerminalTransientFailureRemovesStarterBeforeFailing()
+    {
+        var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(assetPath, "terminal-starter-cleanup");
+        var assetName = Path.GetFileName(assetPath);
+        var deleteObserved = false;
+
+        async Task<HttpListenerContext> NextRequest()
+            => await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        static async Task Respond(HttpListenerContext context, string json, int statusCode = 200)
+        {
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var server = Task.Run(async () =>
+        {
+            await Respond(
+                await NextRequest(),
+                $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""",
+                201);
+            for (var attempt = 1; attempt <= 3; attempt++)
+            {
+                await Respond(await NextRequest(), "{\"message\":\"Bad Gateway\"}", 502);
+                await Respond(await NextRequest(), "[]");
+            }
+
+            await Respond(await NextRequest(), "{\"message\":\"Bad Gateway\"}", 502);
+            var starterAsset = $$"""[{"id":88,"name":"{{assetName}}","state":"starter"}]""";
+            await Respond(await NextRequest(), starterAsset);
+            await Respond(await NextRequest(), starterAsset);
+            var delete = await NextRequest();
+            deleteObserved = delete.Request.HttpMethod == "DELETE";
+            await Respond(delete, string.Empty, 204);
+        });
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new GitHubReleasePublisher(new NullLogger()).PublishRelease(
+                    new GitHubReleasePublishRequest
+                    {
+                        Owner = "EvotecIT",
+                        Repository = "example",
+                        Token = "token",
+                        ApiBaseUrl = apiBaseUrl,
+                        TagName = "v1.2.3",
+                        AssetFilePaths = [assetPath]
+                    }));
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Contains("502", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.True(deleteObserved);
+        }
+        finally
+        {
+            listener.Stop();
+            listener.Close();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
+    public async Task PublishRelease_CancellationDuringRecoveryStopsBeforeRetry()
+    {
+        var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(assetPath, "cancel-recovery");
+        using var cancellation = new CancellationTokenSource();
+        var requests = 0;
+
+        async Task<HttpListenerContext> NextRequest()
+        {
+            var context = await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            Interlocked.Increment(ref requests);
+            return context;
+        }
+
+        static async Task Respond(HttpListenerContext context, string json, int statusCode = 200)
+        {
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var server = Task.Run(async () =>
+        {
+            await Respond(
+                await NextRequest(),
+                $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""",
+                201);
+            await Respond(await NextRequest(), "{\"message\":\"Bad Gateway\"}", 502);
+            await Respond(await NextRequest(), "[]");
+            cancellation.Cancel();
+        });
+
+        try
+        {
+            Assert.ThrowsAny<OperationCanceledException>(() =>
+                new GitHubReleasePublisher(new NullLogger()).PublishRelease(
+                    new GitHubReleasePublishRequest
+                    {
+                        Owner = "EvotecIT",
+                        Repository = "example",
+                        Token = "token",
+                        ApiBaseUrl = apiBaseUrl,
+                        TagName = "v1.2.3",
+                        AssetFilePaths = [assetPath]
+                    },
+                    cancellation.Token));
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Equal(3, requests);
         }
         finally
         {

--- a/PowerForge.Tests/GitHubReleasePublisherTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherTests.cs
@@ -235,6 +235,7 @@ public sealed class GitHubReleasePublisherTests
             await Respond(
                 """{"message":"Validation Failed","errors":[{"resource":"ReleaseAsset","code":"already_exists","field":"name"}]}""",
                 422);
+            await Respond($$"""[{"id":99,"name":"{{Path.GetFileName(assetPath)}}","state":"uploaded"}]""", 200);
         });
 
         try
@@ -291,6 +292,7 @@ public sealed class GitHubReleasePublisherTests
             await Respond(
                 """{"message":"Validation Failed","errors":[{"resource":"ReleaseAsset","code":"already_exists","field":"name"}]}""",
                 422);
+            await Respond($$"""[{"id":99,"name":"{{Path.GetFileName(assetPath)}}","state":"uploaded"}]""", 200);
         });
 
         try
@@ -624,6 +626,7 @@ public sealed class GitHubReleasePublisherTests
             await Respond(releaseJson);
             await Respond($"{{\"object\":{{\"sha\":\"{commit}\",\"type\":\"commit\"}}}}");
             await Respond("{\"message\":\"Validation Failed\",\"errors\":[{\"resource\":\"ReleaseAsset\",\"code\":\"already_exists\",\"field\":\"name\"}]}", 422);
+            await Respond($$"""[{"id":101,"name":"{{Path.GetFileName(assetPath)}}","state":"uploaded"}]""");
         });
 
         try

--- a/PowerForge/Services/GitHubReleasePublisher.Assets.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.Assets.cs
@@ -11,6 +11,14 @@ namespace PowerForge;
 public sealed partial class GitHubReleasePublisher {
     private const int MaximumAssetUploadAttempts = 4;
 
+    private enum AssetUploadReconciliationState {
+        Absent,
+        StarterRemoved,
+        Uploaded,
+        LegacyStateUnavailable,
+        TemporarilyUnavailable
+    }
+
     private static void ReportAssetProgress(
         IGitHubReleaseProgressReporter? progress,
         string assetPath,
@@ -164,33 +172,25 @@ public sealed partial class GitHubReleasePublisher {
         string fileName,
         string token,
         Action<long, long>? reportProgress,
-        Action reconcileInterruptedUpload,
+        Func<AssetUploadReconciliationState> reconcileUpload,
         CancellationToken cancellationToken) {
-        if (reconcileInterruptedUpload is null) throw new ArgumentNullException(nameof(reconcileInterruptedUpload));
+        if (reconcileUpload is null) throw new ArgumentNullException(nameof(reconcileUpload));
+        var sawTransientFailure = false;
         for (var attempt = 1; ; attempt++) {
             cancellationToken.ThrowIfCancellationRequested();
+            HttpResponseMessage response;
             try {
-                var response = UploadAssetOnce(
+                response = UploadAssetOnce(
                     uploadUrl,
                     assetPath,
                     fileName,
                     token,
                     reportProgress,
                     cancellationToken);
-                if (!IsTransientAssetUploadStatus(response.StatusCode) ||
-                    attempt >= MaximumAssetUploadAttempts)
-                    return response;
-
-                var delay = GetAssetUploadRetryDelay(response, attempt);
-                _logger.Warn(
-                    $"GitHub release asset upload for '{fileName}' returned " +
-                    $"{(int)response.StatusCode} {response.ReasonPhrase}; retrying attempt " +
-                    $"{attempt + 1}/{MaximumAssetUploadAttempts} in {FormatRetryDelay(delay)}.");
-                response.Dispose();
-                reconcileInterruptedUpload();
-                WaitBeforeAssetUploadRetry(delay, cancellationToken);
             }
             catch (Exception exception) when (IsTransientAssetUploadException(exception, cancellationToken)) {
+                sawTransientFailure = true;
+                reconcileUpload();
                 if (attempt >= MaximumAssetUploadAttempts) {
                     throw new InvalidOperationException(
                         $"GitHub asset upload failed for '{fileName}' after {MaximumAssetUploadAttempts} attempts. " +
@@ -202,9 +202,83 @@ public sealed partial class GitHubReleasePublisher {
                 _logger.Warn(
                     $"GitHub release asset upload for '{fileName}' was interrupted ({exception.Message}); " +
                     $"retrying attempt {attempt + 1}/{MaximumAssetUploadAttempts} in {FormatRetryDelay(delay)}.");
-                reconcileInterruptedUpload();
                 WaitBeforeAssetUploadRetry(delay, cancellationToken);
+                continue;
             }
+
+            if (IsTransientAssetUploadStatus(response.StatusCode)) {
+                sawTransientFailure = true;
+                var delay = GetAssetUploadRetryDelay(response, attempt);
+                var statusCode = response.StatusCode;
+                var reasonPhrase = response.ReasonPhrase;
+                var terminalAttempt = attempt >= MaximumAssetUploadAttempts;
+                if (!terminalAttempt)
+                    response.Dispose();
+                try {
+                    reconcileUpload();
+                }
+                catch {
+                    if (terminalAttempt)
+                        response.Dispose();
+                    throw;
+                }
+
+                if (terminalAttempt)
+                    return response;
+
+                _logger.Warn(
+                    $"GitHub release asset upload for '{fileName}' returned " +
+                    $"{(int)statusCode} {reasonPhrase}; retrying attempt " +
+                    $"{attempt + 1}/{MaximumAssetUploadAttempts} in {FormatRetryDelay(delay)}.");
+                WaitBeforeAssetUploadRetry(delay, cancellationToken);
+                continue;
+            }
+
+            if ((int)response.StatusCode == 422) {
+                var responseText = response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+                if (IsAlreadyExistsValidationError(responseText, fieldName: "name")) {
+                    AssetUploadReconciliationState reconciliation;
+                    try {
+                        reconciliation = reconcileUpload();
+                    }
+                    catch {
+                        response.Dispose();
+                        throw;
+                    }
+
+                    if (reconciliation == AssetUploadReconciliationState.Absent ||
+                        reconciliation == AssetUploadReconciliationState.StarterRemoved) {
+                        response.Dispose();
+                        if (attempt >= MaximumAssetUploadAttempts) {
+                            throw new InvalidOperationException(
+                                $"GitHub release asset '{fileName}' remained unavailable after " +
+                                $"{MaximumAssetUploadAttempts} upload attempts.");
+                        }
+
+                        var delay = GetAssetUploadRetryDelay(response: null, attempt);
+                        _logger.Warn(
+                            $"GitHub release asset '{fileName}' was absent or incomplete after a name collision; " +
+                            $"retrying attempt {attempt + 1}/{MaximumAssetUploadAttempts} in {FormatRetryDelay(delay)}.");
+                        WaitBeforeAssetUploadRetry(delay, cancellationToken);
+                        continue;
+                    }
+
+                    if (sawTransientFailure) {
+                        response.Dispose();
+                        throw new InvalidOperationException(
+                            $"GitHub release asset '{fileName}' appeared after an interrupted upload with " +
+                            $"state '{reconciliation}'; refusing to accept or skip unverified bytes.");
+                    }
+
+                    if (reconciliation == AssetUploadReconciliationState.TemporarilyUnavailable) {
+                        response.Dispose();
+                        throw new InvalidOperationException(
+                            $"GitHub release asset '{fileName}' already exists, but its state could not be verified before skipping.");
+                    }
+                }
+            }
+
+            return response;
         }
     }
 
@@ -231,6 +305,8 @@ public sealed partial class GitHubReleasePublisher {
         CancellationToken cancellationToken) {
         if (exception is null) throw new ArgumentNullException(nameof(exception));
         if (cancellationToken.IsCancellationRequested) return false;
+        if (exception is GitHubApiRequestException apiException)
+            return IsTransientAssetUploadStatus(apiException.StatusCode);
         return exception is HttpRequestException ||
                exception is IOException ||
                exception is TaskCanceledException;
@@ -265,7 +341,7 @@ public sealed partial class GitHubReleasePublisher {
             ? $"{delay.TotalSeconds:0.#}s"
             : $"{delay.TotalMilliseconds:0}ms";
 
-    private void RemoveIncompleteAssetAfterInterruptedUpload(
+    private AssetUploadReconciliationState ReconcileReleaseAssetAfterUploadFailure(
         string owner,
         string repo,
         string token,
@@ -285,21 +361,26 @@ public sealed partial class GitHubReleasePublisher {
             _logger.Warn(
                 $"Could not reconcile interrupted GitHub release asset '{fileName}' before retry. " +
                 exception.Message);
-            return;
+            return AssetUploadReconciliationState.TemporarilyUnavailable;
         }
 
         var sameNameAssets = currentAssets
             .Where(asset => string.Equals(asset.Name, fileName, StringComparison.Ordinal))
             .ToArray();
         if (sameNameAssets.Length == 0)
-            return;
+            return AssetUploadReconciliationState.Absent;
         if (sameNameAssets.Length > 1)
             throw new InvalidOperationException(
                 $"GitHub release contains duplicate asset name '{fileName}' after an interrupted upload; recovery is ambiguous.");
 
         var incompleteAsset = sameNameAssets[0];
+        if (string.Equals(incompleteAsset.State, "uploaded", StringComparison.OrdinalIgnoreCase))
+            return AssetUploadReconciliationState.Uploaded;
+        if (string.IsNullOrWhiteSpace(incompleteAsset.State))
+            return AssetUploadReconciliationState.LegacyStateUnavailable;
         if (!string.Equals(incompleteAsset.State, "starter", StringComparison.OrdinalIgnoreCase))
-            return;
+            throw new InvalidOperationException(
+                $"GitHub release asset '{fileName}' has unexpected state '{incompleteAsset.State}'.");
 
         ValidateReleaseBeforeAssetMutation(
             owner,
@@ -322,7 +403,17 @@ public sealed partial class GitHubReleasePublisher {
             incompleteAsset.Id,
             cancellationToken)) {
             _logger.Warn($"Removed incomplete GitHub release asset '{fileName}' before retrying its upload.");
+            return AssetUploadReconciliationState.StarterRemoved;
         }
+
+        return AssetUploadReconciliationState.Absent;
+    }
+
+    private sealed class GitHubApiRequestException : InvalidOperationException {
+        internal GitHubApiRequestException(string message, HttpStatusCode statusCode)
+            : base(message) => StatusCode = statusCode;
+
+        internal HttpStatusCode StatusCode { get; }
     }
 
     private bool DeleteExpectedExistingAsset(
@@ -376,7 +467,9 @@ public sealed partial class GitHubReleasePublisher {
             var responseText = response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
             using (response) {
                 if (!response.IsSuccessStatusCode)
-                    throw new InvalidOperationException($"GitHub list-release-assets failed for release '{releaseId}' ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}");
+                    throw new GitHubApiRequestException(
+                        $"GitHub list-release-assets failed for release '{releaseId}' ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}",
+                        response.StatusCode);
             }
 
             var pageAssets = Deserialize<GitHubReleaseAssetResponse[]>(responseText) ?? Array.Empty<GitHubReleaseAssetResponse>();

--- a/PowerForge/Services/GitHubReleasePublisher.Assets.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.Assets.cs
@@ -9,6 +9,8 @@ using System.Threading;
 namespace PowerForge;
 
 public sealed partial class GitHubReleasePublisher {
+    private const int MaximumAssetUploadAttempts = 4;
+
     private static void ReportAssetProgress(
         IGitHubReleaseProgressReporter? progress,
         string assetPath,
@@ -156,7 +158,57 @@ public sealed partial class GitHubReleasePublisher {
         }
     }
 
-    private static HttpResponseMessage UploadAsset(
+    private HttpResponseMessage UploadAsset(
+        string uploadUrl,
+        string assetPath,
+        string fileName,
+        string token,
+        Action<long, long>? reportProgress,
+        Action reconcileInterruptedUpload,
+        CancellationToken cancellationToken) {
+        if (reconcileInterruptedUpload is null) throw new ArgumentNullException(nameof(reconcileInterruptedUpload));
+        for (var attempt = 1; ; attempt++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            try {
+                var response = UploadAssetOnce(
+                    uploadUrl,
+                    assetPath,
+                    fileName,
+                    token,
+                    reportProgress,
+                    cancellationToken);
+                if (!IsTransientAssetUploadStatus(response.StatusCode) ||
+                    attempt >= MaximumAssetUploadAttempts)
+                    return response;
+
+                var delay = GetAssetUploadRetryDelay(response, attempt);
+                _logger.Warn(
+                    $"GitHub release asset upload for '{fileName}' returned " +
+                    $"{(int)response.StatusCode} {response.ReasonPhrase}; retrying attempt " +
+                    $"{attempt + 1}/{MaximumAssetUploadAttempts} in {FormatRetryDelay(delay)}.");
+                response.Dispose();
+                reconcileInterruptedUpload();
+                WaitBeforeAssetUploadRetry(delay, cancellationToken);
+            }
+            catch (Exception exception) when (IsTransientAssetUploadException(exception, cancellationToken)) {
+                if (attempt >= MaximumAssetUploadAttempts) {
+                    throw new InvalidOperationException(
+                        $"GitHub asset upload failed for '{fileName}' after {MaximumAssetUploadAttempts} attempts. " +
+                        exception.Message,
+                        exception);
+                }
+
+                var delay = GetAssetUploadRetryDelay(response: null, attempt);
+                _logger.Warn(
+                    $"GitHub release asset upload for '{fileName}' was interrupted ({exception.Message}); " +
+                    $"retrying attempt {attempt + 1}/{MaximumAssetUploadAttempts} in {FormatRetryDelay(delay)}.");
+                reconcileInterruptedUpload();
+                WaitBeforeAssetUploadRetry(delay, cancellationToken);
+            }
+        }
+    }
+
+    private static HttpResponseMessage UploadAssetOnce(
         string uploadUrl,
         string assetPath,
         string fileName,
@@ -172,6 +224,105 @@ public sealed partial class GitHubReleasePublisher {
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
         return SharedClient.SendAsync(request, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+    }
+
+    internal static bool IsTransientAssetUploadException(
+        Exception exception,
+        CancellationToken cancellationToken) {
+        if (exception is null) throw new ArgumentNullException(nameof(exception));
+        if (cancellationToken.IsCancellationRequested) return false;
+        return exception is HttpRequestException ||
+               exception is IOException ||
+               exception is TaskCanceledException;
+    }
+
+    internal static bool IsTransientAssetUploadStatus(HttpStatusCode statusCode)
+        => statusCode == HttpStatusCode.RequestTimeout ||
+           (int)statusCode == 429 ||
+           statusCode == HttpStatusCode.InternalServerError ||
+           statusCode == HttpStatusCode.BadGateway ||
+           statusCode == HttpStatusCode.ServiceUnavailable ||
+           statusCode == HttpStatusCode.GatewayTimeout;
+
+    private static TimeSpan GetAssetUploadRetryDelay(HttpResponseMessage? response, int failedAttempt) {
+        var retryAfter = response?.Headers.RetryAfter;
+        if (retryAfter?.Delta is TimeSpan delta && delta > TimeSpan.Zero)
+            return delta > TimeSpan.FromSeconds(30) ? TimeSpan.FromSeconds(30) : delta;
+        if (retryAfter?.Date is DateTimeOffset date) {
+            var until = date - DateTimeOffset.UtcNow;
+            if (until > TimeSpan.Zero)
+                return until > TimeSpan.FromSeconds(30) ? TimeSpan.FromSeconds(30) : until;
+        }
+
+        return TimeSpan.FromMilliseconds(250 * (1 << Math.Min(failedAttempt - 1, 3)));
+    }
+
+    private static void WaitBeforeAssetUploadRetry(TimeSpan delay, CancellationToken cancellationToken)
+        => Task.Delay(delay, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+
+    private static string FormatRetryDelay(TimeSpan delay)
+        => delay.TotalSeconds >= 1
+            ? $"{delay.TotalSeconds:0.#}s"
+            : $"{delay.TotalMilliseconds:0}ms";
+
+    private void RemoveIncompleteAssetAfterInterruptedUpload(
+        string owner,
+        string repo,
+        string token,
+        string apiBaseUrl,
+        long releaseId,
+        string tagName,
+        string? expectedReleaseBodyMarker,
+        string? expectedTagCommitSha,
+        bool requirePublishedStableRelease,
+        string fileName,
+        CancellationToken cancellationToken) {
+        IReadOnlyList<GitHubReleaseAssetResponse> currentAssets;
+        try {
+            currentAssets = ListReleaseAssets(owner, repo, token, apiBaseUrl, releaseId, cancellationToken);
+        }
+        catch (Exception exception) when (IsTransientAssetUploadException(exception, cancellationToken)) {
+            _logger.Warn(
+                $"Could not reconcile interrupted GitHub release asset '{fileName}' before retry. " +
+                exception.Message);
+            return;
+        }
+
+        var sameNameAssets = currentAssets
+            .Where(asset => string.Equals(asset.Name, fileName, StringComparison.Ordinal))
+            .ToArray();
+        if (sameNameAssets.Length == 0)
+            return;
+        if (sameNameAssets.Length > 1)
+            throw new InvalidOperationException(
+                $"GitHub release contains duplicate asset name '{fileName}' after an interrupted upload; recovery is ambiguous.");
+
+        var incompleteAsset = sameNameAssets[0];
+        if (!string.Equals(incompleteAsset.State, "starter", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        ValidateReleaseBeforeAssetMutation(
+            owner,
+            repo,
+            token,
+            apiBaseUrl,
+            releaseId,
+            tagName,
+            expectedReleaseBodyMarker,
+            expectedTagCommitSha,
+            requirePublishedStableRelease,
+            cancellationToken);
+        if (DeleteExpectedExistingAsset(
+            owner,
+            repo,
+            token,
+            apiBaseUrl,
+            releaseId,
+            fileName,
+            incompleteAsset.Id,
+            cancellationToken)) {
+            _logger.Warn($"Removed incomplete GitHub release asset '{fileName}' before retrying its upload.");
+        }
     }
 
     private bool DeleteExpectedExistingAsset(

--- a/PowerForge/Services/GitHubReleasePublisher.Assets.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.Assets.cs
@@ -10,6 +10,7 @@ namespace PowerForge;
 
 public sealed partial class GitHubReleasePublisher {
     private const int MaximumAssetUploadAttempts = 4;
+    private const int MaximumAssetReconciliationAttempts = 3;
 
     private enum AssetUploadReconciliationState {
         Absent,
@@ -190,7 +191,7 @@ public sealed partial class GitHubReleasePublisher {
             }
             catch (Exception exception) when (IsTransientAssetUploadException(exception, cancellationToken)) {
                 sawTransientFailure = true;
-                reconcileUpload();
+                ReconcileUploadWithRetry(reconcileUpload, fileName, cancellationToken);
                 if (attempt >= MaximumAssetUploadAttempts) {
                     throw new InvalidOperationException(
                         $"GitHub asset upload failed for '{fileName}' after {MaximumAssetUploadAttempts} attempts. " +
@@ -215,7 +216,7 @@ public sealed partial class GitHubReleasePublisher {
                 if (!terminalAttempt)
                     response.Dispose();
                 try {
-                    reconcileUpload();
+                    ReconcileUploadWithRetry(reconcileUpload, fileName, cancellationToken);
                 }
                 catch {
                     if (terminalAttempt)
@@ -239,7 +240,10 @@ public sealed partial class GitHubReleasePublisher {
                 if (IsAlreadyExistsValidationError(responseText, fieldName: "name")) {
                     AssetUploadReconciliationState reconciliation;
                     try {
-                        reconciliation = reconcileUpload();
+                        reconciliation = ReconcileUploadWithRetry(
+                            reconcileUpload,
+                            fileName,
+                            cancellationToken);
                     }
                     catch {
                         response.Dispose();
@@ -263,17 +267,27 @@ public sealed partial class GitHubReleasePublisher {
                         continue;
                     }
 
+                    if (reconciliation == AssetUploadReconciliationState.TemporarilyUnavailable) {
+                        response.Dispose();
+                        if (attempt >= MaximumAssetUploadAttempts) {
+                            throw new InvalidOperationException(
+                                $"GitHub release asset '{fileName}' state could not be verified after " +
+                                $"{MaximumAssetUploadAttempts} upload attempts.");
+                        }
+
+                        var delay = GetAssetUploadRetryDelay(response: null, attempt);
+                        _logger.Warn(
+                            $"GitHub release asset '{fileName}' state remained temporarily unavailable; " +
+                            $"retrying attempt {attempt + 1}/{MaximumAssetUploadAttempts} in {FormatRetryDelay(delay)}.");
+                        WaitBeforeAssetUploadRetry(delay, cancellationToken);
+                        continue;
+                    }
+
                     if (sawTransientFailure) {
                         response.Dispose();
                         throw new InvalidOperationException(
                             $"GitHub release asset '{fileName}' appeared after an interrupted upload with " +
                             $"state '{reconciliation}'; refusing to accept or skip unverified bytes.");
-                    }
-
-                    if (reconciliation == AssetUploadReconciliationState.TemporarilyUnavailable) {
-                        response.Dispose();
-                        throw new InvalidOperationException(
-                            $"GitHub release asset '{fileName}' already exists, but its state could not be verified before skipping.");
                     }
                 }
             }
@@ -341,6 +355,27 @@ public sealed partial class GitHubReleasePublisher {
             ? $"{delay.TotalSeconds:0.#}s"
             : $"{delay.TotalMilliseconds:0}ms";
 
+    private AssetUploadReconciliationState ReconcileUploadWithRetry(
+        Func<AssetUploadReconciliationState> reconcileUpload,
+        string fileName,
+        CancellationToken cancellationToken) {
+        for (var attempt = 1; attempt <= MaximumAssetReconciliationAttempts; attempt++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            var reconciliation = reconcileUpload();
+            if (reconciliation != AssetUploadReconciliationState.TemporarilyUnavailable ||
+                attempt >= MaximumAssetReconciliationAttempts)
+                return reconciliation;
+
+            var delay = GetAssetUploadRetryDelay(response: null, attempt);
+            _logger.Warn(
+                $"GitHub release asset reconciliation for '{fileName}' is temporarily unavailable; " +
+                $"retrying check {attempt + 1}/{MaximumAssetReconciliationAttempts} in {FormatRetryDelay(delay)}.");
+            WaitBeforeAssetUploadRetry(delay, cancellationToken);
+        }
+
+        return AssetUploadReconciliationState.TemporarilyUnavailable;
+    }
+
     private AssetUploadReconciliationState ReconcileReleaseAssetAfterUploadFailure(
         string owner,
         string repo,
@@ -401,6 +436,7 @@ public sealed partial class GitHubReleasePublisher {
             releaseId,
             fileName,
             incompleteAsset.Id,
+            requiredState: "starter",
             cancellationToken)) {
             _logger.Warn($"Removed incomplete GitHub release asset '{fileName}' before retrying its upload.");
             return AssetUploadReconciliationState.StarterRemoved;
@@ -424,6 +460,7 @@ public sealed partial class GitHubReleasePublisher {
         long releaseId,
         string fileName,
         long expectedAssetId,
+        string? requiredState,
         CancellationToken cancellationToken) {
         if (releaseId <= 0)
             throw new InvalidOperationException("GitHub release asset replacement requires the release id returned by GitHub.");
@@ -433,6 +470,12 @@ public sealed partial class GitHubReleasePublisher {
         if (asset is null)
             return false;
         ValidateExpectedAssetId(fileName, expectedAssetId, asset.Id);
+        if (!string.IsNullOrWhiteSpace(requiredState) &&
+            !string.Equals(asset.State, requiredState, StringComparison.OrdinalIgnoreCase)) {
+            throw new InvalidOperationException(
+                $"GitHub release asset '{fileName}' changed from state '{requiredState}' to " +
+                $"'{asset.State ?? "<missing>"}' before deletion.");
+        }
 
         var uri = BuildApiUri(apiBaseUrl, $"/repos/{owner}/{repo}/releases/assets/{expectedAssetId}");
         using var request = new HttpRequestMessage(HttpMethod.Delete, uri);

--- a/PowerForge/Services/GitHubReleasePublisher.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.cs
@@ -426,7 +426,7 @@ public sealed partial class GitHubReleasePublisher
                     GitHubReleaseAssetProgressState.Uploading,
                     transferred,
                     total),
-                () => RemoveIncompleteAssetAfterInterruptedUpload(
+                () => ReconcileReleaseAssetAfterUploadFailure(
                     owner,
                     repo,
                     token,

--- a/PowerForge/Services/GitHubReleasePublisher.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.cs
@@ -381,6 +381,7 @@ public sealed partial class GitHubReleasePublisher
                     releaseId,
                     fileName,
                     expectedAssetId,
+                    requiredState: null,
                     cancellationToken))
                 {
                     replacedExistingAssets.Add(fileName);

--- a/PowerForge/Services/GitHubReleasePublisher.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.cs
@@ -426,6 +426,18 @@ public sealed partial class GitHubReleasePublisher
                     GitHubReleaseAssetProgressState.Uploading,
                     transferred,
                     total),
+                () => RemoveIncompleteAssetAfterInterruptedUpload(
+                    owner,
+                    repo,
+                    token,
+                    apiBaseUrl,
+                    releaseId,
+                    tagName,
+                    expectedReleaseBodyMarker,
+                    expectedTagCommitSha,
+                    requirePublishedStableRelease,
+                    fileName,
+                    cancellationToken),
                 cancellationToken);
             var respText = resp.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
@@ -709,6 +721,9 @@ public sealed partial class GitHubReleasePublisher
 
         [DataMember(Name = "name")]
         public string? Name { get; set; }
+
+        [DataMember(Name = "state")]
+        public string? State { get; set; }
     }
 
     [DataContract]


### PR DESCRIPTION
## Summary

- retry transient GitHub release asset uploads with fresh streams and bounded backoff
- reconcile interrupted `starter` assets and delete them only when both asset identity and state still match
- fail closed when an interrupted upload leaves ambiguous completed bytes, while preserving compatible reuse of existing release assets

This prevents one transient stream-copy failure from permanently stopping a large multi-asset release.

## Validation

- `dotnet build .\PowerForge\PowerForge.csproj -c Release --no-restore --verbosity minimal`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~GitHubReleasePublisher" --verbosity minimal` (31 passed)