### PR TITLE
Honor ignored transitive module dependencies

### DIFF
--- a/Module/Docs/New-ConfigurationModuleSkip.md
+++ b/Module/Docs/New-ConfigurationModuleSkip.md
@@ -84,7 +84,7 @@ Accept wildcard characters: False
 ```
 
 ### -IgnoreModuleName
-Ignore module name(s) during missing-command validation.
+Ignore module name(s) during missing-command validation and transitive dependency resolution.
 
 ```yaml
 Type: String[]

--- a/Module/en-US/PSPublishModule-help.xml
+++ b/Module/en-US/PSPublishModule-help.xml
@@ -46481,7 +46481,7 @@ want selected missing modules or commands to be ignored. -Force keeps the legacy
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>IgnoreModuleName</maml:name>
           <maml:description>
-            <maml:para>Ignore module name(s) during missing-command validation.</maml:para>
+            <maml:para>Ignore module name(s) during missing-command validation and transitive dependency resolution.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
           <dev:type>
@@ -46532,7 +46532,7 @@ want selected missing modules or commands to be ignored. -Force keeps the legacy
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>IgnoreModuleName</maml:name>
         <maml:description>
-          <maml:para>Ignore module name(s) during missing-command validation.</maml:para>
+          <maml:para>Ignore module name(s) during missing-command validation and transitive dependency resolution.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
         <dev:type>

--- a/PSPublishModule/Cmdlets/NewConfigurationModuleSkipCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationModuleSkipCommand.cs
@@ -26,7 +26,7 @@ namespace PSPublishModule;
 [Cmdlet(VerbsCommon.New, "ConfigurationModuleSkip")]
 public sealed class NewConfigurationModuleSkipCommand : PSCmdlet
 {
-    /// <summary>Ignore module name(s) during missing-command validation.</summary>
+    /// <summary>Ignore module name(s) during missing-command validation and transitive dependency resolution.</summary>
     [Parameter] public string[]? IgnoreModuleName { get; set; }
 
     /// <summary>Ignore command/function name(s) during missing-command validation.</summary>

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
@@ -254,6 +254,7 @@ public sealed partial class ModulePipelineRunner
         IReadOnlyList<RequiredModuleDraft> requiredModules,
         IReadOnlyList<RequiredModuleDraft> requiredModulesForPackaging,
         IReadOnlyList<RequiredModuleDraft> embeddedModules,
+        IReadOnlyCollection<string> ignoredModules,
         bool resolveMissingModulesOnline,
         bool warnIfRequiredModulesOutdated,
         DependencyVersionSourceRepository? publishVersionSource,
@@ -266,6 +267,7 @@ public sealed partial class ModulePipelineRunner
                 requiredModules,
                 requiredModulesForPackaging,
                 embeddedModules,
+                ignoredModules,
                 resolveMissingModulesOnline,
                 warnIfRequiredModulesOutdated,
                 publishVersionSource))
@@ -369,6 +371,7 @@ public sealed partial class ModulePipelineRunner
         IReadOnlyList<RequiredModuleDraft> requiredModules,
         IReadOnlyList<RequiredModuleDraft> requiredModulesForPackaging,
         IReadOnlyList<RequiredModuleDraft> embeddedModules,
+        IReadOnlyCollection<string> ignoredModules,
         bool resolveMissingModulesOnline,
         bool warnIfRequiredModulesOutdated,
         DependencyVersionSourceRepository? publishVersionSource)
@@ -387,7 +390,7 @@ public sealed partial class ModulePipelineRunner
             return true;
         }
 
-        if (HasRepositoryPreferredTransitiveRequiredModules(drafts, publishVersionSource))
+        if (HasRepositoryPreferredTransitiveRequiredModules(drafts, ignoredModules, publishVersionSource))
             return true;
 
         return resolveMissingModulesOnline && HasOnlineResolvableAutoRequiredModules(drafts);
@@ -402,10 +405,12 @@ public sealed partial class ModulePipelineRunner
 
     private bool HasRepositoryPreferredTransitiveRequiredModules(
         IEnumerable<RequiredModuleDraft> drafts,
+        IReadOnlyCollection<string> ignoredModules,
         DependencyVersionSourceRepository? publishVersionSource)
     {
         var sourceDrafts = BuildRequiredModuleDraftMap(drafts ?? Array.Empty<RequiredModuleDraft>());
         var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var ignored = new HashSet<string>(NormalizeStringArray(ignoredModules), StringComparer.OrdinalIgnoreCase);
 
         foreach (var draft in sourceDrafts.Values)
         {
@@ -420,6 +425,7 @@ public sealed partial class ModulePipelineRunner
                     draft.ModuleName,
                     draft.VersionSource,
                     sourceDrafts,
+                    ignored,
                     publishVersionSource,
                     visited))
             {
@@ -434,6 +440,7 @@ public sealed partial class ModulePipelineRunner
         string moduleName,
         ModuleDependencyVersionSource inheritedVersionSource,
         IReadOnlyDictionary<string, RequiredModuleDraft> sourceDrafts,
+        IReadOnlyCollection<string> ignoredModules,
         DependencyVersionSourceRepository? publishVersionSource,
         HashSet<string> visited)
     {
@@ -451,6 +458,8 @@ public sealed partial class ModulePipelineRunner
                 continue;
 
             var depName = dep.ModuleName.Trim();
+            if (ignoredModules.Contains(depName))
+                continue;
             if (ModulePipelinePlanningHelpers.ShouldSkipTransitiveRequiredDependencyModule(depName))
                 continue;
 
@@ -465,6 +474,7 @@ public sealed partial class ModulePipelineRunner
                     depName,
                     childVersionSource,
                     sourceDrafts,
+                    ignoredModules,
                     publishVersionSource,
                     visited))
             {
@@ -494,6 +504,7 @@ public sealed partial class ModulePipelineRunner
             input.RequiredModules,
             input.RequiredModulesForPackaging,
             input.EmbeddedModules,
+            input.IgnoredModules,
             input.ResolveMissingModulesOnline,
             input.WarnIfRequiredModulesOutdated,
             input.PublishVersionSource);
@@ -675,6 +686,7 @@ public sealed partial class ModulePipelineRunner
             input.RequiredModules,
             input.RequiredModulesForPackaging,
             input.EmbeddedModules,
+            input.IgnoredModules,
             input.ResolveMissingModulesOnline,
             input.WarnIfRequiredModulesOutdated,
             input.PublishVersionSource,
@@ -695,6 +707,7 @@ public sealed partial class ModulePipelineRunner
         var requiredPackagingIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         var embeddedModulesDraft = new List<RequiredModuleDraft>();
         var embeddedIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var ignoredModules = new List<string>();
         var publishes = new List<ConfigurationPublishSegment>();
         var resolveMissingModulesOnline = false;
         var resolveMissingModulesOnlineSet = false;
@@ -766,6 +779,9 @@ public sealed partial class ModulePipelineRunner
                     }
                     break;
                 }
+                case ConfigurationModuleSkipSegment skip:
+                    ignoredModules.AddRange(skip.Configuration?.IgnoreModuleName ?? Array.Empty<string>());
+                    break;
                 case ConfigurationPublishSegment publish:
                     publishes.Add(publish);
                     break;
@@ -801,7 +817,8 @@ public sealed partial class ModulePipelineRunner
             refreshPsd1Only,
             requiredModulesDraft.ToArray(),
             requiredModulesDraftForPackaging.ToArray(),
-            embeddedModulesDraft.ToArray());
+            embeddedModulesDraft.ToArray(),
+            NormalizeStringArray(ignoredModules));
     }
 
     private static void AddOrReplaceRequiredModuleDraft(
@@ -835,7 +852,8 @@ public sealed partial class ModulePipelineRunner
             refreshPsd1Only: false,
             requiredModules: Array.Empty<RequiredModuleDraft>(),
             requiredModulesForPackaging: Array.Empty<RequiredModuleDraft>(),
-            embeddedModules: Array.Empty<RequiredModuleDraft>());
+            embeddedModules: Array.Empty<RequiredModuleDraft>(),
+            ignoredModules: Array.Empty<string>());
 
         public bool ResolveMissingModulesOnline { get; }
         public bool WarnIfRequiredModulesOutdated { get; }
@@ -848,6 +866,7 @@ public sealed partial class ModulePipelineRunner
         public RequiredModuleDraft[] RequiredModules { get; }
         public RequiredModuleDraft[] RequiredModulesForPackaging { get; }
         public RequiredModuleDraft[] EmbeddedModules { get; }
+        public string[] IgnoredModules { get; }
 
         public RequiredModulePreflightInput(
             bool resolveMissingModulesOnline,
@@ -860,7 +879,8 @@ public sealed partial class ModulePipelineRunner
             bool refreshPsd1Only,
             RequiredModuleDraft[] requiredModules,
             RequiredModuleDraft[] requiredModulesForPackaging,
-            RequiredModuleDraft[] embeddedModules)
+            RequiredModuleDraft[] embeddedModules,
+            string[] ignoredModules)
         {
             ResolveMissingModulesOnline = resolveMissingModulesOnline;
             WarnIfRequiredModulesOutdated = warnIfRequiredModulesOutdated;
@@ -873,6 +893,7 @@ public sealed partial class ModulePipelineRunner
             RequiredModules = requiredModules ?? Array.Empty<RequiredModuleDraft>();
             RequiredModulesForPackaging = requiredModulesForPackaging ?? Array.Empty<RequiredModuleDraft>();
             EmbeddedModules = embeddedModules ?? Array.Empty<RequiredModuleDraft>();
+            IgnoredModules = ignoredModules ?? Array.Empty<string>();
         }
     }
 

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.MergeAndTests.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.MergeAndTests.cs
@@ -53,7 +53,10 @@ public sealed partial class ModulePipelineRunner
         {
             var requiredModules = GetRequiredModuleNames(plan);
             var approvedModules = plan.ApprovedModules ?? Array.Empty<string>();
-            dependentRequiredModules = ResolveDependentRequiredModules(requiredModules, approvedModules);
+            dependentRequiredModules = ResolveDependentRequiredModules(
+                requiredModules,
+                approvedModules,
+                plan.ModuleSkip?.IgnoreModuleName ?? Array.Empty<string>());
 
             missingReport = AnalyzeMissingFunctions(analysisPath, analysisCode, plan);
             LogMergeSummary(plan, mergeInfo, missingReport, dependentRequiredModules);

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.MissingAnalysis.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.MissingAnalysis.cs
@@ -58,7 +58,10 @@ public sealed partial class ModulePipelineRunner
                 .Where(static module => module is not null && !string.IsNullOrWhiteSpace(module.ModuleName))
                 .Select(static module => module.ModuleName.Trim()),
             StringComparer.OrdinalIgnoreCase);
-        var dependentRequiredModules = dependentModules ?? ResolveDependentRequiredModules(requiredModules, approved);
+        var dependentRequiredModules = dependentModules ?? ResolveDependentRequiredModules(
+            requiredModules,
+            approved,
+            plan.ModuleSkip?.IgnoreModuleName ?? Array.Empty<string>());
         var dependent = new HashSet<string>(dependentRequiredModules, StringComparer.OrdinalIgnoreCase);
         var ignoreModules = new HashSet<string>(plan.ModuleSkip?.IgnoreModuleName ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
         var ignoreFunctions = new HashSet<string>(plan.ModuleSkip?.IgnoreFunctionName ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
@@ -398,10 +401,14 @@ public sealed partial class ModulePipelineRunner
             : $"{module.ModuleName} ({string.Join(", ", parts)})";
     }
 
-    private string[] ResolveDependentRequiredModules(IEnumerable<string> requiredModules, IReadOnlyCollection<string> approvedModules)
+    private string[] ResolveDependentRequiredModules(
+        IEnumerable<string> requiredModules,
+        IReadOnlyCollection<string> approvedModules,
+        IReadOnlyCollection<string> ignoredModules)
     {
         var deps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var ignored = new HashSet<string>(ignoredModules ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
 
         foreach (var module in requiredModules ?? Array.Empty<string>())
         {
@@ -410,13 +417,17 @@ public sealed partial class ModulePipelineRunner
             if (approvedModules is not null && approvedModules.Contains(module))
                 continue;
 
-            CollectModuleDependencies(module, visited, deps);
+            CollectModuleDependencies(module, ignored, visited, deps);
         }
 
         return deps.ToArray();
     }
 
-    private void CollectModuleDependencies(string moduleName, HashSet<string> visited, HashSet<string> output)
+    private void CollectModuleDependencies(
+        string moduleName,
+        IReadOnlyCollection<string> ignoredModules,
+        HashSet<string> visited,
+        HashSet<string> output)
     {
         if (string.IsNullOrWhiteSpace(moduleName))
             return;
@@ -430,8 +441,10 @@ public sealed partial class ModulePipelineRunner
             if (string.IsNullOrWhiteSpace(depName))
                 continue;
             var normalizedDepName = depName!.Trim();
+            if (ignoredModules.Contains(normalizedDepName))
+                continue;
             if (output.Add(normalizedDepName))
-                CollectModuleDependencies(normalizedDepName, visited, output);
+                CollectModuleDependencies(normalizedDepName, ignoredModules, visited, output);
         }
     }
 

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -800,6 +800,7 @@ public sealed partial class ModulePipelineRunner
             ResolveDependencyVersionSourcePublishes(gateMode, publishes));
 
         var approved = NormalizeApprovedModules(approvedModules);
+        var ignoredModules = NormalizeStringArray(moduleSkipIgnoreModules);
         ApplyMergeDefaultsForPlan(
             refreshPsd1Only,
             csproj,
@@ -813,6 +814,7 @@ public sealed partial class ModulePipelineRunner
             requiredModulesDraft,
             requiredModulesDraftForPackaging,
             approved,
+            ignoredModules,
             mergeMissing,
             importModules,
             compatible,
@@ -842,6 +844,7 @@ public sealed partial class ModulePipelineRunner
             embeddedModules,
             embeddedRoots,
             embeddedSourceDrafts,
+            ignoredModules,
             resolveMissingModulesOnline,
             warnIfRequiredModulesOutdated,
             installMissingModulesPrerelease,
@@ -868,11 +871,7 @@ public sealed partial class ModulePipelineRunner
             {
                 Force = moduleSkipForce,
                 FailOnMissingCommands = moduleSkipFailOnMissingCommands,
-                IgnoreModuleName = moduleSkipIgnoreModules
-                    .Where(s => !string.IsNullOrWhiteSpace(s))
-                    .Select(s => s.Trim())
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .ToArray(),
+                IgnoreModuleName = ignoredModules,
                 IgnoreFunctionName = moduleSkipIgnoreFunctions
                     .Where(s => !string.IsNullOrWhiteSpace(s))
                     .Select(s => s.Trim())

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.RequiredModules.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.RequiredModules.cs
@@ -144,6 +144,7 @@ public sealed partial class ModulePipelineRunner
         IReadOnlyList<RequiredModuleDraft> requiredModulesDraft,
         IReadOnlyList<RequiredModuleDraft> requiredModulesDraftForPackaging,
         string[] approved,
+        IReadOnlyCollection<string> ignoredModules,
         bool mergeMissing,
         ImportModulesConfiguration? importModules,
         string[] compatible,
@@ -174,6 +175,7 @@ public sealed partial class ModulePipelineRunner
                 requiredModules,
                 approvedRequiredRoots,
                 requiredSourceDrafts,
+                ignoredModules,
                 resolveMissingModulesOnline,
                 warnIfRequiredModulesOutdated,
                 prerelease,
@@ -205,6 +207,7 @@ public sealed partial class ModulePipelineRunner
             requiredModulesForPackaging,
             requiredPackagingRoots,
             requiredPackagingSourceDrafts,
+            ignoredModules,
             resolveMissingModulesOnline,
             warnIfRequiredModulesOutdated,
             prerelease,
@@ -225,6 +228,7 @@ public sealed partial class ModulePipelineRunner
         RequiredModuleReference[] modules,
         IEnumerable<string> rootModules,
         IReadOnlyDictionary<string, RequiredModuleDraft> sourceDrafts,
+        IReadOnlyCollection<string> ignoredModules,
         bool resolveMissingModulesOnline,
         bool warnIfRequiredModulesOutdated,
         bool prerelease,
@@ -242,6 +246,7 @@ public sealed partial class ModulePipelineRunner
         var discovered = new List<(RequiredModuleReference Reference, ModuleDependencyVersionSource VersionSource)>();
         var discoveredIndex = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var ignored = new HashSet<string>(ignoredModules ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
 
         var rootsByName = output
             .GroupBy(static module => module.ModuleName!, StringComparer.OrdinalIgnoreCase)
@@ -253,7 +258,7 @@ public sealed partial class ModulePipelineRunner
             var rootReference = rootsByName.TryGetValue(root, out var resolvedRoot)
                 ? resolvedRoot
                 : new RequiredModuleReference(root);
-            CollectTransitiveRequiredModules(rootReference, source, sourceDrafts, known, discoveredIndex, visited, discovered);
+            CollectTransitiveRequiredModules(rootReference, source, sourceDrafts, ignored, known, discoveredIndex, visited, discovered);
         }
 
         if (discovered.Count == 0)
@@ -318,6 +323,7 @@ public sealed partial class ModulePipelineRunner
         RequiredModuleReference module,
         ModuleDependencyVersionSource inheritedVersionSource,
         IReadOnlyDictionary<string, RequiredModuleDraft> sourceDrafts,
+        IReadOnlyCollection<string> ignoredModules,
         HashSet<string> known,
         HashSet<string> discoveredIndex,
         HashSet<string> visited,
@@ -336,6 +342,8 @@ public sealed partial class ModulePipelineRunner
                 continue;
 
             var depName = dep.ModuleName.Trim();
+            if (ignoredModules.Contains(depName))
+                continue;
             if (ModulePipelinePlanningHelpers.ShouldSkipTransitiveRequiredDependencyModule(depName))
                 continue;
 
@@ -352,7 +360,7 @@ public sealed partial class ModulePipelineRunner
                     childVersionSource));
             }
 
-            CollectTransitiveRequiredModules(dep, childVersionSource, sourceDrafts, known, discoveredIndex, visited, discovered);
+            CollectTransitiveRequiredModules(dep, childVersionSource, sourceDrafts, ignoredModules, known, discoveredIndex, visited, discovered);
         }
     }
 

--- a/PowerForge.Tests/ModulePipelineDependencyMetadataProviderTests.cs
+++ b/PowerForge.Tests/ModulePipelineDependencyMetadataProviderTests.cs
@@ -569,11 +569,12 @@ public sealed class ModulePipelineDependencyMetadataProviderTests
 
         var dependencies = (string[])method!.Invoke(
             runner,
-            new object?[]
-            {
-                new[] { "Alpha.Tools" },
-                Array.Empty<string>()
-            })!;
+                new object?[]
+                {
+                    new[] { "Alpha.Tools" },
+                    Array.Empty<string>(),
+                    Array.Empty<string>()
+                })!;
 
         Assert.Equal(3, dependencies.Length);
         Assert.Contains("Beta.Tools", dependencies);
@@ -618,6 +619,156 @@ public sealed class ModulePipelineDependencyMetadataProviderTests
             var child = Assert.Single(requiredModules, module => string.Equals(module.ModuleName, "Child.Tools", StringComparison.OrdinalIgnoreCase));
             Assert.Equal("2.0.0", child.ModuleVersion);
             Assert.Equal("22222222-2222-2222-2222-222222222222", child.Guid);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Run_DoesNotPreserveIgnoredTransitiveDependency_WhenApprovedModuleIsMergedAway()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var provider = new FakeModuleDependencyMetadataProvider(
+                installedModules: new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = new("Parent.Tools", "1.0.0", null, @"C:\Modules\Parent.Tools\1.0.0")
+                },
+                onlineModules: new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase),
+                installedRequiredModules: new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = new[]
+                    {
+                        new RequiredModuleReference("ActiveDirectory")
+                    }
+                });
+
+            var spec = CreateApprovedParentSpec(root.FullName, moduleName, ModuleDependencyVersionSource.PSGallery);
+            spec.Segments = spec.Segments
+                .Concat(new IConfigurationSegment[]
+                {
+                    new ConfigurationModuleSkipSegment
+                    {
+                        Configuration = new ModuleSkipConfiguration
+                        {
+                            IgnoreModuleName = new[] { " activedirectory " }
+                        }
+                    }
+                })
+                .ToArray();
+
+            var logger = new CollectingLogger();
+            var result = new ModulePipelineRunner(logger, new ThrowingPowerShellRunner(), provider).Run(spec);
+
+            Assert.True(ManifestEditor.TryGetRequiredModules(result.BuildResult.ManifestPath, out RequiredModuleReference[]? required));
+            Assert.DoesNotContain(required!, module => string.Equals(module.ModuleName, "Parent.Tools", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(required!, module => string.Equals(module.ModuleName, "ActiveDirectory", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(logger.Infos, message => message.Contains("ActiveDirectory", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(provider.OnlineLookupNames, name => string.Equals(name, "ActiveDirectory", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_ExcludesIgnoredTransitiveDependencyFromPackagingAndEmbeddedModules()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var provider = new FakeModuleDependencyMetadataProvider(
+                installedModules: new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase),
+                onlineModules: new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase),
+                installedRequiredModules: new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = new[] { new RequiredModuleReference("ActiveDirectory", moduleVersion: "1.0.1.0") }
+                });
+            var skip = new ConfigurationModuleSkipSegment
+            {
+                Configuration = new ModuleSkipConfiguration
+                {
+                    IgnoreModuleName = new[] { " ActiveDirectory " }
+                }
+            };
+
+            var requiredSpec = CreateRequiredParentSpec(root.FullName, moduleName, ModuleDependencyVersionSource.Auto);
+            requiredSpec.Segments = requiredSpec.Segments.Concat(new IConfigurationSegment[] { skip }).ToArray();
+            var requiredPlan = new ModulePipelineRunner(new NullLogger(), new ThrowingPowerShellRunner(), provider).Plan(requiredSpec);
+
+            Assert.Contains(requiredPlan.RequiredModulesForPackaging, module => string.Equals(module.ModuleName, "Parent.Tools", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(requiredPlan.RequiredModulesForPackaging, module => string.Equals(module.ModuleName, "ActiveDirectory", StringComparison.OrdinalIgnoreCase));
+
+            var embeddedSpec = CreateEmbeddedParentSpec(root.FullName, moduleName, ModuleDependencyVersionSource.Auto);
+            embeddedSpec.Segments = embeddedSpec.Segments.Concat(new IConfigurationSegment[] { skip }).ToArray();
+            var embeddedPlan = new ModulePipelineRunner(new NullLogger(), new ThrowingPowerShellRunner(), provider).Plan(embeddedSpec);
+
+            Assert.Equal(new[] { "Parent.Tools" }, embeddedPlan.EmbeddedModules.Select(static module => module.ModuleName));
+            Assert.DoesNotContain(provider.OnlineLookupNames, name => string.Equals(name, "ActiveDirectory", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_PreservesExplicitRequiredRoot_WhenSameModuleIsIgnoredAsTransitiveDependency()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var provider = new FakeModuleDependencyMetadataProvider(
+                installedModules: new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = new("Parent.Tools", "1.0.0", null, @"C:\Modules\Parent.Tools\1.0.0"),
+                    ["ActiveDirectory"] = new("ActiveDirectory", "1.0.1.0", null, @"C:\Windows\System32\WindowsPowerShell\v1.0\Modules\ActiveDirectory")
+                },
+                onlineModules: new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase),
+                installedRequiredModules: new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = new[] { new RequiredModuleReference("ActiveDirectory", moduleVersion: "1.0.1.0") }
+                });
+
+            var spec = CreateRequiredParentSpec(root.FullName, moduleName, ModuleDependencyVersionSource.Auto);
+            spec.Segments = spec.Segments.Concat(new IConfigurationSegment[]
+            {
+                new ConfigurationModuleSegment
+                {
+                    Kind = ModuleDependencyKind.RequiredModule,
+                    Configuration = new ModuleDependencyConfiguration
+                    {
+                        ModuleName = "ActiveDirectory",
+                        ModuleVersion = "1.0.1.0",
+                        VersionSource = ModuleDependencyVersionSource.Installed
+                    }
+                },
+                new ConfigurationModuleSkipSegment
+                {
+                    Configuration = new ModuleSkipConfiguration
+                    {
+                        IgnoreModuleName = new[] { "ActiveDirectory" }
+                    }
+                }
+            }).ToArray();
+
+            var plan = new ModulePipelineRunner(new NullLogger(), new ThrowingPowerShellRunner(), provider).Plan(spec);
+
+            Assert.Contains(plan.RequiredModules, module => string.Equals(module.ModuleName, "ActiveDirectory", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(plan.RequiredModulesForPackaging, module => string.Equals(module.ModuleName, "ActiveDirectory", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {
@@ -1046,9 +1197,12 @@ public sealed class ModulePipelineDependencyMetadataProviderTests
             }
         };
 
-    private static ModulePipelineSpec CreateApprovedParentSpec(string sourcePath, string moduleName)
+    private static ModulePipelineSpec CreateApprovedParentSpec(
+        string sourcePath,
+        string moduleName,
+        ModuleDependencyVersionSource versionSource = ModuleDependencyVersionSource.Auto)
     {
-        var spec = CreateRequiredParentSpec(sourcePath, moduleName, ModuleDependencyVersionSource.Auto);
+        var spec = CreateRequiredParentSpec(sourcePath, moduleName, versionSource);
         spec.Segments = spec.Segments
             .Concat(new IConfigurationSegment[]
             {
@@ -1197,6 +1351,7 @@ public sealed class Marker
         internal int OnlineLookups { get; private set; }
         internal int RequiredModuleLookups { get; private set; }
         internal List<RequiredModuleReference> RequiredModuleReferenceLookups { get; } = new();
+        internal List<string> OnlineLookupNames { get; } = new();
         internal string? LastOnlineRepository { get; private set; }
 
         internal FakeModuleDependencyMetadataProvider(
@@ -1254,6 +1409,7 @@ public sealed class Marker
             bool prerelease)
         {
             OnlineLookups++;
+            OnlineLookupNames.AddRange(names ?? Array.Empty<string>());
             LastOnlineRepository = repository;
             var result = new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase);
             foreach (var name in names ?? Array.Empty<string>())

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -1383,6 +1383,79 @@ public sealed class ModulePipelineHostedOperationsTests
     }
 
     [Fact]
+    public void RunPreflight_DoesNotInstallPSResourceGetForIgnoredRepositorySourcedTransitiveMetadata()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildSegment
+                    {
+                        BuildModule = new BuildModuleConfiguration
+                        {
+                            ResolveMissingModulesOnline = false
+                        }
+                    },
+                    new ConfigurationModuleSegment
+                    {
+                        Kind = ModuleDependencyKind.RequiredModule,
+                        Configuration = new ModuleDependencyConfiguration
+                        {
+                            ModuleName = "Parent.Tools",
+                            ModuleVersion = "1.0.0",
+                            Guid = "11111111-1111-1111-1111-111111111111",
+                            VersionSource = ModuleDependencyVersionSource.PSGallery
+                        }
+                    },
+                    new ConfigurationModuleSkipSegment
+                    {
+                        Configuration = new ModuleSkipConfiguration
+                        {
+                            IgnoreModuleName = new[] { " child.tools " }
+                        }
+                    }
+                }
+            };
+            var hostedOperations = new FakeHostedOperations();
+            var provider = new FakeMetadataProvider(
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+                new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = new[]
+                    {
+                        new RequiredModuleReference("Child.Tools")
+                    }
+                });
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                provider,
+                hostedOperations);
+
+            InvokeEnsureRequiredModuleOnlineResolutionToolInstalledIfNeededForRun(runner, spec);
+
+            Assert.Equal(0, hostedOperations.DependencyInstallCalls);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void RunPreflight_InstallsPSResourceGetForRepositorySourcedEmbeddedTransitiveMetadata()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge/Models/Configuration/ConfigurationMiscSegments.cs
+++ b/PowerForge/Models/Configuration/ConfigurationMiscSegments.cs
@@ -103,7 +103,7 @@ public sealed class ConfigurationModuleSkipSegment : IConfigurationSegment
 /// </summary>
 public sealed class ModuleSkipConfiguration
 {
-    /// <summary>Ignore module name(s) during missing-command validation.</summary>
+    /// <summary>Ignore module name(s) during missing-command validation and transitive dependency resolution.</summary>
     public string[]? IgnoreModuleName { get; set; }
 
     /// <summary>Ignore command/function name(s) during missing-command validation.</summary>


### PR DESCRIPTION
## Summary

- honor `IgnoreModuleName` while resolving transitive dependencies for manifest output, packaging, embedding, merge summaries, and preflight checks
- normalize ignored module names consistently while preserving explicitly declared required-module roots
- document that ignored names apply to discovered transitive dependencies

## Validation

- focused dependency and preflight tests: 25 passed
- documentation and configuration contract tests: 47 passed
- EFLegacyReporting integration build omitted ActiveDirectory from the final artifact manifest while retaining its RSAT runtime requirement