### PR TITLE
Fix GitHub content reusable workflow token contract

### DIFF
--- a/.github/workflows/powerforge-github-content.yml
+++ b/.github/workflows/powerforge-github-content.yml
@@ -24,7 +24,7 @@ on:
         default: "docs: update GitHub sponsors"
         type: string
     secrets:
-      github_token:
+      github-token:
         required: false
 
 permissions:
@@ -97,7 +97,7 @@ jobs:
         uses: ./.powerforge-runtime/pspublishmodule/.github/actions/github-content
         with:
           config-path: ${{ inputs.config_path }}
-          github-token: ${{ secrets.github_token != '' && secrets.github_token || github.token }}
+          github-token: ${{ secrets['github-token'] != '' && secrets['github-token'] || github.token }}
 
       - name: Commit generated content
         if: inputs.commit_changes && steps.content.outputs.changed == 'true'

--- a/Docs/PowerForge.GitHubContent.md
+++ b/Docs/PowerForge.GitHubContent.md
@@ -101,7 +101,7 @@ With the default `commit_changes: true`, the caller must run on a branch ref bec
 
 ```yaml
     secrets:
-      github_token: ${{ secrets.SPONSORS_TOKEN }}
+      github-token: ${{ secrets.SPONSORS_TOKEN }}
 ```
 
 GitHub does not expose a public sponsorship's selected tier to every viewer. The repository `GITHUB_TOKEN` is sufficient for the public roster, but it may return no tier for every sponsor. In that case all accounts use `unmappedTierKey`; no amount is guessed. Store a suitable user token as `SPONSORS_TOKEN` (or another repository or organization secret) when tier grouping must reflect the selected GitHub tier.

--- a/PowerForge.Tests/GitHubContentActionTests.cs
+++ b/PowerForge.Tests/GitHubContentActionTests.cs
@@ -54,6 +54,17 @@ public sealed class GitHubContentActionTests
     }
 
     [Fact]
+    public void ReusableWorkflow_UsesSupportedOptionalTokenSecret()
+    {
+        var repoRoot = FindRepoRoot();
+        var workflow = File.ReadAllText(Path.Combine(repoRoot, ".github", "workflows", "powerforge-github-content.yml"));
+
+        Assert.Contains("github-token:\n        required: false", Normalize(workflow), StringComparison.Ordinal);
+        Assert.Contains("github-token: ${{ secrets['github-token'] != '' && secrets['github-token'] || github.token }}", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("github_token", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Schema_AllowsEnvironmentBasedSponsorableLoginFallback()
     {
         var repoRoot = FindRepoRoot();


### PR DESCRIPTION
## Summary

- rename the optional reusable-workflow secret from GitHub's reserved `github_token` name to `github-token`
- preserve the built-in repository-token fallback
- update the public caller example and regression coverage

## Migration

Callers that provide a custom sponsorship token should pass it as `github-token`.

The current workflow is rejected before GitHub creates a job, so this restores workflow validation and downstream execution.