### PR TITLE
Add coordinated repository version bindings

### DIFF
--- a/Docs/PSPublishModule.ProjectBuild.md
+++ b/Docs/PSPublishModule.ProjectBuild.md
@@ -290,6 +290,13 @@ Example configuration
       ]
     }
   },
+  "VersionBindings": [
+    {
+      "Path": ".agents/plugins/example/.mcp.json",
+      "Project": "ExampleSuite.Tool",
+      "Pattern": "(?<=ExampleSuite\\.Tool@)\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?"
+    }
+  ],
   "ExpectedVersionMapAsInclude": true,
   "ExpectedVersionMapUseWildcards": false,
   "ExcludeProjects": [ "ExampleSuite.Legacy", "ExampleSuite.Experimental" ],
@@ -336,6 +343,7 @@ Versioning
 - `VersionTracks.<Name>.AnchorPackageId`: optional explicit package identity when it differs from the project name.
 - `VersionTracks.<Name>.Projects`: sibling projects that should be stamped to the same resolved version. `AnchorProject` is included automatically.
 - When `AnchorPackageId` is used, also set `AnchorProject` so the anchor project itself is stamped automatically.
+- `VersionBindings`: keeps an explicitly configured repository file synchronized with a resolved project version. Each binding names a repository-relative `Path`, a source `Project`, and a regular-expression `Pattern` that must match exactly once. `Replacement` defaults to `{Version}` and may add surrounding text, but it must contain that token. Bindings are validated in plan mode and are applied only when `UpdateVersions` is enabled. Missing files or project versions, paths outside the repository, symbolic links/junctions, invalid patterns, and zero/multiple matches fail the release. Project and binding updates are prepared together and use rollback-backed replacements so a failed write does not knowingly leave a partial version set.
 - `AlignPackageVersions`: defaults to false. When true, ordinary projects using the same X-pattern are stepped from the highest current package version found for any project in that group. For example, if one `2.0.X` package is at `2.0.5` and another is new, both plan `2.0.6`. Ordinary exact-version overrides outside a version track remain exact. `VersionTracks` already coordinate their members when alignment is false and remain explicit, separate group boundaries when it is true. This does not assign one universal version to every project. See [Unified Module And Project Releases](PSPublishModule.UnifiedModuleProjectRelease.md) for complete aligned, non-aligned, and version-track behavior.
 - In a module pipeline with `Release.SynchronizeModuleVersion`, the next available module version is also a floor for `Release.PrimaryProject`. If that project belongs to an aligned X-pattern group, the whole group is raised to the floor. A higher numeric NuGet-derived package candidate still wins. At the same numeric version, a stable X-pattern candidate does not erase the configured module prerelease; explicit prerelease versions retain normal semantic-version ordering. The module and primary package patterns must describe the same version line.
 - When no expected version is provided for a project, the existing csproj version is used.

--- a/PSPublishModule/Cmdlets/NewConfigurationPackageBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationPackageBuildCommand.cs
@@ -170,6 +170,9 @@ public sealed class NewConfigurationPackageBuildCommand : PSCmdlet
     /// <summary>Shared version tracks keyed by track name.</summary>
     [Parameter] public IDictionary? VersionTracks { get; set; }
 
+    /// <summary>Repository files whose embedded versions follow a resolved project version.</summary>
+    [Parameter] public ProjectVersionBinding[]? VersionBindings { get; set; }
+
     /// <summary>When true, <c>ExpectedVersionMap</c> acts as an include list.</summary>
     [Parameter] public SwitchParameter ExpectedVersionMapAsInclude { get; set; }
 
@@ -357,6 +360,7 @@ public sealed class NewConfigurationPackageBuildCommand : PSCmdlet
                 ExpectedVersion = Normalize(ExpectedVersion),
                 ExpectedVersionMap = PackageBuildConfiguration.ToStringDictionary(ExpectedVersionMap),
                 VersionTracks = PackageBuildConfiguration.ToVersionTracksDictionary(VersionTracks),
+                VersionBindings = VersionBindings,
                 ExpectedVersionMapAsInclude = ExpectedVersionMapAsInclude.IsPresent,
                 ExpectedVersionMapUseWildcards = ExpectedVersionMapUseWildcards.IsPresent,
                 AlignPackageVersions = AlignPackageVersions.IsPresent,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseFingerprint.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseFingerprint.cs
@@ -400,6 +400,7 @@ public sealed partial class ModulePipelineRunner
             configuration.ExpectedVersion,
             SerializeSynchronizedReleaseStringMap(configuration.ExpectedVersionMap),
             SerializeSynchronizedReleaseVersionTracks(configuration.VersionTracks),
+            SerializeSynchronizedReleaseVersionBindings(configuration.VersionBindings),
             configuration.ExpectedVersionMapAsInclude.ToString(),
             configuration.ExpectedVersionMapUseWildcards.ToString(),
             configuration.AlignPackageVersions.ToString(),
@@ -473,6 +474,18 @@ public sealed partial class ModulePipelineRunner
                     entry.Value?.IncludePrerelease?.ToString() ?? string.Empty
                 })
                 .ToArray());
+
+    private static string SerializeSynchronizedReleaseVersionBindings(
+        IReadOnlyList<ProjectVersionBinding>? bindings)
+        => bindings is null
+            ? string.Empty
+            : JsonSerializer.Serialize(bindings.Select(static binding => new[]
+            {
+                binding?.Path?.Trim() ?? string.Empty,
+                binding?.Project?.Trim() ?? string.Empty,
+                binding?.Pattern ?? string.Empty,
+                binding?.Replacement ?? string.Empty
+            }).ToArray());
 
     private static string SerializeSynchronizedReleaseValues(IEnumerable<string>? values)
         => values is null

--- a/PowerForge.Tests/DotNetRepositoryReleaseVersionBindingTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseVersionBindingTests.cs
@@ -1,0 +1,124 @@
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed class DotNetRepositoryReleaseVersionBindingTests
+{
+    [Fact]
+    public void Execute_updates_project_and_bound_file_to_the_same_version()
+    {
+        var root = CreateRepository();
+
+        try
+        {
+            var result = Execute(root, pattern: @"(?<=Example\.Tool@)\d+\.\d+\.\d+");
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Contains("<VersionPrefix>1.2.4</VersionPrefix>", Read(root, "Example.Tool", "Example.Tool.csproj"), StringComparison.Ordinal);
+            Assert.Equal("Example.Tool@1.2.4", Read(root, "tool.txt"));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_invalid_binding_does_not_partially_update_the_project()
+    {
+        var root = CreateRepository();
+
+        try
+        {
+            var result = Execute(root, pattern: @"Missing@\d+\.\d+\.\d+");
+
+            Assert.False(result.Success);
+            Assert.Contains("found 0 matches", result.ErrorMessage, StringComparison.Ordinal);
+            Assert.Contains("<VersionPrefix>1.2.3</VersionPrefix>", Read(root, "Example.Tool", "Example.Tool.csproj"), StringComparison.Ordinal);
+            Assert.Equal("Example.Tool@1.2.3", Read(root, "tool.txt"));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_composes_a_binding_that_targets_the_versioned_project_file()
+    {
+        var root = CreateRepository();
+
+        try
+        {
+            var projectPath = Path.Combine(root.FullName, "Example.Tool", "Example.Tool.csproj");
+            File.WriteAllText(
+                projectPath,
+                "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net8.0</TargetFramework><VersionPrefix>1.2.3</VersionPrefix><ToolVersion>1.2.3</ToolVersion></PropertyGroup></Project>");
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                IncludeProjects = new[] { "Example.Tool" },
+                ExpectedVersion = "1.2.4",
+                UpdateVersions = true,
+                Pack = false,
+                VersionBindings = new[]
+                {
+                    new ProjectVersionBinding
+                    {
+                        Path = "Example.Tool/Example.Tool.csproj",
+                        Project = "Example.Tool",
+                        Pattern = @"(?<=<ToolVersion>)\d+\.\d+\.\d+(?=</ToolVersion>)"
+                    }
+                }
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            var projectContent = File.ReadAllText(projectPath);
+            Assert.Contains("<VersionPrefix>1.2.4</VersionPrefix>", projectContent, StringComparison.Ordinal);
+            Assert.Contains("<ToolVersion>1.2.4</ToolVersion>", projectContent, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    private static DotNetRepositoryReleaseResult Execute(DirectoryInfo root, string pattern)
+        => new DotNetRepositoryReleaseService(new NullLogger()).Execute(new DotNetRepositoryReleaseSpec
+        {
+            RootPath = root.FullName,
+            IncludeProjects = new[] { "Example.Tool" },
+            ExpectedVersion = "1.2.4",
+            UpdateVersions = true,
+            Pack = false,
+            VersionBindings = new[]
+            {
+                new ProjectVersionBinding
+                {
+                    Path = "tool.txt",
+                    Project = "Example.Tool",
+                    Pattern = pattern
+                }
+            }
+        });
+
+    private static DirectoryInfo CreateRepository()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-release-binding-" + Guid.NewGuid().ToString("N")));
+        var project = Directory.CreateDirectory(Path.Combine(root.FullName, "Example.Tool"));
+        File.WriteAllText(
+            Path.Combine(project.FullName, "Example.Tool.csproj"),
+            "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net8.0</TargetFramework><VersionPrefix>1.2.3</VersionPrefix></PropertyGroup></Project>");
+        File.WriteAllText(Path.Combine(root.FullName, "tool.txt"), "Example.Tool@1.2.3");
+        return root;
+    }
+
+    private static string Read(DirectoryInfo root, params string[] segments)
+        => File.ReadAllText(segments.Aggregate(root.FullName, Path.Combine));
+
+    private static void TryDelete(DirectoryInfo directory)
+    {
+        try { directory.Delete(recursive: true); } catch { }
+    }
+}

--- a/PowerForge.Tests/DotNetRepositoryReleaseVersionBindingTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseVersionBindingTests.cs
@@ -84,6 +84,46 @@ public sealed class DotNetRepositoryReleaseVersionBindingTests
         }
     }
 
+    [Fact]
+    public void Execute_plan_composes_project_version_updates_before_validating_bindings()
+    {
+        var root = CreateRepository();
+
+        try
+        {
+            var projectPath = Path.Combine(root.FullName, "Example.Tool", "Example.Tool.csproj");
+            var originalContent =
+                "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net8.0</TargetFramework><VersionPrefix>1.2.3</VersionPrefix><ToolVersion>1.2.3</ToolVersion></PropertyGroup></Project>";
+            File.WriteAllText(projectPath, originalContent);
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                IncludeProjects = new[] { "Example.Tool" },
+                ExpectedVersion = "1.2.4",
+                UpdateVersions = true,
+                WhatIf = true,
+                Pack = false,
+                VersionBindings = new[]
+                {
+                    new ProjectVersionBinding
+                    {
+                        Path = "Example.Tool/Example.Tool.csproj",
+                        Project = "Example.Tool",
+                        Pattern = @"\b1\.2\.3\b"
+                    }
+                }
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(originalContent, File.ReadAllText(projectPath));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
     private static DotNetRepositoryReleaseResult Execute(DirectoryInfo root, string pattern)
         => new DotNetRepositoryReleaseService(new NullLogger()).Execute(new DotNetRepositoryReleaseSpec
         {

--- a/PowerForge.Tests/PowerForgeProjectCmdletTests.cs
+++ b/PowerForge.Tests/PowerForgeProjectCmdletTests.cs
@@ -155,6 +155,15 @@ public sealed class PowerForgeProjectCmdletTests
                     ["IncludePrerelease"] = true
                 }
             })
+            .AddParameter("VersionBindings", new[]
+            {
+                new ProjectVersionBinding
+                {
+                    Path = "tool.json",
+                    Project = "HtmlTinkerX",
+                    Pattern = @"(?<=HtmlTinkerX@)\d+\.\d+\.\d+"
+                }
+            })
             .AddParameter("AlignPackageVersions")
             .AddParameter("BuildBeforeModule")
             .AddParameter("IncludeSymbols")
@@ -180,6 +189,8 @@ public sealed class PowerForgeProjectCmdletTests
         Assert.True(segment.Configuration.UseGitHubPackages);
         Assert.Equal("EvotecIT", segment.Configuration.GitHubPackagesOwner);
         Assert.False(segment.Configuration.GitHubIncludeProjectNameInTag);
+        var binding = Assert.Single(segment.Configuration.VersionBindings!);
+        Assert.Equal("tool.json", binding.Path);
         Assert.NotNull(segment.Configuration.VersionTracks);
         var track = segment.Configuration.VersionTracks!["Core"];
         Assert.Equal("2.0.X", track.ExpectedVersion);

--- a/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
@@ -43,6 +43,29 @@ public sealed class ProjectBuildPreparationServiceTests
     }
 
     [Fact]
+    public void Prepare_propagates_version_bindings()
+    {
+        var service = new ProjectBuildPreparationService();
+        var binding = new ProjectVersionBinding
+        {
+            Path = "tool.json",
+            Project = "Example.Tool",
+            Pattern = @"(?<=Example\.Tool@)\d+\.\d+\.\d+"
+        };
+
+        var context = service.Prepare(
+            new ProjectBuildConfiguration
+            {
+                VersionBindings = new[] { binding }
+            },
+            Directory.GetCurrentDirectory(),
+            null,
+            new ProjectBuildRequestedActions());
+
+        Assert.Same(binding, Assert.Single(context.Spec.VersionBindings!));
+    }
+
+    [Fact]
     public void Prepare_propagates_internal_release_version_floor()
     {
         var service = new ProjectBuildPreparationService();

--- a/PowerForge.Tests/ProjectBuildSupportServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildSupportServiceTests.cs
@@ -70,6 +70,39 @@ public sealed class ProjectBuildSupportServiceTests
     }
 
     [Fact]
+    public void LoadConfig_deserializes_version_bindings()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-projectbuild-bindings-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var configPath = Path.Combine(root.FullName, "project.build.json");
+            File.WriteAllText(configPath, """
+{
+  "VersionBindings": [
+    {
+      "Path": "tool.json",
+      "Project": "Example.Tool",
+      "Pattern": "(?<=Example\\.Tool@)\\d+\\.\\d+\\.\\d+"
+    }
+  ]
+}
+""");
+
+            var config = new ProjectBuildSupportService(new NullLogger()).LoadConfig(configPath);
+            var binding = Assert.Single(config.VersionBindings!);
+
+            Assert.Equal("tool.json", binding.Path);
+            Assert.Equal("Example.Tool", binding.Project);
+            Assert.Equal("{Version}", binding.Replacement);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void LoadConfig_reads_packages_from_unified_release_configuration()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-projectbuild-release-" + Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ProjectVersionBindingServiceTests.cs
+++ b/PowerForge.Tests/ProjectVersionBindingServiceTests.cs
@@ -98,6 +98,97 @@ public sealed class ProjectVersionBindingServiceTests
     }
 
     [Fact]
+    public void Apply_preserves_whitespace_that_is_part_of_the_pattern()
+    {
+        var root = CreateTemporaryDirectory();
+
+        try
+        {
+            var path = WriteFile(root, "tool.txt", "preferred 1.2.3 version; compact=1.2.3");
+            var binding = CreateBinding("tool.txt");
+            binding.Pattern = @" 1\.2\.3 ";
+
+            new ProjectVersionBindingService(new NullLogger()).Apply(
+                root.FullName,
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Example.Tool"] = "1.2.4"
+                },
+                new[] { binding },
+                whatIf: false);
+
+            Assert.Equal("preferred1.2.4version; compact=1.2.3", File.ReadAllText(path));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Apply_preserves_whitespace_in_the_replacement()
+    {
+        var root = CreateTemporaryDirectory();
+
+        try
+        {
+            var path = WriteFile(root, "tool.txt", "Example.Tool@1.2.3");
+            var binding = CreateBinding("tool.txt");
+            binding.Replacement = " {Version} ";
+
+            new ProjectVersionBindingService(new NullLogger()).Apply(
+                root.FullName,
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Example.Tool"] = "1.2.4"
+                },
+                new[] { binding },
+                whatIf: false);
+
+            Assert.Equal("Example.Tool@ 1.2.4 ", File.ReadAllText(path));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Apply_rejects_bomless_non_utf8_without_modifying_the_file()
+    {
+        var root = CreateTemporaryDirectory();
+
+        try
+        {
+            var path = Path.Combine(root.FullName, "tool.txt");
+            var originalBytes = new byte[]
+            {
+                (byte)'E', (byte)'x', (byte)'a', (byte)'m', (byte)'p', (byte)'l', (byte)'e', (byte)'.',
+                (byte)'T', (byte)'o', (byte)'o', (byte)'l', (byte)'@', (byte)'1', (byte)'.', (byte)'2',
+                (byte)'.', (byte)'3', (byte)' ', 0xE9
+            };
+            File.WriteAllBytes(path, originalBytes);
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new ProjectVersionBindingService(new NullLogger()).Apply(
+                    root.FullName,
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Example.Tool"] = "1.2.4"
+                    },
+                    new[] { CreateBinding("tool.txt") },
+                    whatIf: false));
+
+            Assert.Contains("not valid UTF-8", exception.Message, StringComparison.Ordinal);
+            Assert.Equal(originalBytes, File.ReadAllBytes(path));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Apply_rejects_paths_outside_the_repository()
     {
         var root = CreateTemporaryDirectory();

--- a/PowerForge.Tests/ProjectVersionBindingServiceTests.cs
+++ b/PowerForge.Tests/ProjectVersionBindingServiceTests.cs
@@ -1,0 +1,191 @@
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed class ProjectVersionBindingServiceTests
+{
+    [Fact]
+    public void Apply_updates_configured_files_from_the_resolved_project_version()
+    {
+        var root = CreateTemporaryDirectory();
+
+        try
+        {
+            var jsonPath = WriteFile(root, "tool.json", "{ \"command\": \"Example.Tool@1.2.3\" }");
+            var readmePath = WriteFile(root, "README.md", "Run `Example.Tool@1.2.3`.");
+            var bindings = new[]
+            {
+                CreateBinding("tool.json"),
+                CreateBinding("README.md")
+            };
+
+            new ProjectVersionBindingService(new NullLogger()).Apply(
+                root.FullName,
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Example.Tool"] = "1.2.4"
+                },
+                bindings,
+                whatIf: false);
+
+            Assert.Contains("Example.Tool@1.2.4", File.ReadAllText(jsonPath), StringComparison.Ordinal);
+            Assert.Contains("Example.Tool@1.2.4", File.ReadAllText(readmePath), StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Apply_validates_every_binding_before_writing_any_file()
+    {
+        var root = CreateTemporaryDirectory();
+
+        try
+        {
+            var firstPath = WriteFile(root, "first.txt", "Example.Tool@1.2.3");
+            WriteFile(root, "second.txt", "No version is present.");
+            var bindings = new[]
+            {
+                CreateBinding("first.txt"),
+                CreateBinding("second.txt")
+            };
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new ProjectVersionBindingService(new NullLogger()).Apply(
+                    root.FullName,
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Example.Tool"] = "1.2.4"
+                    },
+                    bindings,
+                    whatIf: false));
+
+            Assert.Contains("found 0 matches", exception.Message, StringComparison.Ordinal);
+            Assert.Equal("Example.Tool@1.2.3", File.ReadAllText(firstPath));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Apply_in_plan_mode_validates_without_writing()
+    {
+        var root = CreateTemporaryDirectory();
+
+        try
+        {
+            var path = WriteFile(root, "tool.txt", "Example.Tool@1.2.3");
+
+            new ProjectVersionBindingService(new NullLogger()).Apply(
+                root.FullName,
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Example.Tool"] = "1.2.4"
+                },
+                new[] { CreateBinding("tool.txt") },
+                whatIf: true);
+
+            Assert.Equal("Example.Tool@1.2.3", File.ReadAllText(path));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Apply_rejects_paths_outside_the_repository()
+    {
+        var root = CreateTemporaryDirectory();
+        var outside = CreateTemporaryDirectory();
+
+        try
+        {
+            WriteFile(outside, "tool.txt", "Example.Tool@1.2.3");
+            var relativePath = Path.GetRelativePath(root.FullName, Path.Combine(outside.FullName, "tool.txt"));
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new ProjectVersionBindingService(new NullLogger()).Apply(
+                    root.FullName,
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Example.Tool"] = "1.2.4"
+                    },
+                    new[] { CreateBinding(relativePath) },
+                    whatIf: false));
+
+            Assert.Contains("must resolve inside", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+            TryDelete(outside);
+        }
+    }
+
+    [Fact]
+    public void Apply_rejects_symbolic_links_that_escape_the_repository()
+    {
+        var root = CreateTemporaryDirectory();
+        var outside = CreateTemporaryDirectory();
+
+        try
+        {
+            var outsidePath = WriteFile(outside, "tool.txt", "Example.Tool@1.2.3");
+            var linkPath = Path.Combine(root.FullName, "tool.txt");
+            try
+            {
+                File.CreateSymbolicLink(linkPath, outsidePath);
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                return;
+            }
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new ProjectVersionBindingService(new NullLogger()).Apply(
+                    root.FullName,
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Example.Tool"] = "1.2.4"
+                    },
+                    new[] { CreateBinding("tool.txt") },
+                    whatIf: false));
+
+            Assert.Contains("symbolic link or junction", exception.Message, StringComparison.Ordinal);
+            Assert.Equal("Example.Tool@1.2.3", File.ReadAllText(outsidePath));
+        }
+        finally
+        {
+            TryDelete(root);
+            TryDelete(outside);
+        }
+    }
+
+    private static ProjectVersionBinding CreateBinding(string path)
+        => new()
+        {
+            Path = path,
+            Project = "Example.Tool",
+            Pattern = @"(?<=Example\.Tool@)\d+\.\d+\.\d+"
+        };
+
+    private static DirectoryInfo CreateTemporaryDirectory()
+        => Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-version-binding-" + Guid.NewGuid().ToString("N")));
+
+    private static string WriteFile(DirectoryInfo root, string relativePath, string content)
+    {
+        var path = Path.Combine(root.FullName, relativePath);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private static void TryDelete(DirectoryInfo directory)
+    {
+        try { directory.Delete(recursive: true); } catch { }
+    }
+}

--- a/PowerForge.Tests/RepositoryTextFileTransactionServiceTests.cs
+++ b/PowerForge.Tests/RepositoryTextFileTransactionServiceTests.cs
@@ -155,6 +155,36 @@ public sealed class RepositoryTextFileTransactionServiceTests
         }
     }
 
+    [Fact]
+    public void Apply_cleans_partial_temporary_file_when_preparation_fails()
+    {
+        var root = CreateTemporaryDirectory();
+
+        try
+        {
+            var path = WriteFile(root, "version.txt", "old");
+            var service = new RepositoryTextFileTransactionService(
+                static (source, destination, backup) => File.Replace(source, destination, backup),
+                static (temporaryPath, _, _, _) =>
+                {
+                    File.WriteAllText(temporaryPath, "partial");
+                    throw new IOException("Injected preparation failure.");
+                });
+
+            Assert.Throws<IOException>(() => service.Apply(new[]
+            {
+                new RepositoryTextFileUpdate(path, "old", "new")
+            }));
+
+            Assert.Equal("old", File.ReadAllText(path));
+            Assert.Empty(Directory.EnumerateFiles(root.FullName, "*.powerforge-*"));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
     private static Encoding CreateEncoding(string format)
         => format switch
         {

--- a/PowerForge.Tests/RepositoryTextFileTransactionServiceTests.cs
+++ b/PowerForge.Tests/RepositoryTextFileTransactionServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using PowerForge;
 
 namespace PowerForge.Tests;
@@ -117,6 +118,63 @@ public sealed class RepositoryTextFileTransactionServiceTests
         {
             TryDelete(root);
         }
+    }
+
+    [Theory]
+    [InlineData("utf8")]
+    [InlineData("utf8-bom")]
+    [InlineData("utf16-le")]
+    [InlineData("utf16-be")]
+    [InlineData("utf32-le")]
+    [InlineData("utf32-be")]
+    public void Apply_preserves_text_encoding_and_bom(string format)
+    {
+        var root = CreateTemporaryDirectory();
+
+        try
+        {
+            var path = Path.Combine(root.FullName, "version.txt");
+            var encoding = CreateEncoding(format);
+            WriteEncodedFile(path, "Example.Tool@1.2.3", encoding);
+            var expectedPreamble = encoding.GetPreamble();
+
+            new RepositoryTextFileTransactionService().Apply(new[]
+            {
+                new RepositoryTextFileUpdate(path, "Example.Tool@1.2.3", "Example.Tool@1.2.4")
+            });
+
+            var bytes = File.ReadAllBytes(path);
+            Assert.Equal(expectedPreamble, bytes.Take(expectedPreamble.Length));
+            Assert.Equal(
+                "Example.Tool@1.2.4",
+                encoding.GetString(bytes, expectedPreamble.Length, bytes.Length - expectedPreamble.Length));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    private static Encoding CreateEncoding(string format)
+        => format switch
+        {
+            "utf8" => new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            "utf8-bom" => new UTF8Encoding(encoderShouldEmitUTF8Identifier: true),
+            "utf16-le" => new UnicodeEncoding(bigEndian: false, byteOrderMark: true),
+            "utf16-be" => new UnicodeEncoding(bigEndian: true, byteOrderMark: true),
+            "utf32-le" => new UTF32Encoding(bigEndian: false, byteOrderMark: true),
+            "utf32-be" => new UTF32Encoding(bigEndian: true, byteOrderMark: true),
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unknown encoding fixture.")
+        };
+
+    private static void WriteEncodedFile(string path, string content, Encoding encoding)
+    {
+        var preamble = encoding.GetPreamble();
+        var contentBytes = encoding.GetBytes(content);
+        var bytes = new byte[preamble.Length + contentBytes.Length];
+        Buffer.BlockCopy(preamble, 0, bytes, 0, preamble.Length);
+        Buffer.BlockCopy(contentBytes, 0, bytes, preamble.Length, contentBytes.Length);
+        File.WriteAllBytes(path, bytes);
     }
 
     private static DirectoryInfo CreateTemporaryDirectory()

--- a/PowerForge.Tests/RepositoryTextFileTransactionServiceTests.cs
+++ b/PowerForge.Tests/RepositoryTextFileTransactionServiceTests.cs
@@ -1,0 +1,136 @@
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed class RepositoryTextFileTransactionServiceTests
+{
+    [Fact]
+    public void Apply_replaces_every_file_after_preparation_succeeds()
+    {
+        var root = CreateTemporaryDirectory();
+
+        try
+        {
+            var first = WriteFile(root, "first.txt", "old-first");
+            var second = WriteFile(root, "second.txt", "old-second");
+
+            new RepositoryTextFileTransactionService().Apply(new[]
+            {
+                new RepositoryTextFileUpdate(first, "old-first", "new-first"),
+                new RepositoryTextFileUpdate(second, "old-second", "new-second")
+            });
+
+            Assert.Equal("new-first", File.ReadAllText(first));
+            Assert.Equal("new-second", File.ReadAllText(second));
+            Assert.Empty(Directory.EnumerateFiles(root.FullName, "*.powerforge-*"));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Apply_rolls_back_prior_replacements_when_a_later_replacement_fails()
+    {
+        var root = CreateTemporaryDirectory();
+
+        try
+        {
+            var first = WriteFile(root, "first.txt", "old-first");
+            var second = WriteFile(root, "second.txt", "old-second");
+            var replacementIndex = 0;
+            var service = new RepositoryTextFileTransactionService((source, destination, backup) =>
+            {
+                if (replacementIndex++ == 1)
+                    throw new IOException("Injected second replacement failure.");
+
+                File.Replace(source, destination, backup);
+            });
+
+            var exception = Assert.Throws<InvalidOperationException>(() => service.Apply(new[]
+            {
+                new RepositoryTextFileUpdate(first, "old-first", "new-first"),
+                new RepositoryTextFileUpdate(second, "old-second", "new-second")
+            }));
+
+            Assert.Contains("were rolled back", exception.Message, StringComparison.Ordinal);
+            Assert.Equal("old-first", File.ReadAllText(first));
+            Assert.Equal("old-second", File.ReadAllText(second));
+            Assert.Empty(Directory.EnumerateFiles(root.FullName, "*.powerforge-*"));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Apply_detects_a_file_changed_after_planning_before_any_replacement()
+    {
+        var root = CreateTemporaryDirectory();
+
+        try
+        {
+            var first = WriteFile(root, "first.txt", "old-first");
+            var second = WriteFile(root, "second.txt", "changed-after-plan");
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new RepositoryTextFileTransactionService().Apply(new[]
+                {
+                    new RepositoryTextFileUpdate(first, "old-first", "new-first"),
+                    new RepositoryTextFileUpdate(second, "old-second", "new-second")
+                }));
+
+            Assert.Contains("changed after version planning", exception.Message, StringComparison.Ordinal);
+            Assert.Equal("old-first", File.ReadAllText(first));
+            Assert.Equal("changed-after-plan", File.ReadAllText(second));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Apply_preserves_unix_file_mode()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var root = CreateTemporaryDirectory();
+
+        try
+        {
+            var path = WriteFile(root, "tool.sh", "old");
+            var expectedMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+            File.SetUnixFileMode(path, expectedMode);
+
+            new RepositoryTextFileTransactionService().Apply(new[]
+            {
+                new RepositoryTextFileUpdate(path, "old", "new")
+            });
+
+            Assert.Equal(expectedMode, File.GetUnixFileMode(path));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    private static DirectoryInfo CreateTemporaryDirectory()
+        => Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-file-transaction-" + Guid.NewGuid().ToString("N")));
+
+    private static string WriteFile(DirectoryInfo root, string fileName, string content)
+    {
+        var path = Path.Combine(root.FullName, fileName);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private static void TryDelete(DirectoryInfo directory)
+    {
+        try { directory.Delete(recursive: true); } catch { }
+    }
+}

--- a/PowerForge/Models/Configuration/ConfigurationPackageBuildSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationPackageBuildSegment.cs
@@ -119,6 +119,9 @@ public sealed class PackageBuildConfiguration
     /// <summary>Shared version tracks keyed by track name.</summary>
     public Dictionary<string, PackageBuildVersionTrackConfiguration>? VersionTracks { get; set; }
 
+    /// <summary>Repository files whose embedded versions follow a resolved project version.</summary>
+    public ProjectVersionBinding[]? VersionBindings { get; set; }
+
     /// <summary>When true, <see cref="ExpectedVersionMap"/> acts as an include list.</summary>
     public bool ExpectedVersionMapAsInclude { get; set; }
 

--- a/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
@@ -53,6 +53,12 @@ public sealed class DotNetRepositoryReleaseSpec
     public bool AlignPackageVersions { get; set; }
 
     /// <summary>
+    /// Repository files whose embedded versions follow a resolved project version.
+    /// Bindings are validated during plan mode and applied only when <see cref="UpdateVersions"/> is enabled.
+    /// </summary>
+    public IReadOnlyList<ProjectVersionBinding>? VersionBindings { get; set; }
+
+    /// <summary>
     /// Project-build version tracks that need package-version alignment after project discovery.
     /// </summary>
     internal IReadOnlyList<ProjectBuildVersionAlignmentGroup>? VersionAlignmentGroups { get; set; }

--- a/PowerForge/Models/ProjectBuildConfiguration.cs
+++ b/PowerForge/Models/ProjectBuildConfiguration.cs
@@ -11,6 +11,7 @@ internal sealed class ProjectBuildConfiguration
     public string? ExpectedVersion { get; set; }
     public Dictionary<string, string>? ExpectedVersionMap { get; set; }
     public Dictionary<string, ProjectBuildVersionTrack>? VersionTracks { get; set; }
+    public ProjectVersionBinding[]? VersionBindings { get; set; }
     public bool ExpectedVersionMapAsInclude { get; set; }
     public bool ExpectedVersionMapUseWildcards { get; set; }
     public bool AlignPackageVersions { get; set; }

--- a/PowerForge/Models/ProjectVersionBinding.cs
+++ b/PowerForge/Models/ProjectVersionBinding.cs
@@ -1,0 +1,19 @@
+namespace PowerForge;
+
+/// <summary>
+/// Declares a repository file whose embedded version follows a resolved project version.
+/// </summary>
+public sealed class ProjectVersionBinding
+{
+    /// <summary>Repository-relative path of the file to update.</summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>Project name whose resolved release version is used.</summary>
+    public string Project { get; set; } = string.Empty;
+
+    /// <summary>Regular expression that must match exactly once in the target file.</summary>
+    public string Pattern { get; set; } = string.Empty;
+
+    /// <summary>Replacement text containing the <c>{Version}</c> token.</summary>
+    public string Replacement { get; set; } = "{Version}";
+}

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -263,6 +263,7 @@ public sealed partial class DotNetRepositoryReleaseService
             var versionItems = CreateVersionProgressItems(packable, detailedProgress);
             progress?.PhaseStarted(ProjectBuildProgressPhase.Versioning, packable.Length, "Resolving project versions");
             var versionProgress = 0;
+            var pendingVersionUpdates = new List<KeyValuePair<DotNetRepositoryProjectResult, RepositoryTextFileUpdate>>();
             foreach (var project in packable)
             {
                 var versionItem = versionItems[project];
@@ -359,11 +360,9 @@ public sealed partial class DotNetRepositoryReleaseService
 
                 if (!string.Equals(content, updated, StringComparison.Ordinal))
                 {
-                    File.WriteAllText(project.CsprojPath, updated);
-                    if (!string.IsNullOrWhiteSpace(project.OldVersion))
-                        _logger.Success($"{project.ProjectName}: {project.OldVersion} -> {resolvedVersion}");
-                    else
-                        _logger.Success($"{project.ProjectName}: set version {resolvedVersion}");
+                    pendingVersionUpdates.Add(new KeyValuePair<DotNetRepositoryProjectResult, RepositoryTextFileUpdate>(
+                        project,
+                        new RepositoryTextFileUpdate(project.CsprojPath, content, updated)));
                 }
                 else
                 {
@@ -379,7 +378,53 @@ public sealed partial class DotNetRepositoryReleaseService
             if (packable.Any(project => !string.IsNullOrWhiteSpace(project.ErrorMessage)))
                 progress?.PhaseFailed(ProjectBuildProgressPhase.Versioning, "One or more project versions could not be resolved");
             else
+            {
+                var versionBindingService = new ProjectVersionBindingService(_logger);
+                var pathComparer = FrameworkCompatibility.GetPathStringComparison(root) == StringComparison.OrdinalIgnoreCase
+                    ? StringComparer.OrdinalIgnoreCase
+                    : StringComparer.Ordinal;
+                var plannedProjectContents = pendingVersionUpdates.ToDictionary(
+                    static item => Path.GetFullPath(item.Value.FilePath),
+                    static item => item.Value.UpdatedContent,
+                    pathComparer);
+                var versionBindingPlan = spec.UpdateVersions
+                    ? versionBindingService.Plan(
+                        root,
+                        result.ResolvedVersionsByProject,
+                        spec.VersionBindings,
+                        plannedProjectContents)
+                    : Array.Empty<ProjectVersionBindingFileUpdate>();
+
+                if (spec.WhatIf)
+                {
+                    versionBindingService.LogPlanned(versionBindingPlan);
+                }
+                else
+                {
+                    var boundPaths = new HashSet<string>(
+                        versionBindingPlan.Select(static item => Path.GetFullPath(item.Update.FilePath)),
+                        pathComparer);
+                    var fileUpdates = pendingVersionUpdates
+                        .Where(item => !boundPaths.Contains(Path.GetFullPath(item.Value.FilePath)))
+                        .Select(static item => item.Value)
+                        .Concat(versionBindingPlan.Select(static item => item.Update))
+                        .ToArray();
+                    new RepositoryTextFileTransactionService().Apply(fileUpdates);
+
+                    foreach (var pendingUpdate in pendingVersionUpdates)
+                    {
+                        var project = pendingUpdate.Key;
+                        if (!string.IsNullOrWhiteSpace(project.OldVersion))
+                            _logger.Success($"{project.ProjectName}: {project.OldVersion} -> {project.NewVersion}");
+                        else
+                            _logger.Success($"{project.ProjectName}: set version {project.NewVersion}");
+                    }
+
+                    versionBindingService.LogApplied(versionBindingPlan);
+                }
+
                 progress?.PhaseCompleted(ProjectBuildProgressPhase.Versioning, $"{packable.Length} project version(s) resolved");
+            }
             if (spec.Pack)
             {
                 progress?.PhaseStarted(ProjectBuildProgressPhase.PackageBuild, packable.Length, "Building and packing projects");

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -347,7 +347,7 @@ public sealed partial class DotNetRepositoryReleaseService
                 }
 
                 project.NewVersion = resolvedVersion;
-                if (spec.WhatIf || !shouldUpdateProjectVersion)
+                if (!shouldUpdateProjectVersion)
                 {
                     detailedProgress?.ItemUpdated(versionItem, ProjectBuildProgressItemState.Completed, resolvedVersion);
                     versionProgress++;

--- a/PowerForge/Services/ProjectBuildPreparationService.cs
+++ b/PowerForge/Services/ProjectBuildPreparationService.cs
@@ -98,6 +98,7 @@ internal sealed class ProjectBuildPreparationService
             ExpectedVersionMapAsInclude = config.ExpectedVersionMapAsInclude,
             ExpectedVersionMapUseWildcards = config.ExpectedVersionMapUseWildcards,
             AlignPackageVersions = config.AlignPackageVersions,
+            VersionBindings = config.VersionBindings,
             VersionAlignmentGroups = versionAlignmentGroups,
             IncludeProjects = config.IncludeProjects,
             ExcludeProjects = config.ExcludeProjects,

--- a/PowerForge/Services/ProjectVersionBindingService.cs
+++ b/PowerForge/Services/ProjectVersionBindingService.cs
@@ -42,8 +42,8 @@ internal sealed class ProjectVersionBindingService
 
             var bindingPath = RequireValue(binding.Path, "VersionBindings.Path");
             var project = RequireValue(binding.Project, $"Version binding '{bindingPath}' Project");
-            var pattern = RequireValue(binding.Pattern, $"Version binding '{bindingPath}' Pattern");
-            var replacement = RequireValue(binding.Replacement, $"Version binding '{bindingPath}' Replacement");
+            var pattern = RequireUntrimmedText(binding.Pattern, $"Version binding '{bindingPath}' Pattern");
+            var replacement = RequireUntrimmedText(binding.Replacement, $"Version binding '{bindingPath}' Replacement");
             if (replacement.IndexOf("{Version}", StringComparison.Ordinal) < 0)
                 throw new InvalidOperationException($"Version binding '{bindingPath}' Replacement must contain '{{Version}}'.");
             if (Path.IsPathRooted(bindingPath))
@@ -59,7 +59,7 @@ internal sealed class ProjectVersionBindingService
 
             if (!plannedFiles.TryGetValue(fullPath, out var plannedFile))
             {
-                var content = File.ReadAllText(fullPath);
+                var content = RepositoryTextFileTransactionService.ReadText(fullPath);
                 var plannedContent = plannedContentsByPath is not null &&
                     plannedContentsByPath.TryGetValue(fullPath, out var overlaidContent)
                         ? overlaidContent
@@ -147,6 +147,14 @@ internal sealed class ProjectVersionBindingService
             throw new InvalidOperationException($"{label} is required.");
 
         return value!.Trim();
+    }
+
+    private static string RequireUntrimmedText(string? value, string label)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new InvalidOperationException($"{label} is required.");
+
+        return value!;
     }
 
     private static void EnsureChildPath(

--- a/PowerForge/Services/ProjectVersionBindingService.cs
+++ b/PowerForge/Services/ProjectVersionBindingService.cs
@@ -1,0 +1,217 @@
+using System.Text.RegularExpressions;
+
+namespace PowerForge;
+
+/// <summary>
+/// Applies resolved project versions to explicitly configured repository files.
+/// </summary>
+internal sealed class ProjectVersionBindingService
+{
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(2);
+    private readonly ILogger _logger;
+
+    public ProjectVersionBindingService(ILogger logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public IReadOnlyList<ProjectVersionBindingFileUpdate> Plan(
+        string repositoryRoot,
+        IReadOnlyDictionary<string, string> resolvedVersions,
+        IReadOnlyList<ProjectVersionBinding>? bindings,
+        IReadOnlyDictionary<string, string>? plannedContentsByPath = null)
+    {
+        if (bindings is null || bindings.Count == 0)
+            return Array.Empty<ProjectVersionBindingFileUpdate>();
+        if (string.IsNullOrWhiteSpace(repositoryRoot))
+            throw new ArgumentException("Repository root is required.", nameof(repositoryRoot));
+        if (resolvedVersions is null)
+            throw new ArgumentNullException(nameof(resolvedVersions));
+
+        var root = Path.GetFullPath(repositoryRoot);
+        var comparison = FrameworkCompatibility.GetPathStringComparison(root);
+        var comparer = comparison == StringComparison.OrdinalIgnoreCase
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+        var plannedFiles = new Dictionary<string, PlannedFile>(comparer);
+
+        foreach (var binding in bindings)
+        {
+            if (binding is null)
+                throw new InvalidOperationException("VersionBindings cannot contain null entries.");
+
+            var bindingPath = RequireValue(binding.Path, "VersionBindings.Path");
+            var project = RequireValue(binding.Project, $"Version binding '{bindingPath}' Project");
+            var pattern = RequireValue(binding.Pattern, $"Version binding '{bindingPath}' Pattern");
+            var replacement = RequireValue(binding.Replacement, $"Version binding '{bindingPath}' Replacement");
+            if (replacement.IndexOf("{Version}", StringComparison.Ordinal) < 0)
+                throw new InvalidOperationException($"Version binding '{bindingPath}' Replacement must contain '{{Version}}'.");
+            if (Path.IsPathRooted(bindingPath))
+                throw new InvalidOperationException($"Version binding path '{bindingPath}' must be repository-relative.");
+            if (!resolvedVersions.TryGetValue(project, out var version) || string.IsNullOrWhiteSpace(version))
+                throw new InvalidOperationException($"Version binding '{bindingPath}' references project '{project}', which has no resolved version.");
+
+            var fullPath = Path.GetFullPath(Path.Combine(root, bindingPath));
+            EnsureChildPath(root, fullPath, comparison, bindingPath);
+            EnsureNoReparsePoints(root, fullPath, bindingPath);
+            if (!File.Exists(fullPath))
+                throw new FileNotFoundException($"Version binding file was not found: {bindingPath}", fullPath);
+
+            if (!plannedFiles.TryGetValue(fullPath, out var plannedFile))
+            {
+                var content = File.ReadAllText(fullPath);
+                var plannedContent = plannedContentsByPath is not null &&
+                    plannedContentsByPath.TryGetValue(fullPath, out var overlaidContent)
+                        ? overlaidContent
+                        : content;
+                plannedFile = new PlannedFile(content, plannedContent);
+                plannedFiles.Add(fullPath, plannedFile);
+            }
+
+            Regex regex;
+            try
+            {
+                regex = new Regex(pattern, RegexOptions.CultureInvariant, RegexTimeout);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new InvalidOperationException($"Version binding '{bindingPath}' has an invalid Pattern: {ex.Message}", ex);
+            }
+
+            var matches = regex.Matches(plannedFile.UpdatedContent);
+            if (matches.Count != 1)
+                throw new InvalidOperationException($"Version binding '{bindingPath}' Pattern must match exactly once; found {matches.Count} matches.");
+
+            var replacementText = replacement.Replace("{Version}", version);
+            plannedFile.UpdatedContent = regex.Replace(
+                plannedFile.UpdatedContent,
+                _ => replacementText,
+                count: 1);
+            plannedFile.BindingCount++;
+        }
+
+        return plannedFiles
+            .OrderBy(static pair => pair.Key, comparer)
+            .Select(pair => new ProjectVersionBindingFileUpdate(
+                new RepositoryTextFileUpdate(pair.Key, pair.Value.OriginalContent, pair.Value.UpdatedContent),
+                FrameworkCompatibility.GetRelativePath(root, pair.Key),
+                pair.Value.BindingCount))
+            .ToArray();
+    }
+
+    public void Apply(
+        string repositoryRoot,
+        IReadOnlyDictionary<string, string> resolvedVersions,
+        IReadOnlyList<ProjectVersionBinding>? bindings,
+        bool whatIf,
+        bool logChanges = true)
+    {
+        var plan = Plan(repositoryRoot, resolvedVersions, bindings);
+        if (whatIf)
+        {
+            if (logChanges)
+                LogPlanned(plan);
+            return;
+        }
+
+        new RepositoryTextFileTransactionService().Apply(plan.Select(static item => item.Update).ToArray());
+        if (logChanges)
+            LogApplied(plan);
+    }
+
+    public void LogPlanned(IReadOnlyList<ProjectVersionBindingFileUpdate> plan)
+    {
+        foreach (var item in plan)
+        {
+            if (item.HasChanges)
+                _logger.Info($"Version binding planned: {item.RelativePath} ({item.BindingCount} binding(s)).");
+            else
+                _logger.Info($"Version binding unchanged: {item.RelativePath}.");
+        }
+    }
+
+    public void LogApplied(IReadOnlyList<ProjectVersionBindingFileUpdate> plan)
+    {
+        foreach (var item in plan)
+        {
+            if (item.HasChanges)
+                _logger.Success($"Version binding updated: {item.RelativePath} ({item.BindingCount} binding(s)).");
+            else
+                _logger.Info($"Version binding unchanged: {item.RelativePath}.");
+        }
+    }
+
+    private static string RequireValue(string? value, string label)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new InvalidOperationException($"{label} is required.");
+
+        return value!.Trim();
+    }
+
+    private static void EnsureChildPath(
+        string root,
+        string candidate,
+        StringComparison comparison,
+        string configuredPath)
+    {
+        var normalizedRoot = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var rootPrefix = normalizedRoot + Path.DirectorySeparatorChar;
+        if (!candidate.StartsWith(rootPrefix, comparison))
+            throw new InvalidOperationException($"Version binding path '{configuredPath}' must resolve inside the repository root.");
+    }
+
+    private static void EnsureNoReparsePoints(string root, string candidate, string configuredPath)
+    {
+        var relativePath = FrameworkCompatibility.GetRelativePath(root, candidate);
+        var segments = relativePath.Split(
+            new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+            StringSplitOptions.RemoveEmptyEntries);
+        var currentPath = root;
+        foreach (var segment in segments)
+        {
+            currentPath = Path.Combine(currentPath, segment);
+            try
+            {
+                if ((File.GetAttributes(currentPath) & FileAttributes.ReparsePoint) != 0)
+                    throw new InvalidOperationException($"Version binding path '{configuredPath}' cannot traverse a symbolic link or junction.");
+            }
+            catch (FileNotFoundException)
+            {
+                // The final existence check provides the binding-specific error.
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // The final existence check provides the binding-specific error.
+            }
+        }
+    }
+
+    private sealed class PlannedFile
+    {
+        public PlannedFile(string originalContent, string updatedContent)
+        {
+            OriginalContent = originalContent;
+            UpdatedContent = updatedContent;
+        }
+
+        public string OriginalContent { get; }
+        public string UpdatedContent { get; set; }
+        public int BindingCount { get; set; }
+    }
+}
+
+internal sealed class ProjectVersionBindingFileUpdate
+{
+    public ProjectVersionBindingFileUpdate(RepositoryTextFileUpdate update, string relativePath, int bindingCount)
+    {
+        Update = update;
+        RelativePath = relativePath;
+        BindingCount = bindingCount;
+    }
+
+    public RepositoryTextFileUpdate Update { get; }
+    public string RelativePath { get; }
+    public int BindingCount { get; }
+    public bool HasChanges => !string.Equals(Update.OriginalContent, Update.UpdatedContent, StringComparison.Ordinal);
+}

--- a/PowerForge/Services/RepositoryTextFileTransactionService.cs
+++ b/PowerForge/Services/RepositoryTextFileTransactionService.cs
@@ -19,18 +19,30 @@ internal sealed class RepositoryTextFileUpdate
 internal sealed class RepositoryTextFileTransactionService
 {
     internal delegate void ReplaceFileHandler(string sourcePath, string destinationPath, string backupPath);
+    internal delegate void PrepareFileHandler(string path, string content, Encoding encoding, byte[] preamble);
 
     private readonly ReplaceFileHandler _replaceFile;
+    private readonly PrepareFileHandler _prepareFile;
 
     public RepositoryTextFileTransactionService()
-        : this(static (sourcePath, destinationPath, backupPath) =>
-            File.Replace(sourcePath, destinationPath, backupPath))
+        : this(
+            static (sourcePath, destinationPath, backupPath) =>
+                File.Replace(sourcePath, destinationPath, backupPath),
+            WriteSnapshot)
     {
     }
 
     internal RepositoryTextFileTransactionService(ReplaceFileHandler replaceFile)
+        : this(replaceFile, WriteSnapshot)
+    {
+    }
+
+    internal RepositoryTextFileTransactionService(
+        ReplaceFileHandler replaceFile,
+        PrepareFileHandler prepareFile)
     {
         _replaceFile = replaceFile ?? throw new ArgumentNullException(nameof(replaceFile));
+        _prepareFile = prepareFile ?? throw new ArgumentNullException(nameof(prepareFile));
     }
 
     public void Apply(IReadOnlyList<RepositoryTextFileUpdate> updates)
@@ -69,12 +81,13 @@ internal sealed class RepositoryTextFileTransactionService
                 var suffix = ".powerforge-" + Guid.NewGuid().ToString("N");
                 var temporaryPath = fullPath + suffix + ".tmp";
                 var backupPath = fullPath + suffix + ".bak";
-                WriteSnapshot(temporaryPath, update.UpdatedContent, snapshot);
+                var preparedUpdate = new PreparedUpdate(fullPath, temporaryPath, backupPath);
+                prepared.Add(preparedUpdate);
+                _prepareFile(temporaryPath, update.UpdatedContent, snapshot.Encoding, snapshot.Preamble);
 #if !NET472
                 if (!OperatingSystem.IsWindows())
                     File.SetUnixFileMode(temporaryPath, File.GetUnixFileMode(fullPath));
 #endif
-                prepared.Add(new PreparedUpdate(fullPath, temporaryPath, backupPath));
             }
 
             var replaced = new List<PreparedUpdate>(prepared.Count);
@@ -146,50 +159,62 @@ internal sealed class RepositoryTextFileTransactionService
         }
     }
 
+    internal static string ReadText(string path)
+        => ReadSnapshot(path).Content;
+
     private static TextFileSnapshot ReadSnapshot(string path)
     {
         var bytes = File.ReadAllBytes(path);
-        Encoding encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        Encoding encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
         var preambleLength = 0;
 
         if (StartsWith(bytes, new byte[] { 0x00, 0x00, 0xFE, 0xFF }))
         {
-            encoding = new UTF32Encoding(bigEndian: true, byteOrderMark: true);
+            encoding = new UTF32Encoding(bigEndian: true, byteOrderMark: true, throwOnInvalidCharacters: true);
             preambleLength = 4;
         }
         else if (StartsWith(bytes, new byte[] { 0xFF, 0xFE, 0x00, 0x00 }))
         {
-            encoding = new UTF32Encoding(bigEndian: false, byteOrderMark: true);
+            encoding = new UTF32Encoding(bigEndian: false, byteOrderMark: true, throwOnInvalidCharacters: true);
             preambleLength = 4;
         }
         else if (StartsWith(bytes, new byte[] { 0xEF, 0xBB, 0xBF }))
         {
-            encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+            encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true, throwOnInvalidBytes: true);
             preambleLength = 3;
         }
         else if (StartsWith(bytes, new byte[] { 0xFE, 0xFF }))
         {
-            encoding = new UnicodeEncoding(bigEndian: true, byteOrderMark: true);
+            encoding = new UnicodeEncoding(bigEndian: true, byteOrderMark: true, throwOnInvalidBytes: true);
             preambleLength = 2;
         }
         else if (StartsWith(bytes, new byte[] { 0xFF, 0xFE }))
         {
-            encoding = new UnicodeEncoding(bigEndian: false, byteOrderMark: true);
+            encoding = new UnicodeEncoding(bigEndian: false, byteOrderMark: true, throwOnInvalidBytes: true);
             preambleLength = 2;
         }
 
-        return new TextFileSnapshot(
-            encoding.GetString(bytes, preambleLength, bytes.Length - preambleLength),
-            encoding,
-            preambleLength == 0 ? Array.Empty<byte>() : encoding.GetPreamble());
+        try
+        {
+            return new TextFileSnapshot(
+                encoding.GetString(bytes, preambleLength, bytes.Length - preambleLength),
+                encoding,
+                preambleLength == 0 ? Array.Empty<byte>() : encoding.GetPreamble());
+        }
+        catch (DecoderFallbackException ex)
+        {
+            throw new InvalidOperationException(
+                $"Release text file '{path}' is not valid UTF-8 or BOM-marked UTF-16/UTF-32.",
+                ex);
+        }
     }
 
-    private static void WriteSnapshot(string path, string content, TextFileSnapshot snapshot)
+    private static void WriteSnapshot(string path, string content, Encoding encoding, byte[] preamble)
     {
-        var contentBytes = snapshot.Encoding.GetBytes(content);
-        var bytes = new byte[snapshot.Preamble.Length + contentBytes.Length];
-        Buffer.BlockCopy(snapshot.Preamble, 0, bytes, 0, snapshot.Preamble.Length);
-        Buffer.BlockCopy(contentBytes, 0, bytes, snapshot.Preamble.Length, contentBytes.Length);
+        var contentBytes = encoding.GetBytes(content);
+        var bytes = new byte[preamble.Length + contentBytes.Length];
+        Buffer.BlockCopy(preamble, 0, bytes, 0, preamble.Length);
+        Buffer.BlockCopy(contentBytes, 0, bytes, preamble.Length, contentBytes.Length);
         File.WriteAllBytes(path, bytes);
     }
 

--- a/PowerForge/Services/RepositoryTextFileTransactionService.cs
+++ b/PowerForge/Services/RepositoryTextFileTransactionService.cs
@@ -1,0 +1,159 @@
+namespace PowerForge;
+
+internal sealed class RepositoryTextFileUpdate
+{
+    public RepositoryTextFileUpdate(string filePath, string originalContent, string updatedContent)
+    {
+        FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+        OriginalContent = originalContent ?? throw new ArgumentNullException(nameof(originalContent));
+        UpdatedContent = updatedContent ?? throw new ArgumentNullException(nameof(updatedContent));
+    }
+
+    public string FilePath { get; }
+    public string OriginalContent { get; }
+    public string UpdatedContent { get; }
+}
+
+internal sealed class RepositoryTextFileTransactionService
+{
+    internal delegate void ReplaceFileHandler(string sourcePath, string destinationPath, string backupPath);
+
+    private readonly ReplaceFileHandler _replaceFile;
+
+    public RepositoryTextFileTransactionService()
+        : this(static (sourcePath, destinationPath, backupPath) =>
+            File.Replace(sourcePath, destinationPath, backupPath))
+    {
+    }
+
+    internal RepositoryTextFileTransactionService(ReplaceFileHandler replaceFile)
+    {
+        _replaceFile = replaceFile ?? throw new ArgumentNullException(nameof(replaceFile));
+    }
+
+    public void Apply(IReadOnlyList<RepositoryTextFileUpdate> updates)
+    {
+        if (updates is null)
+            throw new ArgumentNullException(nameof(updates));
+        if (updates.Count == 0)
+            return;
+
+        var comparison = FrameworkCompatibility.GetPathStringComparison(
+            Path.GetDirectoryName(updates[0].FilePath) ?? updates[0].FilePath);
+        var comparer = comparison == StringComparison.OrdinalIgnoreCase
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+        var prepared = new List<PreparedUpdate>(updates.Count);
+        var uniquePaths = new HashSet<string>(comparer);
+        var preserveBackups = false;
+
+        try
+        {
+            foreach (var update in updates)
+            {
+                var fullPath = Path.GetFullPath(update.FilePath);
+                if (!uniquePaths.Add(fullPath))
+                    throw new InvalidOperationException($"A release file update was configured more than once: {fullPath}");
+                if (!File.Exists(fullPath))
+                    throw new FileNotFoundException($"Release file update target was not found: {fullPath}", fullPath);
+
+                var currentContent = File.ReadAllText(fullPath);
+                if (!string.Equals(currentContent, update.OriginalContent, StringComparison.Ordinal))
+                    throw new InvalidOperationException($"Release file changed after version planning and was not modified: {fullPath}");
+                if (string.Equals(currentContent, update.UpdatedContent, StringComparison.Ordinal))
+                    continue;
+
+                var suffix = ".powerforge-" + Guid.NewGuid().ToString("N");
+                var temporaryPath = fullPath + suffix + ".tmp";
+                var backupPath = fullPath + suffix + ".bak";
+                File.WriteAllText(temporaryPath, update.UpdatedContent);
+#if !NET472
+                if (!OperatingSystem.IsWindows())
+                    File.SetUnixFileMode(temporaryPath, File.GetUnixFileMode(fullPath));
+#endif
+                prepared.Add(new PreparedUpdate(fullPath, temporaryPath, backupPath));
+            }
+
+            var replaced = new List<PreparedUpdate>(prepared.Count);
+            try
+            {
+                foreach (var update in prepared)
+                {
+                    _replaceFile(update.TemporaryPath, update.FilePath, update.BackupPath);
+                    replaced.Add(update);
+                }
+            }
+            catch (Exception writeException)
+            {
+                var rollbackErrors = RollBack(replaced);
+                preserveBackups = rollbackErrors.Count > 0;
+                var message = rollbackErrors.Count == 0
+                    ? "Release file transaction failed; prior file replacements were rolled back."
+                    : "Release file transaction failed and one or more prior file replacements could not be rolled back: "
+                      + string.Join(" | ", rollbackErrors);
+                throw new InvalidOperationException(message, writeException);
+            }
+        }
+        finally
+        {
+            foreach (var update in prepared)
+            {
+                TryDelete(update.TemporaryPath);
+                if (!preserveBackups)
+                    TryDelete(update.BackupPath);
+            }
+        }
+    }
+
+    private static List<string> RollBack(IReadOnlyList<PreparedUpdate> replaced)
+    {
+        var errors = new List<string>();
+        for (var index = replaced.Count - 1; index >= 0; index--)
+        {
+            var update = replaced[index];
+            try
+            {
+                if (!File.Exists(update.BackupPath))
+                    throw new FileNotFoundException("Release file transaction backup was not found.", update.BackupPath);
+
+                if (File.Exists(update.FilePath))
+                    File.Replace(update.BackupPath, update.FilePath, destinationBackupFileName: null);
+                else
+                    File.Move(update.BackupPath, update.FilePath);
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"{update.FilePath}: {ex.Message}");
+            }
+        }
+
+        return errors;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch
+        {
+            // Best-effort cleanup. A rollback error is reported separately.
+        }
+    }
+
+    private sealed class PreparedUpdate
+    {
+        public PreparedUpdate(string filePath, string temporaryPath, string backupPath)
+        {
+            FilePath = filePath;
+            TemporaryPath = temporaryPath;
+            BackupPath = backupPath;
+        }
+
+        public string FilePath { get; }
+        public string TemporaryPath { get; }
+        public string BackupPath { get; }
+    }
+}

--- a/PowerForge/Services/RepositoryTextFileTransactionService.cs
+++ b/PowerForge/Services/RepositoryTextFileTransactionService.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace PowerForge;
 
 internal sealed class RepositoryTextFileUpdate
@@ -57,7 +59,8 @@ internal sealed class RepositoryTextFileTransactionService
                 if (!File.Exists(fullPath))
                     throw new FileNotFoundException($"Release file update target was not found: {fullPath}", fullPath);
 
-                var currentContent = File.ReadAllText(fullPath);
+                var snapshot = ReadSnapshot(fullPath);
+                var currentContent = snapshot.Content;
                 if (!string.Equals(currentContent, update.OriginalContent, StringComparison.Ordinal))
                     throw new InvalidOperationException($"Release file changed after version planning and was not modified: {fullPath}");
                 if (string.Equals(currentContent, update.UpdatedContent, StringComparison.Ordinal))
@@ -66,7 +69,7 @@ internal sealed class RepositoryTextFileTransactionService
                 var suffix = ".powerforge-" + Guid.NewGuid().ToString("N");
                 var temporaryPath = fullPath + suffix + ".tmp";
                 var backupPath = fullPath + suffix + ".bak";
-                File.WriteAllText(temporaryPath, update.UpdatedContent);
+                WriteSnapshot(temporaryPath, update.UpdatedContent, snapshot);
 #if !NET472
                 if (!OperatingSystem.IsWindows())
                     File.SetUnixFileMode(temporaryPath, File.GetUnixFileMode(fullPath));
@@ -143,6 +146,67 @@ internal sealed class RepositoryTextFileTransactionService
         }
     }
 
+    private static TextFileSnapshot ReadSnapshot(string path)
+    {
+        var bytes = File.ReadAllBytes(path);
+        Encoding encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        var preambleLength = 0;
+
+        if (StartsWith(bytes, new byte[] { 0x00, 0x00, 0xFE, 0xFF }))
+        {
+            encoding = new UTF32Encoding(bigEndian: true, byteOrderMark: true);
+            preambleLength = 4;
+        }
+        else if (StartsWith(bytes, new byte[] { 0xFF, 0xFE, 0x00, 0x00 }))
+        {
+            encoding = new UTF32Encoding(bigEndian: false, byteOrderMark: true);
+            preambleLength = 4;
+        }
+        else if (StartsWith(bytes, new byte[] { 0xEF, 0xBB, 0xBF }))
+        {
+            encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+            preambleLength = 3;
+        }
+        else if (StartsWith(bytes, new byte[] { 0xFE, 0xFF }))
+        {
+            encoding = new UnicodeEncoding(bigEndian: true, byteOrderMark: true);
+            preambleLength = 2;
+        }
+        else if (StartsWith(bytes, new byte[] { 0xFF, 0xFE }))
+        {
+            encoding = new UnicodeEncoding(bigEndian: false, byteOrderMark: true);
+            preambleLength = 2;
+        }
+
+        return new TextFileSnapshot(
+            encoding.GetString(bytes, preambleLength, bytes.Length - preambleLength),
+            encoding,
+            preambleLength == 0 ? Array.Empty<byte>() : encoding.GetPreamble());
+    }
+
+    private static void WriteSnapshot(string path, string content, TextFileSnapshot snapshot)
+    {
+        var contentBytes = snapshot.Encoding.GetBytes(content);
+        var bytes = new byte[snapshot.Preamble.Length + contentBytes.Length];
+        Buffer.BlockCopy(snapshot.Preamble, 0, bytes, 0, snapshot.Preamble.Length);
+        Buffer.BlockCopy(contentBytes, 0, bytes, snapshot.Preamble.Length, contentBytes.Length);
+        File.WriteAllBytes(path, bytes);
+    }
+
+    private static bool StartsWith(byte[] bytes, byte[] prefix)
+    {
+        if (bytes.Length < prefix.Length)
+            return false;
+
+        for (var index = 0; index < prefix.Length; index++)
+        {
+            if (bytes[index] != prefix[index])
+                return false;
+        }
+
+        return true;
+    }
+
     private sealed class PreparedUpdate
     {
         public PreparedUpdate(string filePath, string temporaryPath, string backupPath)
@@ -155,5 +219,19 @@ internal sealed class RepositoryTextFileTransactionService
         public string FilePath { get; }
         public string TemporaryPath { get; }
         public string BackupPath { get; }
+    }
+
+    private sealed class TextFileSnapshot
+    {
+        public TextFileSnapshot(string content, Encoding encoding, byte[] preamble)
+        {
+            Content = content;
+            Encoding = encoding;
+            Preamble = preamble;
+        }
+
+        public string Content { get; }
+        public Encoding Encoding { get; }
+        public byte[] Preamble { get; }
     }
 }

--- a/Schemas/project.build.schema.json
+++ b/Schemas/project.build.schema.json
@@ -34,6 +34,16 @@
         "$ref": "#/definitions/versionTrack"
       }
     },
+    "VersionBindings": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "description": "Repository files whose embedded versions follow a resolved project version. Every binding must match exactly once.",
+      "items": {
+        "$ref": "#/definitions/versionBinding"
+      }
+    },
     "ExpectedVersionMapAsInclude": {
       "type": "boolean"
     },
@@ -327,6 +337,38 @@
     }
   },
   "definitions": {
+    "versionBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Path",
+        "Project",
+        "Pattern"
+      ],
+      "properties": {
+        "Path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Repository-relative path of the file to update."
+        },
+        "Project": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Project name whose resolved release version is used."
+        },
+        "Pattern": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Regular expression that must match exactly once in the target file."
+        },
+        "Replacement": {
+          "type": "string",
+          "minLength": 1,
+          "default": "{Version}",
+          "description": "Replacement text containing the {Version} token."
+        }
+      }
+    },
     "versionTrack": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
## Summary

- add declarative `VersionBindings` to project-build JSON and the PowerShell package-build surface
- resolve each binding from a named project's planned release version and require exactly one regex match
- preserve configured pattern and replacement text, including intentional boundary whitespace
- compose project and bound-file updates in execution and plan mode, while applying execution updates as one rollback-backed transaction
- reject path traversal and reparse points; preserve each target's encoding, BOM state, and Unix file mode; and fail closed for unsupported BOM-less encodings
- include bindings in synchronized-release fingerprints, schema documentation, and focused contract coverage

## Release note

Consumers should configure `VersionBindings` only after this PSPublishModule/PowerForge version is published. Older installed versions do not apply the new binding contract.

## Validation

- focused version-binding and configuration tests: 75 passed
- `dotnet build PSPublishModule.sln -c Release --no-restore`: passed across `net472`, `net8.0`, and `net10.0`
- binding and transaction tests: 19 passed under Ubuntu/WSL, including encoding/BOM and Unix executable-mode coverage
- local OfficeIMO `Invoke-ProjectBuild -Plan`: passed with the new bindings