### PR TITLE
Streamline Apple release candidate preparation

### DIFF
--- a/PSPublishModule/Cmdlets/NewConfigurationAppleAppCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationAppleAppCommand.cs
@@ -55,6 +55,11 @@ public sealed class NewConfigurationAppleAppCommand : PSCmdlet
     [Parameter]
     public string? AppStoreConnectAppId { get; set; }
 
+    /// <summary>Privacy purpose-string keys that must contain non-empty values in the final archived app before upload.</summary>
+    [Parameter]
+    [ValidateNotNull]
+    public string[] RequiredPrivacyUsageDescriptionKeys { get; set; } = System.Array.Empty<string>();
+
     /// <summary>The value to assign to all <c>MARKETING_VERSION</c> entries.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "ExplicitVersion")]
     [ValidateNotNullOrEmpty]
@@ -96,6 +101,7 @@ public sealed class NewConfigurationAppleAppCommand : PSCmdlet
                 ProjectPath = ProjectPath,
                 Scheme = Scheme,
                 AppStoreConnectAppId = AppStoreConnectAppId,
+                RequiredPrivacyUsageDescriptionKeys = RequiredPrivacyUsageDescriptionKeys,
                 MarketingVersion = MarketingVersion,
                 UseResolvedVersion = UseResolvedVersion.IsPresent,
                 BuildNumber = BuildNumber,

--- a/PowerForge.Cli/Program.Command.AppleScreenshots.cs
+++ b/PowerForge.Cli/Program.Command.AppleScreenshots.cs
@@ -5,7 +5,7 @@ using PowerForge.Cli;
 internal static partial class Program
 {
     private const string AppleScreenshotsUsage =
-        "Usage: powerforge apple-screenshots manifest --config <screenshots.json> " +
+        "Usage: powerforge apple-screenshots <manifest --config <screenshots.json> | manifests --release-config <powerforge.release.json>> " +
         "[--capture-provenance <json> --expected-repository <owner/repo> --expected-workflow-ref <workflow-ref> | --version <x.y|x.y.z> --source-commit <sha>] " +
         "--approved-by <identity> --allowed-root <reviewed-capture-root> [--out <manifest.json>] " +
         "[--write-root <trusted-output-root>] " +
@@ -25,77 +25,43 @@ internal static partial class Program
 
         try
         {
-            if (!argv[0].Equals("manifest", StringComparison.OrdinalIgnoreCase))
-                throw new ArgumentException("Apple screenshot command must be 'manifest'.");
-            var configPath = Path.GetFullPath(RequiredOption(argv, "--config"));
-            var baseDirectory = Path.GetDirectoryName(configPath) ?? Directory.GetCurrentDirectory();
-            var spec = CliJson.DeserializeOrThrow(
-                File.ReadAllText(configPath),
-                CliJson.Context.AppStoreConnectScreenshotSyncSpec,
-                configPath);
-            var appId = ResolveScreenshotApprovalAppId(argv, spec);
-            var allowedRoot = Path.GetFullPath(RequiredOption(argv, "--allowed-root"));
-            var provenance = ResolveScreenshotCaptureProvenance(argv);
-            var manifest = new AppStoreConnectScreenshotApprovalService().Create(
-                new AppStoreConnectScreenshotApprovalRequest
-                {
-                    Spec = spec,
-                    AppId = appId,
-                    BaseDirectory = baseDirectory,
-                    AllowedRoot = allowedRoot,
-                    VersionString = ResolveProvenanceBoundOption(argv, "--version", provenance?.MarketingVersion)!,
-                    SourceCommit = ResolveProvenanceBoundOption(argv, "--source-commit", provenance?.SourceCommit)!,
-                    CaptureRunId = provenance?.CaptureRunId,
-                    CaptureRepository = provenance?.Repository,
-                    CaptureWorkflowRef = provenance?.WorkflowRef,
-                    ApprovedBy = RequiredOption(argv, "--approved-by"),
-                    InitiatedBy = TryGetOptionValue(argv, "--initiated-by"),
-                    ApprovalEvidence = TryGetOptionValue(argv, "--approval-evidence"),
-                    XcodeVersion = ResolveProvenanceBoundOption(argv, "--xcode-version", provenance?.XcodeVersion, required: false),
-                    Runtime = ResolveProvenanceBoundOption(argv, "--runtime", provenance?.Runtime, required: false),
-                    Device = ResolveProvenanceBoundOption(argv, "--device", provenance?.Device, required: false),
-                    Theme = ResolveProvenanceBoundOption(argv, "--theme", provenance?.Theme, required: false),
-                    Scenario = ResolveProvenanceBoundOption(argv, "--scenario", provenance?.Scenario, required: false)
-                });
-            if (provenance is not null)
-                ValidateScreenshotCaptureInventory(provenance, manifest, baseDirectory, allowedRoot);
-            var configuredOutput = spec.Quality?.ApprovalManifestPath;
-            var outputPath = ResolvePathFromBase(
-                baseDirectory,
-                TryGetOptionValue(argv, "--out") ??
-                configuredOutput ??
-                Path.GetFileNameWithoutExtension(configPath) + ".approval.json");
-            var writeRoot = TryGetOptionValue(argv, "--write-root");
-            if (!string.IsNullOrWhiteSpace(writeRoot))
-                EnsureTrustedScreenshotManifestPath(outputPath, Path.GetFullPath(writeRoot));
-            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
-            if (!string.IsNullOrWhiteSpace(writeRoot))
-                EnsureTrustedScreenshotManifestPath(outputPath, Path.GetFullPath(writeRoot));
-            File.WriteAllText(
-                outputPath,
-                JsonSerializer.Serialize(manifest, CliJson.Context.AppStoreConnectScreenshotApprovalManifest) + Environment.NewLine);
+            var operation = argv[0];
+            var configPaths = ResolveScreenshotManifestConfigPaths(operation, argv);
+            if (configPaths.Length > 1 && !string.IsNullOrWhiteSpace(TryGetOptionValue(argv, "--out")))
+                throw new ArgumentException("--out is valid only when generating one screenshot approval manifest.");
+            var outputs = configPaths
+                .Select(configPath => CreateScreenshotApprovalManifest(configPath, argv))
+                .ToArray();
 
             if (outputJson)
             {
                 WriteJson(new CliJsonEnvelope
                 {
                     SchemaVersion = OutputSchemaVersion,
-                    Command = "apple-screenshots.manifest",
+                    Command = operation.Equals("manifests", StringComparison.OrdinalIgnoreCase)
+                        ? "apple-screenshots.manifests"
+                        : "apple-screenshots.manifest",
                     Success = true,
                     ExitCode = 0,
                     Result = JsonSerializer.SerializeToElement(new
                     {
-                        outputPath,
-                        screenshotCount = manifest.Screenshots.Length,
-                        manifest.VersionString,
-                        manifest.SourceCommit,
-                        manifest.ApprovedBy
+                        manifestCount = outputs.Length,
+                        screenshotCount = outputs.Sum(static output => output.Manifest.Screenshots.Length),
+                        manifests = outputs.Select(static output => new
+                        {
+                            output.OutputPath,
+                            screenshotCount = output.Manifest.Screenshots.Length,
+                            output.Manifest.VersionString,
+                            output.Manifest.SourceCommit,
+                            output.Manifest.ApprovedBy
+                        }).ToArray()
                     })
                 });
             }
             else
             {
-                logger.Success($"Approved {manifest.Screenshots.Length} screenshot(s): {outputPath}");
+                foreach (var output in outputs)
+                    logger.Success($"Approved {output.Manifest.Screenshots.Length} screenshot(s): {output.OutputPath}");
             }
             return 0;
         }
@@ -103,6 +69,82 @@ internal static partial class Program
         {
             return WriteReleaseError(outputJson, "apple-screenshots.manifest", 1, exception.Message, logger);
         }
+    }
+
+    private static ScreenshotManifestOutput CreateScreenshotApprovalManifest(string configPath, string[] argv)
+    {
+        var baseDirectory = Path.GetDirectoryName(configPath) ?? Directory.GetCurrentDirectory();
+        var spec = CliJson.DeserializeOrThrow(
+            File.ReadAllText(configPath),
+            CliJson.Context.AppStoreConnectScreenshotSyncSpec,
+            configPath);
+        var appId = ResolveScreenshotApprovalAppId(argv, spec);
+        var allowedRoot = Path.GetFullPath(RequiredOption(argv, "--allowed-root"));
+        var provenance = ResolveScreenshotCaptureProvenance(argv);
+        var manifest = new AppStoreConnectScreenshotApprovalService().Create(
+            new AppStoreConnectScreenshotApprovalRequest
+            {
+                Spec = spec,
+                AppId = appId,
+                BaseDirectory = baseDirectory,
+                AllowedRoot = allowedRoot,
+                VersionString = ResolveProvenanceBoundOption(argv, "--version", provenance?.MarketingVersion)!,
+                SourceCommit = ResolveProvenanceBoundOption(argv, "--source-commit", provenance?.SourceCommit)!,
+                CaptureRunId = provenance?.CaptureRunId,
+                CaptureRepository = provenance?.Repository,
+                CaptureWorkflowRef = provenance?.WorkflowRef,
+                ApprovedBy = RequiredOption(argv, "--approved-by"),
+                InitiatedBy = TryGetOptionValue(argv, "--initiated-by"),
+                ApprovalEvidence = TryGetOptionValue(argv, "--approval-evidence"),
+                XcodeVersion = ResolveProvenanceBoundOption(argv, "--xcode-version", provenance?.XcodeVersion, required: false),
+                Runtime = ResolveProvenanceBoundOption(argv, "--runtime", provenance?.Runtime, required: false),
+                Device = ResolveProvenanceBoundOption(argv, "--device", provenance?.Device, required: false),
+                Theme = ResolveProvenanceBoundOption(argv, "--theme", provenance?.Theme, required: false),
+                Scenario = ResolveProvenanceBoundOption(argv, "--scenario", provenance?.Scenario, required: false)
+            });
+        if (provenance is not null)
+            ValidateScreenshotCaptureInventory(provenance, manifest, baseDirectory, allowedRoot);
+        var configuredOutput = spec.Quality?.ApprovalManifestPath;
+        var outputPath = ResolvePathFromBase(
+            baseDirectory,
+            TryGetOptionValue(argv, "--out") ??
+            configuredOutput ??
+            Path.GetFileNameWithoutExtension(configPath) + ".approval.json");
+        var writeRoot = TryGetOptionValue(argv, "--write-root");
+        if (!string.IsNullOrWhiteSpace(writeRoot))
+            EnsureTrustedScreenshotManifestPath(outputPath, Path.GetFullPath(writeRoot));
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+        if (!string.IsNullOrWhiteSpace(writeRoot))
+            EnsureTrustedScreenshotManifestPath(outputPath, Path.GetFullPath(writeRoot));
+        File.WriteAllText(
+            outputPath,
+            JsonSerializer.Serialize(manifest, CliJson.Context.AppStoreConnectScreenshotApprovalManifest) + Environment.NewLine);
+        return new ScreenshotManifestOutput(outputPath, manifest);
+    }
+
+    private static string[] ResolveScreenshotManifestConfigPaths(string operation, string[] argv)
+    {
+        if (operation.Equals("manifest", StringComparison.OrdinalIgnoreCase))
+            return new[] { Path.GetFullPath(RequiredOption(argv, "--config")) };
+        if (!operation.Equals("manifests", StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException("Apple screenshot command must be 'manifest' or 'manifests'.");
+
+        var releaseConfigValue = RequiredOption(argv, "--release-config");
+        var (releaseSpec, releaseConfigPath) = LoadPowerForgeReleaseSpecWithPath(releaseConfigValue);
+        var apple = releaseSpec.AppleApps ?? throw new InvalidOperationException("Release configuration does not contain AppleApps.");
+        var releaseDirectory = Path.GetDirectoryName(releaseConfigPath) ?? Directory.GetCurrentDirectory();
+        var projectRoot = ResolvePathFromBase(
+            releaseDirectory,
+            string.IsNullOrWhiteSpace(apple.ProjectRoot) ? "." : apple.ProjectRoot);
+        var configured = new[] { apple.ScreenshotConfigPath }
+            .Concat(apple.ScreenshotConfigPaths ?? Array.Empty<string>())
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => ResolvePathFromBase(projectRoot, value!))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (configured.Length == 0)
+            throw new InvalidOperationException("AppleApps must configure ScreenshotConfigPath or ScreenshotConfigPaths.");
+        return configured;
     }
 
     private static ScreenshotCaptureProvenance? ResolveScreenshotCaptureProvenance(string[] argv)
@@ -184,9 +226,8 @@ internal static partial class Program
         string baseDirectory,
         string allowedRoot)
     {
-        var expected = provenance.Screenshots
-            .OrderBy(static item => item.Path, StringComparer.Ordinal)
-            .ToArray();
+        var retained = provenance.Screenshots
+            .ToHashSet();
         var actual = manifest.Screenshots.Select(item =>
         {
             var fullPath = Path.GetFullPath(Path.Combine(baseDirectory, item.File));
@@ -194,10 +235,10 @@ internal static partial class Program
             if (Path.IsPathRooted(relative) || relative.Equals("..", StringComparison.Ordinal) || relative.StartsWith("../", StringComparison.Ordinal))
                 throw new InvalidOperationException($"Approved screenshot '{item.File}' escapes the capture inventory root.");
             return new ScreenshotCaptureInventoryEntry(relative, item.Sha256.ToLowerInvariant(), item.Width, item.Height);
-        }).OrderBy(static item => item.Path, StringComparer.Ordinal).ToArray();
+        }).ToArray();
 
-        if (expected.Length != actual.Length || !expected.SequenceEqual(actual))
-            throw new InvalidOperationException("Selected screenshots do not exactly match the retained capture provenance byte inventory.");
+        if (actual.Distinct().Count() != actual.Length || actual.Any(item => !retained.Contains(item)))
+            throw new InvalidOperationException("Selected screenshots are not an exact byte-for-byte subset of the retained capture provenance inventory.");
     }
 
     private static string? ResolveProvenanceBoundOption(
@@ -233,6 +274,10 @@ internal static partial class Program
         ScreenshotCaptureInventoryEntry[] Screenshots);
 
     private sealed record ScreenshotCaptureInventoryEntry(string Path, string Sha256, int Width, int Height);
+
+    private sealed record ScreenshotManifestOutput(
+        string OutputPath,
+        AppStoreConnectScreenshotApprovalManifest Manifest);
 
     private static string? ResolveScreenshotApprovalAppId(
         string[] argv,

--- a/PowerForge.Cli/Program.Helpers.cs
+++ b/PowerForge.Cli/Program.Helpers.cs
@@ -38,7 +38,7 @@ internal static partial class Program
                         [--apple-wait|--no-apple-wait] [--apple-timeout-seconds <seconds>] [--apple-poll-seconds <seconds>]
                                 [--target <Name[,Name...]>] [--summary] [--output json]
       powerforge apple-deploy [--config <powerforge.release.json>] [--platform <iOS|iPadOS|watchOS|macOS|tvOS|visionOS>] [--target <name-or-scheme>] [--device <name>|--device-id <id>] [--profile <name>] [--configuration <Debug|Release>] [--install-root </Applications>] [--build-mirror|--no-build-mirror] [--launch|--no-launch] [--plan] [--output json]
-      powerforge apple-screenshots manifest --config <screenshots.json> [--capture-provenance <json> --expected-repository <owner/repo> --expected-workflow-ref <workflow-ref> | --version <x.y|x.y.z> --source-commit <sha>] --approved-by <reviewer-or-boundary> --allowed-root <reviewed-capture-root>
+      powerforge apple-screenshots <manifest --config <screenshots.json> | manifests --release-config <release.json>> [--capture-provenance <json> --expected-repository <owner/repo> --expected-workflow-ref <workflow-ref> | --version <x.y|x.y.z> --source-commit <sha>] --approved-by <reviewer-or-boundary> --allowed-root <reviewed-capture-root>
                         [--app-id <asc-app-id> | --release-config <release.json> [--target <name-or-scheme>]]
                         [--out <manifest.json>] [--xcode-version <value>] [--runtime <value>] [--device <value>]
                         [--theme <value>] [--scenario <value>] [--output json]

--- a/PowerForge.Tests/AppleAppArchiveServiceTests.cs
+++ b/PowerForge.Tests/AppleAppArchiveServiceTests.cs
@@ -458,15 +458,20 @@ public sealed class AppleAppArchiveServiceTests
         }
     }
 
-    [Fact]
-    public async Task UploadArchiveAsync_validates_required_privacy_purpose_strings_in_final_archive()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task UploadArchiveAsync_validates_required_privacy_purpose_strings_in_final_archive(bool macBundleLayout)
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
         {
             var archive = Directory.CreateDirectory(Path.Combine(root.FullName, "CasaRay.xcarchive"));
             var app = Directory.CreateDirectory(Path.Combine(archive.FullName, "Products", "Applications", "CasaRay.app"));
-            File.WriteAllText(Path.Combine(app.FullName, "Info.plist"), "fixture");
+            var bundleRoot = macBundleLayout
+                ? Directory.CreateDirectory(Path.Combine(app.FullName, "Contents")).FullName
+                : app.FullName;
+            File.WriteAllText(Path.Combine(bundleRoot, "Info.plist"), "fixture");
             var runner = new PrivacyProcessRunner(new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["CFBundleIdentifier"] = "com.evotecit.casaray",

--- a/PowerForge.Tests/AppleAppArchiveServiceTests.cs
+++ b/PowerForge.Tests/AppleAppArchiveServiceTests.cs
@@ -458,6 +458,72 @@ public sealed class AppleAppArchiveServiceTests
         }
     }
 
+    [Fact]
+    public async Task UploadArchiveAsync_validates_required_privacy_purpose_strings_in_final_archive()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var archive = Directory.CreateDirectory(Path.Combine(root.FullName, "CasaRay.xcarchive"));
+            var app = Directory.CreateDirectory(Path.Combine(archive.FullName, "Products", "Applications", "CasaRay.app"));
+            File.WriteAllText(Path.Combine(app.FullName, "Info.plist"), "fixture");
+            var runner = new PrivacyProcessRunner(new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["CFBundleIdentifier"] = "com.evotecit.casaray",
+                ["NSCameraUsageDescription"] = "CasaRay does not capture from this device's camera."
+            });
+
+            var result = await new AppleAppArchiveService(runner).UploadArchiveAsync(new AppleAppArchiveUploadRequest
+            {
+                ArchivePath = archive.FullName,
+                ExportPath = Path.Combine(root.FullName, "export"),
+                BundleId = "com.evotecit.casaray",
+                RequiredPrivacyUsageDescriptionKeys = ["NSCameraUsageDescription"]
+            });
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(3, runner.Requests.Count);
+            Assert.EndsWith("xcodebuild", runner.Requests[^1].FileName, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task UploadArchiveAsync_blocks_upload_when_required_privacy_purpose_string_is_missing()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var archive = Directory.CreateDirectory(Path.Combine(root.FullName, "CasaRay.xcarchive"));
+            var app = Directory.CreateDirectory(Path.Combine(archive.FullName, "Products", "Applications", "CasaRay.app"));
+            File.WriteAllText(Path.Combine(app.FullName, "Info.plist"), "fixture");
+            var runner = new PrivacyProcessRunner(new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["CFBundleIdentifier"] = "com.evotecit.casaray"
+            });
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                new AppleAppArchiveService(runner).UploadArchiveAsync(new AppleAppArchiveUploadRequest
+                {
+                    ArchivePath = archive.FullName,
+                    ExportPath = Path.Combine(root.FullName, "export"),
+                    BundleId = "com.evotecit.casaray",
+                    RequiredPrivacyUsageDescriptionKeys = ["NSCameraUsageDescription"]
+                }));
+
+            Assert.Contains("NSCameraUsageDescription", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("blocked before App Store Connect delivery", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(runner.Requests, request => request.FileName.EndsWith("xcodebuild", StringComparison.Ordinal));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     private sealed class CapturingProcessRunner : IProcessRunner
     {
         private readonly ProcessRunResult _result;
@@ -473,6 +539,43 @@ public sealed class AppleAppArchiveServiceTests
         {
             Requests.Add(request);
             return Task.FromResult(_result);
+        }
+    }
+
+    private sealed class PrivacyProcessRunner : IProcessRunner
+    {
+        private readonly IReadOnlyDictionary<string, string> _plistValues;
+
+        public PrivacyProcessRunner(IReadOnlyDictionary<string, string> plistValues)
+        {
+            _plistValues = plistValues;
+        }
+
+        public List<ProcessRunRequest> Requests { get; } = new();
+
+        public Task<ProcessRunResult> RunAsync(ProcessRunRequest request, CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+            if (request.FileName.EndsWith("plutil", StringComparison.Ordinal))
+            {
+                var key = request.Arguments[1];
+                var found = _plistValues.TryGetValue(key, out var value);
+                return Task.FromResult(new ProcessRunResult(
+                    found ? 0 : 1,
+                    found ? value! : string.Empty,
+                    found ? string.Empty : $"Missing {key}",
+                    request.FileName,
+                    TimeSpan.FromMilliseconds(1),
+                    false));
+            }
+
+            return Task.FromResult(new ProcessRunResult(
+                0,
+                "ok",
+                string.Empty,
+                request.FileName,
+                TimeSpan.FromMilliseconds(1),
+                false));
         }
     }
 }

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
@@ -229,6 +229,14 @@ public sealed partial class AppleReleaseWorkflowTests
                 . $Support
                 Register-AppleAutomationEvidence -SourceCommit '{{commit}}'
                 Assert-ConsumerRepositoryContent
+                foreach ($nextArguments in @(
+                    @('apple-release','Status','--config','powerforge.release.json'),
+                    @('apple-release','SubmitAppReview','--config','powerforge.release.json','--plan'))) {
+                    $script:allowedConsumerEvidencePaths = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+                    $ArgumentList = $nextArguments
+                    Register-AppleAutomationEvidence -SourceCommit '{{commit}}'
+                    Assert-ConsumerRepositoryContent
+                }
                 Set-Content -LiteralPath (Join-Path $consumer 'build/powerforge/apple/injected.bin') -Value 'not reviewed'
                 try { Assert-ConsumerRepositoryContent; throw 'Unreviewed file was accepted.' }
                 catch { if ($_.Exception.Message -notlike '*non-reviewed content*') { throw }; 'PASS' }

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
@@ -183,4 +183,69 @@ public sealed partial class AppleReleaseWorkflowTests
             if (Directory.Exists(parent)) Directory.Delete(parent, recursive: true);
         }
     }
+
+    [Fact]
+    public void ApprovedApplePlanAndBoundAutomationOutputsDoNotRequireASecondCheckout()
+    {
+        var root = FindRepoRoot();
+        var parent = Path.Combine(root, ".test-temp", $"powerforge-plan-evidence-{Guid.NewGuid():N}");
+        var sandbox = Path.Combine(parent, "consumer");
+        const string commit = "0123456789abcdef0123456789abcdef01234567";
+        const string planSha256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        try
+        {
+            var output = Path.Combine(sandbox, "build", "powerforge", "apple");
+            Directory.CreateDirectory(output);
+            File.WriteAllText(Path.Combine(sandbox, "powerforge.release.json"),
+                """{ "AppleApps": { "ProjectRoot": ".", "Automation": { "ReceiptPath": "build/powerforge/apple/release-receipt.json", "PlanReceiptPath": "build/powerforge/apple/release-plan.json", "LockPath": "build/powerforge/apple/release.lock" }, "Apps": [ { "Enabled": true, "DistributionRoute": "AppStore", "ProjectPath": "Sample.xcodeproj" } ] } }""");
+            File.WriteAllText(Path.Combine(sandbox, ".gitignore"), "build/\n");
+            File.WriteAllText(Path.Combine(output, "release-receipt.json"), JsonSerializer.Serialize(new { sourceCommit = commit }));
+            File.WriteAllText(Path.Combine(output, "release-plan.json"), JsonSerializer.Serialize(new
+            {
+                planOnly = true,
+                action = "Advance",
+                sourceCommit = commit,
+                planSha256
+            }));
+            File.WriteAllText(Path.Combine(output, "release.lock"), "stale generated lock state");
+            Run("git", sandbox, "init", "--quiet").EnsureSuccess();
+            Run("git", sandbox, "add", "powerforge.release.json", ".gitignore").EnsureSuccess();
+            CommitTrackedReleaseSandbox(sandbox, "Tracked release configuration");
+
+            var harness = Path.Combine(parent, "plan-evidence-harness.ps1");
+            File.WriteAllText(harness,
+                $$"""
+                param([string] $Consumer, [string] $Support)
+                $ErrorActionPreference = 'Stop'
+                $script:gitPath = '/usr/bin/git'
+                $script:allowedConsumerEvidencePaths = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+                $consumer = [IO.Path]::GetFullPath($Consumer)
+                $ArgumentList = @('apple-release','Advance','--config','powerforge.release.json','--apple-expected-plan-sha256','{{planSha256}}')
+                function Invoke-GitText { param([string]$Root,[string[]]$Arguments); $o=@(& $script:gitPath -c core.quotePath=false -C $Root @Arguments 2>&1); if($LASTEXITCODE -ne 0){throw 'git failed'}; return ($o -join [Environment]::NewLine).Trim() }
+                function Get-OptionValue { param([string]$Option); $i=[Array]::IndexOf($ArgumentList,$Option); if($i -ge 0 -and $i+1 -lt $ArgumentList.Count){return $ArgumentList[$i+1]}; return $null }
+                function Resolve-OptionPath { param([string]$Value); if([IO.Path]::IsPathRooted($Value)){return [IO.Path]::GetFullPath($Value)}; return [IO.Path]::GetFullPath((Join-Path $consumer $Value)) }
+                function Resolve-PathFromBase { param([string]$BasePath,[string]$Value); if([IO.Path]::IsPathRooted($Value)){return [IO.Path]::GetFullPath($Value)}; return [IO.Path]::GetFullPath((Join-Path $BasePath $Value)) }
+                function Assert-UnlinkedPath { param([string]$Path,[string]$Name,[switch]$AllowMissingLeaf) }
+                . $Support
+                Register-AppleAutomationEvidence -SourceCommit '{{commit}}'
+                Assert-ConsumerRepositoryContent
+                Set-Content -LiteralPath (Join-Path $consumer 'build/powerforge/apple/injected.bin') -Value 'not reviewed'
+                try { Assert-ConsumerRepositoryContent; throw 'Unreviewed file was accepted.' }
+                catch { if ($_.Exception.Message -notlike '*non-reviewed content*') { throw }; 'PASS' }
+                """);
+
+            var result = Run(
+                "pwsh",
+                parent,
+                "-NoLogo", "-NoProfile", "-File", harness,
+                "-Consumer", sandbox,
+                "-Support", Path.Combine(root, "scripts", "Invoke-PinnedPowerForge.Evidence.ps1"));
+            result.EnsureSuccess();
+            Assert.Contains("PASS", result.StandardOutput, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(parent)) Directory.Delete(parent, recursive: true);
+        }
+    }
 }

--- a/PowerForge.Tests/PowerForgeCliAppleReleaseTests.cs
+++ b/PowerForge.Tests/PowerForgeCliAppleReleaseTests.cs
@@ -273,12 +273,14 @@ public sealed class PowerForgeCliAppleReleaseTests
             var screenshotDirectory = Directory.CreateDirectory(Path.Combine(tempRoot, "screenshots"));
             File.WriteAllBytes(Path.Combine(screenshotDirectory.FullName, "01-home.png"),
                 Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2n1sAAAAASUVORK5CYII="));
+            File.WriteAllBytes(Path.Combine(screenshotDirectory.FullName, "02-unselected-mac.png"),
+                Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2n1sAAAAASUVORK5CYII="));
             var configPath = Path.Combine(tempRoot, "screenshots.json");
             File.WriteAllText(configPath,
-                """{ "AppId": "1234567890", "Platform": "iOS", "Locale": "en-US", "ScreenshotSets": [ { "ScreenshotDisplayType": "APP_IPHONE_67", "Path": "screenshots", "AllowedDimensions": [ "1x1" ] } ], "Quality": { "Enabled": true, "MinimumFileBytes": 1, "MinimumKilobytesPerMegapixel": 0 } }""");
+                """{ "AppId": "1234567890", "Platform": "iOS", "Locale": "en-US", "ScreenshotSets": [ { "ScreenshotDisplayType": "APP_IPHONE_67", "Path": "screenshots", "Filter": "01-*.png", "AllowedDimensions": [ "1x1" ] } ], "Quality": { "Enabled": true, "MinimumFileBytes": 1, "MinimumKilobytesPerMegapixel": 0 } }""");
             var provenancePath = Path.Combine(tempRoot, "powerforge-apple-screenshot-provenance.json");
             File.WriteAllText(provenancePath,
-                $$"""{ "schemaVersion": 2, "repository": "EvotecIT/Sample", "captureRunId": "123", "sourceCommit": "{{ApprovedSourceCommit}}", "marketingVersion": "1.5.0", "workflowRef": "EvotecIT/Sample/.github/workflows/apple-screenshots.yml@refs/heads/main", "xcodeVersion": "Xcode 26", "runtime": "macOS 26 arm64", "device": "Mac", "theme": "all", "scenario": "app-store", "screenshots": [ { "path": "01-home.png", "sha256": "d268b9b4a10c5990e181efed7c66f7369e43f3382bdef6c6ea9858098e0fab95", "width": 1, "height": 1 } ] }""");
+                $$"""{ "schemaVersion": 2, "repository": "EvotecIT/Sample", "captureRunId": "123", "sourceCommit": "{{ApprovedSourceCommit}}", "marketingVersion": "1.5.0", "workflowRef": "EvotecIT/Sample/.github/workflows/apple-screenshots.yml@refs/heads/main", "xcodeVersion": "Xcode 26", "runtime": "macOS 26 arm64", "device": "Mac", "theme": "all", "scenario": "app-store", "screenshots": [ { "path": "01-home.png", "sha256": "d268b9b4a10c5990e181efed7c66f7369e43f3382bdef6c6ea9858098e0fab95", "width": 1, "height": 1 }, { "path": "02-unselected-mac.png", "sha256": "d268b9b4a10c5990e181efed7c66f7369e43f3382bdef6c6ea9858098e0fab95", "width": 1, "height": 1 } ] }""");
             var manifestPath = Path.Combine(tempRoot, "approval.json");
 
             var result = await RunCliAsync(repoRoot,
@@ -306,7 +308,7 @@ public sealed class PowerForgeCliAppleReleaseTests
             var byteMismatch = await RunCliAsync(repoRoot,
                 $"\"{GetCliPath(repoRoot)}\" apple-screenshots manifest --config \"{configPath}\" --capture-provenance \"{provenancePath}\" --expected-repository EvotecIT/Sample --expected-workflow-ref EvotecIT/Sample/.github/workflows/apple-screenshots.yml@refs/heads/main --approved-by release-owner --allowed-root \"{screenshotDirectory.FullName}\" --out \"{manifestPath}\" --output json");
             Assert.Equal(1, byteMismatch.ExitCode);
-            Assert.Contains("do not exactly match", byteMismatch.StdOut + byteMismatch.StdErr, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("byte-for-byte subset", byteMismatch.StdOut + byteMismatch.StdErr, StringComparison.OrdinalIgnoreCase);
 
             File.WriteAllText(provenancePath,
                 $$"""{ "schemaVersion": 2, "repository": "EvotecIT/Sample", "captureRunId": "123", "sourceCommit": "{{ApprovedSourceCommit}}", "marketingVersion": "1.5.0", "workflowRef": "EvotecIT/Sample/.github/workflows/apple-screenshots.yml@refs/heads/main", "xcodeVersion": "Xcode 26", "runtime": "macOS 26 arm64", "device": "Mac", "theme": "all", "scenario": "app-store", "screenshots": [ { "path": "/01-home.png", "sha256": "d268b9b4a10c5990e181efed7c66f7369e43f3382bdef6c6ea9858098e0fab95", "width": 1, "height": 1 } ] }""");
@@ -314,6 +316,45 @@ public sealed class PowerForgeCliAppleReleaseTests
                 $"\"{GetCliPath(repoRoot)}\" apple-screenshots manifest --config \"{configPath}\" --capture-provenance \"{provenancePath}\" --expected-repository EvotecIT/Sample --expected-workflow-ref EvotecIT/Sample/.github/workflows/apple-screenshots.yml@refs/heads/main --approved-by release-owner --allowed-root \"{screenshotDirectory.FullName}\" --out \"{manifestPath}\" --output json");
             Assert.Equal(1, unsafePath.ExitCode);
             Assert.Contains("unsafe screenshot path", unsafePath.StdOut + unsafePath.StdErr, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot)) Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task AppleScreenshots_ManifestsApprovesEveryConfiguredPlatformSubsetInOneCommand()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var tempRoot = CreateTempDirectory();
+        try
+        {
+            var png = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2n1sAAAAASUVORK5CYII=");
+            Directory.CreateDirectory(Path.Combine(tempRoot, "ios"));
+            Directory.CreateDirectory(Path.Combine(tempRoot, "mac"));
+            File.WriteAllBytes(Path.Combine(tempRoot, "ios", "01-home.png"), png);
+            File.WriteAllBytes(Path.Combine(tempRoot, "mac", "01-home.png"), png);
+            File.WriteAllText(Path.Combine(tempRoot, "ios.json"),
+                """{ "AppId": "123", "Platform": "iOS", "ScreenshotSets": [ { "ScreenshotDisplayType": "APP_IPHONE_67", "Path": "ios", "AllowedDimensions": [ "1x1" ] } ], "Quality": { "Enabled": true, "MinimumFileBytes": 1, "MinimumKilobytesPerMegapixel": 0, "ApprovalManifestPath": "ios.approval.json" } }""");
+            File.WriteAllText(Path.Combine(tempRoot, "mac.json"),
+                """{ "AppId": "123", "Platform": "macOS", "ScreenshotSets": [ { "ScreenshotDisplayType": "APP_DESKTOP", "Path": "mac", "AllowedDimensions": [ "1x1" ] } ], "Quality": { "Enabled": true, "MinimumFileBytes": 1, "MinimumKilobytesPerMegapixel": 0, "ApprovalManifestPath": "mac.approval.json" } }""");
+            var releaseConfigPath = Path.Combine(tempRoot, "powerforge.release.json");
+            File.WriteAllText(releaseConfigPath,
+                """{ "AppleApps": { "ProjectRoot": ".", "ScreenshotConfigPaths": [ "ios.json", "mac.json" ], "Apps": [ { "Name": "Phone", "Platform": "iOS", "ProjectPath": "Sample.xcodeproj", "AppStoreConnectAppId": "123" }, { "Name": "Mac", "Platform": "macOS", "ProjectPath": "Sample.xcodeproj", "AppStoreConnectAppId": "123" } ] } }""");
+            var provenancePath = Path.Combine(tempRoot, "powerforge-apple-screenshot-provenance.json");
+            File.WriteAllText(provenancePath,
+                $$"""{ "schemaVersion": 2, "repository": "EvotecIT/Sample", "captureRunId": "123", "sourceCommit": "{{ApprovedSourceCommit}}", "marketingVersion": "1.5.0", "workflowRef": "EvotecIT/Sample/.github/workflows/apple-screenshots.yml@refs/heads/main", "xcodeVersion": "Xcode 26", "runtime": "iOS and macOS 26", "device": "Phone and Mac", "theme": "all", "scenario": "app-store", "screenshots": [ { "path": "ios/01-home.png", "sha256": "d268b9b4a10c5990e181efed7c66f7369e43f3382bdef6c6ea9858098e0fab95", "width": 1, "height": 1 }, { "path": "mac/01-home.png", "sha256": "d268b9b4a10c5990e181efed7c66f7369e43f3382bdef6c6ea9858098e0fab95", "width": 1, "height": 1 } ] }""");
+
+            var result = await RunCliAsync(repoRoot,
+                $"\"{GetCliPath(repoRoot)}\" apple-screenshots manifests --release-config \"{releaseConfigPath}\" --capture-provenance \"{provenancePath}\" --expected-repository EvotecIT/Sample --expected-workflow-ref EvotecIT/Sample/.github/workflows/apple-screenshots.yml@refs/heads/main --approved-by release-owner --allowed-root \"{tempRoot}\" --output json");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.True(File.Exists(Path.Combine(tempRoot, "ios.approval.json")));
+            Assert.True(File.Exists(Path.Combine(tempRoot, "mac.approval.json")));
+            using var output = JsonDocument.Parse(result.StdOut);
+            Assert.Equal(2, output.RootElement.GetProperty("result").GetProperty("manifestCount").GetInt32());
+            Assert.Equal(2, output.RootElement.GetProperty("result").GetProperty("screenshotCount").GetInt32());
         }
         finally
         {

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleAutomation.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleAutomation.cs
@@ -789,6 +789,64 @@ public sealed partial class PowerForgeReleaseServiceTests
         }
     }
 
+    [Fact]
+    public void Execute_ApplePrepareReceiptUsesCompletedPreparationWhenRemoteReadbackIsStale()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.2.0", "9");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var service = CreateAppleAutomationService(
+                request => new AppStoreConnectReleaseStateResult
+                {
+                    AppId = request.AppId,
+                    VersionString = request.VersionString,
+                    BuildNumber = request.BuildNumber,
+                    Platforms =
+                    [
+                        new AppStoreConnectPlatformReleaseState
+                        {
+                            Platform = request.Platforms.Single(),
+                            MatchedBuild = new AppStoreConnectBuildInfo
+                            {
+                                Id = "build-id",
+                                Version = request.BuildNumber,
+                                ProcessingState = "VALID",
+                                MarketingVersion = request.VersionString
+                            },
+                            NextActions =
+                            [
+                                "Create App Store distribution version.",
+                                "Select the requested build on the App Store version."
+                            ]
+                        }
+                    ]
+                },
+                prepareAppleDistribution: CreateSuccessfulPreparation);
+
+            var result = service.Execute(
+                CreateAppleAutomationSpec(root, keyPath),
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    AppleAction = PowerForgeAppleReleaseAction.Prepare
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            var target = Assert.Single(result.AppleReceipt!.Targets);
+            Assert.Equal("version-id", target.DistributionVersionId);
+            Assert.True(target.BuildSelected);
+            Assert.DoesNotContain(target.NextActions, action => action.Contains("Create App Store distribution version", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(target.NextActions, action => action.StartsWith("Select ", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
     private static PowerForgeReleaseSpec CreateAppleAutomationSpec(string root, string keyPath)
         => new()
         {

--- a/PowerForge/Models/AppleAppArchiveModels.cs
+++ b/PowerForge/Models/AppleAppArchiveModels.cs
@@ -80,6 +80,12 @@ public sealed class AppleAppArchiveUploadRequest
     /// <summary>Path to the .xcarchive to upload.</summary>
     public string ArchivePath { get; set; } = string.Empty;
 
+    /// <summary>Expected primary app bundle identifier used to select the archived product.</summary>
+    public string? BundleId { get; set; }
+
+    /// <summary>Privacy purpose-string keys that must contain non-empty values in the final archived app.</summary>
+    public string[] RequiredPrivacyUsageDescriptionKeys { get; set; } = Array.Empty<string>();
+
     /// <summary>Temporary export path used by xcodebuild.</summary>
     public string? ExportPath { get; set; }
 

--- a/PowerForge/Models/Configuration/ConfigurationMiscSegments.cs
+++ b/PowerForge/Models/Configuration/ConfigurationMiscSegments.cs
@@ -227,6 +227,9 @@ public sealed class AppleAppConfiguration
     /// <summary>Bundle identifiers that must be present inside the independently distributed archive.</summary>
     public string[] RequiredEmbeddedBundleIds { get; set; } = Array.Empty<string>();
 
+    /// <summary>Privacy purpose-string keys that must contain non-empty values in the final archived app before upload.</summary>
+    public string[] RequiredPrivacyUsageDescriptionKeys { get; set; } = Array.Empty<string>();
+
     /// <summary>Path to a .xcodeproj directory or project.pbxproj file. Relative paths resolve from the pipeline project root.</summary>
     public string ProjectPath { get; set; } = string.Empty;
 

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -622,6 +622,8 @@ internal sealed class PowerForgeAppleAppReleaseTargetPlan
 
     public string[] RequiredEmbeddedBundleIds { get; set; } = Array.Empty<string>();
 
+    public string[] RequiredPrivacyUsageDescriptionKeys { get; set; } = Array.Empty<string>();
+
     public string? AppStoreConnectAppId { get; set; }
 
     public bool AppStoreConnectAppIdDiscovered { get; set; }

--- a/PowerForge/Services/AppleAppArchiveService.Privacy.cs
+++ b/PowerForge/Services/AppleAppArchiveService.Privacy.cs
@@ -35,22 +35,29 @@ public sealed partial class AppleAppArchiveService
         string? selectedInfoPlist = null;
         foreach (var appPath in appPaths)
         {
-            var infoPlist = Path.Combine(appPath, "Info.plist");
-            if (!File.Exists(infoPlist))
-                continue;
-            if (string.IsNullOrWhiteSpace(expectedBundleId))
+            var infoPlists = new[]
             {
-                if (appPaths.Length == 1)
-                    selectedInfoPlist = infoPlist;
-                continue;
-            }
+                Path.Combine(appPath, "Info.plist"),
+                Path.Combine(appPath, "Contents", "Info.plist")
+            }.Where(File.Exists);
+            foreach (var infoPlist in infoPlists)
+            {
+                if (string.IsNullOrWhiteSpace(expectedBundleId))
+                {
+                    if (appPaths.Length == 1)
+                        selectedInfoPlist = infoPlist;
+                    break;
+                }
 
-            var archivedBundleId = await ReadPlistStringAsync(infoPlist, "CFBundleIdentifier", cancellationToken).ConfigureAwait(false);
-            if (string.Equals(archivedBundleId, expectedBundleId, StringComparison.Ordinal))
-            {
-                selectedInfoPlist = infoPlist;
-                break;
+                var archivedBundleId = await ReadPlistStringAsync(infoPlist, "CFBundleIdentifier", cancellationToken).ConfigureAwait(false);
+                if (string.Equals(archivedBundleId, expectedBundleId, StringComparison.Ordinal))
+                {
+                    selectedInfoPlist = infoPlist;
+                    break;
+                }
             }
+            if (selectedInfoPlist is not null)
+                break;
         }
 
         if (selectedInfoPlist is null)

--- a/PowerForge/Services/AppleAppArchiveService.Privacy.cs
+++ b/PowerForge/Services/AppleAppArchiveService.Privacy.cs
@@ -1,0 +1,91 @@
+using System.Text.RegularExpressions;
+
+namespace PowerForge;
+
+public sealed partial class AppleAppArchiveService
+{
+    private static readonly Regex PrivacyUsageDescriptionKey = new(
+        "^NS[A-Za-z0-9]+UsageDescription$",
+        RegexOptions.CultureInvariant);
+
+    private async Task ValidatePrivacyUsageDescriptionsAsync(
+        AppleAppArchiveUploadRequest request,
+        string archivePath,
+        CancellationToken cancellationToken)
+    {
+        var requiredKeys = (request.RequiredPrivacyUsageDescriptionKeys ?? Array.Empty<string>())
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (requiredKeys.Length == 0)
+            return;
+        var invalidKey = requiredKeys.FirstOrDefault(key => !PrivacyUsageDescriptionKey.IsMatch(key));
+        if (invalidKey is not null)
+            throw new ArgumentException($"Privacy usage-description key '{invalidKey}' is invalid.", nameof(request));
+
+        var applicationsPath = Path.Combine(archivePath, "Products", "Applications");
+        var appPaths = Directory.Exists(applicationsPath)
+            ? Directory.GetDirectories(applicationsPath, "*.app", SearchOption.TopDirectoryOnly)
+            : Array.Empty<string>();
+        if (appPaths.Length == 0)
+            throw new InvalidOperationException($"Apple archive contains no primary app under '{applicationsPath}'.");
+
+        var expectedBundleId = request.BundleId?.Trim();
+        string? selectedInfoPlist = null;
+        foreach (var appPath in appPaths)
+        {
+            var infoPlist = Path.Combine(appPath, "Info.plist");
+            if (!File.Exists(infoPlist))
+                continue;
+            if (string.IsNullOrWhiteSpace(expectedBundleId))
+            {
+                if (appPaths.Length == 1)
+                    selectedInfoPlist = infoPlist;
+                continue;
+            }
+
+            var archivedBundleId = await ReadPlistStringAsync(infoPlist, "CFBundleIdentifier", cancellationToken).ConfigureAwait(false);
+            if (string.Equals(archivedBundleId, expectedBundleId, StringComparison.Ordinal))
+            {
+                selectedInfoPlist = infoPlist;
+                break;
+            }
+        }
+
+        if (selectedInfoPlist is null)
+        {
+            var identity = string.IsNullOrWhiteSpace(expectedBundleId) ? "the configured target" : $"bundle '{expectedBundleId}'";
+            throw new InvalidOperationException($"Apple archive contains no primary app matching {identity}.");
+        }
+
+        foreach (var key in requiredKeys)
+        {
+            var value = await ReadPlistStringAsync(selectedInfoPlist, key, cancellationToken).ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidOperationException(
+                    $"Archived app '{Path.GetFileName(Path.GetDirectoryName(selectedInfoPlist))}' is missing non-empty privacy purpose string '{key}'. Upload was blocked before App Store Connect delivery.");
+            }
+        }
+    }
+
+    private async Task<string?> ReadPlistStringAsync(
+        string infoPlist,
+        string key,
+        CancellationToken cancellationToken)
+    {
+        var executable = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+            System.Runtime.InteropServices.OSPlatform.OSX)
+            ? "/usr/bin/plutil"
+            : "plutil";
+        var result = await _processRunner.RunAsync(
+            new ProcessRunRequest(
+                executable,
+                Path.GetDirectoryName(infoPlist)!,
+                new[] { "-extract", key, "raw", "-o", "-", infoPlist },
+                TimeSpan.FromSeconds(30)),
+            cancellationToken).ConfigureAwait(false);
+        return result.Succeeded ? result.StdOut.Trim() : null;
+    }
+}

--- a/PowerForge/Services/AppleAppArchiveService.cs
+++ b/PowerForge/Services/AppleAppArchiveService.cs
@@ -7,7 +7,7 @@ namespace PowerForge;
 /// <summary>
 /// Creates and uploads Apple app archives through xcodebuild.
 /// </summary>
-public sealed class AppleAppArchiveService
+public sealed partial class AppleAppArchiveService
 {
     private readonly IProcessRunner _processRunner;
 
@@ -107,6 +107,8 @@ public sealed class AppleAppArchiveService
         var archivePath = Path.GetFullPath(request.ArchivePath);
         if (!Directory.Exists(archivePath))
             throw new DirectoryNotFoundException($"Archive path was not found: {archivePath}");
+
+        await ValidatePrivacyUsageDescriptionsAsync(request, archivePath, cancellationToken).ConfigureAwait(false);
 
         var exportPath = ResolveExportPath(request);
         var plistPath = ResolveExportOptionsPlistPath(request);

--- a/PowerForge/Services/PowerForgeReleaseService.AppleAutomation.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleAutomation.cs
@@ -580,7 +580,9 @@ internal sealed partial class PowerForgeReleaseService
             resultByName.TryGetValue(app.Name, out var result);
             var state = result?.RemoteState;
             var platform = state?.Platforms.SingleOrDefault(value => value.Platform == app.Platform);
-            var build = platform?.MatchedBuild ?? platform?.SelectedBuild;
+            var preparedVersion = result?.Distribution?.Version;
+            var receiptVersion = platform?.Version ?? preparedVersion;
+            var build = platform?.MatchedBuild ?? platform?.SelectedBuild ?? result?.Distribution?.Build;
             var review = platform?.ReviewSubmissions.FirstOrDefault(static value => value.IsSubmitted == true) ??
                          platform?.ReviewSubmissions.FirstOrDefault();
             (string? MarketingVersion, string? BuildNumber) values = (null, null);
@@ -636,8 +638,14 @@ internal sealed partial class PowerForgeReleaseService
                 .GroupBy(static diagnostic => diagnostic.Code, StringComparer.OrdinalIgnoreCase)
                 .Select(static group => group.First())
                 .ToArray();
+            var observedNextActions = (platform?.NextActions ?? Array.Empty<string>())
+                .Where(action => preparedVersion is null ||
+                                 !action.Equals("Create App Store distribution version.", StringComparison.OrdinalIgnoreCase))
+                .Where(action => result?.Distribution?.Build is null || !plan.SelectBuildForDistribution ||
+                                 !action.StartsWith("Select ", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
             var nextActions = BuildAppleReceiptNextActions(
-                    platform?.NextActions,
+                    observedNextActions,
                     betaGroupsConfigured,
                     app.TestFlightPolicy,
                     app.AppStoreConnectAppIdDiscovered)
@@ -662,9 +670,10 @@ internal sealed partial class PowerForgeReleaseService
                 BuildId = build?.Id,
                 BuildProcessingState = build?.ProcessingState,
                 BuildUploadId = result?.Upload?.BuildUploadId,
-                DistributionVersionId = platform?.Version?.Id,
-                DistributionState = platform?.Version?.AppStoreState ?? platform?.Version?.AppVersionState,
-                BuildSelected = platform?.MatchedBuildSelected,
+                DistributionVersionId = receiptVersion?.Id,
+                DistributionState = receiptVersion?.AppStoreState ?? receiptVersion?.AppVersionState,
+                BuildSelected = platform?.MatchedBuildSelected ??
+                                (result?.Distribution?.Build is not null && plan.SelectBuildForDistribution ? true : null),
                 TestFlightInternalState = platform?.BetaDetail?.InternalBuildState,
                 TestFlightExternalState = platform?.BetaDetail?.ExternalBuildState,
                 TestFlightReviewState = platform?.BetaReviewSubmission?.BetaReviewState,

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -1810,6 +1810,7 @@ internal sealed partial class PowerForgeReleaseService
             Capabilities = NormalizeStrings(app.Capabilities),
             TestFlightPolicy = app.TestFlightPolicy,
             RequiredEmbeddedBundleIds = NormalizeStrings(app.RequiredEmbeddedBundleIds),
+            RequiredPrivacyUsageDescriptionKeys = NormalizeStrings(app.RequiredPrivacyUsageDescriptionKeys),
             AppStoreConnectAppId = string.IsNullOrWhiteSpace(app.AppStoreConnectAppId) ? null : app.AppStoreConnectAppId!.Trim(),
             ProjectPath = projectPath,
             IsWorkspace = isWorkspace,
@@ -2097,6 +2098,8 @@ internal sealed partial class PowerForgeReleaseService
                 var upload = _uploadAppleApp(new AppleAppArchiveUploadRequest
                 {
                     ArchivePath = app.ArchivePath,
+                    BundleId = app.BundleId,
+                    RequiredPrivacyUsageDescriptionKeys = app.RequiredPrivacyUsageDescriptionKeys,
                     ExportPath = app.ExportPath,
                     TeamId = app.TeamId,
                     XcodeBuildExecutable = plan.XcodeBuildExecutable,

--- a/Schemas/powerforge.segments.schema.json
+++ b/Schemas/powerforge.segments.schema.json
@@ -283,6 +283,7 @@
         "Capabilities": { "type": "array", "items": { "type": "string" } },
         "TestFlightPolicy": { "$ref": "powerforge.common.schema.json#/$defs/AppleTestFlightPolicy" },
         "RequiredEmbeddedBundleIds": { "type": "array", "items": { "type": "string" } },
+        "RequiredPrivacyUsageDescriptionKeys": { "type": "array", "items": { "type": "string", "pattern": "^NS[A-Za-z0-9]+UsageDescription$" } },
         "ProjectPath": { "type": "string", "minLength": 1 },
         "Scheme": { "type": ["string", "null"] },
         "ProductName": { "type": ["string", "null"] },

--- a/scripts/Invoke-PinnedPowerForge.Evidence.ps1
+++ b/scripts/Invoke-PinnedPowerForge.Evidence.ps1
@@ -32,6 +32,62 @@ function Assert-ConsumerRepositoryContent {
     }
 }
 
+function Register-AppleAutomationEvidence {
+    param([Parameter(Mandatory)][string] $SourceCommit)
+    if ($ArgumentList[0] -ne 'apple-release') { return }
+
+    $releaseConfigPath = Resolve-OptionPath -Value (Get-OptionValue -Option '--config')
+    $release = Get-Content -LiteralPath $releaseConfigPath -Raw | ConvertFrom-Json
+    $apple = $release.AppleApps
+    $projectRootValue = if ([string]::IsNullOrWhiteSpace([string]$apple.ProjectRoot)) { '.' } else { [string]$apple.ProjectRoot }
+    $projectRoot = Resolve-PathFromBase -BasePath (Split-Path -Parent $releaseConfigPath) -Value $projectRootValue
+    $automation = $apple.Automation
+
+    $lockValue = if ([string]::IsNullOrWhiteSpace([string]$automation.LockPath)) {
+        'build/powerforge/apple/release.lock'
+    } else { [string]$automation.LockPath }
+    $lockPath = Resolve-PathFromBase -BasePath $projectRoot -Value $lockValue
+    if (Test-Path -LiteralPath $lockPath) {
+        Add-AllowedConsumerEvidencePath -Path $lockPath -Name 'Apple release operation lock'
+    }
+
+    $receiptValue = if ([string]::IsNullOrWhiteSpace([string]$automation.ReceiptPath)) {
+        'build/powerforge/apple/release-receipt.json'
+    } else { [string]$automation.ReceiptPath }
+    $receiptPath = Resolve-PathFromBase -BasePath $projectRoot -Value $receiptValue
+    if (Test-Path -LiteralPath $receiptPath) {
+        $directTargets = @($apple.Apps | Where-Object { $_.Enabled -ne $false -and [string]$_.DistributionRoute -eq 'DirectNotarized' })
+        if ($directTargets.Count -eq 0) {
+            $receipt = Get-Content -LiteralPath $receiptPath -Raw | ConvertFrom-Json
+            if (-not ([string]$receipt.sourceCommit).Equals($SourceCommit, [StringComparison]::OrdinalIgnoreCase)) {
+                throw "Apple release receipt source commit does not match the exact consumer HEAD '$SourceCommit'."
+            }
+            Add-AllowedConsumerEvidencePath -Path $receiptPath -Name 'Apple release receipt'
+        }
+    }
+
+    $expectedPlanSha256 = Get-OptionValue -Option '--apple-expected-plan-sha256'
+    if ([string]::IsNullOrWhiteSpace($expectedPlanSha256)) { return }
+    if ($expectedPlanSha256 -notmatch '^[0-9A-Fa-f]{64}$') {
+        throw '--apple-expected-plan-sha256 must contain exactly 64 hexadecimal characters.'
+    }
+
+    $planValue = if ([string]::IsNullOrWhiteSpace([string]$automation.PlanReceiptPath)) {
+        'build/powerforge/apple/release-plan.json'
+    } else { [string]$automation.PlanReceiptPath }
+    $planPath = Resolve-PathFromBase -BasePath $projectRoot -Value $planValue
+    if (-not (Test-Path -LiteralPath $planPath -PathType Leaf)) { return }
+    $plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+    $requestedAction = if ($ArgumentList.Count -gt 1) { [string]$ArgumentList[1] } else { '' }
+    if ($plan.planOnly -ne $true -or
+        -not ([string]$plan.action).Equals($requestedAction, [StringComparison]::OrdinalIgnoreCase) -or
+        -not ([string]$plan.sourceCommit).Equals($SourceCommit, [StringComparison]::OrdinalIgnoreCase) -or
+        -not ([string]$plan.planSha256).Equals($expectedPlanSha256, [StringComparison]::OrdinalIgnoreCase)) {
+        throw 'Apple release plan receipt does not match the approved action, source commit, and plan SHA-256.'
+    }
+    Add-AllowedConsumerEvidencePath -Path $planPath -Name 'Apple release plan receipt'
+}
+
 function Assert-TrackedSourceLinks {
     $comparison = if ($IsWindows) { [StringComparison]::OrdinalIgnoreCase } else { [StringComparison]::Ordinal }
     $rootPrefix = $consumer.TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
@@ -94,17 +150,32 @@ function Register-StandaloneScreenshotEvidence {
         Add-AllowedConsumerEvidencePath -Path $path -Name 'Reviewed screenshot evidence'
     }
 
-    $configPath = Resolve-OptionPath -Value (Get-OptionValue -Option '--config')
-    $config = Get-Content -LiteralPath $configPath -Raw | ConvertFrom-Json
-    $configuredOutput = [string]$config.Quality.ApprovalManifestPath
-    $outputValue = Get-OptionValue -Option '--out'
-    if ([string]::IsNullOrWhiteSpace($outputValue)) {
-        $outputValue = if ([string]::IsNullOrWhiteSpace($configuredOutput)) {
-            [IO.Path]::GetFileNameWithoutExtension($configPath) + '.approval.json'
-        } else { $configuredOutput }
+    $operation = if ($ArgumentList.Count -gt 1) { [string]$ArgumentList[1] } else { '' }
+    $configPaths = if ($operation -eq 'manifests') {
+        $releaseConfigPath = Resolve-OptionPath -Value (Get-OptionValue -Option '--release-config')
+        $release = Get-Content -LiteralPath $releaseConfigPath -Raw | ConvertFrom-Json
+        $apple = $release.AppleApps
+        $projectRootValue = if ([string]::IsNullOrWhiteSpace([string]$apple.ProjectRoot)) { '.' } else { [string]$apple.ProjectRoot }
+        $projectRoot = Resolve-PathFromBase -BasePath (Split-Path -Parent $releaseConfigPath) -Value $projectRootValue
+        @(@([string]$apple.ScreenshotConfigPath) + @($apple.ScreenshotConfigPaths) |
+            Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) } |
+            ForEach-Object { Resolve-PathFromBase -BasePath $projectRoot -Value ([string]$_) } |
+            Sort-Object -Unique)
+    } else {
+        @(Resolve-OptionPath -Value (Get-OptionValue -Option '--config'))
     }
-    $outputPath = Resolve-PathFromBase -BasePath (Split-Path -Parent $configPath) -Value $outputValue
-    Add-AllowedConsumerEvidencePath -Path $outputPath -Name 'Screenshot approval manifest output'
+    foreach ($configPath in $configPaths) {
+        $config = Get-Content -LiteralPath $configPath -Raw | ConvertFrom-Json
+        $configuredOutput = [string]$config.Quality.ApprovalManifestPath
+        $outputValue = Get-OptionValue -Option '--out'
+        if ([string]::IsNullOrWhiteSpace($outputValue)) {
+            $outputValue = if ([string]::IsNullOrWhiteSpace($configuredOutput)) {
+                [IO.Path]::GetFileNameWithoutExtension($configPath) + '.approval.json'
+            } else { $configuredOutput }
+        }
+        $outputPath = Resolve-PathFromBase -BasePath (Split-Path -Parent $configPath) -Value $outputValue
+        Add-AllowedConsumerEvidencePath -Path $outputPath -Name 'Screenshot approval manifest output'
+    }
 }
 
 function Get-ScreenshotInventoryKey {

--- a/scripts/Invoke-PinnedPowerForge.Evidence.ps1
+++ b/scripts/Invoke-PinnedPowerForge.Evidence.ps1
@@ -67,8 +67,7 @@ function Register-AppleAutomationEvidence {
     }
 
     $expectedPlanSha256 = Get-OptionValue -Option '--apple-expected-plan-sha256'
-    if ([string]::IsNullOrWhiteSpace($expectedPlanSha256)) { return }
-    if ($expectedPlanSha256 -notmatch '^[0-9A-Fa-f]{64}$') {
+    if (-not [string]::IsNullOrWhiteSpace($expectedPlanSha256) -and $expectedPlanSha256 -notmatch '^[0-9A-Fa-f]{64}$') {
         throw '--apple-expected-plan-sha256 must contain exactly 64 hexadecimal characters.'
     }
 
@@ -78,12 +77,17 @@ function Register-AppleAutomationEvidence {
     $planPath = Resolve-PathFromBase -BasePath $projectRoot -Value $planValue
     if (-not (Test-Path -LiteralPath $planPath -PathType Leaf)) { return }
     $plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
-    $requestedAction = if ($ArgumentList.Count -gt 1) { [string]$ArgumentList[1] } else { '' }
     if ($plan.planOnly -ne $true -or
-        -not ([string]$plan.action).Equals($requestedAction, [StringComparison]::OrdinalIgnoreCase) -or
         -not ([string]$plan.sourceCommit).Equals($SourceCommit, [StringComparison]::OrdinalIgnoreCase) -or
-        -not ([string]$plan.planSha256).Equals($expectedPlanSha256, [StringComparison]::OrdinalIgnoreCase)) {
-        throw 'Apple release plan receipt does not match the approved action, source commit, and plan SHA-256.'
+        ([string]$plan.planSha256) -notmatch '^[0-9A-Fa-f]{64}$') {
+        throw 'Apple release plan receipt is not bounded to the exact consumer source commit.'
+    }
+    if (-not [string]::IsNullOrWhiteSpace($expectedPlanSha256)) {
+        $requestedAction = if ($ArgumentList.Count -gt 1) { [string]$ArgumentList[1] } else { '' }
+        if (-not ([string]$plan.action).Equals($requestedAction, [StringComparison]::OrdinalIgnoreCase) -or
+            -not ([string]$plan.planSha256).Equals($expectedPlanSha256, [StringComparison]::OrdinalIgnoreCase)) {
+            throw 'Apple release plan receipt does not match the approved action and plan SHA-256.'
+        }
     }
     Add-AllowedConsumerEvidencePath -Path $planPath -Name 'Apple release plan receipt'
 }

--- a/scripts/Invoke-PinnedPowerForge.ps1
+++ b/scripts/Invoke-PinnedPowerForge.ps1
@@ -201,9 +201,15 @@ function Assert-SafeArguments {
         throw 'UploadExisting is forbidden at the pinned local operator boundary because existing archive bytes lack reviewed provenance.'
     }
     $config = Get-OptionValue -Option '--config'
-    if (($command -eq 'apple-release' -or $command -eq 'apple-screenshots' -or $command -eq 'apple-review-details' -or
-        ($command -eq 'apple-governance' -and $operation -ne 'snapshot')) -and -not $config) {
+    $requiresConfig = $command -eq 'apple-release' -or
+        ($command -eq 'apple-screenshots' -and $operation -ne 'manifests') -or
+        $command -eq 'apple-review-details' -or
+        ($command -eq 'apple-governance' -and $operation -ne 'snapshot')
+    if ($requiresConfig -and -not $config) {
         throw "$command requires an explicit --config at the pinned local operator boundary."
+    }
+    if ($command -eq 'apple-screenshots' -and $operation -eq 'manifests' -and -not (Get-OptionValue -Option '--release-config')) {
+        throw 'apple-screenshots manifests requires an explicit --release-config at the pinned local operator boundary.'
     }
     $script:validatedReleaseConfigPaths = @()
     foreach ($option in @('--config', '--release-config')) {
@@ -592,6 +598,7 @@ try {
     }
     Register-StandaloneScreenshotEvidence
     Assert-ScreenshotPublicationBinding -SourceCommit $consumerHead
+    Register-AppleAutomationEvidence -SourceCommit $consumerHead
     Assert-ConsumerRepositoryContent
     Assert-TrackedSourceLinks
     $tar = Resolve-FixedTool -Name tar


### PR DESCRIPTION
## Summary

- generate every configured Apple screenshot approval manifest in one provenance-bound command
- keep same-source release plans, receipts, locks, manifests, and reviewed images as bounded operator evidence
- validate required privacy purpose strings in iOS and Mac Catalyst archives before export/upload
- make preparation receipts resilient to immediate stale App Store Connect readback

## Operator contract

`apple-release Advance` can now own archive/upload, draft preparation, reviewed screenshot sync, readiness, and configured TestFlight distribution while preserving separate confirmed actions for TestFlight review, App Review, and public release.

## Compatibility

The privacy archive check is opt-in through `RequiredPrivacyUsageDescriptionKeys`; existing consumers remain unchanged until they declare required keys.