### PR TITLE
Harden hardware certificate signing across PowerShell hosts

### DIFF
--- a/Module/Docs/Readme.md
+++ b/Module/Docs/Readme.md
@@ -2,7 +2,7 @@
 Module Name: PSPublishModule
 Module Guid: eb76426a-1992-40a5-82cd-6480f883ef4d
 Download Help Link: https://github.com/EvotecIT/PSPublishModule
-Help Version: 3.0.103
+Help Version: 3.0.104
 Locale: en-US
 ---
 # PSPublishModule Module

--- a/Module/PSPublishModule.psd1
+++ b/Module/PSPublishModule.psd1
@@ -9,7 +9,7 @@
     DotNetFrameworkVersion = '4.5.2'
     FunctionsToExport      = @()
     GUID                   = 'eb76426a-1992-40a5-82cd-6480f883ef4d'
-    ModuleVersion          = '3.0.103'
+    ModuleVersion          = '3.0.104'
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{

--- a/PSPublishModule/packages.lock.json
+++ b/PSPublishModule/packages.lock.json
@@ -278,7 +278,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.5.ReferenceAssemblies": "[1.1.0, )",
-          "PowerForge": "[3.0.103, )",
+          "PowerForge": "[3.0.104, )",
           "System.Security.Cryptography.Xml": "[10.0.10, )",
           "System.Text.Json": "[10.0.10, )"
         }
@@ -1063,7 +1063,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.6.4, )",
-          "PowerForge": "[3.0.103, )",
+          "PowerForge": "[3.0.104, )",
           "System.Security.Cryptography.Xml": "[10.0.10, )"
         }
       }
@@ -1807,7 +1807,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.4.18, )",
-          "PowerForge": "[3.0.103, )",
+          "PowerForge": "[3.0.104, )",
           "System.Security.Cryptography.Xml": "[10.0.10, )"
         }
       }

--- a/PowerForge.Blazor/PowerForge.Blazor.csproj
+++ b/PowerForge.Blazor/PowerForge.Blazor.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>3.0.103</VersionPrefix>
+    <VersionPrefix>3.0.104</VersionPrefix>
 
     <!-- Package metadata -->
     <PackageId>PowerForge.Blazor</PackageId>

--- a/PowerForge.Cli/PowerForge.Cli.csproj
+++ b/PowerForge.Cli/PowerForge.Cli.csproj
@@ -11,7 +11,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>powerforge</ToolCommandName>
     <Description>PowerForge command-line interface for building and publishing PowerShell modules.</Description>
-    <VersionPrefix>3.0.103</VersionPrefix>
+    <VersionPrefix>3.0.104</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Przemyslaw Klys</Authors>
     <Company>Evotec Services sp. z o.o.</Company>

--- a/PowerForge.Cli/packages.lock.json
+++ b/PowerForge.Cli/packages.lock.json
@@ -732,7 +732,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.6.4, )",
-          "PowerForge": "[3.0.103, )",
+          "PowerForge": "[3.0.104, )",
           "System.Security.Cryptography.Xml": "[10.0.10, )"
         }
       }
@@ -1428,7 +1428,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.4.18, )",
-          "PowerForge": "[3.0.103, )",
+          "PowerForge": "[3.0.104, )",
           "System.Security.Cryptography.Xml": "[10.0.10, )"
         }
       }

--- a/PowerForge.Net472SmokeTests/packages.lock.json
+++ b/PowerForge.Net472SmokeTests/packages.lock.json
@@ -260,7 +260,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.5.ReferenceAssemblies": "[1.1.0, )",
-          "PowerForge": "[3.0.103, )",
+          "PowerForge": "[3.0.104, )",
           "System.Security.Cryptography.Xml": "[10.0.10, )",
           "System.Text.Json": "[10.0.10, )"
         }

--- a/PowerForge.PowerShell/PowerForge.PowerShell.csproj
+++ b/PowerForge.PowerShell/PowerForge.PowerShell.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsAsErrors>CS1591</WarningsAsErrors>
-    <VersionPrefix>3.0.103</VersionPrefix>
+    <VersionPrefix>3.0.104</VersionPrefix>
     <PackageId>PowerForge.PowerShell</PackageId>
     <Description>PowerForge PowerShell-hosted module pipeline services.</Description>
     <AssemblyName>PowerForge.PowerShell</AssemblyName>

--- a/PowerForge.PowerShell/Services/PowerShellModulePipelineHostedOperations.cs
+++ b/PowerForge.PowerShell/Services/PowerShellModulePipelineHostedOperations.cs
@@ -12,11 +12,18 @@ internal sealed class PowerShellModulePipelineHostedOperations :
 {
     private readonly IPowerShellRunner _runner;
     private readonly ILogger _logger;
+    private readonly bool _isWindows;
 
     internal PowerShellModulePipelineHostedOperations(IPowerShellRunner runner, ILogger logger)
+        : this(runner, logger, Path.DirectorySeparatorChar == '\\')
+    {
+    }
+
+    internal PowerShellModulePipelineHostedOperations(IPowerShellRunner runner, ILogger logger, bool isWindows)
     {
         _runner = runner ?? throw new ArgumentNullException(nameof(runner));
         _logger = logger ?? new NullLogger();
+        _isWindows = isWindows;
     }
 
     internal PowerShellModulePipelineHostedOperations(ILogger logger)
@@ -246,6 +253,7 @@ internal sealed class PowerShellModulePipelineHostedOperations :
         SigningOptionsConfiguration signing)
     {
         var packageFileListPath = WriteTemporaryLineFile(packageFilePaths);
+        var temporaryPackageFileLists = new List<string> { packageFileListPath };
         var args = new List<string>(9)
         {
             rootPath,
@@ -261,24 +269,72 @@ internal sealed class PowerShellModulePipelineHostedOperations :
 
         var script = EmbeddedScripts.Load("Scripts/Signing/Sign-Module.ps1");
         PowerShellRunResult result;
+        ModuleSigningResult? summary;
+        ModuleSigningResult? attemptSummary;
+        PowerShellRunResult? initialFailedResult = null;
+        ModuleSigningResult? initialFailedSummary = null;
         try
         {
             result = RunScript(script, args, TimeSpan.FromMinutes(10), preferPwsh: true);
+            attemptSummary = TryExtractSigningSummary(result.StdOut);
+            summary = attemptSummary;
+
+            if (TryGetWindowsPowerShellRetryFiles(
+                    result,
+                    attemptSummary,
+                    signing,
+                    rootPath,
+                    packageFilePaths,
+                    out var retryFilePaths))
+            {
+                initialFailedResult = result;
+                initialFailedSummary = summary;
+                _logger.Warn(
+                    $"Authenticode signing with '{DescribePowerShellHost(result.Executable)}' returned a retryable provider result for every failed file. " +
+                    "Retrying once with Windows PowerShell preferred for compatibility with the Windows certificate provider.");
+
+                var retryPackageFileListPath = WriteTemporaryLineFile(retryFilePaths);
+                temporaryPackageFileLists.Add(retryPackageFileListPath);
+                var retryArgs = args.ToArray();
+                retryArgs[1] = retryPackageFileListPath;
+                retryArgs[8] = "1";
+
+                result = RunScript(script, retryArgs, TimeSpan.FromMinutes(10), preferPwsh: false);
+                attemptSummary = TryExtractSigningSummary(result.StdOut);
+                if (attemptSummary is null && result.ExitCode == 0)
+                {
+                    attemptSummary = new ModuleSigningResult
+                    {
+                        Attempted = retryFilePaths.Length,
+                        SignedNew = ParseSignedCount(result.StdOut)
+                    };
+                }
+
+                summary = attemptSummary is null
+                    ? initialFailedSummary
+                    : MergeSigningRetrySummaries(initialFailedSummary!, attemptSummary);
+            }
         }
         finally
         {
-            try { File.Delete(packageFileListPath); } catch { /* best effort */ }
+            foreach (var path in temporaryPackageFileLists)
+            {
+                try { File.Delete(path); } catch { /* best effort */ }
+            }
         }
-        var summary = TryExtractSigningSummary(result.StdOut);
 
-        if (result.ExitCode != 0 || (summary?.Failed ?? 0) > 0)
+        if (result.ExitCode != 0 || (attemptSummary?.Failed ?? 0) > 0)
         {
-            var message = TryExtractSigningError(result.StdOut) ?? result.StdErr;
-            var extra = summary is null ? string.Empty : $" {FormatSigningSummary(summary)}";
-            var full = $"Signing failed (exit {result.ExitCode}). {message}{extra}".Trim();
+            var full = FormatSigningFailure(result, attemptSummary);
+            if (initialFailedResult is not null)
+            {
+                full = $"Signing failed after the Windows PowerShell compatibility retry. " +
+                       $"Initial attempt: {FormatSigningFailure(initialFailedResult, initialFailedSummary)} " +
+                       $"Retry: {full}";
+                LogSigningDiagnostics(initialFailedResult);
+            }
 
-            if (_logger.IsVerbose && !string.IsNullOrWhiteSpace(result.StdOut)) _logger.Verbose(result.StdOut.Trim());
-            if (_logger.IsVerbose && !string.IsNullOrWhiteSpace(result.StdErr)) _logger.Verbose(result.StdErr.Trim());
+            LogSigningDiagnostics(result);
 
             throw new ModuleSigningException(full, summary);
         }
@@ -288,6 +344,9 @@ internal sealed class PowerShellModulePipelineHostedOperations :
             Attempted = ParseSignedCount(result.StdOut),
             SignedNew = ParseSignedCount(result.StdOut)
         };
+
+        _logger.Verbose(
+            $"Authenticode signing for '{moduleName}' used '{DescribePowerShellHost(result.Executable)}'.");
 
         if (summary.SignedTotal > 0)
         {
@@ -304,6 +363,92 @@ internal sealed class PowerShellModulePipelineHostedOperations :
 
         return summary;
     }
+
+    private bool TryGetWindowsPowerShellRetryFiles(
+        PowerShellRunResult result,
+        ModuleSigningResult? summary,
+        SigningOptionsConfiguration signing,
+        string rootPath,
+        IReadOnlyList<string> packageFilePaths,
+        out string[] retryFilePaths)
+    {
+        retryFilePaths = Array.Empty<string>();
+        if (!_isWindows || summary is null || summary.Failed <= 0 || summary.UnknownError + summary.SigningException != summary.Failed)
+            return false;
+        if (string.IsNullOrWhiteSpace(signing.CertificateThumbprint))
+            return false;
+        if (!string.IsNullOrWhiteSpace(signing.CertificatePFXPath) || !string.IsNullOrWhiteSpace(signing.CertificatePFXBase64))
+            return false;
+
+        if (!string.Equals(
+                Path.GetFileNameWithoutExtension(result.Executable),
+                "pwsh",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (summary.FailedFilePaths is not { } failedFilePaths || failedFilePaths.Length != summary.Failed)
+            return false;
+
+        try
+        {
+            var packageSet = new HashSet<string>(
+                packageFilePaths
+                    .Where(static path => !string.IsNullOrWhiteSpace(path))
+                    .Select(path => Path.GetFullPath(Path.IsPathRooted(path) ? path : Path.Combine(rootPath, path))),
+                StringComparer.OrdinalIgnoreCase);
+            retryFilePaths = failedFilePaths
+                .Where(static path => !string.IsNullOrWhiteSpace(path))
+                .Select(Path.GetFullPath)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            return retryFilePaths.Length == summary.Failed && retryFilePaths.All(packageSet.Contains);
+        }
+        catch
+        {
+            retryFilePaths = Array.Empty<string>();
+            return false;
+        }
+    }
+
+    private static ModuleSigningResult MergeSigningRetrySummaries(
+        ModuleSigningResult initial,
+        ModuleSigningResult retry)
+        => new()
+        {
+            TotalMatched = initial.TotalMatched,
+            TotalAfterExclude = initial.TotalAfterExclude,
+            AlreadySignedByThisCert = initial.AlreadySignedByThisCert,
+            AlreadySignedOther = initial.AlreadySignedOther,
+            Attempted = initial.Attempted,
+            SignedNew = initial.SignedNew + retry.SignedNew,
+            Resigned = initial.Resigned + retry.Resigned,
+            Failed = retry.Failed,
+            UnknownError = retry.UnknownError,
+            SigningException = retry.SigningException,
+            CertificateThumbprint = retry.CertificateThumbprint ?? initial.CertificateThumbprint,
+            FailedFiles = retry.FailedFiles ?? Array.Empty<string>(),
+            FailedFilePaths = retry.FailedFilePaths ?? Array.Empty<string>()
+        };
+
+    private void LogSigningDiagnostics(PowerShellRunResult result)
+    {
+        if (!_logger.IsVerbose) return;
+        if (!string.IsNullOrWhiteSpace(result.StdOut)) _logger.Verbose(result.StdOut.Trim());
+        if (!string.IsNullOrWhiteSpace(result.StdErr)) _logger.Verbose(result.StdErr.Trim());
+    }
+
+    private static string FormatSigningFailure(PowerShellRunResult result, ModuleSigningResult? summary)
+    {
+        var message = TryExtractSigningError(result.StdOut) ?? result.StdErr;
+        var extra = summary is null ? string.Empty : $" {FormatSigningSummary(summary)}";
+        return $"Signing failed using '{DescribePowerShellHost(result.Executable)}' (exit {result.ExitCode}). {message}{extra}".Trim();
+    }
+
+    private static string DescribePowerShellHost(string? executable)
+        => string.IsNullOrWhiteSpace(executable) ? "unknown PowerShell host" : Path.GetFileName(executable);
 
     private static string WriteTemporaryLineFile(IEnumerable<string> lines)
     {

--- a/PowerForge.PowerShell/Services/PowerShellModulePipelineHostedOperations.cs
+++ b/PowerForge.PowerShell/Services/PowerShellModulePipelineHostedOperations.cs
@@ -373,7 +373,8 @@ internal sealed class PowerShellModulePipelineHostedOperations :
         out string[] retryFilePaths)
     {
         retryFilePaths = Array.Empty<string>();
-        if (!_isWindows || summary is null || summary.Failed <= 0 || summary.UnknownError + summary.SigningException != summary.Failed)
+        if (!_isWindows || summary is null || summary.Failed <= 0 || summary.PrecheckFailure > 0 ||
+            summary.UnknownError + summary.SigningException != summary.Failed)
             return false;
         if (string.IsNullOrWhiteSpace(signing.CertificateThumbprint))
             return false;
@@ -426,6 +427,7 @@ internal sealed class PowerShellModulePipelineHostedOperations :
             SignedNew = initial.SignedNew + retry.SignedNew,
             Resigned = initial.Resigned + retry.Resigned,
             Failed = retry.Failed,
+            PrecheckFailure = retry.PrecheckFailure,
             UnknownError = retry.UnknownError,
             SigningException = retry.SigningException,
             CertificateThumbprint = retry.CertificateThumbprint ?? initial.CertificateThumbprint,

--- a/PowerForge.PowerShell/Services/PowerShellModulePipelineHostedOperations.cs
+++ b/PowerForge.PowerShell/Services/PowerShellModulePipelineHostedOperations.cs
@@ -299,7 +299,12 @@ internal sealed class PowerShellModulePipelineHostedOperations :
                 retryArgs[1] = retryPackageFileListPath;
                 retryArgs[8] = "1";
 
-                result = RunScript(script, retryArgs, TimeSpan.FromMinutes(10), preferPwsh: false);
+                result = RunScript(
+                    script,
+                    retryArgs,
+                    TimeSpan.FromMinutes(10),
+                    preferPwsh: false,
+                    hostRequirement: PowerShellHostRequirement.WindowsPowerShell);
                 attemptSummary = TryExtractSigningSummary(result.StdOut);
                 if (attemptSummary is null && result.ExitCode == 0)
                 {
@@ -477,7 +482,12 @@ internal sealed class PowerShellModulePipelineHostedOperations :
         return Convert.ToBase64String(Encoding.UTF8.GetBytes(json));
     }
 
-    private PowerShellRunResult RunScript(string scriptText, IReadOnlyList<string> args, TimeSpan timeout, bool preferPwsh)
+    private PowerShellRunResult RunScript(
+        string scriptText,
+        IReadOnlyList<string> args,
+        TimeSpan timeout,
+        bool preferPwsh,
+        PowerShellHostRequirement hostRequirement = PowerShellHostRequirement.Any)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), "PowerForge", "modulepipeline");
         Directory.CreateDirectory(tempDir);
@@ -485,7 +495,9 @@ internal sealed class PowerShellModulePipelineHostedOperations :
         File.WriteAllText(scriptPath, scriptText, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
         try
         {
-            return _runner.Run(new PowerShellRunRequest(scriptPath, args, timeout, preferPwsh));
+            return _runner.Run(hostRequirement == PowerShellHostRequirement.Any
+                ? new PowerShellRunRequest(scriptPath, args, timeout, preferPwsh)
+                : new PowerShellRunRequest(scriptPath, args, timeout, preferPwsh, hostRequirement));
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -2209,6 +2209,7 @@ public sealed class ModulePipelineHostedOperationsTests
         Assert.Equal(2, requests.Count);
         Assert.True(requests[0].PreferPwsh);
         Assert.False(requests[1].PreferPwsh);
+        Assert.Equal(PowerShellHostRequirement.WindowsPowerShell, requests[1].HostRequirement);
         Assert.Equal("0", requests[0].Arguments[8]);
         Assert.Equal("1", requests[1].Arguments[8]);
         Assert.Equal(new[] { manifestPath, modulePath }, requestedPackageFiles[0]);
@@ -2259,6 +2260,7 @@ public sealed class ModulePipelineHostedOperationsTests
 
         Assert.Equal(2, requests.Count);
         Assert.False(requests[1].PreferPwsh);
+        Assert.Equal(PowerShellHostRequirement.WindowsPowerShell, requests[1].HostRequirement);
         Assert.Equal("1", requests[1].Arguments[8]);
         Assert.Equal(1, result.SignedNew);
     }

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -2157,6 +2157,267 @@ public sealed class ModulePipelineHostedOperationsTests
     }
 
     [Fact]
+    public void SignModuleOutput_RetriesStoreCertificateUnknownErrorsWithWindowsPowerShell()
+    {
+        var requests = new List<PowerShellRunRequest>();
+        var requestedPackageFiles = new List<string[]>();
+        var rootPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        var manifestPath = Path.Combine(rootPath, "TestModule.psd1");
+        var modulePath = Path.Combine(rootPath, "TestModule.psm1");
+        var failedSummary = new ModuleSigningResult
+        {
+            TotalMatched = 2,
+            TotalAfterExclude = 2,
+            Attempted = 2,
+            SignedNew = 1,
+            Failed = 1,
+            UnknownError = 1,
+            FailedFiles = new[]
+            {
+                $"{modulePath} :: signing returned status UnknownError"
+            },
+            FailedFilePaths = new[]
+            {
+                modulePath
+            }
+        };
+        var successSummary = new ModuleSigningResult
+        {
+            TotalMatched = 1,
+            TotalAfterExclude = 1,
+            Attempted = 1,
+            SignedNew = 1
+        };
+        var runner = new RecordingPowerShellRunner(request =>
+        {
+            requests.Add(request);
+            requestedPackageFiles.Add(File.ReadAllLines(request.Arguments[1]));
+            return requests.Count == 1
+                ? new PowerShellRunResult(2, EncodeSigningSummary(failedSummary), string.Empty, "pwsh.exe")
+                : new PowerShellRunResult(0, EncodeSigningSummary(successSummary), string.Empty, "powershell.exe");
+        });
+
+        var operations = new PowerShellModulePipelineHostedOperations(runner, new NullLogger(), isWindows: true);
+        var result = operations.SignModuleOutput(
+            moduleName: "TestModule",
+            rootPath: rootPath,
+            packageFilePaths: new[] { manifestPath, modulePath },
+            includePatterns: new[] { "*.psd1", "*.psm1" },
+            excludeSubstrings: Array.Empty<string>(),
+            signing: new SigningOptionsConfiguration { CertificateThumbprint = "0123456789ABCDEF" });
+
+        Assert.Equal(2, requests.Count);
+        Assert.True(requests[0].PreferPwsh);
+        Assert.False(requests[1].PreferPwsh);
+        Assert.Equal("0", requests[0].Arguments[8]);
+        Assert.Equal("1", requests[1].Arguments[8]);
+        Assert.Equal(new[] { manifestPath, modulePath }, requestedPackageFiles[0]);
+        Assert.Equal(new[] { modulePath }, requestedPackageFiles[1]);
+        Assert.Equal(2, result.SignedNew);
+        Assert.Equal(0, result.Failed);
+    }
+
+    [Fact]
+    public void SignModuleOutput_RetriesTerminatingSigningExceptionsWithWindowsPowerShell()
+    {
+        var requests = new List<PowerShellRunRequest>();
+        var rootPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        var modulePath = Path.Combine(rootPath, "TestModule.psm1");
+        var failedSummary = new ModuleSigningResult
+        {
+            TotalMatched = 1,
+            TotalAfterExclude = 1,
+            Attempted = 1,
+            Failed = 1,
+            SigningException = 1,
+            FailedFiles = new[] { $"{modulePath} :: key container access failed" },
+            FailedFilePaths = new[] { modulePath }
+        };
+        var successSummary = new ModuleSigningResult
+        {
+            TotalMatched = 1,
+            TotalAfterExclude = 1,
+            Attempted = 1,
+            SignedNew = 1
+        };
+        var runner = new RecordingPowerShellRunner(request =>
+        {
+            requests.Add(request);
+            return requests.Count == 1
+                ? new PowerShellRunResult(2, EncodeSigningSummary(failedSummary), string.Empty, "pwsh.exe")
+                : new PowerShellRunResult(0, EncodeSigningSummary(successSummary), string.Empty, "powershell.exe");
+        });
+
+        var operations = new PowerShellModulePipelineHostedOperations(runner, new NullLogger(), isWindows: true);
+        var result = operations.SignModuleOutput(
+            moduleName: "TestModule",
+            rootPath: rootPath,
+            packageFilePaths: new[] { modulePath },
+            includePatterns: new[] { "*.psm1" },
+            excludeSubstrings: Array.Empty<string>(),
+            signing: new SigningOptionsConfiguration { CertificateThumbprint = "0123456789ABCDEF" });
+
+        Assert.Equal(2, requests.Count);
+        Assert.False(requests[1].PreferPwsh);
+        Assert.Equal("1", requests[1].Arguments[8]);
+        Assert.Equal(1, result.SignedNew);
+    }
+
+    [Fact]
+    public void SignModuleOutput_DoesNotRetryPfxSigningUnknownErrors()
+    {
+        var requests = new List<PowerShellRunRequest>();
+        var failedSummary = new ModuleSigningResult
+        {
+            TotalMatched = 1,
+            TotalAfterExclude = 1,
+            Attempted = 1,
+            Failed = 1,
+            UnknownError = 1,
+            FailedFiles = new[] { @"C:\Temp\TestModule\TestModule.psm1 :: signing returned status UnknownError" }
+        };
+        var runner = new RecordingPowerShellRunner(request =>
+        {
+            requests.Add(request);
+            return new PowerShellRunResult(2, EncodeSigningSummary(failedSummary), string.Empty, "pwsh.exe");
+        });
+
+        var operations = new PowerShellModulePipelineHostedOperations(runner, new NullLogger(), isWindows: true);
+        var exception = Assert.Throws<ModuleSigningException>(() => operations.SignModuleOutput(
+            moduleName: "TestModule",
+            rootPath: @"C:\Temp\TestModule",
+            packageFilePaths: new[] { @"C:\Temp\TestModule\TestModule.psm1" },
+            includePatterns: new[] { "*.psm1" },
+            excludeSubstrings: Array.Empty<string>(),
+            signing: new SigningOptionsConfiguration { CertificatePFXPath = @"C:\Temp\signing.pfx" }));
+
+        Assert.Single(requests);
+        Assert.Contains("pwsh.exe", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SignModuleOutput_DoesNotRetryStoreCertificateOutsideWindows()
+    {
+        var requests = new List<PowerShellRunRequest>();
+        var modulePath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"), "TestModule.psm1");
+        var failedSummary = new ModuleSigningResult
+        {
+            TotalMatched = 1,
+            TotalAfterExclude = 1,
+            Attempted = 1,
+            Failed = 1,
+            UnknownError = 1,
+            FailedFiles = new[] { $"{modulePath} :: signing returned status UnknownError" },
+            FailedFilePaths = new[] { modulePath }
+        };
+        var runner = new RecordingPowerShellRunner(request =>
+        {
+            requests.Add(request);
+            return new PowerShellRunResult(2, EncodeSigningSummary(failedSummary), string.Empty, "pwsh");
+        });
+
+        var operations = new PowerShellModulePipelineHostedOperations(runner, new NullLogger(), isWindows: false);
+        Assert.Throws<ModuleSigningException>(() => operations.SignModuleOutput(
+            moduleName: "TestModule",
+            rootPath: Path.GetDirectoryName(modulePath)!,
+            packageFilePaths: new[] { modulePath },
+            includePatterns: new[] { "*.psm1" },
+            excludeSubstrings: Array.Empty<string>(),
+            signing: new SigningOptionsConfiguration { CertificateThumbprint = "0123456789ABCDEF" }));
+
+        Assert.Single(requests);
+    }
+
+    [Fact]
+    public void SignModuleOutput_PreservesBothFailuresWhenWindowsPowerShellRetryFails()
+    {
+        var requests = new List<PowerShellRunRequest>();
+        var rootPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        var modulePath = Path.Combine(rootPath, "TestModule.psm1");
+        var initialSummary = new ModuleSigningResult
+        {
+            TotalMatched = 1,
+            TotalAfterExclude = 1,
+            Attempted = 1,
+            Failed = 1,
+            UnknownError = 1,
+            FailedFiles = new[] { $"{modulePath} :: initial provider failure" },
+            FailedFilePaths = new[] { modulePath }
+        };
+        var retrySummary = new ModuleSigningResult
+        {
+            TotalMatched = 1,
+            TotalAfterExclude = 1,
+            Attempted = 1,
+            Failed = 1,
+            FailedFiles = new[] { $"{modulePath} :: retry certificate failure" },
+            FailedFilePaths = new[] { modulePath }
+        };
+        var runner = new RecordingPowerShellRunner(request =>
+        {
+            requests.Add(request);
+            return requests.Count == 1
+                ? new PowerShellRunResult(2, EncodeSigningSummary(initialSummary), string.Empty, "pwsh.exe")
+                : new PowerShellRunResult(2, EncodeSigningSummary(retrySummary), string.Empty, "powershell.exe");
+        });
+
+        var operations = new PowerShellModulePipelineHostedOperations(runner, new NullLogger(), isWindows: true);
+        var exception = Assert.Throws<ModuleSigningException>(() => operations.SignModuleOutput(
+            moduleName: "TestModule",
+            rootPath: rootPath,
+            packageFilePaths: new[] { modulePath },
+            includePatterns: new[] { "*.psm1" },
+            excludeSubstrings: Array.Empty<string>(),
+            signing: new SigningOptionsConfiguration { CertificateThumbprint = "0123456789ABCDEF" }));
+
+        Assert.Equal(2, requests.Count);
+        Assert.Contains("pwsh.exe", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("powershell.exe", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("initial provider failure", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("retry certificate failure", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(retrySummary.FailedFiles, exception.Result?.FailedFiles);
+    }
+
+    [Fact]
+    public void SignModuleOutput_RetainsInitialStructuredFailureWhenRetryHasNoSummary()
+    {
+        var requests = new List<PowerShellRunRequest>();
+        var rootPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        var modulePath = Path.Combine(rootPath, "TestModule.psm1");
+        var initialSummary = new ModuleSigningResult
+        {
+            TotalMatched = 1,
+            TotalAfterExclude = 1,
+            Attempted = 1,
+            Failed = 1,
+            UnknownError = 1,
+            FailedFiles = new[] { $"{modulePath} :: initial provider failure" },
+            FailedFilePaths = new[] { modulePath }
+        };
+        var runner = new RecordingPowerShellRunner(request =>
+        {
+            requests.Add(request);
+            return requests.Count == 1
+                ? new PowerShellRunResult(2, EncodeSigningSummary(initialSummary), string.Empty, "pwsh.exe")
+                : new PowerShellRunResult(1, string.Empty, "Windows PowerShell host failed", "powershell.exe");
+        });
+
+        var operations = new PowerShellModulePipelineHostedOperations(runner, new NullLogger(), isWindows: true);
+        var exception = Assert.Throws<ModuleSigningException>(() => operations.SignModuleOutput(
+            moduleName: "TestModule",
+            rootPath: rootPath,
+            packageFilePaths: new[] { modulePath },
+            includePatterns: new[] { "*.psm1" },
+            excludeSubstrings: Array.Empty<string>(),
+            signing: new SigningOptionsConfiguration { CertificateThumbprint = "0123456789ABCDEF" }));
+
+        Assert.Equal(2, requests.Count);
+        Assert.Equal(initialSummary.FailedFiles, exception.Result?.FailedFiles);
+        Assert.Contains("initial provider failure", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Windows PowerShell host failed", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SigningScript_FailsClosedForInvalidCertificatesAndUnknownSignatures()
     {
         var script = EmbeddedScripts.Load("Scripts/Signing/Sign-Module.ps1");
@@ -2165,6 +2426,45 @@ public sealed class ModulePipelineHostedOperationsTests
         Assert.Contains("if ($status -eq 'Valid')", script, StringComparison.Ordinal);
         Assert.DoesNotContain("$status -eq 'Valid' -or $status -eq 'UnknownError'", script, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void SigningScript_OnlyAcceptsValidPreexistingSignaturesAndTargetsInvalidOnOverwrite()
+    {
+        var script = EmbeddedScripts.Load("Scripts/Signing/Sign-Module.ps1");
+        var ast = System.Management.Automation.Language.Parser.ParseInput(script, out _, out var parseErrors);
+        Assert.Empty(parseErrors);
+        var function = ast.Find(
+            node => node is System.Management.Automation.Language.FunctionDefinitionAst definition &&
+                    definition.Name.Equals("Get-SigningPrecheckDisposition", StringComparison.Ordinal),
+            searchNestedScriptBlocks: true);
+        Assert.NotNull(function);
+
+        using var powerShell = System.Management.Automation.PowerShell.Create();
+        powerShell.AddScript(function!.Extent.Text + "\n" + """
+            Get-SigningPrecheckDisposition -status 'Valid' -overwrite $false
+            Get-SigningPrecheckDisposition -status 'Valid' -overwrite $true
+            Get-SigningPrecheckDisposition -status 'NotSigned' -overwrite $false
+            Get-SigningPrecheckDisposition -status 'UnknownError' -overwrite $false
+            Get-SigningPrecheckDisposition -status 'UnknownError' -overwrite $true
+            Get-SigningPrecheckDisposition -status 'HashMismatch' -overwrite $false
+            """);
+
+        var results = powerShell.Invoke().Select(result => result.ToString()).ToArray();
+
+        Assert.Empty(powerShell.Streams.Error);
+        Assert.Equal(new[] { "Accept", "Target", "Target", "Fail", "Target", "Fail" }, results);
+    }
+
+    [Fact]
+    public void SigningScript_AvoidsPowerShell7OnlyNullConditionalSyntax()
+    {
+        var script = EmbeddedScripts.Load("Scripts/Signing/Sign-Module.ps1");
+
+        Assert.DoesNotContain("?.", script, StringComparison.Ordinal);
+    }
+
+    private static string EncodeSigningSummary(ModuleSigningResult summary)
+        => "PFSIGN::SUMMARY::" + Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(summary)));
 
     [Fact]
     public void SigningScript_AllowsTheFirstFailedFileToBeRecorded()

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -2264,6 +2264,43 @@ public sealed class ModulePipelineHostedOperationsTests
     }
 
     [Fact]
+    public void SignModuleOutput_DoesNotRetryUnknownErrorsRaisedBySignaturePrecheck()
+    {
+        var requests = new List<PowerShellRunRequest>();
+        var rootPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        var modulePath = Path.Combine(rootPath, "TestModule.psm1");
+        var failedSummary = new ModuleSigningResult
+        {
+            TotalMatched = 1,
+            TotalAfterExclude = 1,
+            Attempted = 0,
+            Failed = 1,
+            PrecheckFailure = 1,
+            UnknownError = 1,
+            FailedFiles = new[] { $"{modulePath} :: precheck returned status UnknownError" },
+            FailedFilePaths = new[] { modulePath }
+        };
+        var runner = new RecordingPowerShellRunner(request =>
+        {
+            requests.Add(request);
+            return new PowerShellRunResult(2, EncodeSigningSummary(failedSummary), string.Empty, "pwsh.exe");
+        });
+
+        var operations = new PowerShellModulePipelineHostedOperations(runner, new NullLogger(), isWindows: true);
+        var exception = Assert.Throws<ModuleSigningException>(() => operations.SignModuleOutput(
+            moduleName: "TestModule",
+            rootPath: rootPath,
+            packageFilePaths: new[] { modulePath },
+            includePatterns: new[] { "*.psm1" },
+            excludeSubstrings: Array.Empty<string>(),
+            signing: new SigningOptionsConfiguration { CertificateThumbprint = "0123456789ABCDEF" }));
+
+        Assert.Single(requests);
+        Assert.Equal(1, exception.Result?.PrecheckFailure);
+        Assert.Contains("precheck returned status UnknownError", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SignModuleOutput_DoesNotRetryPfxSigningUnknownErrors()
     {
         var requests = new List<PowerShellRunRequest>();

--- a/PowerForge.Tests/PowerShellRunnerTests.cs
+++ b/PowerForge.Tests/PowerShellRunnerTests.cs
@@ -203,6 +203,98 @@ public sealed class PowerShellRunnerTests
         }
     }
 
+    [Fact]
+    public void Run_WindowsPowerShellRequired_RejectsPwshOverrideWithoutFallback()
+    {
+        if (Path.DirectorySeparatorChar != '\\')
+            return;
+
+        using var directory = new TemporaryDirectory();
+        File.WriteAllText(Path.Combine(directory.Path, "pwsh.exe"), string.Empty);
+
+        var pwshPath = Path.Combine(directory.Path, "pwsh.exe");
+        var processRunner = new StubProcessRunner(request =>
+            throw new InvalidOperationException($"Unexpected process invocation: {request.FileName}"));
+        var runner = new PowerShellRunner(processRunner);
+
+        var result = runner.Run(new PowerShellRunRequest(
+            scriptPath: @"C:\repo\sign.ps1",
+            arguments: Array.Empty<string>(),
+            timeout: TimeSpan.FromMinutes(1),
+            preferPwsh: false,
+            hostRequirement: PowerShellHostRequirement.WindowsPowerShell,
+            executableOverride: pwshPath));
+
+        Assert.Equal(127, result.ExitCode);
+        Assert.Empty(result.Executable);
+        Assert.Contains("is not powershell.exe", result.StdErr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Run_WindowsPowerShellRequired_RejectsPowerShellCoreRenamedAsPowerShell()
+    {
+        if (Path.DirectorySeparatorChar != '\\')
+            return;
+
+        using var directory = new TemporaryDirectory();
+        var executablePath = Path.Combine(directory.Path, "powershell.exe");
+        File.WriteAllText(executablePath, string.Empty);
+        var requests = new List<ProcessRunRequest>();
+        var processRunner = new StubProcessRunner(request =>
+        {
+            requests.Add(request);
+            return new ProcessRunResult(0, "Core", string.Empty, request.FileName, TimeSpan.Zero, timedOut: false);
+        });
+        var runner = new PowerShellRunner(processRunner);
+
+        var result = runner.Run(new PowerShellRunRequest(
+            scriptPath: @"C:\repo\sign.ps1",
+            arguments: Array.Empty<string>(),
+            timeout: TimeSpan.FromMinutes(1),
+            preferPwsh: false,
+            hostRequirement: PowerShellHostRequirement.WindowsPowerShell,
+            executableOverride: executablePath));
+
+        Assert.Equal(127, result.ExitCode);
+        Assert.Empty(result.Executable);
+        Assert.Contains("did not identify as Windows PowerShell Desktop", result.StdErr, StringComparison.Ordinal);
+        var probe = Assert.Single(requests);
+        Assert.Contains("$PSVersionTable.PSEdition", probe.Arguments);
+    }
+
+    [Fact]
+    public void Run_WindowsPowerShellRequired_UsesVerifiedDesktopHost()
+    {
+        if (Path.DirectorySeparatorChar != '\\')
+            return;
+
+        using var directory = new TemporaryDirectory();
+        var executablePath = Path.Combine(directory.Path, "powershell.exe");
+        File.WriteAllText(executablePath, string.Empty);
+        var requests = new List<ProcessRunRequest>();
+        var processRunner = new StubProcessRunner(request =>
+        {
+            requests.Add(request);
+            var output = request.Arguments.Contains("$PSVersionTable.PSEdition") ? "Desktop" : "signed";
+            return new ProcessRunResult(0, output, string.Empty, request.FileName, TimeSpan.Zero, timedOut: false);
+        });
+        var runner = new PowerShellRunner(processRunner);
+
+        var result = runner.Run(new PowerShellRunRequest(
+            scriptPath: @"C:\repo\sign.ps1",
+            arguments: Array.Empty<string>(),
+            timeout: TimeSpan.FromMinutes(1),
+            preferPwsh: false,
+            hostRequirement: PowerShellHostRequirement.WindowsPowerShell,
+            executableOverride: executablePath));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(executablePath, result.Executable);
+        Assert.Equal(2, requests.Count);
+        Assert.Contains("$PSVersionTable.PSEdition", requests[0].Arguments);
+        Assert.Contains("-File", requests[1].Arguments);
+    }
+
     private static string CreateStubExecutablePath()
     {
         var path = Path.Combine(Path.GetTempPath(), "powerforge-pwsh-stub.exe");

--- a/PowerForge.Tests/SigningScriptRetryTests.cs
+++ b/PowerForge.Tests/SigningScriptRetryTests.cs
@@ -1,0 +1,163 @@
+using System.Text;
+using System.Text.Json;
+
+namespace PowerForge.Tests;
+
+public sealed class SigningScriptRetryTests
+{
+    [Fact]
+    public void PowerShellCoreStoreProviderFailuresAreBoundedAndEmitEveryRetryPath()
+    {
+        if (Path.DirectorySeparatorChar != '\\')
+            return;
+
+        var evidence = RunSigningProviderFailureHarness(
+            includePrecheckFailure: false,
+            includeNonCompatibilitySigningFailure: false);
+
+        Assert.Equal(12, evidence.Summary.Attempted);
+        Assert.Equal(12, evidence.Summary.Failed);
+        Assert.Equal(12, evidence.Summary.SigningException);
+        Assert.Equal(evidence.PackageFilePaths.OrderBy(path => path), evidence.Summary.FailedFilePaths.OrderBy(path => path));
+        Assert.Equal(3, evidence.SigningCallCount);
+        Assert.Contains(evidence.Summary.FailedFiles, failure => failure.Contains(
+            "deferred to Windows PowerShell compatibility retry",
+            StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void PrecheckFailuresPreventDeferringTargets()
+    {
+        if (Path.DirectorySeparatorChar != '\\')
+            return;
+
+        var evidence = RunSigningProviderFailureHarness(
+            includePrecheckFailure: true,
+            includeNonCompatibilitySigningFailure: false);
+
+        Assert.Equal(11, evidence.Summary.Attempted);
+        Assert.Equal(12, evidence.Summary.Failed);
+        Assert.Equal(1, evidence.Summary.PrecheckFailure);
+        Assert.Equal(11, evidence.Summary.SigningException);
+        Assert.Equal(evidence.PackageFilePaths.OrderBy(path => path), evidence.Summary.FailedFilePaths.OrderBy(path => path));
+        Assert.Equal(11 * 15, evidence.SigningCallCount);
+        Assert.DoesNotContain(evidence.Summary.FailedFiles, failure => failure.Contains(
+            "deferred to Windows PowerShell compatibility retry",
+            StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void NonCompatibilitySigningFailuresPreventDeferringLaterTargets()
+    {
+        if (Path.DirectorySeparatorChar != '\\')
+            return;
+
+        var evidence = RunSigningProviderFailureHarness(
+            includePrecheckFailure: false,
+            includeNonCompatibilitySigningFailure: true);
+
+        Assert.Equal(12, evidence.Summary.Attempted);
+        Assert.Equal(12, evidence.Summary.Failed);
+        Assert.Equal(0, evidence.Summary.PrecheckFailure);
+        Assert.Equal(11, evidence.Summary.SigningException);
+        Assert.Equal(1 + (11 * 15), evidence.SigningCallCount);
+        Assert.DoesNotContain(evidence.Summary.FailedFiles, failure => failure.Contains(
+            "deferred to Windows PowerShell compatibility retry",
+            StringComparison.Ordinal));
+    }
+
+    private static (ModuleSigningResult Summary, int SigningCallCount, string[] PackageFilePaths)
+        RunSigningProviderFailureHarness(
+            bool includePrecheckFailure,
+            bool includeNonCompatibilitySigningFailure)
+    {
+        var rootPath = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N"))).FullName;
+        var packageFileListPath = Path.Combine(rootPath, "package-files.txt");
+        var callLogPath = Path.Combine(rootPath, "signing-calls.txt");
+        try
+        {
+            var packageFilePaths = Enumerable.Range(1, 12)
+                .Select(index => Path.Combine(rootPath, $"File{index:D2}.ps1"))
+                .ToArray();
+            foreach (var path in packageFilePaths)
+                File.WriteAllText(path, "# test");
+            File.WriteAllLines(packageFileListPath, packageFilePaths);
+
+            var script = EmbeddedScripts.Load("Scripts/Signing/Sign-Module.ps1");
+            var includeB64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("*.ps1"));
+            var precheckFailurePath = includePrecheckFailure ? packageFilePaths[0] : string.Empty;
+            var harness = $$"""
+                $scriptText = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(script))}}'))
+                $rootPath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(rootPath))}}'))
+                $packageFileListPath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(packageFileListPath))}}'))
+                $callLogPath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(callLogPath))}}'))
+                $precheckFailurePath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(precheckFailurePath))}}'))
+                $includeNonCompatibilitySigningFailure = [Convert]::ToBoolean('{{includeNonCompatibilitySigningFailure}}')
+                $script:firstSigningCall = $true
+                function Get-ChildItem {
+                  [CmdletBinding()]
+                  param([string]$Path, [switch]$CodeSigningCert)
+                  [pscustomobject]@{
+                    Thumbprint = '0123456789ABCDEF'
+                    NotBefore = [DateTime]::Now.AddDays(-1)
+                    NotAfter = [DateTime]::Now.AddDays(1)
+                  }
+                }
+                function Get-AuthenticodeSignature {
+                  [CmdletBinding()]
+                  param([string]$FilePath)
+                  $status = if ($FilePath -eq $precheckFailurePath) { 'HashMismatch' } else { 'NotSigned' }
+                  [pscustomobject]@{ Status = $status; SignerCertificate = $null }
+                }
+                function Set-AuthenticodeSignature {
+                  [CmdletBinding()]
+                  param(
+                    [string]$FilePath,
+                    [object]$Certificate,
+                    [string]$TimestampServer,
+                    [object]$IncludeChain,
+                    [string]$HashAlgorithm,
+                    [switch]$Force
+                  )
+                  [IO.File]::AppendAllText($callLogPath, 'x')
+                  if ($includeNonCompatibilitySigningFailure -and $script:firstSigningCall) {
+                    $script:firstSigningCall = $false
+                    return [pscustomobject]@{ Status = 'HashMismatch'; StatusMessage = 'file is not retryable' }
+                  }
+                  throw 'hardware provider unavailable'
+                }
+                function Start-Sleep { param([int]$Milliseconds) }
+                & ([scriptblock]::Create($scriptText)) `
+                  -RootPath $rootPath `
+                  -PackageFileListPath $packageFileListPath `
+                  -IncludeB64 '{{includeB64}}' `
+                  -ExcludeB64 '' `
+                  -Thumbprint '0123456789ABCDEF' `
+                  -PfxPath '' `
+                  -PfxBase64 '' `
+                  -PfxPassword '' `
+                  -OverwriteSigned '0'
+                """;
+
+            using var powerShell = System.Management.Automation.PowerShell.Create();
+            powerShell.AddScript(harness);
+            var output = powerShell.Invoke().Select(item => item.ToString()).ToArray();
+
+            var summaryLine = Assert.Single(output, line => line.StartsWith("PFSIGN::SUMMARY::", StringComparison.Ordinal));
+            var summaryJson = Encoding.UTF8.GetString(Convert.FromBase64String(summaryLine["PFSIGN::SUMMARY::".Length..]));
+            var summary = JsonSerializer.Deserialize<ModuleSigningResult>(
+                summaryJson,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            Assert.NotNull(summary);
+            return (summary!, File.ReadAllText(callLogPath).Length, packageFilePaths);
+        }
+        finally
+        {
+            try { Directory.Delete(rootPath, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/PowerForge.Tests/packages.lock.json
+++ b/PowerForge.Tests/packages.lock.json
@@ -1127,7 +1127,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.6.4, )",
-          "PowerForge": "[3.0.103, )",
+          "PowerForge": "[3.0.104, )",
           "System.Security.Cryptography.Xml": "[10.0.10, )"
         }
       },
@@ -1138,7 +1138,7 @@
           "HtmlTinkerX": "[2.2.2, )",
           "Magick.NET-Q8-AnyCPU": "[14.16.0, )",
           "OfficeIMO.Markdown": "[3.0.3, )",
-          "PowerForge": "[3.0.103, )",
+          "PowerForge": "[3.0.104, )",
           "Scriban": "[7.2.6, )",
           "YamlDotNet": "[18.1.0, )"
         }
@@ -1147,7 +1147,7 @@
         "type": "Project",
         "dependencies": {
           "DBAClientX.SQLite": "[0.13.0, )",
-          "PowerForge.Web": "[3.0.103, )"
+          "PowerForge.Web": "[3.0.104, )"
         }
       },
       "powerforgestudio.domain": {
@@ -1159,8 +1159,8 @@
           "HtmlForgeX": "[0.54.0, )",
           "HtmlForgeX.Markdown": "[0.54.0, )",
           "OfficeIMO.Markdown": "[3.0.3, )",
-          "PowerForge": "[3.0.103, )",
-          "PowerForge.PowerShell": "[3.0.103, )",
+          "PowerForge": "[3.0.104, )",
+          "PowerForge.PowerShell": "[3.0.104, )",
           "Spectre.Console": "[0.57.2, )",
           "Spectre.Console.Json": "[0.57.2, )",
           "System.IO.Packaging": "[10.0.10, )",

--- a/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj
+++ b/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj
@@ -11,7 +11,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>powerforge-web</ToolCommandName>
     <Description>PowerForge.Web command-line interface for building and serving static sites.</Description>
-    <VersionPrefix>3.0.103</VersionPrefix>
+    <VersionPrefix>3.0.104</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Przemyslaw Klys</Authors>
     <Company>Evotec Services sp. z o.o.</Company>

--- a/PowerForge.Web.Cli/packages.lock.json
+++ b/PowerForge.Web.Cli/packages.lock.json
@@ -362,7 +362,7 @@
           "HtmlTinkerX": "[2.2.2, )",
           "Magick.NET-Q8-AnyCPU": "[14.16.0, )",
           "OfficeIMO.Markdown": "[3.0.3, )",
-          "PowerForge": "[3.0.103, )",
+          "PowerForge": "[3.0.104, )",
           "Scriban": "[7.2.6, )",
           "YamlDotNet": "[18.1.0, )"
         }

--- a/PowerForge.Web/PowerForge.Web.csproj
+++ b/PowerForge.Web/PowerForge.Web.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <VersionPrefix>3.0.103</VersionPrefix>
+    <VersionPrefix>3.0.104</VersionPrefix>
     <PackageId>PowerForge.Web</PackageId>
     <RootNamespace>PowerForge.Web</RootNamespace>
     <Description>PowerForge.Web static-site engine and reusable website build components.</Description>

--- a/PowerForge/Abstractions/IPowerShellRunner.cs
+++ b/PowerForge/Abstractions/IPowerShellRunner.cs
@@ -22,6 +22,18 @@ public enum PowerShellInvocationMode
 }
 
 /// <summary>
+/// Optional PowerShell host requirement for an out-of-process invocation.
+/// </summary>
+public enum PowerShellHostRequirement
+{
+    /// <summary>Use the normal preferred-host resolution and fallback behavior.</summary>
+    Any = 0,
+
+    /// <summary>Require Windows PowerShell and never fall back to PowerShell Core.</summary>
+    WindowsPowerShell = 1
+}
+
+/// <summary>
 /// Request to execute a PowerShell script out-of-process.
 /// </summary>
 public sealed class PowerShellRunRequest
@@ -36,6 +48,8 @@ public sealed class PowerShellRunRequest
     public TimeSpan Timeout { get; }
     /// <summary>When true, prefer <c>pwsh</c>; otherwise use Windows PowerShell first on Windows.</summary>
     public bool PreferPwsh { get; }
+    /// <summary>Gets the required PowerShell host, if the request must not use normal fallback behavior.</summary>
+    public PowerShellHostRequirement HostRequirement { get; }
     /// <summary>
     /// Minimum .NET runtime major version required from a PowerShell Core host.
     /// A value of zero allows the normal preferred-host fallback behavior.
@@ -86,6 +100,49 @@ public sealed class PowerShellRunRequest
     }
 
     /// <summary>
+    /// Creates a file-based request with a strict PowerShell host requirement.
+    /// </summary>
+    /// <param name="scriptPath">Path to the script to execute with <c>-File</c>.</param>
+    /// <param name="arguments">Arguments passed to the script.</param>
+    /// <param name="timeout">Maximum allowed execution time.</param>
+    /// <param name="preferPwsh">When true, prefer <c>pwsh</c> when the requirement permits it.</param>
+    /// <param name="hostRequirement">Strict host requirement that disables normal fallback.</param>
+    /// <param name="workingDirectory">Optional working directory.</param>
+    /// <param name="environmentVariables">Optional environment variable overrides.</param>
+    /// <param name="executableOverride">Optional explicit executable.</param>
+    /// <param name="captureOutput">When true, capture standard output.</param>
+    /// <param name="captureError">When true, capture standard error.</param>
+    public PowerShellRunRequest(
+        string scriptPath,
+        IReadOnlyList<string> arguments,
+        TimeSpan timeout,
+        bool preferPwsh,
+        PowerShellHostRequirement hostRequirement,
+        string? workingDirectory = null,
+        IReadOnlyDictionary<string, string?>? environmentVariables = null,
+        string? executableOverride = null,
+        bool captureOutput = true,
+        bool captureError = true)
+        : this(
+            scriptPath: scriptPath,
+            commandText: null,
+            arguments: arguments,
+            timeout: timeout,
+            preferPwsh: preferPwsh,
+            workingDirectory: workingDirectory,
+            environmentVariables: environmentVariables,
+            executableOverride: executableOverride,
+            captureOutput: captureOutput,
+            captureError: captureError,
+            outputLineReceived: null,
+            errorLineReceived: null,
+            requiredRuntimeMajor: 0,
+            hostRequirement: hostRequirement,
+            invocationMode: PowerShellInvocationMode.File)
+    {
+    }
+
+    /// <summary>
     /// Creates a new streaming file-based request while retaining captured output.
     /// </summary>
     /// <param name="scriptPath">Path to the script to execute with <c>-File</c>.</param>
@@ -117,6 +174,7 @@ public sealed class PowerShellRunRequest
         Arguments = arguments;
         Timeout = timeout;
         PreferPwsh = preferPwsh;
+        HostRequirement = PowerShellHostRequirement.Any;
         WorkingDirectory = workingDirectory;
         EnvironmentVariables = environmentVariables;
         ExecutableOverride = executableOverride;
@@ -204,6 +262,7 @@ public sealed class PowerShellRunRequest
             outputLineReceived: outputLineReceived,
             errorLineReceived: errorLineReceived,
             requiredRuntimeMajor: 0,
+            hostRequirement: PowerShellHostRequirement.Any,
             invocationMode: PowerShellInvocationMode.Command);
     }
 
@@ -285,6 +344,7 @@ public sealed class PowerShellRunRequest
             outputLineReceived: outputLineReceived,
             errorLineReceived: errorLineReceived,
             requiredRuntimeMajor: requiredRuntimeMajor,
+            hostRequirement: PowerShellHostRequirement.Any,
             invocationMode: PowerShellInvocationMode.Command);
     }
 
@@ -302,6 +362,7 @@ public sealed class PowerShellRunRequest
         Action<string>? outputLineReceived,
         Action<string>? errorLineReceived,
         int requiredRuntimeMajor,
+        PowerShellHostRequirement hostRequirement,
         PowerShellInvocationMode invocationMode)
     {
         ScriptPath = scriptPath;
@@ -309,6 +370,7 @@ public sealed class PowerShellRunRequest
         Arguments = arguments;
         Timeout = timeout;
         PreferPwsh = preferPwsh;
+        HostRequirement = hostRequirement;
         WorkingDirectory = workingDirectory;
         EnvironmentVariables = environmentVariables;
         ExecutableOverride = executableOverride;
@@ -386,9 +448,11 @@ public sealed class PowerShellRunner : IPowerShellRunner, ICancellablePowerShell
         CancellationToken cancellationToken)
     {
         string? resolutionError = null;
-        var exe = request.RequiredRuntimeMajor > 0
-            ? ResolveCompatiblePwsh(request, out resolutionError)
-            : ResolveExecutable(request.PreferPwsh, request.ExecutableOverride);
+        var exe = request.HostRequirement == PowerShellHostRequirement.WindowsPowerShell
+            ? ResolveRequiredWindowsPowerShell(request, out resolutionError)
+            : request.RequiredRuntimeMajor > 0
+                ? ResolveCompatiblePwsh(request, out resolutionError)
+                : ResolveExecutable(request.PreferPwsh, request.ExecutableOverride);
         if (exe is null)
         {
             var error = resolutionError ?? "No PowerShell executable found (pwsh or powershell.exe).";
@@ -486,6 +550,68 @@ public sealed class PowerShellRunner : IPowerShellRunner, ICancellablePowerShell
         }
 
         return false;
+    }
+
+    private string? ResolveRequiredWindowsPowerShell(PowerShellRunRequest request, out string? error)
+    {
+        if (Path.DirectorySeparatorChar != '\\')
+        {
+            error = "Windows PowerShell was required, but the current platform is not Windows.";
+            return null;
+        }
+
+        var executable = string.IsNullOrWhiteSpace(request.ExecutableOverride)
+            ? ResolveOnPath("powershell.exe")
+            : ResolveOnPath(request.ExecutableOverride!) ??
+              (File.Exists(request.ExecutableOverride) ? request.ExecutableOverride : null);
+        if (executable is null)
+        {
+            error = "Windows PowerShell was required, but powershell.exe was not found.";
+            return null;
+        }
+
+        if (!string.Equals(
+                Path.GetFileNameWithoutExtension(executable),
+                "powershell",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            error = $"Windows PowerShell was required, but executable '{executable}' is not powershell.exe.";
+            return null;
+        }
+
+        if (!IsWindowsPowerShellDesktop(executable, request))
+        {
+            error = $"Windows PowerShell was required, but executable '{executable}' did not identify as Windows PowerShell Desktop.";
+            return null;
+        }
+
+        error = null;
+        return executable;
+    }
+
+    private bool IsWindowsPowerShellDesktop(string executable, PowerShellRunRequest request)
+    {
+        var probeArguments = new[] {
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            "$PSVersionTable.PSEdition"
+        };
+        var probeResult = _processRunner.RunAsync(
+            new ProcessRunRequest(
+                executable,
+                request.WorkingDirectory ?? Environment.CurrentDirectory,
+                probeArguments,
+                TimeSpan.FromSeconds(15),
+                request.EnvironmentVariables,
+                captureOutput: true,
+                captureError: true)).GetAwaiter().GetResult();
+
+        return probeResult.Succeeded && probeResult.StdOut
+            .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .Any(line => string.Equals(line.Trim(), "Desktop", StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/PowerForge/Models/ModuleSigningResult.cs
+++ b/PowerForge/Models/ModuleSigningResult.cs
@@ -39,6 +39,10 @@ public sealed class ModuleSigningResult
     [JsonPropertyName("failed")]
     public int Failed { get; set; }
 
+    /// <summary>Number of failures raised while inspecting a pre-existing signature, before any signing attempt.</summary>
+    [JsonPropertyName("precheckFailure")]
+    public int PrecheckFailure { get; set; }
+
     /// <summary>Number of sign operations that returned an "UnknownError" status.</summary>
     [JsonPropertyName("unknownError")]
     public int UnknownError { get; set; }

--- a/PowerForge/Models/ModuleSigningResult.cs
+++ b/PowerForge/Models/ModuleSigningResult.cs
@@ -43,6 +43,10 @@ public sealed class ModuleSigningResult
     [JsonPropertyName("unknownError")]
     public int UnknownError { get; set; }
 
+    /// <summary>Number of signing operations that ended in a terminating host/provider exception.</summary>
+    [JsonPropertyName("signingException")]
+    public int SigningException { get; set; }
+
     /// <summary>Thumbprint of the certificate used for signing (if available).</summary>
     [JsonPropertyName("certificateThumbprint")]
     public string? CertificateThumbprint { get; set; }
@@ -50,6 +54,10 @@ public sealed class ModuleSigningResult
     /// <summary>List of file paths that failed signing (truncated).</summary>
     [JsonPropertyName("failedFiles")]
     public string[] FailedFiles { get; set; } = Array.Empty<string>();
+
+    /// <summary>Exact package file paths that failed signing, used for a scoped compatibility retry.</summary>
+    [JsonPropertyName("failedFilePaths")]
+    public string[] FailedFilePaths { get; set; } = Array.Empty<string>();
 
     /// <summary>Total number of files already signed (by this cert + third-party).</summary>
     [JsonIgnore]

--- a/PowerForge/PowerForge.csproj
+++ b/PowerForge/PowerForge.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsAsErrors>CS1591</WarningsAsErrors>
-    <VersionPrefix>3.0.103</VersionPrefix>
+    <VersionPrefix>3.0.104</VersionPrefix>
     <PackageId>PowerForge</PackageId>
     <Description>PowerForge core library: reusable engine for building, formatting, packaging and publishing PowerShell modules.</Description>
     <AssemblyName>PowerForge</AssemblyName>

--- a/PowerForge/Scripts/Signing/Sign-Module.ps1
+++ b/PowerForge/Scripts/Signing/Sign-Module.ps1
@@ -50,6 +50,16 @@ function Test-ExcludedPackagePath([string]$relativePath, [string[]]$exclusions) 
   return $false
 }
 
+function Get-SigningPrecheckDisposition([string]$status, [bool]$overwrite) {
+  if ($status -eq 'Valid') {
+    if ($overwrite) { return 'Target' }
+    return 'Accept'
+  }
+  if ($status -eq 'NotSigned') { return 'Target' }
+  if ($overwrite) { return 'Target' }
+  return 'Fail'
+}
+
 function EmitError([string]$msg) {
   $b64 = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(([string]$msg)))
   Write-Output ('PFSIGN::ERROR::' + $b64)
@@ -65,8 +75,10 @@ function EmitSummary(
   [int]$resigned,
   [int]$failed,
   [int]$unknownError,
+  [int]$signingException,
   [string]$certThumbprint,
-  [object[]]$failedFiles
+  [object[]]$failedFiles,
+  [object[]]$failedFilePaths
 ) {
   $summary = [ordered]@{
     totalMatched            = $totalMatched
@@ -78,8 +90,10 @@ function EmitSummary(
     resigned                = $resigned
     failed                  = $failed
     unknownError            = $unknownError
+    signingException        = $signingException
     certificateThumbprint   = $certThumbprint
     failedFiles             = @($failedFiles | Select-Object -First 25)
+    failedFilePaths         = @($failedFilePaths)
   }
 
   $json = $summary | ConvertTo-Json -Compress -Depth 6
@@ -238,12 +252,15 @@ try {
   $alreadyByThis = 0
   $alreadyOther = 0
   $preStatus = @{}
+  $preDisposition = @{}
   $attempted = 0
   $signedNew = 0
   $resigned = 0
   $failed = 0
   $unknownError = 0
+  $signingException = 0
   $failedFiles = New-Object 'System.Collections.Generic.List[string]'
+  $failedFilePaths = New-Object 'System.Collections.Generic.List[string]'
   $precheckFailures = @{}
 
   if ($IsWindows -or $PSVersionTable.PSVersion.Major -le 5) {
@@ -261,19 +278,27 @@ try {
         }
         $status = [string]$sig.Status
         $preStatus[$f] = $status
+        $preDisposition[$f] = Get-SigningPrecheckDisposition -status $status -overwrite $overwrite
 
-        if ($status -ne 'NotSigned') {
-          $tp = $sig.SignerCertificate?.Thumbprint
+        if ($status -eq 'Valid') {
+          $tp = $null
+          if ($null -ne $sig -and $null -ne $sig.SignerCertificate) {
+            $tp = [string]$sig.SignerCertificate.Thumbprint
+          }
           if (-not [string]::IsNullOrWhiteSpace($tp)) { $tp = ($tp -replace '\s','').ToUpperInvariant() }
           if (-not [string]::IsNullOrWhiteSpace($tp) -and $tp -eq $thisTp) { $alreadyByThis++ } else { $alreadyOther++ }
+        } elseif ($preDisposition[$f] -eq 'Fail') {
+          $precheckFailures[$f] = "precheck returned status $status"
+          if ($status -eq 'UnknownError') { $unknownError++ }
         }
       } catch {
         $preStatus[$f] = 'PrecheckFailed'
+        $preDisposition[$f] = 'Fail'
         $precheckFailures[$f] = "precheck failed: " + $_.Exception.Message
       }
     }
 
-    $targets = if ($overwrite) { $all } else { $all | Where-Object { $preStatus[$_] -eq 'NotSigned' } }
+    $targets = $all | Where-Object { $preDisposition[$_] -eq 'Target' }
     $attempted = $targets.Count
 
     foreach ($f in $targets) {
@@ -299,16 +324,20 @@ try {
           $failed++
           $statusMessage = if ($r) { [string]$r.StatusMessage } else { '' }
           Add-FailedFile -List $failedFiles -FilePath $f -Message ("signing returned status " + $status + " " + $statusMessage)
+          $failedFilePaths.Add($f) | Out-Null
         }
       } catch {
         $failed++
+        $signingException++
         Add-FailedFile -List $failedFiles -FilePath $f -Message $_.Exception.Message
+        $failedFilePaths.Add($f) | Out-Null
       }
     }
 
     foreach ($entry in $precheckFailures.GetEnumerator()) {
       $failed++
       Add-FailedFile -List $failedFiles -FilePath $entry.Key -Message $entry.Value
+      $failedFilePaths.Add([string]$entry.Key) | Out-Null
     }
   } else {
     if (-not (Get-Command Set-OpenAuthenticodeSignature -ErrorAction SilentlyContinue)) {
@@ -325,14 +354,21 @@ try {
         }
         $status = [string]$sig.SStatus
         $preStatus[$f] = $status
-        if ($status -ne 'NotSigned') { $alreadyOther++ }
+        $preDisposition[$f] = Get-SigningPrecheckDisposition -status $status -overwrite $overwrite
+        if ($status -eq 'Valid') {
+          $alreadyOther++
+        } elseif ($preDisposition[$f] -eq 'Fail') {
+          $precheckFailures[$f] = "precheck returned status $status"
+          if ($status -eq 'UnknownError') { $unknownError++ }
+        }
       } catch {
         $preStatus[$f] = 'PrecheckFailed'
+        $preDisposition[$f] = 'Fail'
         $precheckFailures[$f] = "precheck failed: " + $_.Exception.Message
       }
     }
 
-    $targets = if ($overwrite) { $all } else { $all | Where-Object { $preStatus[$_] -eq 'NotSigned' } }
+    $targets = $all | Where-Object { $preDisposition[$_] -eq 'Target' }
     $attempted = $targets.Count
 
     foreach ($f in $targets) {
@@ -358,16 +394,20 @@ try {
           $failed++
           $statusMessage = if ($r) { [string]$r.StatusMessage } else { '' }
           Add-FailedFile -List $failedFiles -FilePath $f -Message ("signing returned status " + $status + " " + $statusMessage)
+          $failedFilePaths.Add($f) | Out-Null
         }
       } catch {
         $failed++
+        $signingException++
         Add-FailedFile -List $failedFiles -FilePath $f -Message $_.Exception.Message
+        $failedFilePaths.Add($f) | Out-Null
       }
     }
 
     foreach ($entry in $precheckFailures.GetEnumerator()) {
       $failed++
       Add-FailedFile -List $failedFiles -FilePath $entry.Key -Message $entry.Value
+      $failedFilePaths.Add([string]$entry.Key) | Out-Null
     }
   }
 
@@ -381,8 +421,10 @@ try {
     -resigned $resigned `
     -failed $failed `
     -unknownError $unknownError `
+    -signingException $signingException `
     -certThumbprint $thisTp `
-    -failedFiles @($failedFiles)
+    -failedFiles @($failedFiles) `
+    -failedFilePaths @($failedFilePaths)
 
   if ($failed -gt 0) { exit 2 } else { exit 0 }
 } catch {

--- a/PowerForge/Scripts/Signing/Sign-Module.ps1
+++ b/PowerForge/Scripts/Signing/Sign-Module.ps1
@@ -108,22 +108,23 @@ function Invoke-WithFileRetry {
   param(
     [Parameter(Mandatory = $true)] [scriptblock]$ScriptBlock,
     [Parameter(Mandatory = $true)] [string]$FilePath,
-    [Parameter(Mandatory = $true)] [string]$Action
+    [Parameter(Mandatory = $true)] [string]$Action,
+    [int]$MaxAttempts = 15
   )
 
-  $maxAttempts = 15
+  if ($MaxAttempts -lt 1) { throw 'MaxAttempts must be at least 1.' }
   $delay = 200
-  for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+  for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
     try {
       return & $ScriptBlock
     } catch {
-      if ($attempt -ge $maxAttempts) {
+      if ($attempt -ge $MaxAttempts) {
         $message = $_.Exception.Message
         if ([string]::IsNullOrWhiteSpace($message)) {
           $message = 'unknown error'
         }
 
-        throw ('{0} failed for ''{1}'' after {2} attempt(s): {3}' -f $Action, $FilePath, $maxAttempts, $message)
+        throw ('{0} failed for ''{1}'' after {2} attempt(s): {3}' -f $Action, $FilePath, $MaxAttempts, $message)
       }
 
       Start-Sleep -Milliseconds $delay
@@ -264,6 +265,17 @@ try {
   $failedFiles = New-Object 'System.Collections.Generic.List[string]'
   $failedFilePaths = New-Object 'System.Collections.Generic.List[string]'
   $precheckFailures = @{}
+  $useWindowsPowerShellCompatibility = `
+    [System.IO.Path]::DirectorySeparatorChar -eq '\' -and `
+    $PSVersionTable.PSEdition -eq 'Core' -and `
+    -not [string]::IsNullOrWhiteSpace($Thumbprint) -and `
+    [string]::IsNullOrWhiteSpace($PfxPath) -and `
+    [string]::IsNullOrWhiteSpace($PfxBase64)
+  $signingMaxAttempts = 15
+  $canDeferToWindowsPowerShell = $false
+  $hasNonCompatibilitySigningFailure = $false
+  $deferRemainingSigningTargets = $false
+  $compatibilityFailureMessage = $null
 
   if ($IsWindows -or $PSVersionTable.PSVersion.Major -le 5) {
     if (-not (Get-Command Get-AuthenticodeSignature -ErrorAction SilentlyContinue)) {
@@ -299,19 +311,28 @@ try {
       }
     }
 
+    $canDeferToWindowsPowerShell = $useWindowsPowerShellCompatibility -and $precheckFailures.Count -eq 0
+    $signingMaxAttempts = if ($canDeferToWindowsPowerShell) { 3 } else { 15 }
     $targets = $all | Where-Object { $preDisposition[$_] -eq 'Target' }
     $attempted = $targets.Count
 
     foreach ($f in $targets) {
       if ($precheckFailures.ContainsKey($f)) { [void]$precheckFailures.Remove($f) }
       $wasSigned = $preStatus[$f] -ne 'NotSigned'
+      if ($deferRemainingSigningTargets) {
+        $failed++
+        $signingException++
+        Add-FailedFile -List $failedFiles -FilePath $f -Message ("deferred to Windows PowerShell compatibility retry after provider failure: " + $compatibilityFailureMessage)
+        $failedFilePaths.Add($f) | Out-Null
+        continue
+      }
       try {
         if ($overwrite) {
-          $r = Invoke-WithFileRetry -FilePath $f -Action 'Set-AuthenticodeSignature' -ScriptBlock {
+          $r = Invoke-WithFileRetry -FilePath $f -Action 'Set-AuthenticodeSignature' -MaxAttempts $signingMaxAttempts -ScriptBlock {
             Set-AuthenticodeSignature -FilePath $f -Certificate $cert -TimestampServer $ts -IncludeChain All -HashAlgorithm SHA256 -Force -ErrorAction Stop
           }
         } else {
-          $r = Invoke-WithFileRetry -FilePath $f -Action 'Set-AuthenticodeSignature' -ScriptBlock {
+          $r = Invoke-WithFileRetry -FilePath $f -Action 'Set-AuthenticodeSignature' -MaxAttempts $signingMaxAttempts -ScriptBlock {
             Set-AuthenticodeSignature -FilePath $f -Certificate $cert -TimestampServer $ts -IncludeChain All -HashAlgorithm SHA256 -ErrorAction Stop
           }
         }
@@ -323,6 +344,10 @@ try {
           if ($wasSigned) { $resigned++ } else { $signedNew++ }
         } else {
           $failed++
+          if ($status -ne 'UnknownError') {
+            $hasNonCompatibilitySigningFailure = $true
+            $signingMaxAttempts = 15
+          }
           $statusMessage = if ($r) { [string]$r.StatusMessage } else { '' }
           Add-FailedFile -List $failedFiles -FilePath $f -Message ("signing returned status " + $status + " " + $statusMessage)
           $failedFilePaths.Add($f) | Out-Null
@@ -332,6 +357,10 @@ try {
         $signingException++
         Add-FailedFile -List $failedFiles -FilePath $f -Message $_.Exception.Message
         $failedFilePaths.Add($f) | Out-Null
+        if ($canDeferToWindowsPowerShell -and -not $hasNonCompatibilitySigningFailure) {
+          $deferRemainingSigningTargets = $true
+          $compatibilityFailureMessage = $_.Exception.Message
+        }
       }
     }
 

--- a/PowerForge/Scripts/Signing/Sign-Module.ps1
+++ b/PowerForge/Scripts/Signing/Sign-Module.ps1
@@ -74,6 +74,7 @@ function EmitSummary(
   [int]$signedNew,
   [int]$resigned,
   [int]$failed,
+  [int]$precheckFailure,
   [int]$unknownError,
   [int]$signingException,
   [string]$certThumbprint,
@@ -89,6 +90,7 @@ function EmitSummary(
     signedNew               = $signedNew
     resigned                = $resigned
     failed                  = $failed
+    precheckFailure         = $precheckFailure
     unknownError            = $unknownError
     signingException        = $signingException
     certificateThumbprint   = $certThumbprint
@@ -289,7 +291,6 @@ try {
           if (-not [string]::IsNullOrWhiteSpace($tp) -and $tp -eq $thisTp) { $alreadyByThis++ } else { $alreadyOther++ }
         } elseif ($preDisposition[$f] -eq 'Fail') {
           $precheckFailures[$f] = "precheck returned status $status"
-          if ($status -eq 'UnknownError') { $unknownError++ }
         }
       } catch {
         $preStatus[$f] = 'PrecheckFailed'
@@ -359,7 +360,6 @@ try {
           $alreadyOther++
         } elseif ($preDisposition[$f] -eq 'Fail') {
           $precheckFailures[$f] = "precheck returned status $status"
-          if ($status -eq 'UnknownError') { $unknownError++ }
         }
       } catch {
         $preStatus[$f] = 'PrecheckFailed'
@@ -420,6 +420,7 @@ try {
     -signedNew $signedNew `
     -resigned $resigned `
     -failed $failed `
+    -precheckFailure $precheckFailures.Count `
     -unknownError $unknownError `
     -signingException $signingException `
     -certThumbprint $thisTp `

--- a/PowerForgeStudio.Cli/packages.lock.json
+++ b/PowerForgeStudio.Cli/packages.lock.json
@@ -122,7 +122,7 @@
           "DBAClientX.Core": "[0.15.0, )",
           "DBAClientX.SQLite": "[0.13.0, )",
           "Microsoft.Data.Sqlite": "[10.0.10, )",
-          "PowerForge": "[3.0.103, )",
+          "PowerForge": "[3.0.104, )",
           "PowerForgeStudio.Domain": "[1.0.0, )"
         }
       }

--- a/PowerForgeStudio.Tests/packages.lock.json
+++ b/PowerForgeStudio.Tests/packages.lock.json
@@ -213,7 +213,7 @@
           "DBAClientX.Core": "[0.15.0, )",
           "DBAClientX.SQLite": "[0.13.0, )",
           "Microsoft.Data.Sqlite": "[10.0.10, )",
-          "PowerForge": "[3.0.103, )",
+          "PowerForge": "[3.0.104, )",
           "PowerForgeStudio.Domain": "[1.0.0, )"
         }
       }

--- a/PowerForgeStudio.Wpf/packages.lock.json
+++ b/PowerForgeStudio.Wpf/packages.lock.json
@@ -212,7 +212,7 @@
           "DBAClientX.Core": "[0.15.0, )",
           "DBAClientX.SQLite": "[0.13.0, )",
           "Microsoft.Data.Sqlite": "[10.0.10, )",
-          "PowerForge": "[3.0.103, )",
+          "PowerForge": "[3.0.104, )",
           "PowerForgeStudio.Domain": "[1.0.0, )"
         }
       }


### PR DESCRIPTION
## Summary

- retries certificate-store signing once with verified Windows PowerShell Desktop when PowerShell 7 reports only retryable provider failures from actual signing attempts
- bounds PowerShell 7 certificate-store provider retries so multi-file modules emit a complete exact-path failure summary and reach Windows PowerShell fallback before the process timeout
- refuses to run the forced-overwrite retry through `pwsh`, including when Windows PowerShell is missing or an override points to the wrong host
- keeps pre-existing signature inspection failures separate and fail-closed so they can never authorize a forced-overwrite compatibility retry
- retries only the exact failed package files and force-signs those files so invalid or partially written signatures from an attempted sign cannot be skipped
- preserves diagnostics from both signing hosts when recovery fails
- keeps the embedded signing script compatible with both PowerShell 7 and Windows PowerShell 5.1
- aligns the PSPublishModule manifest, all configured PowerForge package projects, and associated dependency locks at release version 3.0.104

## Behavior

PowerShell 7 remains the normal signing host. For the exact Windows certificate-store compatibility case, provider calls are tried three times; after a persistent provider exception, the remaining eligible package files are recorded for the verified Windows PowerShell Desktop retry instead of consuming the fixed process timeout. The retry still receives the complete exact path set. Precheck failures, PFX signing, non-Windows signing, and non-provider signing failures keep the normal 15-attempt, fail-closed behavior.

The compatibility retry requires a resolved `powershell.exe` that identifies as Windows PowerShell Desktop before the signing script starts. Every retry path still requires a `Valid` signature result.

A pre-existing `UnknownError`, invalid signature, or signature-precheck exception remains a terminal precheck failure unless overwrite was explicitly requested by the caller. Only provider failures produced by a real signing attempt qualify for the automatic Windows PowerShell retry.

The release-shaped module was imported under PowerShell 7 and Windows PowerShell 5.1, and the full signing script produced valid signatures with a hardware-backed certificate under both hosts. Focused retry/fallback tests cover 12-file modules plus precheck and non-provider boundaries. The committed public-release version preflight, locked solution restore, release tests, focused strict-host/API compatibility tests, cross-target builds, and full Release build pass for 3.0.104.