### PR TITLE
Fix project telemetry and API documentation ingestion

### DIFF
--- a/PowerForge.Tests/WebEcosystemStatsGeneratorTests.cs
+++ b/PowerForge.Tests/WebEcosystemStatsGeneratorTests.cs
@@ -49,6 +49,11 @@ public sealed class WebEcosystemStatsGeneratorTests
             var gitHub = rootElement.GetProperty("gitHub");
             Assert.Equal("EvotecIT", gitHub.GetProperty("organization").GetString());
             Assert.Equal(2, gitHub.GetProperty("repositoryCount").GetInt32());
+            Assert.Equal(1, gitHub.GetProperty("totalOpenIssues").GetInt32());
+            var repositories = gitHub.GetProperty("repositories");
+            Assert.Equal(0, repositories[0].GetProperty("openIssues").GetInt32());
+            Assert.Equal("PSWriteHTML", repositories[0].GetProperty("name").GetString());
+            Assert.Equal(1, repositories[1].GetProperty("openIssues").GetInt32());
 
             var nuget = rootElement.GetProperty("nuget");
             Assert.Equal("Evotec", nuget.GetProperty("owner").GetString());
@@ -130,6 +135,33 @@ public sealed class WebEcosystemStatsGeneratorTests
         }
     }
 
+    [Fact]
+    public void Generate_GitHubIncompleteIssueSearch_DoesNotPublishFalseZeroCounts()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-ecosystem-stats-incomplete-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var outPath = Path.Combine(root, "data", "ecosystem-stats.json");
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                WebEcosystemStatsGenerator.Generate(new WebEcosystemStatsOptions
+                {
+                    OutputPath = outPath,
+                    GitHubOrganization = "EvotecIT",
+                    MaxItems = 10
+                }, new GitHubIncompleteIssueSearchHandler()));
+
+            Assert.Contains("incomplete", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.False(File.Exists(outPath));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
     private static void TryDeleteDirectory(string path)
     {
         try
@@ -158,6 +190,22 @@ public sealed class WebEcosystemStatsGeneratorTests
 
             if (uri.Host.Equals("api.github.com", StringComparison.OrdinalIgnoreCase))
             {
+                if (uri.AbsolutePath.Equals("/search/issues", StringComparison.OrdinalIgnoreCase))
+                {
+                    const string issueSearch = """
+                    {
+                      "total_count": 1,
+                      "incomplete_results": false,
+                      "items": [
+                        {
+                          "repository_url": "https://api.github.com/repos/EvotecIT/ADEssentials"
+                        }
+                      ]
+                    }
+                    """;
+                    return JsonResponse(issueSearch);
+                }
+
                 var page = ParseQuery(uri, "page", fallback: 1);
                 if (page == 1)
                 {
@@ -346,6 +394,24 @@ public sealed class WebEcosystemStatsGeneratorTests
 
             if (uri.Host.Equals("api.github.com", StringComparison.OrdinalIgnoreCase))
             {
+                if (uri.AbsolutePath.Equals("/search/issues", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (request.Headers.Authorization is not null)
+                    {
+                        SawAuthorizedForbidden = true;
+                        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Forbidden)
+                        {
+                            Content = new StringContent("forbidden", Encoding.UTF8, "text/plain")
+                        });
+                    }
+
+                    SawAnonymousSuccess = true;
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{\"total_count\":0,\"incomplete_results\":false,\"items\":[]}", Encoding.UTF8, "application/json")
+                    });
+                }
+
                 var page = ParseQuery(uri, "page", fallback: 1);
                 if (page == 1 && request.Headers.Authorization is not null)
                 {
@@ -425,6 +491,24 @@ public sealed class WebEcosystemStatsGeneratorTests
 
             if (uri.Host.Equals("api.github.com", StringComparison.OrdinalIgnoreCase))
             {
+                if (uri.AbsolutePath.Equals("/search/issues", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (request.Headers.Authorization is not null)
+                    {
+                        SawAuthorizedUnauthorized = true;
+                        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                        {
+                            Content = new StringContent("unauthorized", Encoding.UTF8, "text/plain")
+                        });
+                    }
+
+                    SawAnonymousSuccess = true;
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{\"total_count\":0,\"incomplete_results\":false,\"items\":[]}", Encoding.UTF8, "application/json")
+                    });
+                }
+
                 if (request.Headers.Authorization is not null)
                 {
                     SawAuthorizedUnauthorized = true;
@@ -460,6 +544,49 @@ public sealed class WebEcosystemStatsGeneratorTests
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
             {
                 Content = new StringContent("{}", Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private sealed class GitHubIncompleteIssueSearchHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var uri = request.RequestUri;
+            if (uri?.AbsolutePath.Equals("/search/issues", StringComparison.OrdinalIgnoreCase) is true)
+            {
+                return JsonResponse("{\"total_count\":1,\"incomplete_results\":true,\"items\":[]}");
+            }
+
+            if (uri?.AbsolutePath.EndsWith("/repos", StringComparison.OrdinalIgnoreCase) is true)
+            {
+                const string repositoryPayload = """
+                [
+                  {
+                    "name":"ImagePlayground",
+                    "full_name":"EvotecIT/ImagePlayground",
+                    "html_url":"https://github.com/EvotecIT/ImagePlayground",
+                    "language":"C#",
+                    "archived":false,
+                    "stargazers_count":98,
+                    "forks_count":7,
+                    "watchers_count":98,
+                    "open_issues_count":2,
+                    "pushed_at":"2026-08-07T08:00:00Z"
+                  }
+                ]
+                """;
+                return JsonResponse(repositoryPayload);
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        private static Task<HttpResponseMessage> JsonResponse(string json)
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
             });
         }
     }

--- a/PowerForge.Tests/WebPipelineRunnerProjectApiDocsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectApiDocsTests.cs
@@ -221,6 +221,17 @@ public class WebPipelineRunnerProjectApiDocsTests
                   </members>
                 </doc>
                 """);
+            File.WriteAllText(Path.Combine(dotNetRoot, "Beta.Interactivity.xml"),
+                """
+                <doc>
+                  <assembly><name>Beta.Interactivity</name></assembly>
+                  <members>
+                    <member name="T:Beta.Interactivity.Explorer">
+                      <summary>Explores an interactive project scene.</summary>
+                    </member>
+                  </members>
+                </doc>
+                """);
 
             var pipelinePath = Path.Combine(root, "pipeline.json");
             File.WriteAllText(pipelinePath,
@@ -250,6 +261,8 @@ public class WebPipelineRunnerProjectApiDocsTests
             Assert.Contains("Beta API Reference", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Widget", html, StringComparison.Ordinal);
             Assert.Contains("Creates a project widget", html, StringComparison.Ordinal);
+            Assert.Contains("Explorer", html, StringComparison.Ordinal);
+            Assert.Contains("Explores an interactive project scene", html, StringComparison.Ordinal);
 
             var summary = File.ReadAllText(Path.Combine(root, "summary.json"));
             Assert.Contains("\"generated\": 1", summary, StringComparison.OrdinalIgnoreCase);

--- a/PowerForge.Tests/WebPipelineRunnerProjectApiDocsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectApiDocsTests.cs
@@ -185,7 +185,7 @@ public class WebPipelineRunnerProjectApiDocsTests
     }
 
     [Fact]
-    public void RunPipeline_ProjectApiDocs_GeneratesProjectScopedDotNetApi()
+    public void RunPipeline_ProjectApiDocs_GeneratesProjectScopedDotNetApiFromXmlOnly()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-project-apidocs-dotnet-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
@@ -210,15 +210,13 @@ public class WebPipelineRunnerProjectApiDocsTests
 
             var dotNetRoot = Path.Combine(root, "data", "project-api", "beta", "dotnet");
             Directory.CreateDirectory(dotNetRoot);
-            var assemblyPath = typeof(WebPipelineRunnerProjectApiDocsTests).Assembly.Location;
-            File.Copy(assemblyPath, Path.Combine(dotNetRoot, "PowerForge.Tests.dll"));
-            File.WriteAllText(Path.Combine(dotNetRoot, "PowerForge.Tests.xml"),
-                $"""
+            File.WriteAllText(Path.Combine(dotNetRoot, "Beta.xml"),
+                """
                 <doc>
-                  <assembly><name>PowerForge.Tests</name></assembly>
+                  <assembly><name>Beta</name></assembly>
                   <members>
-                    <member name="T:{typeof(WebPipelineRunnerProjectApiDocsTests).FullName}">
-                      <summary>Project API docs test type.</summary>
+                    <member name="T:Beta.Widget">
+                      <summary>Creates a project widget.</summary>
                     </member>
                   </members>
                 </doc>
@@ -250,6 +248,8 @@ public class WebPipelineRunnerProjectApiDocsTests
             Assert.True(File.Exists(indexPath));
             var html = File.ReadAllText(indexPath);
             Assert.Contains("Beta API Reference", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Widget", html, StringComparison.Ordinal);
+            Assert.Contains("Creates a project widget", html, StringComparison.Ordinal);
 
             var summary = File.ReadAllText(Path.Combine(root, "summary.json"));
             Assert.Contains("\"generated\": 1", summary, StringComparison.OrdinalIgnoreCase);

--- a/PowerForge.Tests/WebPipelineRunnerProjectDocsSyncPowerShellGalleryTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectDocsSyncPowerShellGalleryTests.cs
@@ -1,0 +1,175 @@
+using System.IO.Compression;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using PowerForge.Web.Cli;
+
+namespace PowerForge.Tests;
+
+public sealed class WebPipelineRunnerProjectDocsSyncPowerShellGalleryTests
+{
+    [Fact]
+    public async Task RunPipeline_ProjectDocsSync_HydratesMissingPowerShellApiFromExactGalleryPackageWithoutArtifactToken()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-project-docs-gallery-" + Guid.NewGuid().ToString("N"));
+        var port = GetFreeTcpPort();
+        using var listener = new HttpListener();
+        listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+        listener.Start();
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var packageBytes = CreateHelpPackage("Sample-help.xml", "<helpItems />");
+            string? requestPath = null;
+            string? authorization = null;
+            var serverTask = Task.Run(async () =>
+            {
+                var context = await listener.GetContextAsync();
+                requestPath = context.Request.RawUrl;
+                authorization = context.Request.Headers["Authorization"];
+                context.Response.StatusCode = (int)HttpStatusCode.OK;
+                context.Response.ContentType = "application/octet-stream";
+                context.Response.ContentLength64 = packageBytes.Length;
+                await context.Response.OutputStream.WriteAsync(packageBytes);
+                context.Response.Close();
+            });
+
+            WriteCatalog(root,
+                """
+                {
+                  "slug": "sample",
+                  "contentMode": "hybrid",
+                  "surfaces": { "apiPowerShell": true },
+                  "links": { "apiPowerShell": "https://example.test/api" },
+                  "metrics": {
+                    "powerShellGallery": { "id": "Sample Module", "version": "1.2.3-preview.1" }
+                  }
+                }
+                """);
+            WritePipeline(root, $"http://127.0.0.1:{port}/api/v2/package", includeArtifactToken: true);
+
+            var result = WebPipelineRunner.RunPipeline(Path.Combine(root, "pipeline.json"), logger: null);
+            await serverTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Assert.True(result.Success);
+            Assert.Equal("/api/v2/package/Sample%20Module/1.2.3-preview.1", requestPath);
+            Assert.Null(authorization);
+            Assert.True(File.Exists(Path.Combine(root, "data", "apidocs", "sample", "Sample-help.xml")));
+            Assert.Contains("api=1/1", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            listener.Stop();
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void RunPipeline_ProjectDocsSync_DoesNotReplaceExistingApiWithGalleryPackage()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-project-docs-gallery-existing-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            WriteCatalog(root,
+                """
+                {
+                  "slug": "sample",
+                  "contentMode": "hybrid",
+                  "surfaces": { "apiPowerShell": true },
+                  "metrics": {
+                    "powerShellGallery": { "id": "Sample", "version": "1.2.3" }
+                  }
+                }
+                """);
+            WritePipeline(root, "http://127.0.0.1:1/api/v2/package", includeArtifactToken: false);
+
+            var sourceRoot = Path.Combine(root, "projects-sources", "sample", "en-US");
+            Directory.CreateDirectory(sourceRoot);
+            File.WriteAllText(Path.Combine(sourceRoot, "Sample-help.xml"), "<local />");
+
+            var result = WebPipelineRunner.RunPipeline(Path.Combine(root, "pipeline.json"), logger: null);
+
+            Assert.True(result.Success);
+            var copiedHelp = File.ReadAllText(Path.Combine(root, "data", "apidocs", "sample", "Sample-help.xml"));
+            Assert.Equal("<local />", copiedHelp);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    private static byte[] CreateHelpPackage(string fileName, string content)
+    {
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = archive.CreateEntry("en-US/" + fileName);
+            using var writer = new StreamWriter(entry.Open(), Encoding.UTF8);
+            writer.Write(content);
+        }
+
+        return stream.ToArray();
+    }
+
+    private static void WriteCatalog(string root, string projectJson)
+    {
+        var catalogPath = Path.Combine(root, "data", "projects", "catalog.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(catalogPath)!);
+        File.WriteAllText(catalogPath, $$"""{ "projects": [ {{projectJson}} ] }""");
+    }
+
+    private static void WritePipeline(string root, string packageBaseUrl, bool includeArtifactToken)
+    {
+        var artifactToken = includeArtifactToken ? "\"artifactToken\": \"must-not-leak\"," : string.Empty;
+        File.WriteAllText(Path.Combine(root, "pipeline.json"),
+            $$"""
+            {
+              "steps": [
+                {
+                  "task": "project-docs-sync",
+                  "catalog": "./data/projects/catalog.json",
+                  "sourcesRoot": "./projects-sources",
+                  "contentRoot": "./content/docs",
+                  "syncDocs": false,
+                  "syncApi": true,
+                  "syncExamples": false,
+                  "apiRoot": "./data/apidocs",
+                  "sourceApiPaths": ["en-US"],
+                  "hydrateFromArtifacts": true,
+                  "onlyLocalLinks": true,
+                  "powerShellGalleryPackageBaseUrl": "{{packageBaseUrl}}",
+                  {{artifactToken}}
+                  "failOnMissingApiSource": true,
+                  "strict": true
+                }
+              ]
+            }
+            """);
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup for test artifacts.
+        }
+    }
+}

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.Content.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.Content.cs
@@ -34,6 +34,11 @@ internal static partial class WebPipelineRunner
 
         var typeText = GetString(step, "type");
         var xml = ResolvePath(baseDir, GetString(step, "xml"));
+        var xmls = (GetArrayOfStrings(step, "xmls") ?? GetArrayOfStrings(step, "xmlPaths") ?? Array.Empty<string>())
+            .Select(path => ResolvePath(baseDir, path))
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .Cast<string>()
+            .ToArray();
         var help = ResolvePath(baseDir, GetString(step, "help") ?? GetString(step, "helpPath") ?? GetString(step, "help-path"));
         var outPath = ResolvePath(baseDir, GetString(step, "out") ?? GetString(step, "output"));
         var assembly = ResolvePath(baseDir, GetString(step, "assembly"));
@@ -314,6 +319,7 @@ internal static partial class WebPipelineRunner
             {
                 Type = apiType,
                 XmlPath = xml ?? string.Empty,
+                XmlPaths = xmls,
                 HelpPath = help,
                 PowerShellModuleManifestPath = powerShellManifestPath,
                 PowerShellCommandMetadataPath = powerShellCommandMetadataPath,

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectApiDocs.DotNetInputs.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectApiDocs.DotNetInputs.cs
@@ -1,0 +1,59 @@
+namespace PowerForge.Web.Cli;
+
+internal static partial class WebPipelineRunner
+{
+    private static bool TryBuildDotNetProjectApiInput(
+        string root,
+        IReadOnlyList<string> placeholderMarkers,
+        out ProjectApiInputCandidate? candidate)
+    {
+        candidate = null;
+        var dotNetRoot = ResolveExistingSubdirectory(root, "dotnet", "DotNet", "csharp", "CSharp");
+        if (string.IsNullOrWhiteSpace(dotNetRoot))
+            dotNetRoot = root;
+        if (!Directory.Exists(dotNetRoot))
+            return false;
+
+        var xmlFiles = Directory.GetFiles(dotNetRoot, "*.xml", SearchOption.AllDirectories)
+            .Select(Path.GetFullPath)
+            .OrderBy(static path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (xmlFiles.Length == 0)
+            return false;
+
+        var hasPlaceholder = false;
+        var placeholderPath = string.Empty;
+        foreach (var xmlPath in xmlFiles)
+        {
+            if (!TryDetectPlaceholderContent(xmlPath, placeholderMarkers, out var detectedPath))
+                continue;
+            hasPlaceholder = true;
+            placeholderPath = detectedPath;
+            break;
+        }
+
+        string? assemblyPath = null;
+        if (xmlFiles.Length == 1)
+        {
+            var baseName = Path.GetFileNameWithoutExtension(xmlFiles[0]);
+            var xmlDirectory = Path.GetDirectoryName(xmlFiles[0]) ?? dotNetRoot;
+            assemblyPath = Directory.GetFiles(xmlDirectory, "*.dll", SearchOption.TopDirectoryOnly)
+                .FirstOrDefault(path => Path.GetFileNameWithoutExtension(path).Equals(baseName, StringComparison.OrdinalIgnoreCase));
+            assemblyPath ??= Directory.GetFiles(dotNetRoot, "*.dll", SearchOption.AllDirectories)
+                .OrderBy(static path => path, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+        }
+
+        candidate = new ProjectApiInputCandidate
+        {
+            Type = "CSharp",
+            RootPath = dotNetRoot,
+            XmlPath = xmlFiles[0],
+            XmlPaths = xmlFiles,
+            AssemblyPath = string.IsNullOrWhiteSpace(assemblyPath) ? null : Path.GetFullPath(assemblyPath),
+            HasPlaceholderContent = hasPlaceholder,
+            PlaceholderPath = placeholderPath
+        };
+        return true;
+    }
+}

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectApiDocs.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectApiDocs.cs
@@ -627,50 +627,6 @@ internal static partial class WebPipelineRunner
         return true;
     }
 
-    private static bool TryBuildDotNetProjectApiInput(
-        string root,
-        IReadOnlyList<string> placeholderMarkers,
-        out ProjectApiInputCandidate? candidate)
-    {
-        candidate = null;
-        var dotNetRoot = ResolveExistingSubdirectory(root, "dotnet", "DotNet", "csharp", "CSharp");
-        if (string.IsNullOrWhiteSpace(dotNetRoot))
-            dotNetRoot = root;
-        if (!Directory.Exists(dotNetRoot))
-            return false;
-
-        var xmlFiles = Directory.GetFiles(dotNetRoot, "*.xml", SearchOption.AllDirectories)
-            .OrderBy(static path => path, StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-        if (xmlFiles.Length == 0)
-            return false;
-
-        foreach (var xmlPath in xmlFiles)
-        {
-            var baseName = Path.GetFileNameWithoutExtension(xmlPath);
-            var xmlDirectory = Path.GetDirectoryName(xmlPath) ?? dotNetRoot;
-            var assemblyPath = Directory.GetFiles(xmlDirectory, "*.dll", SearchOption.TopDirectoryOnly)
-                .FirstOrDefault(path => Path.GetFileNameWithoutExtension(path).Equals(baseName, StringComparison.OrdinalIgnoreCase));
-            assemblyPath ??= Directory.GetFiles(dotNetRoot, "*.dll", SearchOption.AllDirectories)
-                .OrderBy(static path => path, StringComparer.OrdinalIgnoreCase)
-                .FirstOrDefault();
-
-            var hasPlaceholder = TryDetectPlaceholderContent(xmlPath, placeholderMarkers, out var placeholderPath);
-            candidate = new ProjectApiInputCandidate
-            {
-                Type = "CSharp",
-                RootPath = dotNetRoot,
-                XmlPath = Path.GetFullPath(xmlPath),
-                AssemblyPath = string.IsNullOrWhiteSpace(assemblyPath) ? null : Path.GetFullPath(assemblyPath),
-                HasPlaceholderContent = hasPlaceholder,
-                PlaceholderPath = placeholderPath
-            };
-            return true;
-        }
-
-        return false;
-    }
-
     private static string? ResolveExistingSubdirectory(string root, params string[] candidates)
     {
         if (string.IsNullOrWhiteSpace(root) || !Directory.Exists(root))
@@ -845,6 +801,8 @@ internal static partial class WebPipelineRunner
             node["psExamplesPath"] = selected.PowerShellExamplesPath;
         if (!string.IsNullOrWhiteSpace(selected.XmlPath))
             node["xml"] = selected.XmlPath;
+        if (selected.XmlPaths is { Length: > 1 })
+            node["xmls"] = new JsonArray(selected.XmlPaths.Select(static path => (JsonNode?)path).ToArray());
         if (!string.IsNullOrWhiteSpace(selected.AssemblyPath))
             node["assembly"] = selected.AssemblyPath;
 
@@ -2802,6 +2760,7 @@ internal static partial class WebPipelineRunner
         public string? PowerShellCommandMetadataPath { get; init; }
         public string? PowerShellExamplesPath { get; init; }
         public string? XmlPath { get; init; }
+        public string[] XmlPaths { get; init; } = Array.Empty<string>();
         public string? AssemblyPath { get; init; }
         public bool HasPlaceholderContent { get; init; }
         public string PlaceholderPath { get; init; } = string.Empty;

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectApiDocs.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectApiDocs.cs
@@ -654,8 +654,6 @@ internal static partial class WebPipelineRunner
             assemblyPath ??= Directory.GetFiles(dotNetRoot, "*.dll", SearchOption.AllDirectories)
                 .OrderBy(static path => path, StringComparer.OrdinalIgnoreCase)
                 .FirstOrDefault();
-            if (string.IsNullOrWhiteSpace(assemblyPath))
-                continue;
 
             var hasPlaceholder = TryDetectPlaceholderContent(xmlPath, placeholderMarkers, out var placeholderPath);
             candidate = new ProjectApiInputCandidate
@@ -663,7 +661,7 @@ internal static partial class WebPipelineRunner
                 Type = "CSharp",
                 RootPath = dotNetRoot,
                 XmlPath = Path.GetFullPath(xmlPath),
-                AssemblyPath = Path.GetFullPath(assemblyPath),
+                AssemblyPath = string.IsNullOrWhiteSpace(assemblyPath) ? null : Path.GetFullPath(assemblyPath),
                 HasPlaceholderContent = hasPlaceholder,
                 PlaceholderPath = placeholderPath
             };

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectDocsSync.PowerShellGallery.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectDocsSync.PowerShellGallery.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Text.Json;
+
+namespace PowerForge.Web.Cli;
+
+internal static partial class WebPipelineRunner
+{
+    private const string DefaultPowerShellGalleryPackageBaseUrl = "https://www.powershellgallery.com/api/v2/package";
+
+    /// <summary>
+    /// Resolves the exact-package endpoint used only as a fallback for PowerShell API help.
+    /// </summary>
+    private static string ResolvePowerShellGalleryPackageBaseUrl(JsonElement step)
+    {
+        var configured = GetString(step, "powerShellGalleryPackageBaseUrl") ??
+                         GetString(step, "powershell-gallery-package-base-url");
+        return string.IsNullOrWhiteSpace(configured)
+            ? DefaultPowerShellGalleryPackageBaseUrl
+            : configured.Trim().TrimEnd('/');
+    }
+
+    private static bool HasPowerShellGalleryPackage(string? packageId, string? packageVersion)
+    {
+        return !string.IsNullOrWhiteSpace(packageId) && !string.IsNullOrWhiteSpace(packageVersion);
+    }
+
+    /// <summary>
+    /// Builds a version-pinned PSGallery download URL from catalog metadata. The caller intentionally
+    /// downloads this source without the GitHub artifact bearer token.
+    /// </summary>
+    private static bool TryBuildPowerShellGalleryPackageUrl(
+        ProjectDocsCatalogItem project,
+        string packageBaseUrl,
+        out string? packageUrl)
+    {
+        packageUrl = null;
+        if (!HasPowerShellGalleryPackage(project.PowerShellGalleryPackageId, project.PowerShellGalleryPackageVersion) ||
+            string.IsNullOrWhiteSpace(packageBaseUrl))
+        {
+            return false;
+        }
+
+        packageUrl = $"{packageBaseUrl.TrimEnd('/')}/{Uri.EscapeDataString(project.PowerShellGalleryPackageId!.Trim())}/{Uri.EscapeDataString(project.PowerShellGalleryPackageVersion!.Trim())}";
+        return true;
+    }
+}

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectDocsSync.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectDocsSync.cs
@@ -109,6 +109,7 @@ internal static partial class WebPipelineRunner
         var artifactTokenEnv = GetString(step, "artifactTokenEnv") ?? GetString(step, "artifact-token-env") ?? "GITHUB_TOKEN";
         if (string.IsNullOrWhiteSpace(artifactToken) && !string.IsNullOrWhiteSpace(artifactTokenEnv))
             artifactToken = Environment.GetEnvironmentVariable(artifactTokenEnv);
+        var powerShellGalleryPackageBaseUrl = ResolvePowerShellGalleryPackageBaseUrl(step);
         var projectsContentRoot = ResolvePath(baseDir,
             GetString(step, "projectsContentRoot") ??
             GetString(step, "projects-content-root"));
@@ -260,6 +261,7 @@ internal static partial class WebPipelineRunner
                 artifactWorkRoot,
                 artifactTimeoutSeconds,
                 artifactToken,
+                powerShellGalleryPackageBaseUrl,
                 artifactCache,
                 artifactStats);
         }
@@ -1205,6 +1207,8 @@ internal static partial class WebPipelineRunner
             string? artifactDocs = null;
             string? artifactApi = null;
             string? artifactExamples = null;
+            string? powerShellGalleryPackageId = null;
+            string? powerShellGalleryPackageVersion = null;
 
             if (projectElement.TryGetProperty("surfaces", out var surfacesElement) &&
                 surfacesElement.ValueKind == JsonValueKind.Object)
@@ -1233,6 +1237,15 @@ internal static partial class WebPipelineRunner
                 artifactExamples = GetString(artifactsElement, "examples");
             }
 
+            if (projectElement.TryGetProperty("metrics", out var metricsElement) &&
+                metricsElement.ValueKind == JsonValueKind.Object &&
+                metricsElement.TryGetProperty("powerShellGallery", out var galleryElement) &&
+                galleryElement.ValueKind == JsonValueKind.Object)
+            {
+                powerShellGalleryPackageId = GetString(galleryElement, "id");
+                powerShellGalleryPackageVersion = GetString(galleryElement, "version");
+            }
+
             var normalizedContentMode = NormalizeCatalogContentMode(contentMode, mode);
             if (normalizedContentMode.Equals("external", StringComparison.OrdinalIgnoreCase))
             {
@@ -1250,7 +1263,10 @@ internal static partial class WebPipelineRunner
                 if (hasApiDotNetSurface && !IsLocalSurfaceLink(apiDotNetLink) && !IsZipArtifactSource(artifactApi))
                     hasApiDotNetSurface = false;
 
-                if (hasApiPowerShellSurface && !IsLocalSurfaceLink(apiPowerShellLink) && !IsZipArtifactSource(artifactApi))
+                if (hasApiPowerShellSurface &&
+                    !IsLocalSurfaceLink(apiPowerShellLink) &&
+                    !IsZipArtifactSource(artifactApi) &&
+                    !HasPowerShellGalleryPackage(powerShellGalleryPackageId, powerShellGalleryPackageVersion))
                     hasApiPowerShellSurface = false;
 
                 if (hasExamplesSurface && !IsLocalSurfaceLink(examplesLink) && !IsZipArtifactSource(artifactExamples))
@@ -1273,7 +1289,9 @@ internal static partial class WebPipelineRunner
                 GitHubRepoUrl = sourceLink,
                 ArtifactDocs = artifactDocs,
                 ArtifactApi = artifactApi,
-                ArtifactExamples = artifactExamples
+                ArtifactExamples = artifactExamples,
+                PowerShellGalleryPackageId = powerShellGalleryPackageId,
+                PowerShellGalleryPackageVersion = powerShellGalleryPackageVersion
             });
         }
 
@@ -1332,6 +1350,7 @@ internal static partial class WebPipelineRunner
         string artifactWorkRoot,
         int timeoutSeconds,
         string? artifactToken,
+        string powerShellGalleryPackageBaseUrl,
         Dictionary<string, string> artifactCache,
         ProjectArtifactHydrationStats stats)
     {
@@ -1355,6 +1374,7 @@ internal static partial class WebPipelineRunner
                     artifactWorkRoot,
                     timeoutSeconds,
                     artifactToken,
+                    powerShellGalleryPackageBaseUrl,
                     artifactCache,
                     stats);
             }
@@ -1370,6 +1390,7 @@ internal static partial class WebPipelineRunner
                     artifactWorkRoot,
                     timeoutSeconds,
                     artifactToken,
+                    powerShellGalleryPackageBaseUrl,
                     artifactCache,
                     stats);
             }
@@ -1385,6 +1406,7 @@ internal static partial class WebPipelineRunner
                     artifactWorkRoot,
                     timeoutSeconds,
                     artifactToken,
+                    powerShellGalleryPackageBaseUrl,
                     artifactCache,
                     stats);
             }
@@ -1400,18 +1422,29 @@ internal static partial class WebPipelineRunner
         string artifactWorkRoot,
         int timeoutSeconds,
         string? artifactToken,
+        string powerShellGalleryPackageBaseUrl,
         Dictionary<string, string> artifactCache,
         ProjectArtifactHydrationStats stats)
     {
-        var artifactSource = TryGetProjectArtifactSource(project, surface);
-        if (!IsZipArtifactSource(artifactSource))
+        var artifactSource = TryGetProjectArtifactSource(
+            project,
+            surface,
+            powerShellGalleryPackageBaseUrl,
+            out var isPowerShellGalleryPackage);
+        if (!IsZipArtifactSource(artifactSource) && !isPowerShellGalleryPackage)
             return;
+
+        if (isPowerShellGalleryPackage &&
+            Directory.Exists(ResolveExistingProjectSourcePath(sourcesRoot, slug, sourceCandidates)))
+        {
+            return;
+        }
 
         if (!TryExtractArtifactZip(
                 artifactSource!,
                 artifactWorkRoot,
                 timeoutSeconds,
-                artifactToken,
+                isPowerShellGalleryPackage ? null : artifactToken,
                 artifactCache,
                 stats,
                 out var extractedRoot))
@@ -1440,8 +1473,13 @@ internal static partial class WebPipelineRunner
             stats.ExamplesHydrated++;
     }
 
-    private static string? TryGetProjectArtifactSource(ProjectDocsCatalogItem project, ProjectDocsSurfaceType surface)
+    private static string? TryGetProjectArtifactSource(
+        ProjectDocsCatalogItem project,
+        ProjectDocsSurfaceType surface,
+        string powerShellGalleryPackageBaseUrl,
+        out bool isPowerShellGalleryPackage)
     {
+        isPowerShellGalleryPackage = false;
         string? directArtifact = surface switch
         {
             ProjectDocsSurfaceType.Docs => project.ArtifactDocs,
@@ -1453,13 +1491,26 @@ internal static partial class WebPipelineRunner
         if (IsZipArtifactSource(directArtifact))
             return directArtifact;
 
-        return surface switch
+        var linkedArtifact = surface switch
         {
             ProjectDocsSurfaceType.Docs => project.DocsLink,
             ProjectDocsSurfaceType.Api => !string.IsNullOrWhiteSpace(project.ApiPowerShellLink) ? project.ApiPowerShellLink : project.ApiDotNetLink,
             ProjectDocsSurfaceType.Examples => project.ExamplesLink,
             _ => null
         };
+
+        if (IsZipArtifactSource(linkedArtifact))
+            return linkedArtifact;
+
+        if (surface == ProjectDocsSurfaceType.Api &&
+            project.HasApiPowerShellSurface &&
+            TryBuildPowerShellGalleryPackageUrl(project, powerShellGalleryPackageBaseUrl, out var packageUrl))
+        {
+            isPowerShellGalleryPackage = true;
+            return packageUrl;
+        }
+
+        return linkedArtifact;
     }
 
     private static bool IsZipArtifactSource(string? source)
@@ -1772,6 +1823,8 @@ internal static partial class WebPipelineRunner
         public string? ArtifactDocs { get; init; }
         public string? ArtifactApi { get; init; }
         public string? ArtifactExamples { get; init; }
+        public string? PowerShellGalleryPackageId { get; init; }
+        public string? PowerShellGalleryPackageVersion { get; init; }
     }
 
     private enum ProjectDocsSurfaceType

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.XmlSources.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.XmlSources.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+
+namespace PowerForge.Web;
+
+public static partial class WebApiDocsGenerator
+{
+    private static string[] ResolveCSharpXmlPaths(WebApiDocsOptions options)
+    {
+        var paths = new List<string>();
+        if (!string.IsNullOrWhiteSpace(options.XmlPath))
+            paths.Add(options.XmlPath);
+        if (options.XmlPaths is not null)
+            paths.AddRange(options.XmlPaths.Where(static path => !string.IsNullOrWhiteSpace(path)));
+
+        return paths
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static ApiDocModel ParseXmlDocuments(
+        IReadOnlyList<string> xmlPaths,
+        Assembly? assembly,
+        WebApiDocsOptions options)
+    {
+        var combined = new ApiDocModel();
+        foreach (var xmlPath in xmlPaths)
+        {
+            var parsed = ParseXml(xmlPath, assembly, options);
+            combined.AssemblyName ??= parsed.AssemblyName;
+            combined.AssemblyVersion ??= parsed.AssemblyVersion;
+
+            foreach (var pair in parsed.Types)
+            {
+                if (!pair.Value.OriginFiles.Contains(xmlPath, StringComparer.OrdinalIgnoreCase))
+                    pair.Value.OriginFiles.Add(xmlPath);
+                combined.Types.TryAdd(pair.Key, pair.Value);
+            }
+        }
+
+        return combined;
+    }
+}

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Freshness.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Freshness.cs
@@ -132,7 +132,11 @@ public static partial class WebApiDocsGenerator
         if (files.Count == 0)
         {
             if (options.Type == ApiDocsType.CSharp)
+            {
                 AddFreshnessCandidate(files, options.XmlPath);
+                foreach (var xmlPath in options.XmlPaths)
+                    AddFreshnessCandidate(files, xmlPath);
+            }
             else
                 AddFreshnessCandidate(files, options.HelpPath);
         }

--- a/PowerForge.Web/Services/WebApiDocsGenerator.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.cs
@@ -18,6 +18,8 @@ public sealed class WebApiDocsOptions
     public ApiDocsType Type { get; set; } = ApiDocsType.CSharp;
     /// <summary>Path to the XML documentation file.</summary>
     public string XmlPath { get; set; } = string.Empty;
+    /// <summary>Optional additional XML documentation files that belong to the same project API.</summary>
+    public IReadOnlyList<string> XmlPaths { get; set; } = Array.Empty<string>();
     /// <summary>Path to PowerShell help XML or folder.</summary>
     public string? HelpPath { get; set; }
     /// <summary>Optional path to a PowerShell module manifest used for detached website artifacts.</summary>
@@ -382,16 +384,17 @@ public static partial class WebApiDocsGenerator
     public static WebApiDocsResult Generate(WebApiDocsOptions options)
     {
         if (options is null) throw new ArgumentNullException(nameof(options));
-        if (options.Type == ApiDocsType.CSharp && string.IsNullOrWhiteSpace(options.XmlPath))
-            throw new ArgumentException("XmlPath is required for CSharp API docs.", nameof(options));
+        var xmlPaths = options.Type == ApiDocsType.CSharp
+            ? ResolveCSharpXmlPaths(options)
+            : Array.Empty<string>();
+        if (options.Type == ApiDocsType.CSharp && xmlPaths.Length == 0)
+            throw new ArgumentException("XmlPath or XmlPaths is required for CSharp API docs.", nameof(options));
         if (options.Type == ApiDocsType.PowerShell && string.IsNullOrWhiteSpace(options.HelpPath))
             throw new ArgumentException("HelpPath is required for PowerShell API docs.", nameof(options));
         if (string.IsNullOrWhiteSpace(options.OutputPath))
             throw new ArgumentException("OutputPath is required.", nameof(options));
 
-        var xmlPath = options.Type == ApiDocsType.CSharp
-            ? Path.GetFullPath(options.XmlPath)
-            : string.Empty;
+        var xmlPath = xmlPaths.FirstOrDefault() ?? string.Empty;
         var helpPath = options.Type == ApiDocsType.PowerShell && !string.IsNullOrWhiteSpace(options.HelpPath)
             ? Path.GetFullPath(options.HelpPath)
             : string.Empty;
@@ -400,8 +403,11 @@ public static partial class WebApiDocsGenerator
         var previousTypeSlugs = ReadExistingApiTypeSlugs(outputPath);
 
         var warnings = new List<string>();
-        if (options.Type == ApiDocsType.CSharp && !File.Exists(xmlPath))
-            warnings.Add($"XML docs not found: {xmlPath}");
+        if (options.Type == ApiDocsType.CSharp)
+        {
+            foreach (var missingXmlPath in xmlPaths.Where(static path => !File.Exists(path)))
+                warnings.Add($"XML docs not found: {missingXmlPath}");
+        }
         if (options.Type == ApiDocsType.PowerShell && !File.Exists(helpPath) && !Directory.Exists(helpPath))
             warnings.Add($"PowerShell help not found: {helpPath}");
 
@@ -422,7 +428,7 @@ public static partial class WebApiDocsGenerator
 
         var apiDoc = options.Type == ApiDocsType.PowerShell
             ? ParsePowerShellHelp(helpPath, warnings, options)
-            : ParseXml(xmlPath, assembly, options);
+            : ParseXmlDocuments(xmlPaths, assembly, options);
         var usedReflectionFallback = false;
         if (options.Type == ApiDocsType.CSharp && assembly is not null && options.IncludeUndocumentedTypes)
         {

--- a/PowerForge.Web/Services/WebEcosystemStatsGenerator.GitHubIssues.cs
+++ b/PowerForge.Web/Services/WebEcosystemStatsGenerator.GitHubIssues.cs
@@ -1,0 +1,112 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace PowerForge.Web;
+
+public static partial class WebEcosystemStatsGenerator
+{
+    private const int GitHubSearchPageSize = 100;
+    private const int GitHubSearchResultLimit = 1000;
+
+    private static void PopulateGitHubOpenIssueCounts(
+        HttpClient http,
+        WebEcosystemStatsOptions options,
+        string organization,
+        List<WebEcosystemGitHubRepository> repositories,
+        List<string> warnings)
+    {
+        if (repositories.Count == 0)
+            return;
+
+        var counts = repositories.ToDictionary(
+            static repository => repository.FullName,
+            static _ => 0,
+            StringComparer.OrdinalIgnoreCase);
+
+        var page = 1;
+        var fetched = 0;
+        int? totalCount = null;
+
+        while (fetched < GitHubSearchResultLimit)
+        {
+            var query = Uri.EscapeDataString($"org:{organization} is:issue is:open");
+            var url = $"{GitHubApiBase}/search/issues?q={query}&per_page={GitHubSearchPageSize}&page={page}";
+            using var request = CreateGitHubRequest(url, options.GitHubToken);
+            using var response = Send(http, request, warnings, "GitHub open issue count");
+            if (response is null)
+                throw new InvalidOperationException("GitHub returned repository data but accurate open issue counts could not be retrieved.");
+
+            using var stream = response.Content.ReadAsStream();
+            using var document = JsonDocument.Parse(stream);
+            if (document.RootElement.ValueKind != JsonValueKind.Object ||
+                !document.RootElement.TryGetProperty("items", out var itemsElement) ||
+                itemsElement.ValueKind != JsonValueKind.Array)
+            {
+                throw new InvalidOperationException("GitHub open issue search response did not include an items array.");
+            }
+
+            if (document.RootElement.TryGetProperty("incomplete_results", out var incompleteElement) &&
+                incompleteElement.ValueKind is JsonValueKind.True)
+            {
+                throw new InvalidOperationException("GitHub open issue search returned incomplete results.");
+            }
+
+            if (!totalCount.HasValue &&
+                document.RootElement.TryGetProperty("total_count", out var totalCountElement) &&
+                totalCountElement.TryGetInt32(out var parsedTotalCount))
+            {
+                totalCount = parsedTotalCount;
+                if (parsedTotalCount > GitHubSearchResultLimit)
+                {
+                    throw new InvalidOperationException(
+                        $"GitHub reports {parsedTotalCount} open issues for {organization}, above the search API's {GitHubSearchResultLimit}-result accuracy limit.");
+                }
+            }
+
+            var pageCount = 0;
+            foreach (var issueElement in itemsElement.EnumerateArray())
+            {
+                pageCount++;
+                fetched++;
+                var repositoryUrl = ReadString(issueElement, "repository_url");
+                var fullName = ParseGitHubRepositoryFullName(repositoryUrl);
+                if (fullName is not null && counts.ContainsKey(fullName))
+                    counts[fullName]++;
+            }
+
+            if (pageCount < GitHubSearchPageSize || (totalCount.HasValue && fetched >= totalCount.Value))
+                break;
+
+            page++;
+        }
+
+        foreach (var repository in repositories)
+            repository.OpenIssues = counts[repository.FullName];
+    }
+
+    private static HttpRequestMessage CreateGitHubRequest(string url, string? token)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        if (!string.IsNullOrWhiteSpace(token))
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return request;
+    }
+
+    private static string? ParseGitHubRepositoryFullName(string? repositoryUrl)
+    {
+        if (string.IsNullOrWhiteSpace(repositoryUrl) ||
+            !Uri.TryCreate(repositoryUrl, UriKind.Absolute, out var uri) ||
+            !uri.Host.Equals("api.github.com", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var segments = uri.AbsolutePath
+            .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (segments.Length != 3 || !segments[0].Equals("repos", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        return $"{segments[1]}/{segments[2]}";
+    }
+}

--- a/PowerForge.Web/Services/WebEcosystemStatsGenerator.cs
+++ b/PowerForge.Web/Services/WebEcosystemStatsGenerator.cs
@@ -8,7 +8,7 @@ using System.Xml.Linq;
 namespace PowerForge.Web;
 
 /// <summary>Generates ecosystem statistics from GitHub, NuGet, and PowerShell Gallery.</summary>
-public static class WebEcosystemStatsGenerator
+public static partial class WebEcosystemStatsGenerator
 {
     private const string GitHubApiBase = "https://api.github.com";
     private const string NuGetSearchApiBase = "https://api-v2v3search-0.nuget.org/query";
@@ -150,6 +150,8 @@ public static class WebEcosystemStatsGenerator
             }
         }
 
+        PopulateGitHubOpenIssueCounts(http, options, organization, repositories, warnings);
+
         repositories = repositories
             .OrderByDescending(repository => repository.Stars)
             .ThenBy(repository => repository.Name, StringComparer.OrdinalIgnoreCase)
@@ -185,7 +187,9 @@ public static class WebEcosystemStatsGenerator
             Stars = ReadInt32(element, "stargazers_count"),
             Forks = ReadInt32(element, "forks_count"),
             Watchers = ReadInt32(element, "watchers_count"),
-            OpenIssues = ReadInt32(element, "open_issues_count"),
+            // GitHub's repository-level open_issues_count includes pull requests.
+            // PopulateGitHubOpenIssueCounts replaces this with the issue-only count.
+            OpenIssues = 0,
             PushedAt = ReadDateTimeOffset(element, "pushed_at")
         };
     }


### PR DESCRIPTION
## What changed

- correct GitHub project telemetry so open issue counts exclude pull requests
- allow project API generation from XML documentation without requiring a matching assembly
- merge multiple XML documentation assemblies into one project API reference
- hydrate missing PowerShell API help from an exact published PowerShell Gallery package version
- keep checked-out or explicit artifacts authoritative and never forward the GitHub artifact token to PowerShell Gallery
- preserve freshness, placeholder, and source checks across every API input
- add regression coverage for issue pagination, multi-assembly APIs, exact package selection, token isolation, and local-source precedence

## Why

Project hubs were displaying GitHub's combined issue-and-pull-request count as open issues. Multi-package projects such as ChartForgeX need one coherent API surface rather than silently documenting only the first assembly. Clean website runners also cannot rely on ignored WebsiteArtifacts folders, so PowerShell help now falls back to the exact public package already recorded in the catalog.

The clean Website integration generated all seven configured API projects from tracked source or public packages, including 663 ChartForgeX types from six XML inputs.