### PR TITLE
Add config-driven Apple local deployment

### DIFF
--- a/Docs/PSPublishModule.AppleRelease.md
+++ b/Docs/PSPublishModule.AppleRelease.md
@@ -12,10 +12,66 @@ The helpers live in shared `PowerForge` services first and are exposed through t
 PowerShell cmdlets, so the same release logic can be reused by scripts, tests, CLI,
 and future project release pipelines.
 
-## Local Device Deployment
+## Local Deployment
 
-For developer-device smoke testing, use the local deployment cmdlets. They wrap
-`xcodebuild build` and `xcrun devicectl` with structured arguments and typed results:
+Use the config-driven CLI for the everyday developer loop. It reads the same targets,
+schemes, bundle identifiers, project paths, and Mac Catalyst variants as the release
+flow, defaults to Debug, and keeps stable DerivedData per repo/platform/scheme so
+repeated builds reuse Xcode's cache:
+
+```text
+powerforge apple-deploy --platform iOS --profile Plus
+powerforge apple-deploy --platform iOS --profile Free
+powerforge apple-deploy --platform macOS --profile Plus
+```
+
+The iOS/iPadOS/watchOS device path runs `xcodebuild build`, installs with
+`xcrun devicectl`, and launches the selected profile. The macOS path builds the
+native or Mac Catalyst product, atomically replaces the app in `/Applications`,
+and launches the installed copy. Use `--plan` for a no-build selection check,
+`--no-launch` to install only, or `--install-root ~/Applications` when a per-user
+location is preferred.
+
+Set a target's optional `ProductName` when its built `.app` name differs from its
+scheme; PowerForge also discovers the sole app product when that is unambiguous.
+Concurrent runs for the same build cache or install destination fail fast instead
+of corrupting DerivedData. If a locked device accepts installation but rejects
+launch, the receipt keeps `installSucceeded: true`, sets `deviceLocked: true`, and
+returns failure because the selected profile was not applied to a running app.
+
+Declare app-specific launch profiles once in `powerforge.release.json`:
+
+```json
+{
+  "AppleApps": {
+    "LocalDeployment": {
+      "DefaultPlatform": "iOS",
+      "DefaultDevice": "EvoPhone",
+      "Configuration": "Debug",
+      "InstallRoot": "/Applications",
+      "DefaultProfile": "Plus",
+      "Profiles": [
+        {
+          "Name": "Free",
+          "Environment": { "MYAPP_ENABLE_SANDBOX_PURCHASES": "1" }
+        },
+        {
+          "Name": "Plus",
+          "Environment": { "MYAPP_ENABLE_SANDBOX_PURCHASES": "0" }
+        }
+      ]
+    }
+  }
+}
+```
+
+Free/Plus should normally be two launch profiles over one app binary, not separate
+build products. Embedded companions such as Watch apps inherit the containing app's
+product and entitlement contract. Store/TestFlight behavior remains the signed
+release path below.
+
+For lower-level device scripts, the PowerShell cmdlets wrap `xcodebuild build` and
+`xcrun devicectl` with structured arguments and typed results:
 
 ```powershell
 Get-AppleDevice

--- a/PowerForge.Cli/AppleLocalDeploymentCliModels.cs
+++ b/PowerForge.Cli/AppleLocalDeploymentCliModels.cs
@@ -1,0 +1,54 @@
+using PowerForge;
+
+namespace PowerForge.Cli;
+
+internal sealed class AppleLocalDeploymentCliResult
+{
+    public bool Planned { get; set; }
+
+    public bool Success { get; set; }
+
+    public string Target { get; set; } = string.Empty;
+
+    public ApplePlatform Platform { get; set; }
+
+    public AppleArchiveVariant ArchiveVariant { get; set; }
+
+    public string Configuration { get; set; } = "Debug";
+
+    public string? Profile { get; set; }
+
+    public string ProjectPath { get; set; } = string.Empty;
+
+    public string Scheme { get; set; } = string.Empty;
+
+    public string DerivedDataPath { get; set; } = string.Empty;
+
+    public string? Device { get; set; }
+
+    public string? InstallRoot { get; set; }
+
+    public bool Launch { get; set; }
+
+    public bool UseBuildMirror { get; set; }
+
+    public string? BuildMirrorPath { get; set; }
+
+    public string? AppPath { get; set; }
+
+    public string? InstalledAppPath { get; set; }
+
+    public string? DeviceIdentifier { get; set; }
+
+    public bool? BuildSucceeded { get; set; }
+
+    public bool? InstallSucceeded { get; set; }
+
+    public bool? LaunchSucceeded { get; set; }
+
+    public bool DeviceLocked { get; set; }
+
+    public string? Warning { get; set; }
+
+    public string? Diagnostic { get; set; }
+}

--- a/PowerForge.Cli/PowerForgeCliJsonContext.cs
+++ b/PowerForge.Cli/PowerForgeCliJsonContext.cs
@@ -94,6 +94,7 @@ namespace PowerForge.Cli;
 [JsonSerializable(typeof(AppStoreConnectReviewDetailsCopyPlan))]
 [JsonSerializable(typeof(AppStoreConnectReviewDetailsCopyResult))]
 [JsonSerializable(typeof(AppleReleaseCliPlanSummary))]
+[JsonSerializable(typeof(AppleLocalDeploymentCliResult))]
 [JsonSerializable(typeof(PowerForgeWingetManifestArtifact))]
 [JsonSerializable(typeof(PowerForgeWingetSubmissionPlan))]
 [JsonSerializable(typeof(PowerForgeWingetSubmissionResult))]

--- a/PowerForge.Cli/Program.Command.AppleDeploy.cs
+++ b/PowerForge.Cli/Program.Command.AppleDeploy.cs
@@ -1,0 +1,353 @@
+using System.Security.Cryptography;
+using System.Text;
+using PowerForge;
+using PowerForge.Cli;
+
+internal static partial class Program
+{
+    private const string AppleDeployUsage =
+        "Usage: powerforge apple-deploy [--config <powerforge.release.json>] " +
+        "[--platform <iOS|iPadOS|watchOS|macOS|tvOS|visionOS>] [--target <name-or-scheme>] " +
+        "[--device <name>|--device-id <id>] [--profile <name>] [--configuration <Debug|Release>] " +
+        "[--install-root </Applications>] [--build-mirror|--no-build-mirror] [--launch|--no-launch] " +
+        "[--plan] [--output json]";
+
+    private static int CommandAppleDeploy(string[] filteredArgs, CliOptions cli, ILogger logger)
+    {
+        var argv = filteredArgs.Skip(1).ToArray();
+        var outputJson = IsJsonOutput(argv);
+        if (argv.Any(static value => value.Equals("-h", StringComparison.OrdinalIgnoreCase) || value.Equals("--help", StringComparison.OrdinalIgnoreCase)))
+        {
+            if (outputJson)
+            {
+                WriteJson(new CliJsonEnvelope
+                {
+                    SchemaVersion = OutputSchemaVersion,
+                    Command = "apple-deploy",
+                    Success = true,
+                    ExitCode = 0,
+                    Result = System.Text.Json.JsonSerializer.SerializeToElement(new { usage = AppleDeployUsage })
+                });
+            }
+            else
+            {
+                Console.WriteLine(AppleDeployUsage);
+            }
+            return 0;
+        }
+
+        try
+        {
+            ValidateAppleDeployArguments(argv);
+            var configPath = TryGetOptionValue(argv, "--config") ?? FindDefaultReleaseConfig(Directory.GetCurrentDirectory());
+            if (string.IsNullOrWhiteSpace(configPath))
+                throw new ArgumentException("Missing --config and no default release config found.");
+
+            var (release, fullConfigPath) = LoadPowerForgeReleaseSpecWithPath(configPath);
+            var apple = release.AppleApps ?? throw new InvalidOperationException("Release config has no AppleApps section.");
+            var local = apple.LocalDeployment;
+            var requestedPlatform = ParseAppleDeployPlatform(TryGetOptionValue(argv, "--platform"), local.DefaultPlatform);
+            var selectedTarget = SelectAppleDeployTarget(
+                apple.Apps,
+                requestedPlatform,
+                TryGetOptionValue(argv, "--target"));
+            var scheme = selectedTarget.Scheme?.Trim();
+            if (string.IsNullOrWhiteSpace(scheme))
+                throw new InvalidOperationException($"Apple target '{selectedTarget.Name}' has no Scheme.");
+
+            var configDirectory = Path.GetDirectoryName(fullConfigPath) ?? Directory.GetCurrentDirectory();
+            var projectRoot = ResolvePathFromBase(configDirectory, string.IsNullOrWhiteSpace(apple.ProjectRoot) ? "." : apple.ProjectRoot!);
+            var projectPath = ResolvePathFromBase(projectRoot, selectedTarget.ProjectPath);
+            if (!Directory.Exists(projectPath) && !File.Exists(projectPath))
+                throw new FileNotFoundException("Xcode project or workspace was not found.", projectPath);
+
+            var profile = SelectAppleDeployProfile(local, TryGetOptionValue(argv, "--profile"));
+            var configuration = TryGetOptionValue(argv, "--configuration") ?? local.Configuration;
+            var deviceIdentifier = TryGetOptionValue(argv, "--device-id");
+            var device = TryGetOptionValue(argv, "--device") ??
+                         (requestedPlatform == ApplePlatform.macOS ? null : local.DefaultDevice);
+            if (!string.IsNullOrWhiteSpace(deviceIdentifier) && argv.Any(static value => value.Equals("--device", StringComparison.OrdinalIgnoreCase)))
+                throw new ArgumentException("Use either --device or --device-id, not both.");
+            if (requestedPlatform == ApplePlatform.macOS && (!string.IsNullOrWhiteSpace(device) || !string.IsNullOrWhiteSpace(deviceIdentifier)))
+                throw new ArgumentException("--device and --device-id apply to device platforms, not macOS deployment.");
+
+            var launch = ResolveAppleDeployFlag(argv, "--launch", "--no-launch", local.Launch);
+            var useBuildMirror = ResolveAppleDeployFlag(argv, "--build-mirror", "--no-build-mirror", local.UseBuildMirror);
+            var localRoot = ResolveStableAppleDeployRoot(projectRoot, requestedPlatform, scheme);
+            var derivedDataPath = Path.Combine(localRoot, "DerivedData");
+            var buildMirrorPath = useBuildMirror ? Path.Combine(localRoot, "Source") : null;
+            var installRoot = TryGetOptionValue(argv, "--install-root") ?? local.InstallRoot;
+            var planOnly = argv.Any(static value => value.Equals("--plan", StringComparison.OrdinalIgnoreCase));
+
+            var cliResult = new AppleLocalDeploymentCliResult
+            {
+                Planned = planOnly,
+                Target = selectedTarget.Name ?? scheme,
+                Platform = requestedPlatform,
+                ArchiveVariant = selectedTarget.ArchiveVariant,
+                Configuration = configuration,
+                Profile = profile?.Name,
+                ProjectPath = projectPath,
+                Scheme = scheme,
+                DerivedDataPath = derivedDataPath,
+                Device = deviceIdentifier ?? device,
+                InstallRoot = requestedPlatform == ApplePlatform.macOS ? Path.GetFullPath(installRoot) : null,
+                Launch = launch,
+                UseBuildMirror = useBuildMirror,
+                BuildMirrorPath = buildMirrorPath
+            };
+
+            if (!planOnly)
+            {
+                using var deploymentLock = AppleLocalDeploymentLock.Acquire(localRoot, $"build cache '{localRoot}'");
+                ExecuteAppleDeploy(cliResult, apple, selectedTarget, projectRoot, profile, device, deviceIdentifier);
+            }
+            else
+                cliResult.Success = true;
+
+            return WriteAppleDeployResult(cliResult, fullConfigPath, outputJson, logger);
+        }
+        catch (Exception exception)
+        {
+            return WriteReleaseError(outputJson, "apple-deploy", 1, exception.Message, logger);
+        }
+    }
+
+    private static void ExecuteAppleDeploy(
+        AppleLocalDeploymentCliResult cliResult,
+        PowerForgeAppleReleaseOptions apple,
+        AppleAppConfiguration selectedTarget,
+        string projectRoot,
+        PowerForgeAppleLocalDeploymentProfile? profile,
+        string? device,
+        string? deviceIdentifier)
+    {
+        var environment = profile is null
+            ? new Dictionary<string, string>(StringComparer.Ordinal)
+            : new Dictionary<string, string>(profile.Environment, StringComparer.Ordinal);
+        var arguments = profile?.Arguments ?? Array.Empty<string>();
+        var isWorkspace = selectedTarget.ProjectPath.EndsWith(".xcworkspace", StringComparison.OrdinalIgnoreCase);
+
+        if (cliResult.Platform == ApplePlatform.macOS)
+        {
+            var request = new AppleMacAppDeploymentRequest
+            {
+                ProjectPath = cliResult.ProjectPath,
+                IsWorkspace = isWorkspace,
+                Scheme = cliResult.Scheme,
+                ProductName = selectedTarget.ProductName,
+                Configuration = cliResult.Configuration,
+                Platform = ApplePlatform.macOS,
+                ArchiveVariant = selectedTarget.ArchiveVariant,
+                DerivedDataPath = cliResult.DerivedDataPath,
+                XcodeBuildExecutable = apple.XcodeBuildExecutable,
+                AllowProvisioningUpdates = apple.AllowProvisioningUpdates,
+                UseBuildMirror = cliResult.UseBuildMirror,
+                BuildRoot = projectRoot,
+                BuildMirrorPath = cliResult.BuildMirrorPath,
+                InstallRoot = cliResult.InstallRoot!,
+                Launch = cliResult.Launch,
+                LaunchEnvironment = environment,
+                LaunchArguments = arguments
+            };
+            var deployment = new AppleMacAppDeploymentService().DeployAsync(request).GetAwaiter().GetResult();
+            cliResult.AppPath = deployment.Build.AppPath;
+            cliResult.InstalledAppPath = deployment.Install?.InstalledAppPath;
+            cliResult.BuildSucceeded = deployment.Build.Succeeded;
+            cliResult.InstallSucceeded = deployment.Install?.Succeeded ?? false;
+            cliResult.LaunchSucceeded = deployment.Launch?.Succeeded;
+            cliResult.Success = deployment.Succeeded;
+            cliResult.Warning = deployment.Install?.Warning;
+            cliResult.Diagnostic = ResolveAppleDeployDiagnostic(
+                deployment.Build.ProcessResult,
+                deployment.Install?.ProcessResult,
+                deployment.Launch?.ProcessResult);
+            return;
+        }
+
+        var deviceRequest = new AppleAppDeviceDeploymentRequest
+        {
+            ProjectPath = cliResult.ProjectPath,
+            IsWorkspace = isWorkspace,
+            Scheme = cliResult.Scheme,
+            ProductName = selectedTarget.ProductName,
+            Configuration = cliResult.Configuration,
+            Platform = selectedTarget.Platform,
+            ArchiveVariant = selectedTarget.ArchiveVariant,
+            Device = device,
+            DeviceIdentifier = deviceIdentifier,
+            BundleIdentifier = selectedTarget.BundleId,
+            Launch = cliResult.Launch,
+            LaunchEnvironment = environment,
+            LaunchArguments = arguments,
+            TerminateExisting = cliResult.Launch,
+            DerivedDataPath = cliResult.DerivedDataPath,
+            XcodeBuildExecutable = apple.XcodeBuildExecutable,
+            AllowProvisioningUpdates = apple.AllowProvisioningUpdates,
+            UseBuildMirror = cliResult.UseBuildMirror,
+            BuildRoot = projectRoot,
+            BuildMirrorPath = cliResult.BuildMirrorPath
+        };
+        var deviceDeployment = new AppleDeviceDeploymentService().DeployAsync(deviceRequest).GetAwaiter().GetResult();
+        cliResult.AppPath = deviceDeployment.Build.AppPath;
+        cliResult.DeviceIdentifier = deviceDeployment.Install?.DeviceIdentifier;
+        cliResult.BuildSucceeded = deviceDeployment.Build.Succeeded;
+        cliResult.InstallSucceeded = deviceDeployment.Install?.Succeeded ?? false;
+        cliResult.LaunchSucceeded = deviceDeployment.Launch?.Succeeded;
+        cliResult.DeviceLocked = deviceDeployment.Launch?.DeviceLocked ?? false;
+        cliResult.Success = deviceDeployment.RequestedStagesSucceeded;
+        cliResult.Diagnostic = ResolveAppleDeployDiagnostic(
+            deviceDeployment.Build.ProcessResult,
+            deviceDeployment.Install?.ProcessResult,
+            deviceDeployment.Launch?.ProcessResult);
+    }
+
+    private static AppleAppConfiguration SelectAppleDeployTarget(
+        IEnumerable<AppleAppConfiguration> configuredTargets,
+        ApplePlatform requestedPlatform,
+        string? requestedTarget)
+    {
+        var targetPlatform = requestedPlatform == ApplePlatform.iPadOS ? ApplePlatform.iOS : requestedPlatform;
+        var candidates = configuredTargets
+            .Where(static target => target.Enabled && target.ProductRole is AppleProductRole.PrimaryApp or AppleProductRole.CompanionApp)
+            .Where(target => target.Platform == targetPlatform)
+            .ToArray();
+
+        if (!string.IsNullOrWhiteSpace(requestedTarget))
+        {
+            candidates = candidates.Where(target =>
+                    string.Equals(target.Name, requestedTarget, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(target.Scheme, requestedTarget, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+        }
+
+        if (candidates.Length == 0)
+            throw new InvalidOperationException($"No deployable Apple target matched platform '{requestedPlatform}'{FormatAppleDeployTargetSuffix(requestedTarget)}.");
+        if (candidates.Length > 1)
+        {
+            var choices = string.Join(", ", candidates.Select(target => target.Name ?? target.Scheme ?? "unnamed"));
+            throw new InvalidOperationException($"Multiple Apple targets matched platform '{requestedPlatform}': {choices}. Use --target.");
+        }
+        return candidates[0];
+    }
+
+    private static PowerForgeAppleLocalDeploymentProfile? SelectAppleDeployProfile(
+        PowerForgeAppleLocalDeploymentOptions options,
+        string? requestedProfile)
+    {
+        var name = requestedProfile ?? options.DefaultProfile;
+        if (string.IsNullOrWhiteSpace(name))
+            return null;
+        var matches = options.Profiles
+            .Where(profile => string.Equals(profile.Name, name, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (matches.Length != 1)
+            throw new InvalidOperationException($"Local deployment profile '{name}' is not configured exactly once.");
+        return matches[0];
+    }
+
+    private static ApplePlatform ParseAppleDeployPlatform(string? value, ApplePlatform fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return fallback;
+        if (!Enum.TryParse<ApplePlatform>(value, ignoreCase: true, out var platform) || !Enum.IsDefined(platform))
+            throw new ArgumentException($"Unknown Apple platform '{value}'.");
+        return platform;
+    }
+
+    private static bool ResolveAppleDeployFlag(string[] argv, string enabledFlag, string disabledFlag, bool fallback)
+    {
+        var enabled = argv.Any(value => value.Equals(enabledFlag, StringComparison.OrdinalIgnoreCase));
+        var disabled = argv.Any(value => value.Equals(disabledFlag, StringComparison.OrdinalIgnoreCase));
+        if (enabled && disabled)
+            throw new ArgumentException($"Use either {enabledFlag} or {disabledFlag}, not both.");
+        return enabled || (!disabled && fallback);
+    }
+
+    private static string ResolveStableAppleDeployRoot(string projectRoot, ApplePlatform platform, string scheme)
+    {
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(Path.GetFullPath(projectRoot))))[..12].ToLowerInvariant();
+        var safeScheme = new string(scheme.Select(character => char.IsLetterOrDigit(character) ? character : '-').ToArray()).Trim('-');
+        return Path.Combine(Path.GetTempPath(), "powerforge-apple-local", hash, platform.ToString(), safeScheme);
+    }
+
+    private static int WriteAppleDeployResult(
+        AppleLocalDeploymentCliResult result,
+        string configPath,
+        bool outputJson,
+        ILogger logger)
+    {
+        var exitCode = result.Success ? 0 : 1;
+        if (outputJson)
+        {
+            WriteJson(new CliJsonEnvelope
+            {
+                SchemaVersion = OutputSchemaVersion,
+                Command = "apple-deploy",
+                Success = result.Success,
+                ExitCode = exitCode,
+                Config = "release",
+                ConfigPath = configPath,
+                Result = CliJson.SerializeToElement(result, CliJson.Context.AppleLocalDeploymentCliResult)
+            });
+            return exitCode;
+        }
+
+        logger.Info($"Target: {result.Target} ({result.Platform}, {result.Configuration})");
+        if (!string.IsNullOrWhiteSpace(result.Profile))
+            logger.Info($"Profile: {result.Profile}");
+        if (result.Planned)
+        {
+            logger.Success("Apple local deployment plan is valid.");
+            return 0;
+        }
+        var appPath = result.InstalledAppPath ?? result.AppPath;
+        if (!string.IsNullOrWhiteSpace(appPath))
+            logger.Info($"App: {appPath}");
+        if (result.Success)
+            logger.Success(result.Launch ? "Apple app installed and launched." : "Apple app installed.");
+        else if (result.DeviceLocked && result.InstallSucceeded == true)
+            logger.Warn("Apple app installed, but launch was deferred because the device is locked.");
+        else
+            logger.Error("Apple local deployment failed.");
+        return exitCode;
+    }
+
+    private static void ValidateAppleDeployArguments(string[] argv)
+    {
+        var flags = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "--build-mirror", "--no-build-mirror", "--launch", "--no-launch", "--plan"
+        };
+        var options = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "--config", "--platform", "--target", "--device", "--device-id", "--profile",
+            "--configuration", "--install-root", "--output"
+        };
+        for (var index = 0; index < argv.Length; index++)
+        {
+            var argument = argv[index];
+            if (flags.Contains(argument))
+                continue;
+            if (!options.Contains(argument))
+                throw new ArgumentException($"Unknown apple-deploy option '{argument}'.");
+            if (++index >= argv.Length || argv[index].StartsWith("-", StringComparison.Ordinal))
+                throw new ArgumentException($"Missing value for apple-deploy option '{argument}'.");
+        }
+    }
+
+    private static string FormatAppleDeployTargetSuffix(string? target)
+        => string.IsNullOrWhiteSpace(target) ? string.Empty : $" and target '{target}'";
+
+    private static string? ResolveAppleDeployDiagnostic(params ProcessRunResult?[] stages)
+    {
+        var failed = stages.FirstOrDefault(static stage => stage is not null && !stage.Succeeded);
+        if (failed is null)
+            return null;
+        var text = string.IsNullOrWhiteSpace(failed.StdErr) ? failed.StdOut : failed.StdErr;
+        if (string.IsNullOrWhiteSpace(text))
+            return $"{failed.Executable} exited with code {failed.ExitCode}.";
+        var compact = text.Trim();
+        return compact.Length <= 2000 ? compact : compact[^2000..];
+    }
+}

--- a/PowerForge.Cli/Program.Helpers.cs
+++ b/PowerForge.Cli/Program.Helpers.cs
@@ -36,7 +36,8 @@ internal static partial class Program
       powerforge apple-release <Status|Doctor|Version|Archive|Upload|UploadExisting|Prepare|Screenshots|TestFlight|Advance|SubmitTestFlightReview|SubmitAppReview|Release|Cleanup>
                         [--config <release.json>] [--plan] [--validate] [--confirm-apple-action] [--apple-expected-plan-sha256 <sha256>] [--apple-resume|--no-apple-resume]
                         [--apple-wait|--no-apple-wait] [--apple-timeout-seconds <seconds>] [--apple-poll-seconds <seconds>]
-                        [--target <Name[,Name...]>] [--summary] [--output json]
+                                [--target <Name[,Name...]>] [--summary] [--output json]
+      powerforge apple-deploy [--config <powerforge.release.json>] [--platform <iOS|iPadOS|watchOS|macOS|tvOS|visionOS>] [--target <name-or-scheme>] [--device <name>|--device-id <id>] [--profile <name>] [--configuration <Debug|Release>] [--install-root </Applications>] [--build-mirror|--no-build-mirror] [--launch|--no-launch] [--plan] [--output json]
       powerforge apple-screenshots manifest --config <screenshots.json> [--capture-provenance <json> --expected-repository <owner/repo> --expected-workflow-ref <workflow-ref> | --version <x.y|x.y.z> --source-commit <sha>] --approved-by <reviewer-or-boundary> --allowed-root <reviewed-capture-root>
                         [--app-id <asc-app-id> | --release-config <release.json> [--target <name-or-scheme>]]
                         [--out <manifest.json>] [--xcode-version <value>] [--runtime <value>] [--device <value>]

--- a/PowerForge.Cli/Program.cs
+++ b/PowerForge.Cli/Program.cs
@@ -76,6 +76,8 @@ internal static partial class Program
             return CommandRelease(filteredArgs, cli, logger);
         case "apple-release":
             return CommandAppleRelease(filteredArgs, cli, logger);
+        case "apple-deploy":
+            return CommandAppleDeploy(filteredArgs, cli, logger);
         case "apple-screenshots":
             return CommandAppleScreenshots(filteredArgs, cli, logger);
         case "apple-governance":

--- a/PowerForge.Tests/AppleDeviceDeploymentServiceTests.cs
+++ b/PowerForge.Tests/AppleDeviceDeploymentServiceTests.cs
@@ -109,6 +109,37 @@ OldPhone   OldPhone.coredevice.local   11111111-1111-1111-1111-111111111111   un
     }
 
     [Fact]
+    public async Task BuildAsync_discovers_single_app_when_product_name_differs_from_scheme()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(root.FullName, "Tactra.xcodeproj"));
+            File.WriteAllText(Path.Combine(project.FullName, "project.pbxproj"), string.Empty);
+            var derived = Path.Combine(root.FullName, "DerivedData");
+            var actualApp = Directory.CreateDirectory(Path.Combine(derived, "Build", "Products", "Debug-maccatalyst", "Tactra.app"));
+            var service = new AppleDeviceDeploymentService(new CapturingProcessRunner(_ => Success("ok")));
+
+            var result = await service.BuildAsync(new AppleAppBuildRequest
+            {
+                ProjectPath = project.FullName,
+                Scheme = "TactraMac",
+                Platform = ApplePlatform.macOS,
+                ArchiveVariant = AppleArchiveVariant.MacCatalyst,
+                DerivedDataPath = derived,
+                XcodeBuildExecutable = "xcodebuild-test"
+            });
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(actualApp.FullName, result.AppPath);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public async Task BuildAsync_uses_plain_configuration_directory_for_macos_app_path()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -132,6 +163,38 @@ OldPhone   OldPhone.coredevice.local   11111111-1111-1111-1111-111111111111   un
 
             Assert.True(result.Succeeded);
             Assert.Equal(Path.Combine(derived, "Build", "Products", "Debug", "Tactra.app"), result.AppPath);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task BuildAsync_uses_maccatalyst_destination_and_product_directory()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(root.FullName, "CasaRay.xcodeproj"));
+            File.WriteAllText(Path.Combine(project.FullName, "project.pbxproj"), string.Empty);
+            var derived = Path.Combine(root.FullName, "DerivedData");
+            var runner = new CapturingProcessRunner(_ => Success("ok"));
+            var service = new AppleDeviceDeploymentService(runner);
+
+            var result = await service.BuildAsync(new AppleAppBuildRequest
+            {
+                ProjectPath = project.FullName,
+                Scheme = "CasaRay",
+                Platform = ApplePlatform.macOS,
+                ArchiveVariant = AppleArchiveVariant.MacCatalyst,
+                DerivedDataPath = derived,
+                XcodeBuildExecutable = "xcodebuild-test"
+            });
+
+            Assert.True(result.Succeeded);
+            Assert.Equal("generic/platform=macOS,variant=Mac Catalyst", result.Destination);
+            Assert.Equal(Path.Combine(derived, "Build", "Products", "Debug-maccatalyst", "CasaRay.app"), result.AppPath);
         }
         finally
         {
@@ -305,7 +368,53 @@ App installed:
     }
 
     [Fact]
-    public async Task DeployAsync_treats_locked_device_launch_as_successful_deployment()
+    public async Task DeployAsync_passes_profile_environment_and_restarts_existing_app()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(root.FullName, "CasaRay.xcodeproj"));
+            File.WriteAllText(Path.Combine(project.FullName, "project.pbxproj"), string.Empty);
+            var app = Directory.CreateDirectory(Path.Combine(root.FullName, "CasaRay.app"));
+            var runner = new CapturingProcessRunner(request => request.Arguments.Contains("install")
+                ? Success("App installed:\n• bundleID: com.evotecit.casaray\n")
+                : Success("ok"));
+            var service = new AppleDeviceDeploymentService(runner);
+
+            var result = await service.DeployAsync(new AppleAppDeviceDeploymentRequest
+            {
+                ProjectPath = project.FullName,
+                Scheme = "CasaRay",
+                AppPath = app.FullName,
+                DeviceIdentifier = "device-1",
+                BundleIdentifier = "com.evotecit.casaray",
+                Launch = true,
+                LaunchEnvironment = new Dictionary<string, string>
+                {
+                    ["CASARAY_ENABLE_SANDBOX_PURCHASES"] = "1"
+                },
+                LaunchArguments = new[] { "--sample" },
+                TerminateExisting = true,
+                XcodeBuildExecutable = "xcodebuild-test",
+                XcrunExecutable = "xcrun-test"
+            });
+
+            Assert.True(result.Succeeded);
+            var launch = runner.Requests[2].Arguments;
+            Assert.Equal("--environment-variables", launch[6]);
+            Assert.Equal("{\"CASARAY_ENABLE_SANDBOX_PURCHASES\":\"1\"}", launch[7]);
+            Assert.Equal("--terminate-existing", launch[8]);
+            Assert.Equal("com.evotecit.casaray", launch[9]);
+            Assert.Equal("--sample", launch[10]);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task DeployAsync_preserves_install_success_but_marks_locked_launch_incomplete()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
@@ -349,6 +458,7 @@ App installed:
             });
 
             Assert.True(result.Succeeded);
+            Assert.False(result.RequestedStagesSucceeded);
             Assert.NotNull(result.Install);
             Assert.True(result.Install.Succeeded);
             Assert.NotNull(result.Launch);

--- a/PowerForge.Tests/AppleMacAppDeploymentServiceTests.cs
+++ b/PowerForge.Tests/AppleMacAppDeploymentServiceTests.cs
@@ -1,0 +1,208 @@
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed class AppleMacAppDeploymentServiceTests
+{
+    [Fact]
+    public async Task DeployAsync_replaces_existing_app_and_launches_selected_profile()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(root.FullName, "CasaRay.xcodeproj"));
+            File.WriteAllText(Path.Combine(project.FullName, "project.pbxproj"), string.Empty);
+            var derived = Directory.CreateDirectory(Path.Combine(root.FullName, "DerivedData"));
+            var source = Directory.CreateDirectory(Path.Combine(derived.FullName, "Build", "Products", "Debug-maccatalyst", "CasaRay.app"));
+            File.WriteAllText(Path.Combine(source.FullName, "version.txt"), "new");
+            var installRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Applications"));
+            var existing = Directory.CreateDirectory(Path.Combine(installRoot.FullName, "CasaRay.app"));
+            File.WriteAllText(Path.Combine(existing.FullName, "version.txt"), "old");
+
+            var runner = new CapturingProcessRunner(request =>
+            {
+                if (request.FileName == "ditto-test")
+                {
+                    CopyDirectory(request.Arguments[0], request.Arguments[1]);
+                    return Success("copied");
+                }
+                if (request.FileName == "open-test")
+                {
+                    var destination = Path.Combine(installRoot.FullName, "CasaRay.app");
+                    Assert.Throws<InvalidOperationException>(() => AppleMacAppBundleReplacement.AcquireInstallLock(destination));
+                }
+                return Success("ok");
+            });
+            var service = new AppleMacAppDeploymentService(runner);
+
+            var result = await service.DeployAsync(new AppleMacAppDeploymentRequest
+            {
+                ProjectPath = project.FullName,
+                Scheme = "CasaRay",
+                Platform = ApplePlatform.macOS,
+                ArchiveVariant = AppleArchiveVariant.MacCatalyst,
+                DerivedDataPath = derived.FullName,
+                InstallRoot = installRoot.FullName,
+                Launch = true,
+                LaunchEnvironment = new Dictionary<string, string>
+                {
+                    ["CASARAY_ENABLE_SANDBOX_PURCHASES"] = "1"
+                },
+                XcodeBuildExecutable = "xcodebuild-test",
+                DittoExecutable = "ditto-test",
+                OpenExecutable = "open-test"
+            });
+
+            Assert.True(result.Succeeded);
+            Assert.Equal("new", File.ReadAllText(Path.Combine(installRoot.FullName, "CasaRay.app", "version.txt")));
+            Assert.DoesNotContain(Directory.EnumerateDirectories(installRoot.FullName), path => path.Contains("powerforge-backup", StringComparison.Ordinal));
+            var terminate = Assert.Single(runner.Requests, request => request.FileName == "/usr/bin/pkill");
+            Assert.Equal("-f", terminate.Arguments[0]);
+            Assert.StartsWith("^", terminate.Arguments[1], StringComparison.Ordinal);
+            Assert.Contains(
+                System.Text.RegularExpressions.Regex.Escape(Path.Combine(installRoot.FullName, "CasaRay.app", "Contents", "MacOS")),
+                terminate.Arguments[1],
+                StringComparison.Ordinal);
+            var launch = Assert.Single(runner.Requests, request => request.FileName == "open-test");
+            Assert.Equal(new[]
+            {
+                "--new", "--fresh", "--env", "CASARAY_ENABLE_SANDBOX_PURCHASES=1",
+                Path.Combine(installRoot.FullName, "CasaRay.app")
+            }, launch.Arguments);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task DeployAsync_removes_partial_stage_when_copy_fails()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(root.FullName, "CasaRay.xcodeproj"));
+            File.WriteAllText(Path.Combine(project.FullName, "project.pbxproj"), string.Empty);
+            var derived = Directory.CreateDirectory(Path.Combine(root.FullName, "DerivedData"));
+            Directory.CreateDirectory(Path.Combine(derived.FullName, "Build", "Products", "Debug-maccatalyst", "CasaRay.app"));
+            var installRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Applications"));
+
+            var runner = new CapturingProcessRunner(request =>
+            {
+                if (request.FileName == "ditto-test")
+                {
+                    Directory.CreateDirectory(request.Arguments[1]);
+                    File.WriteAllText(Path.Combine(request.Arguments[1], "partial"), string.Empty);
+                    return new ProcessRunResult(1, string.Empty, "copy failed", "tool", TimeSpan.FromMilliseconds(1), false);
+                }
+                return Success("ok");
+            });
+
+            var result = await new AppleMacAppDeploymentService(runner).DeployAsync(new AppleMacAppDeploymentRequest
+            {
+                ProjectPath = project.FullName,
+                Scheme = "CasaRay",
+                Platform = ApplePlatform.macOS,
+                ArchiveVariant = AppleArchiveVariant.MacCatalyst,
+                DerivedDataPath = derived.FullName,
+                InstallRoot = installRoot.FullName,
+                Launch = false,
+                XcodeBuildExecutable = "xcodebuild-test",
+                DittoExecutable = "ditto-test"
+            });
+
+            Assert.False(result.Succeeded);
+            Assert.False(result.Install?.Succeeded);
+            Assert.DoesNotContain(Directory.EnumerateDirectories(installRoot.FullName), path => path.Contains("powerforge-stage", StringComparison.Ordinal));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task DeployAsync_recovers_interrupted_backup_before_replacement()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(root.FullName, "CasaRay.xcodeproj"));
+            File.WriteAllText(Path.Combine(project.FullName, "project.pbxproj"), string.Empty);
+            var derived = Directory.CreateDirectory(Path.Combine(root.FullName, "DerivedData"));
+            var source = Directory.CreateDirectory(Path.Combine(derived.FullName, "Build", "Products", "Debug-maccatalyst", "CasaRay.app"));
+            File.WriteAllText(Path.Combine(source.FullName, "version.txt"), "new");
+            var installRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Applications"));
+            var orphanedBackup = Directory.CreateDirectory(Path.Combine(installRoot.FullName, ".CasaRay.app.powerforge-backup-interrupted"));
+            File.WriteAllText(Path.Combine(orphanedBackup.FullName, "version.txt"), "old");
+
+            var runner = new CapturingProcessRunner(request =>
+            {
+                if (request.FileName == "ditto-test")
+                    CopyDirectory(request.Arguments[0], request.Arguments[1]);
+                return Success("ok");
+            });
+
+            var result = await new AppleMacAppDeploymentService(runner).DeployAsync(new AppleMacAppDeploymentRequest
+            {
+                ProjectPath = project.FullName,
+                Scheme = "CasaRay",
+                Platform = ApplePlatform.macOS,
+                ArchiveVariant = AppleArchiveVariant.MacCatalyst,
+                DerivedDataPath = derived.FullName,
+                InstallRoot = installRoot.FullName,
+                Launch = false,
+                XcodeBuildExecutable = "xcodebuild-test",
+                DittoExecutable = "ditto-test"
+            });
+
+            Assert.True(result.Succeeded);
+            Assert.Equal("new", File.ReadAllText(Path.Combine(installRoot.FullName, "CasaRay.app", "version.txt")));
+            Assert.DoesNotContain(Directory.EnumerateDirectories(installRoot.FullName), path => path.Contains("powerforge-", StringComparison.Ordinal));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void AcquireInstallLock_rejects_overlapping_install()
+    {
+        var destination = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"), "CasaRay.app");
+        using var first = AppleMacAppBundleReplacement.AcquireInstallLock(destination);
+
+        Assert.Throws<InvalidOperationException>(() => AppleMacAppBundleReplacement.AcquireInstallLock(destination));
+    }
+
+    private static void CopyDirectory(string source, string destination)
+    {
+        Directory.CreateDirectory(destination);
+        foreach (var file in Directory.EnumerateFiles(source))
+            File.Copy(file, Path.Combine(destination, Path.GetFileName(file)));
+        foreach (var directory in Directory.EnumerateDirectories(source))
+            CopyDirectory(directory, Path.Combine(destination, Path.GetFileName(directory)));
+    }
+
+    private static ProcessRunResult Success(string stdOut)
+        => new(0, stdOut, string.Empty, "tool", TimeSpan.FromMilliseconds(1), false);
+
+    private sealed class CapturingProcessRunner : IProcessRunner
+    {
+        private readonly Func<ProcessRunRequest, ProcessRunResult> _execute;
+
+        public CapturingProcessRunner(Func<ProcessRunRequest, ProcessRunResult> execute)
+        {
+            _execute = execute;
+        }
+
+        public List<ProcessRunRequest> Requests { get; } = new();
+
+        public Task<ProcessRunResult> RunAsync(ProcessRunRequest request, CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+            return Task.FromResult(_execute(request));
+        }
+    }
+}

--- a/PowerForge.Tests/PowerForgeCliAppleDeployTests.cs
+++ b/PowerForge.Tests/PowerForgeCliAppleDeployTests.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace PowerForge.Tests;
+
+public sealed class PowerForgeCliAppleDeployTests
+{
+    [Fact]
+    public async Task AppleDeploy_plan_uses_configured_target_profile_and_platform_defaults()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var tempRoot = Path.Combine(Path.GetTempPath(), "PowerForgeCliAppleDeploy-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(tempRoot, "Sample.xcodeproj"));
+            var configPath = Path.Combine(tempRoot, "powerforge.release.json");
+            File.WriteAllText(configPath, """
+            {
+              "SchemaVersion": 1,
+              "AppleApps": {
+                "ProjectRoot": ".",
+                "LocalDeployment": {
+                  "DefaultPlatform": "iOS",
+                  "DefaultDevice": "EvoPhone",
+                  "Configuration": "Debug",
+                  "InstallRoot": "/Applications",
+                  "DefaultProfile": "Plus",
+                  "Profiles": [
+                    {
+                      "Name": "Free",
+                      "Environment": { "SAMPLE_SANDBOX": "1" }
+                    },
+                    {
+                      "Name": "Plus",
+                      "Environment": { "SAMPLE_SANDBOX": "0" }
+                    }
+                  ]
+                },
+                "Apps": [
+                  {
+                    "Name": "Sample iOS",
+                    "BundleId": "com.example.sample",
+                    "Platform": "iOS",
+                    "ProjectPath": "Sample.xcodeproj",
+                    "Scheme": "Sample"
+                  },
+                  {
+                    "Name": "Sample Mac",
+                    "BundleId": "com.example.sample",
+                    "Platform": "macOS",
+                    "ArchiveVariant": "MacCatalyst",
+                    "ProjectPath": "Sample.xcodeproj",
+                    "Scheme": "Sample"
+                  },
+                  {
+                    "Name": "Sample CarPlay capability",
+                    "BundleId": "com.example.sample",
+                    "Platform": "iOS",
+                    "ProductRole": "Capability",
+                    "ProjectPath": "Sample.xcodeproj",
+                    "Scheme": "Sample"
+                  }
+                ]
+              }
+            }
+            """);
+
+            var ios = await RunCliAsync(repoRoot, $"\"{GetCliPath(repoRoot)}\" apple-deploy --config \"{configPath}\" --plan --output json");
+            Assert.Equal(0, ios.ExitCode);
+            using (var document = JsonDocument.Parse(ios.StdOut))
+            {
+                var result = document.RootElement.GetProperty("result");
+                Assert.Equal("Sample iOS", result.GetProperty("target").GetString());
+                Assert.Equal("iOS", result.GetProperty("platform").GetString());
+                Assert.Equal("Plus", result.GetProperty("profile").GetString());
+                Assert.Equal("EvoPhone", result.GetProperty("device").GetString());
+                Assert.Equal("Debug", result.GetProperty("configuration").GetString());
+            }
+
+            var mac = await RunCliAsync(repoRoot, $"\"{GetCliPath(repoRoot)}\" apple-deploy --config \"{configPath}\" --platform macOS --profile Free --plan --output json");
+            Assert.Equal(0, mac.ExitCode);
+            using var macDocument = JsonDocument.Parse(mac.StdOut);
+            var macResult = macDocument.RootElement.GetProperty("result");
+            Assert.Equal("Sample Mac", macResult.GetProperty("target").GetString());
+            Assert.Equal("MacCatalyst", macResult.GetProperty("archiveVariant").GetString());
+            Assert.Equal("Free", macResult.GetProperty("profile").GetString());
+            Assert.Equal("/Applications", macResult.GetProperty("installRoot").GetString());
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    private static async Task<(int ExitCode, string StdOut, string StdErr)> RunCliAsync(string workingDirectory, string arguments)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = arguments,
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+        process.Start();
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+        return (process.ExitCode, await stdout, await stderr);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "PowerForge.Cli", "PowerForge.Cli.csproj")))
+                return current.FullName;
+            current = current.Parent;
+        }
+        throw new DirectoryNotFoundException("Unable to locate repository root.");
+    }
+
+    private static string GetCliPath(string repoRoot)
+        => Path.Combine(repoRoot, "PowerForge.Cli", "bin", "Release", "net10.0", "PowerForge.Cli.dll");
+
+}

--- a/PowerForge.Tests/PowerForgeReleaseSchemaTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseSchemaTests.cs
@@ -48,6 +48,50 @@ public sealed class PowerForgeReleaseSchemaTests
         Assert.True(appleSchema.Evaluate(node, new EvaluationOptions { OutputFormat = OutputFormat.List }).IsValid);
     }
 
+    [Fact]
+    public void Release_schema_and_runtime_accept_local_Apple_deployment_profiles()
+    {
+        var schemaDocument = JsonNode.Parse(File.ReadAllText(GetSchemaPath("powerforge.release.schema.json")))!;
+        var localSchema = JsonSchema.FromText(
+            schemaDocument["properties"]!["AppleApps"]!["properties"]!["LocalDeployment"]!.ToJsonString());
+        var json = """
+            {
+              "DefaultPlatform": "iOS",
+              "DefaultDevice": "EvoPhone",
+              "Configuration": "Debug",
+              "InstallRoot": "/Applications",
+              "DefaultProfile": "Plus",
+              "Profiles": [
+                {
+                  "Name": "Free",
+                  "Environment": { "CASARAY_ENABLE_SANDBOX_PURCHASES": "1" }
+                },
+                {
+                  "Name": "Plus",
+                  "Environment": { "CASARAY_ENABLE_SANDBOX_PURCHASES": "0" }
+                }
+              ]
+            }
+            """;
+
+        Assert.True(localSchema.Evaluate(JsonNode.Parse(json)!, new EvaluationOptions { OutputFormat = OutputFormat.List }).IsValid);
+
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            File.WriteAllText(path, $$"""{ "AppleApps": { "LocalDeployment": {{json}} } }""");
+            var local = PowerForgeReleaseService.LoadConfiguration(path).AppleApps!.LocalDeployment;
+            Assert.Equal(ApplePlatform.iOS, local.DefaultPlatform);
+            Assert.Equal("EvoPhone", local.DefaultDevice);
+            Assert.Equal("Plus", local.DefaultProfile);
+            Assert.Equal("1", Assert.Single(local.Profiles, profile => profile.Name == "Free").Environment["CASARAY_ENABLE_SANDBOX_PURCHASES"]);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
     [Theory]
     [InlineData("1.X.0", true)]
     [InlineData("1.6.X", true)]

--- a/PowerForge/Models/AppleDeviceDeploymentModels.cs
+++ b/PowerForge/Models/AppleDeviceDeploymentModels.cs
@@ -67,6 +67,9 @@ public class AppleAppBuildRequest
     /// <summary>Apple platform used to resolve the product directory.</summary>
     public ApplePlatform Platform { get; set; } = ApplePlatform.iOS;
 
+    /// <summary>Build variant used to distinguish native macOS from Mac Catalyst products.</summary>
+    public AppleArchiveVariant ArchiveVariant { get; set; } = AppleArchiveVariant.Default;
+
     /// <summary>Explicit xcodebuild destination.</summary>
     public string? Destination { get; set; }
 
@@ -196,6 +199,15 @@ public sealed class AppleAppLaunchRequest
     /// <summary>xcrun executable name or path.</summary>
     public string XcrunExecutable { get; set; } = "xcrun";
 
+    /// <summary>Environment variables supplied to the launched app.</summary>
+    public Dictionary<string, string> EnvironmentVariables { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>Arguments supplied to the launched app.</summary>
+    public string[] Arguments { get; set; } = Array.Empty<string>();
+
+    /// <summary>Terminate an existing app process before launching so the requested profile is applied.</summary>
+    public bool TerminateExisting { get; set; }
+
     /// <summary>Maximum launch runtime.</summary>
     public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(2);
 }
@@ -231,6 +243,15 @@ public sealed class AppleAppDeviceDeploymentRequest : AppleAppBuildRequest
 
     /// <summary>Launch the app after a successful install.</summary>
     public bool Launch { get; set; }
+
+    /// <summary>Environment variables supplied when launching the installed app.</summary>
+    public Dictionary<string, string> LaunchEnvironment { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>Arguments supplied when launching the installed app.</summary>
+    public string[] LaunchArguments { get; set; } = Array.Empty<string>();
+
+    /// <summary>Terminate an existing app process before launch.</summary>
+    public bool TerminateExisting { get; set; }
 }
 
 /// <summary>
@@ -238,6 +259,9 @@ public sealed class AppleAppDeviceDeploymentRequest : AppleAppBuildRequest
 /// </summary>
 public sealed class AppleAppDeviceDeploymentResult
 {
+    /// <summary>True when the caller requested a launch after installation.</summary>
+    public bool LaunchRequested { get; set; }
+
     /// <summary>Build result.</summary>
     public AppleAppBuildResult Build { get; set; } = new();
 
@@ -249,4 +273,9 @@ public sealed class AppleAppDeviceDeploymentResult
 
     /// <summary>True when build and install succeeded, and launch either succeeded or was blocked only because the device was locked.</summary>
     public bool Succeeded => Build.Succeeded && (Install?.Succeeded ?? false) && (Launch is null || Launch.Succeeded || Launch.DeviceLocked);
+
+    /// <summary>True when build, install, and every explicitly requested launch stage completed successfully.</summary>
+    public bool RequestedStagesSucceeded => Build.Succeeded &&
+                                            (Install?.Succeeded ?? false) &&
+                                            (!LaunchRequested || (Launch?.Succeeded ?? false));
 }

--- a/PowerForge/Models/AppleMacAppDeploymentModels.cs
+++ b/PowerForge/Models/AppleMacAppDeploymentModels.cs
@@ -1,0 +1,85 @@
+namespace PowerForge;
+
+/// <summary>
+/// Request to build, install, and optionally launch a macOS app locally.
+/// </summary>
+public sealed class AppleMacAppDeploymentRequest : AppleAppBuildRequest
+{
+    /// <summary>Directory that receives the built app. Defaults to /Applications.</summary>
+    public string InstallRoot { get; set; } = "/Applications";
+
+    /// <summary>Launch the installed app after replacement.</summary>
+    public bool Launch { get; set; } = true;
+
+    /// <summary>Environment variables supplied to the launched app.</summary>
+    public Dictionary<string, string> LaunchEnvironment { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>Arguments supplied to the launched app.</summary>
+    public string[] LaunchArguments { get; set; } = Array.Empty<string>();
+
+    /// <summary>Terminate processes running from the installed bundle before applying the launch profile.</summary>
+    public bool TerminateExisting { get; set; } = true;
+
+    /// <summary>ditto executable used to preserve the application bundle while copying.</summary>
+    public string DittoExecutable { get; set; } = "/usr/bin/ditto";
+
+    /// <summary>open executable used to launch the installed app.</summary>
+    public string OpenExecutable { get; set; } = "/usr/bin/open";
+
+    /// <summary>pkill executable used to terminate prior instances from the installed bundle.</summary>
+    public string PkillExecutable { get; set; } = "/usr/bin/pkill";
+}
+
+/// <summary>
+/// Result of installing a macOS app bundle.
+/// </summary>
+public sealed class AppleMacAppInstallResult
+{
+    /// <summary>Source app bundle produced by xcodebuild.</summary>
+    public string SourceAppPath { get; set; } = string.Empty;
+
+    /// <summary>Final installed app bundle path.</summary>
+    public string InstalledAppPath { get; set; } = string.Empty;
+
+    /// <summary>Copy process result.</summary>
+    public ProcessRunResult ProcessResult { get; set; } = new(0, string.Empty, string.Empty, "/usr/bin/ditto", TimeSpan.Zero, false);
+
+    /// <summary>True when the replacement completed successfully.</summary>
+    public bool Succeeded { get; set; }
+
+    /// <summary>Non-fatal cleanup warning after a successful replacement.</summary>
+    public string? Warning { get; set; }
+}
+
+/// <summary>
+/// Result of launching an installed macOS app.
+/// </summary>
+public sealed class AppleMacAppLaunchResult
+{
+    /// <summary>Installed app bundle path.</summary>
+    public string AppPath { get; set; } = string.Empty;
+
+    /// <summary>Launch process result.</summary>
+    public ProcessRunResult ProcessResult { get; set; } = new(0, string.Empty, string.Empty, "/usr/bin/open", TimeSpan.Zero, false);
+
+    /// <summary>True when open completed successfully.</summary>
+    public bool Succeeded => ProcessResult.Succeeded;
+}
+
+/// <summary>
+/// Result of a local macOS build/install/launch deployment.
+/// </summary>
+public sealed class AppleMacAppDeploymentResult
+{
+    /// <summary>Build result.</summary>
+    public AppleAppBuildResult Build { get; set; } = new();
+
+    /// <summary>Install result, when the build succeeded.</summary>
+    public AppleMacAppInstallResult? Install { get; set; }
+
+    /// <summary>Launch result, when requested and install succeeded.</summary>
+    public AppleMacAppLaunchResult? Launch { get; set; }
+
+    /// <summary>True when every requested stage succeeded.</summary>
+    public bool Succeeded => Build.Succeeded && (Install?.Succeeded ?? false) && (Launch?.Succeeded ?? true);
+}

--- a/PowerForge/Models/Configuration/ConfigurationMiscSegments.cs
+++ b/PowerForge/Models/Configuration/ConfigurationMiscSegments.cs
@@ -233,6 +233,9 @@ public sealed class AppleAppConfiguration
     /// <summary>Xcode scheme name for future archive/export automation.</summary>
     public string? Scheme { get; set; }
 
+    /// <summary>Optional built .app product name when it differs from Scheme.</summary>
+    public string? ProductName { get; set; }
+
     /// <summary>Optional App Store Connect app id for future remote metadata checks.</summary>
     public string? AppStoreConnectAppId { get; set; }
 

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -383,6 +383,8 @@ internal sealed class PowerForgeAppleReleaseOptions
 
     public string? SigningStyle { get; set; }
 
+    public PowerForgeAppleLocalDeploymentOptions LocalDeployment { get; set; } = new();
+
     public PowerForgeAppleReleaseAutomationOptions Automation { get; set; } = new();
 
     public PowerForgeAppleDirectDistributionOptions DirectDistribution { get; set; } = new();
@@ -457,6 +459,34 @@ internal sealed class PowerForgeAppleReleaseOptions
     public bool AllowNonPendingDeveloperRelease { get; set; }
 
     public AppleAppConfiguration[] Apps { get; set; } = Array.Empty<AppleAppConfiguration>();
+}
+
+internal sealed class PowerForgeAppleLocalDeploymentOptions
+{
+    public ApplePlatform DefaultPlatform { get; set; } = ApplePlatform.iOS;
+
+    public string? DefaultDevice { get; set; }
+
+    public string Configuration { get; set; } = "Debug";
+
+    public string InstallRoot { get; set; } = "/Applications";
+
+    public bool Launch { get; set; } = true;
+
+    public bool UseBuildMirror { get; set; }
+
+    public string? DefaultProfile { get; set; }
+
+    public PowerForgeAppleLocalDeploymentProfile[] Profiles { get; set; } = Array.Empty<PowerForgeAppleLocalDeploymentProfile>();
+}
+
+internal sealed class PowerForgeAppleLocalDeploymentProfile
+{
+    public string Name { get; set; } = string.Empty;
+
+    public Dictionary<string, string> Environment { get; set; } = new(StringComparer.Ordinal);
+
+    public string[] Arguments { get; set; } = Array.Empty<string>();
 }
 
 internal sealed class PowerForgeAppleReleasePlan

--- a/PowerForge/Services/AppleDeviceDeploymentService.cs
+++ b/PowerForge/Services/AppleDeviceDeploymentService.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using System.Text.Json;
 
 namespace PowerForge;
 
@@ -94,7 +95,7 @@ public sealed class AppleDeviceDeploymentService
             request.Timeout,
             cancellationToken).ConfigureAwait(false);
 
-        var destination = ResolveDestination(request.Destination, deviceIdentifier, request.Platform);
+        var destination = ResolveDestination(request.Destination, deviceIdentifier, request.Platform, request.ArchiveVariant);
         var derivedDataPath = ResolveDerivedDataPath(request);
         var appPath = ResolveAppPath(request, derivedDataPath);
         var buildProjectPath = projectPath;
@@ -151,9 +152,13 @@ public sealed class AppleDeviceDeploymentService
                 request.Timeout <= TimeSpan.Zero ? TimeSpan.FromHours(1) : request.Timeout),
             cancellationToken).ConfigureAwait(false);
 
+        var resolvedAppPath = result.Succeeded
+            ? ResolveBuiltAppPath(request, derivedDataPath, appPath)
+            : appPath;
+
         return new AppleAppBuildResult
         {
-            AppPath = appPath,
+            AppPath = resolvedAppPath,
             Destination = destination,
             DerivedDataPath = derivedDataPath,
             BuildMirrorPath = mirrorPath,
@@ -233,11 +238,25 @@ public sealed class AppleDeviceDeploymentService
         if (string.IsNullOrWhiteSpace(deviceIdentifier))
             throw new ArgumentException("DeviceIdentifier or Device is required.", nameof(request));
 
+        var arguments = new List<string>
+        {
+            "devicectl", "device", "process", "launch", "--device", deviceIdentifier!
+        };
+        if (request.EnvironmentVariables.Count > 0)
+        {
+            arguments.Add("--environment-variables");
+            arguments.Add(JsonSerializer.Serialize(request.EnvironmentVariables));
+        }
+        if (request.TerminateExisting)
+            arguments.Add("--terminate-existing");
+        arguments.Add(request.BundleIdentifier.Trim());
+        arguments.AddRange(request.Arguments);
+
         var result = await _processRunner.RunAsync(
             new ProcessRunRequest(
                 NormalizeExecutable(request.XcrunExecutable, "xcrun"),
                 Directory.GetCurrentDirectory(),
-                new[] { "devicectl", "device", "process", "launch", "--device", deviceIdentifier!, request.BundleIdentifier.Trim() },
+                arguments,
                 request.Timeout <= TimeSpan.Zero ? TimeSpan.FromMinutes(2) : request.Timeout),
             cancellationToken).ConfigureAwait(false);
 
@@ -265,7 +284,8 @@ public sealed class AppleDeviceDeploymentService
         var build = await BuildAsync(request, cancellationToken).ConfigureAwait(false);
         var deployment = new AppleAppDeviceDeploymentResult
         {
-            Build = build
+            Build = build,
+            LaunchRequested = request.Launch
         };
 
         if (!build.Succeeded)
@@ -297,6 +317,9 @@ public sealed class AppleDeviceDeploymentService
             Device = request.Device,
             BundleIdentifier = bundleIdentifier!,
             XcrunExecutable = request.XcrunExecutable,
+            EnvironmentVariables = new Dictionary<string, string>(request.LaunchEnvironment, StringComparer.Ordinal),
+            Arguments = request.LaunchArguments,
+            TerminateExisting = request.TerminateExisting,
             Timeout = request.Timeout
         }, cancellationToken).ConfigureAwait(false);
 
@@ -407,14 +430,18 @@ public sealed class AppleDeviceDeploymentService
         return new MirrorResult(sourceRoot, mirrorPath, result);
     }
 
-    private static string ResolveDestination(string? destination, string? deviceIdentifier, ApplePlatform platform)
+    private static string ResolveDestination(
+        string? destination,
+        string? deviceIdentifier,
+        ApplePlatform platform,
+        AppleArchiveVariant archiveVariant)
     {
         if (!string.IsNullOrWhiteSpace(destination))
             return destination!.Trim();
         if (!string.IsNullOrWhiteSpace(deviceIdentifier))
             return $"id={deviceIdentifier!.Trim()}";
 
-        return AppleAppArchiveService.GetGenericDestination(platform);
+        return AppleAppArchiveService.GetGenericDestination(platform, archiveVariant);
     }
 
     private static string ResolveDerivedDataPath(AppleAppBuildRequest request)
@@ -436,11 +463,30 @@ public sealed class AppleDeviceDeploymentService
         return Path.Combine(derivedDataPath, "Build", "Products", GetProductDirectory(request), $"{productName}.app");
     }
 
+    private static string ResolveBuiltAppPath(AppleAppBuildRequest request, string derivedDataPath, string expectedAppPath)
+    {
+        if (!string.IsNullOrWhiteSpace(request.AppPath) ||
+            !string.IsNullOrWhiteSpace(request.ProductName) ||
+            Directory.Exists(expectedAppPath))
+        {
+            return expectedAppPath;
+        }
+
+        var productDirectory = Path.Combine(derivedDataPath, "Build", "Products", GetProductDirectory(request));
+        if (!Directory.Exists(productDirectory))
+            return expectedAppPath;
+
+        var candidates = Directory.EnumerateDirectories(productDirectory, "*.app", SearchOption.TopDirectoryOnly).ToArray();
+        return candidates.Length == 1 ? candidates[0] : expectedAppPath;
+    }
+
     private static string GetProductDirectory(AppleAppBuildRequest request)
     {
         var configuration = string.IsNullOrWhiteSpace(request.Configuration) ? "Debug" : request.Configuration.Trim();
         return request.Platform == ApplePlatform.macOS
-            ? configuration
+            ? request.ArchiveVariant == AppleArchiveVariant.MacCatalyst
+                ? $"{configuration}-maccatalyst"
+                : configuration
             : $"{configuration}-{GetSdkProductSuffix(request.Platform)}";
     }
 

--- a/PowerForge/Services/AppleLocalDeploymentLock.cs
+++ b/PowerForge/Services/AppleLocalDeploymentLock.cs
@@ -1,0 +1,29 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace PowerForge;
+
+internal static class AppleLocalDeploymentLock
+{
+    internal static FileStream Acquire(string key, string description)
+    {
+        var lockRoot = Path.Combine(Path.GetTempPath(), "powerforge-apple-local", "locks");
+        Directory.CreateDirectory(lockRoot);
+        var lockPath = Path.Combine(lockRoot, $"{HashKey(key)}.lock");
+        try
+        {
+            return new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+        }
+        catch (IOException exception)
+        {
+            throw new InvalidOperationException($"Another Apple deployment is already using {description}.", exception);
+        }
+    }
+
+    private static string HashKey(string key)
+    {
+        using var sha256 = SHA256.Create();
+        var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(key));
+        return BitConverter.ToString(hash, 0, 12).Replace("-", string.Empty).ToLowerInvariant();
+    }
+}

--- a/PowerForge/Services/AppleMacAppBundleReplacement.cs
+++ b/PowerForge/Services/AppleMacAppBundleReplacement.cs
@@ -1,0 +1,90 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace PowerForge;
+
+internal static class AppleMacAppBundleReplacement
+{
+    private const int AtCurrentWorkingDirectory = -2;
+    private const uint RenameSwap = 0x00000002;
+
+    internal static FileStream AcquireInstallLock(string destination)
+        => AppleLocalDeploymentLock.Acquire(Path.GetFullPath(destination), $"install destination '{destination}'");
+
+    internal static string? RecoverInterruptedReplacement(string destination)
+    {
+        var installRoot = Path.GetDirectoryName(destination)
+            ?? throw new InvalidOperationException($"Install destination has no parent: {destination}");
+        var appName = Path.GetFileName(destination);
+        var backups = Directory.EnumerateDirectories(installRoot, $".{appName}.powerforge-backup-*")
+            .OrderByDescending(Directory.GetLastWriteTimeUtc)
+            .ToList();
+
+        if (!Directory.Exists(destination) && backups.Count > 0)
+        {
+            Directory.Move(backups[0], destination);
+            backups.RemoveAt(0);
+        }
+
+        var warnings = new List<string>();
+        foreach (var path in backups.Concat(Directory.EnumerateDirectories(installRoot, $".{appName}.powerforge-stage-*")))
+        {
+            if (!TryDeleteDirectory(path, out var warning) && warning is not null)
+                warnings.Add(warning);
+        }
+        return warnings.Count == 0 ? null : string.Join(" ", warnings);
+    }
+
+    internal static string? Replace(string stage, string destination, string backup)
+    {
+        if (!Directory.Exists(destination))
+        {
+            Directory.Move(stage, destination);
+            return null;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            if (RenameAtxNp(AtCurrentWorkingDirectory, stage, AtCurrentWorkingDirectory, destination, RenameSwap) != 0)
+            {
+                var error = Marshal.GetLastWin32Error();
+                throw new IOException($"Atomic app replacement failed: {new Win32Exception(error).Message}");
+            }
+            return TryDeleteDirectory(stage, out var warning) ? null : warning;
+        }
+
+        Directory.Move(destination, backup);
+        try
+        {
+            Directory.Move(stage, destination);
+        }
+        catch
+        {
+            if (!Directory.Exists(destination) && Directory.Exists(backup))
+                Directory.Move(backup, destination);
+            throw;
+        }
+        return TryDeleteDirectory(backup, out var fallbackWarning) ? null : fallbackWarning;
+    }
+
+    internal static bool TryDeleteDirectory(string path, out string? warning)
+    {
+        warning = null;
+        if (!Directory.Exists(path))
+            return true;
+
+        try
+        {
+            Directory.Delete(path, recursive: true);
+            return true;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            warning = $"Could not remove temporary app bundle '{path}': {exception.Message}";
+            return false;
+        }
+    }
+
+    [DllImport("/usr/lib/libSystem.B.dylib", EntryPoint = "renameatx_np", SetLastError = true)]
+    private static extern int RenameAtxNp(int fromDirectory, string from, int toDirectory, string to, uint flags);
+}

--- a/PowerForge/Services/AppleMacAppDeploymentService.cs
+++ b/PowerForge/Services/AppleMacAppDeploymentService.cs
@@ -1,0 +1,165 @@
+namespace PowerForge;
+
+/// <summary>
+/// Builds, atomically installs, and launches local macOS application bundles.
+/// </summary>
+public sealed class AppleMacAppDeploymentService
+{
+    private readonly IProcessRunner _processRunner;
+    private readonly AppleDeviceDeploymentService _buildService;
+
+    /// <summary>
+    /// Initializes a new local macOS deployment service.
+    /// </summary>
+    /// <param name="processRunner">Process runner used for xcodebuild, ditto, and open.</param>
+    public AppleMacAppDeploymentService(IProcessRunner? processRunner = null)
+    {
+        _processRunner = processRunner ?? new ProcessRunner();
+        _buildService = new AppleDeviceDeploymentService(_processRunner);
+    }
+
+    /// <summary>
+    /// Builds, installs, and optionally launches a macOS app.
+    /// </summary>
+    /// <param name="request">Deployment request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Deployment result.</returns>
+    public async Task<AppleMacAppDeploymentResult> DeployAsync(
+        AppleMacAppDeploymentRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+        if (request.Platform != ApplePlatform.macOS)
+            throw new ArgumentException("Local macOS deployment requires Platform macOS.", nameof(request));
+
+        var build = await _buildService.BuildAsync(request, cancellationToken).ConfigureAwait(false);
+        var deployment = new AppleMacAppDeploymentResult { Build = build };
+        if (!build.Succeeded)
+            return deployment;
+
+        var installedAppPath = Path.Combine(Path.GetFullPath(request.InstallRoot), Path.GetFileName(build.AppPath));
+        using var installLock = AppleMacAppBundleReplacement.AcquireInstallLock(installedAppPath);
+        var install = await InstallAsync(request, build.AppPath, cancellationToken).ConfigureAwait(false);
+        deployment.Install = install;
+        if (!install.Succeeded || !request.Launch)
+            return deployment;
+
+        deployment.Launch = await LaunchAsync(request, install.InstalledAppPath, cancellationToken).ConfigureAwait(false);
+        return deployment;
+    }
+
+    private async Task<AppleMacAppInstallResult> InstallAsync(
+        AppleMacAppDeploymentRequest request,
+        string sourceAppPath,
+        CancellationToken cancellationToken)
+    {
+        var source = Path.GetFullPath(sourceAppPath);
+        if (!Directory.Exists(source))
+            throw new DirectoryNotFoundException($"Built app path was not found: {source}");
+
+        var installRoot = Path.GetFullPath(request.InstallRoot);
+        Directory.CreateDirectory(installRoot);
+        var destination = Path.Combine(installRoot, Path.GetFileName(source));
+        var suffix = Guid.NewGuid().ToString("N");
+        var stage = Path.Combine(installRoot, $".{Path.GetFileName(source)}.powerforge-stage-{suffix}");
+        var backup = Path.Combine(installRoot, $".{Path.GetFileName(source)}.powerforge-backup-{suffix}");
+        var recoveryWarning = AppleMacAppBundleReplacement.RecoverInterruptedReplacement(destination);
+
+        var copy = await _processRunner.RunAsync(
+            new ProcessRunRequest(
+                NormalizeExecutable(request.DittoExecutable, "/usr/bin/ditto"),
+                installRoot,
+                new[] { source, stage },
+                request.Timeout <= TimeSpan.Zero ? TimeSpan.FromMinutes(10) : request.Timeout),
+            cancellationToken).ConfigureAwait(false);
+
+        var result = new AppleMacAppInstallResult
+        {
+            SourceAppPath = source,
+            InstalledAppPath = destination,
+            ProcessResult = copy
+        };
+        if (!copy.Succeeded)
+        {
+            AppleMacAppBundleReplacement.TryDeleteDirectory(stage, out _);
+            return result;
+        }
+        if (!Directory.Exists(stage))
+            throw new InvalidOperationException($"ditto completed but did not create the staged app: {stage}");
+
+        try
+        {
+            var replacementWarning = AppleMacAppBundleReplacement.Replace(stage, destination, backup);
+            result.Succeeded = true;
+            result.Warning = string.Join(" ", new[] { recoveryWarning, replacementWarning }.Where(static value => !string.IsNullOrWhiteSpace(value)));
+            if (string.IsNullOrWhiteSpace(result.Warning))
+                result.Warning = null;
+            return result;
+        }
+        finally
+        {
+            if (Directory.Exists(stage))
+                AppleMacAppBundleReplacement.TryDeleteDirectory(stage, out _);
+        }
+    }
+
+    private async Task<AppleMacAppLaunchResult> LaunchAsync(
+        AppleMacAppDeploymentRequest request,
+        string appPath,
+        CancellationToken cancellationToken)
+    {
+        if (request.TerminateExisting)
+            await TerminateExistingAsync(request, appPath, cancellationToken).ConfigureAwait(false);
+
+        var arguments = new List<string> { "--new", "--fresh" };
+        foreach (var pair in request.LaunchEnvironment.OrderBy(static pair => pair.Key, StringComparer.Ordinal))
+        {
+            arguments.Add("--env");
+            arguments.Add($"{pair.Key}={pair.Value}");
+        }
+        arguments.Add(appPath);
+        if (request.LaunchArguments.Length > 0)
+        {
+            arguments.Add("--args");
+            arguments.AddRange(request.LaunchArguments);
+        }
+
+        var process = await _processRunner.RunAsync(
+            new ProcessRunRequest(
+                NormalizeExecutable(request.OpenExecutable, "/usr/bin/open"),
+                request.InstallRoot,
+                arguments,
+                request.Timeout <= TimeSpan.Zero ? TimeSpan.FromMinutes(2) : request.Timeout),
+            cancellationToken).ConfigureAwait(false);
+
+        return new AppleMacAppLaunchResult
+        {
+            AppPath = appPath,
+            ProcessResult = process
+        };
+    }
+
+    private async Task TerminateExistingAsync(
+        AppleMacAppDeploymentRequest request,
+        string appPath,
+        CancellationToken cancellationToken)
+    {
+        var executableRoot = Path.Combine(Path.GetFullPath(appPath), "Contents", "MacOS") + Path.DirectorySeparatorChar;
+        var pattern = $"^{System.Text.RegularExpressions.Regex.Escape(executableRoot)}";
+        var process = await _processRunner.RunAsync(
+            new ProcessRunRequest(
+                NormalizeExecutable(request.PkillExecutable, "/usr/bin/pkill"),
+                request.InstallRoot,
+                new[] { "-f", pattern },
+                request.Timeout <= TimeSpan.Zero ? TimeSpan.FromMinutes(2) : request.Timeout),
+            cancellationToken).ConfigureAwait(false);
+
+        if (process.ExitCode is not 0 and not 1)
+            throw new InvalidOperationException($"Could not terminate the existing installed app: {process.StdErr.Trim()}");
+    }
+
+    private static string NormalizeExecutable(string? executable, string fallback)
+        => string.IsNullOrWhiteSpace(executable) ? fallback : executable!.Trim();
+
+}

--- a/Schemas/powerforge.release.schema.json
+++ b/Schemas/powerforge.release.schema.json
@@ -363,6 +363,41 @@
         "UploadSymbols": { "type": "boolean" },
         "GenerateAppStoreInformation": { "type": "boolean" },
         "SigningStyle": { "type": [ "string", "null" ] },
+        "LocalDeployment": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "DefaultPlatform": {
+              "type": "string",
+              "enum": [ "iOS", "iPadOS", "macOS", "tvOS", "watchOS", "visionOS" ]
+            },
+            "DefaultDevice": { "type": [ "string", "null" ] },
+            "Configuration": { "type": "string", "minLength": 1 },
+            "InstallRoot": { "type": "string", "minLength": 1 },
+            "Launch": { "type": "boolean" },
+            "UseBuildMirror": { "type": "boolean" },
+            "DefaultProfile": { "type": [ "string", "null" ] },
+            "Profiles": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [ "Name" ],
+                "properties": {
+                  "Name": { "type": "string", "minLength": 1 },
+                  "Environment": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                  },
+                  "Arguments": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
         "Automation": {
           "type": "object",
           "additionalProperties": false,

--- a/Schemas/powerforge.segments.schema.json
+++ b/Schemas/powerforge.segments.schema.json
@@ -285,6 +285,7 @@
         "RequiredEmbeddedBundleIds": { "type": "array", "items": { "type": "string" } },
         "ProjectPath": { "type": "string", "minLength": 1 },
         "Scheme": { "type": ["string", "null"] },
+        "ProductName": { "type": ["string", "null"] },
         "AppStoreConnectAppId": { "type": ["string", "null"] },
         "MarketingVersion": { "type": ["string", "null"] },
         "UseResolvedVersion": { "type": "boolean" },


### PR DESCRIPTION
## Summary

- add `powerforge apple-deploy` as the config-driven Debug build, install, and launch path for iOS, iPadOS, watchOS, macOS, and Mac Catalyst targets
- support named local launch profiles such as Free and Plus from `AppleApps.LocalDeployment`
- reuse stable DerivedData while serializing overlapping builds and install destinations
- install Mac apps with interruption-safe same-volume exchange and launch only one profile instance
- return compact JSON receipts, including honest installed-but-device-locked state, instead of serializing successful Xcode logs

## Usage

```text
powerforge apple-deploy --platform iOS --profile Free
powerforge apple-deploy --platform iOS --profile Plus
powerforge apple-deploy --platform macOS --profile Plus
```

Use `--plan` to resolve the target, device, profile, and paths without building, or `--no-launch` to install only.

## Release ordering

Consumer migrations require a newer published PowerForge package containing `apple-deploy`. They should not add compatibility shims or ship before that package is available.
