### PR TITLE
Bind pinned Apple receipts to verified source commits

### DIFF
--- a/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
@@ -6,6 +6,85 @@ namespace PowerForge.Tests;
 public sealed partial class AppleReleaseWorkflowTests
 {
     [Fact]
+    public void PinnedAppleReleaseAlwaysForwardsTheVerifiedConsumerCommit()
+    {
+        var root = FindRepoRoot();
+        var parent = Path.Combine(root, ".test-temp", $"powerforge-source-forwarding-{Guid.NewGuid():N}");
+        const string commit = "0123456789abcdef0123456789abcdef01234567";
+        try
+        {
+            Directory.CreateDirectory(parent);
+            var harness = Path.Combine(parent, "source-forwarding-harness.ps1");
+            File.WriteAllText(harness,
+                $$"""
+                param([string] $Support)
+                $ErrorActionPreference = 'Stop'
+                function Get-OptionValue {
+                    param([string] $Option)
+                    for ($index = 0; $index -lt $ArgumentList.Count; $index++) {
+                        if ($ArgumentList[$index] -eq $Option) { return $ArgumentList[$index + 1] }
+                        if ($ArgumentList[$index].StartsWith("$Option=", [StringComparison]::OrdinalIgnoreCase)) {
+                            return $ArgumentList[$index].Substring($Option.Length + 1)
+                        }
+                    }
+                    return $null
+                }
+                . $Support
+
+                $ArgumentList = @('apple-release', 'Status', '--config', 'powerforge.release.json', '--capture-provenance', 'capture.json')
+                $forwarded = @(Get-ForwardedArgumentList -SourceCommit '{{commit}}')
+                if (($forwarded -join '|') -ne 'apple-release|Status|--config|powerforge.release.json|--apple-source-commit|{{commit}}') {
+                    throw "Verified source commit was not injected: $($forwarded -join '|')"
+                }
+
+                $ArgumentList = @('apple-release', 'Status', '--config', 'powerforge.release.json', '--apple-source-commit={{commit}}')
+                $forwarded = @(Get-ForwardedArgumentList -SourceCommit '{{commit}}')
+                if (($forwarded -join '|') -ne 'apple-release|Status|--config|powerforge.release.json|--apple-source-commit|{{commit}}') {
+                    throw "Explicit source commit was not normalized: $($forwarded -join '|')"
+                }
+
+                $ArgumentList = @('apple-release', 'Status', '--config', 'powerforge.release.json', '--capture-provenance', '--apple-source-commit={{commit}}')
+                $forwarded = @(Get-ForwardedArgumentList -SourceCommit '{{commit}}')
+                if (($forwarded -join '|') -ne 'apple-release|Status|--config|powerforge.release.json|--apple-source-commit|{{commit}}') {
+                    throw "A capture path was mistaken for a source option: $($forwarded -join '|')"
+                }
+
+                foreach ($invalidArguments in @(
+                    @('apple-release', 'Status', '--config', 'powerforge.release.json', '--apple-source-commit', ''),
+                    @('apple-release', 'Status', '--config', 'powerforge.release.json', '--apple-source-commit', '{{commit}}', '--apple-source-commit={{commit}}'),
+                    @('apple-release', 'Status', '--config', 'powerforge.release.json', '--apple-source-commit', '89abcdef0123456789abcdef0123456789abcdef'))) {
+                    $ArgumentList = $invalidArguments
+                    try {
+                        Get-ForwardedArgumentList -SourceCommit '{{commit}}' | Out-Null
+                        throw "Invalid source arguments were accepted: $($ArgumentList -join '|')"
+                    } catch {
+                        if ($_.Exception.Message -like 'Invalid source arguments were accepted:*') { throw }
+                    }
+                }
+
+                $ArgumentList = @('apple-governance', 'validate', '--config', 'governance.json')
+                $forwarded = @(Get-ForwardedArgumentList -SourceCommit '{{commit}}')
+                if (($forwarded -join '|') -ne ($ArgumentList -join '|')) {
+                    throw "A non-release command was changed: $($forwarded -join '|')"
+                }
+                'PASS'
+                """);
+
+            var result = Run(
+                "pwsh",
+                parent,
+                "-NoLogo", "-NoProfile", "-File", harness,
+                "-Support", Path.Combine(root, "scripts", "Invoke-PinnedPowerForge.Evidence.ps1"));
+            result.EnsureSuccess();
+            Assert.Contains("PASS", result.StandardOutput, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(parent)) Directory.Delete(parent, recursive: true);
+        }
+    }
+
+    [Fact]
     public void TrackedSourceLinksMustRemainInsideTheExactConsumerCheckout()
     {
         if (OperatingSystem.IsWindows()) return;

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.RunnerLocalCredentials.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.RunnerLocalCredentials.cs
@@ -54,10 +54,11 @@ public sealed partial class AppleReleaseWorkflowTests
         Assert.Contains("UploadExisting is forbidden at the pinned local operator boundary", script, StringComparison.Ordinal);
         Assert.Contains("if ($null -ne (Get-OptionValue -Option '--capture-provenance'))", script, StringComparison.Ordinal);
         Assert.Contains("Capture provenance source commit", script, StringComparison.Ordinal);
-        Assert.Contains("--apple-source-commit must match the exact consumer HEAD", script, StringComparison.Ordinal);
+        Assert.Contains("--apple-source-commit must match the exact consumer HEAD", evidence, StringComparison.Ordinal);
         Assert.Contains("Assert-ScreenshotPublicationBinding -SourceCommit $consumerHead", script, StringComparison.Ordinal);
         Assert.Contains("if ($ArgumentList[0] -ne 'apple-release' -or", evidence, StringComparison.Ordinal);
-        Assert.Contains("$argument -eq '--capture-provenance'", script, StringComparison.Ordinal);
+        Assert.Contains("$argument -eq '--capture-provenance'", evidence, StringComparison.Ordinal);
+        Assert.Contains("$forwardedArgumentList = Get-ForwardedArgumentList -SourceCommit $consumerHead", script, StringComparison.Ordinal);
         Assert.Contains("Screenshot approval manifests do not identify one exact retained capture root and inventory", evidence, StringComparison.Ordinal);
         Assert.Contains("Resolve-PathFromBase -BasePath", evidence, StringComparison.Ordinal);
         Assert.Contains("No screenshot configuration matches the selected release targets", evidence, StringComparison.Ordinal);

--- a/scripts/Invoke-PinnedPowerForge.Evidence.ps1
+++ b/scripts/Invoke-PinnedPowerForge.Evidence.ps1
@@ -10,6 +10,59 @@ function Add-AllowedConsumerEvidencePath {
     $null = $script:allowedConsumerEvidencePaths.Add($full)
 }
 
+function Get-ForwardedArgumentList {
+    param([Parameter(Mandatory)][string] $SourceCommit)
+    if ($ArgumentList[0] -ne 'apple-release') { return @($ArgumentList) }
+    if ($SourceCommit -notmatch '^[0-9A-Fa-f]{40}$') {
+        throw 'Verified consumer source commit must be an exact 40-character Git commit SHA.'
+    }
+
+    $withoutLocalEvidence = [Collections.Generic.List[string]]::new()
+    for ($index = 0; $index -lt $ArgumentList.Count; $index++) {
+        $argument = $ArgumentList[$index]
+        if ($argument -eq '--capture-provenance') {
+            if ($index + 1 -ge $ArgumentList.Count) { throw 'Missing value for --capture-provenance.' }
+            $index++
+            continue
+        }
+        if ($argument.StartsWith('--capture-provenance=', [StringComparison]::OrdinalIgnoreCase)) { continue }
+        $withoutLocalEvidence.Add($argument)
+    }
+
+    $result = [Collections.Generic.List[string]]::new()
+    $sourceCommitFound = $false
+    for ($index = 0; $index -lt $withoutLocalEvidence.Count; $index++) {
+        $argument = $withoutLocalEvidence[$index]
+        $configuredSourceCommit = $null
+        if ($argument -eq '--apple-source-commit') {
+            if ($index + 1 -ge $withoutLocalEvidence.Count) { throw 'Missing value for --apple-source-commit.' }
+            $configuredSourceCommit = $withoutLocalEvidence[++$index]
+        } elseif ($argument.StartsWith('--apple-source-commit=', [StringComparison]::OrdinalIgnoreCase)) {
+            $configuredSourceCommit = $argument.Substring('--apple-source-commit='.Length)
+        } else {
+            $result.Add($argument)
+            continue
+        }
+
+        if ($sourceCommitFound) { throw '--apple-source-commit must be specified at most once.' }
+        $sourceCommitFound = $true
+        if ([string]::IsNullOrWhiteSpace($configuredSourceCommit) -or
+            $configuredSourceCommit -notmatch '^[0-9A-Fa-f]{40}$') {
+            throw '--apple-source-commit must contain an exact 40-character Git commit SHA.'
+        }
+        if (-not $configuredSourceCommit.Equals($SourceCommit, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "--apple-source-commit must match the exact consumer HEAD '$SourceCommit'."
+        }
+        $result.Add('--apple-source-commit')
+        $result.Add($SourceCommit.ToLowerInvariant())
+    }
+    if (-not $sourceCommitFound) {
+        $result.Add('--apple-source-commit')
+        $result.Add($SourceCommit.ToLowerInvariant())
+    }
+    return @($result)
+}
+
 function Assert-ConsumerRepositoryContent {
     $paths = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
     foreach ($arguments in @(

--- a/scripts/Invoke-PinnedPowerForge.ps1
+++ b/scripts/Invoke-PinnedPowerForge.ps1
@@ -173,21 +173,6 @@ function Get-OptionValue {
     return $null
 }
 
-function Get-ForwardedArgumentList {
-    if ($ArgumentList[0] -ne 'apple-release') { return @($ArgumentList) }
-    $result = [Collections.Generic.List[string]]::new()
-    for ($index = 0; $index -lt $ArgumentList.Count; $index++) {
-        $argument = $ArgumentList[$index]
-        if ($argument -eq '--capture-provenance') {
-            $index++
-            continue
-        }
-        if ($argument.StartsWith('--capture-provenance=', [StringComparison]::OrdinalIgnoreCase)) { continue }
-        $result.Add($argument)
-    }
-    return @($result)
-}
-
 function Assert-SafeArguments {
     if ($ArgumentList.Count -lt 1 -or $ArgumentList[0] -notin @('apple-release', 'apple-screenshots', 'apple-governance', 'apple-review-details')) {
         throw 'Pinned local operator accepts only Apple PowerForge commands.'
@@ -586,10 +571,7 @@ try {
     Assert-FixedAppleToolConfiguration
     Invoke-TrackedInputValidator -SourceCommit $consumerHead
     Assert-FixedLocalCredentialProfile -Saved $savedCredentialEnvironment
-    $configuredSourceCommit = Get-OptionValue -Option '--apple-source-commit'
-    if ($configuredSourceCommit -and $configuredSourceCommit.ToLowerInvariant() -ne $consumerHead) {
-        throw "--apple-source-commit must match the exact consumer HEAD '$consumerHead'."
-    }
+    $forwardedArgumentList = Get-ForwardedArgumentList -SourceCommit $consumerHead
 
     $dotnet = Resolve-FixedTool -Name dotnet
     if ($null -ne (Get-OptionValue -Option '--capture-provenance')) {
@@ -630,7 +612,7 @@ try {
     $toolExitCode = Invoke-RedactedProcess `
         -FilePath $dotnet `
         -WorkingDirectory $consumer `
-        -Arguments (@($cliAssembly) + (Get-ForwardedArgumentList)) `
+        -Arguments (@($cliAssembly) + $forwardedArgumentList) `
         -NuGetPackagesPath $nugetPackages `
         -IncludeAppleCredentials
     if ($toolExitCode -ne 0) { exit $toolExitCode }


### PR DESCRIPTION
Pinned local Apple release operations now bind every generated plan and receipt to the exact verified consumer HEAD. Operators no longer need to repeat `--apple-source-commit` for routine commands such as `Status`.

The forwarding boundary also rejects empty, malformed, duplicate, or mismatched source values and normalizes the supported `--apple-source-commit=<sha>` form before invoking the CLI. Local capture-provenance arguments remain wrapper-only, and other Apple command families are unchanged.

This closes the gap where a successful Apple Status receipt could have no `sourceCommit`, making later pinned evidence checks reject it.