### PR TITLE
Verify signed MSI release artifacts

### DIFF
--- a/PowerForge.Cli/PowerForgeCliJsonContext.cs
+++ b/PowerForge.Cli/PowerForgeCliJsonContext.cs
@@ -34,6 +34,7 @@ namespace PowerForge.Cli;
 [JsonSerializable(typeof(DotNetPublishSpec))]
 [JsonSerializable(typeof(DotNetPublishPlan))]
 [JsonSerializable(typeof(DotNetPublishResult))]
+[JsonSerializable(typeof(DotNetPublishReleaseArtifact))]
 [JsonSerializable(typeof(DotNetPublishFailure))]
 [JsonSerializable(typeof(DotNetPublishConfigScaffoldResult))]
 [JsonSerializable(typeof(DotNetPublishAppInstallerOptions))]

--- a/PowerForge.Cli/Program.Command.DotNet.ReleaseArtifact.cs
+++ b/PowerForge.Cli/Program.Command.DotNet.ReleaseArtifact.cs
@@ -23,6 +23,11 @@ internal static partial class Program
         var runtime = TryGetOptionValue(commandArgs, "--rid");
         var framework = TryGetOptionValue(commandArgs, "--framework");
         var style = TryGetOptionValue(commandArgs, "--style");
+        var artifactPath = TryGetOptionValue(commandArgs, "--artifact");
+        var profile = TryGetOptionValue(commandArgs, "--profile");
+        var signProfile = TryGetOptionValue(commandArgs, "--sign-profile");
+        var signThumbprint = TryGetOptionValue(commandArgs, "--sign-thumbprint");
+        var signSubjectName = TryGetOptionValue(commandArgs, "--sign-subject-name");
         if (string.IsNullOrWhiteSpace(projectRoot) ||
             string.IsNullOrWhiteSpace(manifestPath) ||
             string.IsNullOrWhiteSpace(checksumsPath) ||
@@ -63,7 +68,12 @@ internal static partial class Program
                     Target = target,
                     Runtime = runtime,
                     Framework = framework,
-                    Style = style
+                    Style = style,
+                    ArtifactPath = artifactPath,
+                    Profile = profile,
+                    SignProfile = signProfile,
+                    SignThumbprint = signThumbprint,
+                    SignSubjectName = signSubjectName
                 });
             if (outputJson)
             {

--- a/PowerForge.Cli/Program.Command.DotNet.ReleaseArtifact.cs
+++ b/PowerForge.Cli/Program.Command.DotNet.ReleaseArtifact.cs
@@ -1,0 +1,102 @@
+using PowerForge;
+using PowerForge.Cli;
+
+internal static partial class Program
+{
+    private static int CommandDotNetReleaseArtifact(string[] args, CliOptions cli, ILogger logger)
+    {
+        if (args.Length == 0 || !args[0].Equals("verify", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine(DotNetReleaseArtifactVerifyUsage);
+            return 2;
+        }
+
+        var commandArgs = args.Skip(1).ToArray();
+        var outputJson = IsJsonOutput(commandArgs);
+        var projectRoot = TryGetOptionValue(commandArgs, "--project-root");
+        var manifestPath = TryGetOptionValue(commandArgs, "--manifest");
+        var checksumsPath = TryGetOptionValue(commandArgs, "--checksums");
+        var configurationPath = TryGetOptionValue(commandArgs, "--config");
+        var installerId = TryGetOptionValue(commandArgs, "--installer");
+        var sourceRevision = TryGetOptionValue(commandArgs, "--source-revision");
+        if (string.IsNullOrWhiteSpace(projectRoot) ||
+            string.IsNullOrWhiteSpace(manifestPath) ||
+            string.IsNullOrWhiteSpace(checksumsPath) ||
+            string.IsNullOrWhiteSpace(configurationPath) ||
+            string.IsNullOrWhiteSpace(installerId) ||
+            string.IsNullOrWhiteSpace(sourceRevision))
+        {
+            if (outputJson)
+            {
+                WriteJson(new CliJsonEnvelope
+                {
+                    SchemaVersion = OutputSchemaVersion,
+                    Command = "dotnet.release-artifact.verify",
+                    Success = false,
+                    ExitCode = 2,
+                    Error = "Project root, manifest, checksums, config, installer, and source revision are required."
+                });
+            }
+            else
+            {
+                Console.WriteLine(DotNetReleaseArtifactVerifyUsage);
+            }
+
+            return 2;
+        }
+
+        try
+        {
+            DotNetPublishReleaseArtifact result = new DotNetPublishReleaseArtifactVerifier().Verify(
+                new DotNetPublishReleaseArtifactVerificationRequest
+                {
+                    ProjectRoot = projectRoot,
+                    ManifestPath = manifestPath,
+                    ChecksumsPath = checksumsPath,
+                    ConfigurationPath = configurationPath,
+                    InstallerId = installerId,
+                    ExpectedSourceRevision = sourceRevision
+                });
+            if (outputJson)
+            {
+                WriteJson(new CliJsonEnvelope
+                {
+                    SchemaVersion = OutputSchemaVersion,
+                    Command = "dotnet.release-artifact.verify",
+                    Success = true,
+                    ExitCode = 0,
+                    Result = CliJson.SerializeToElement(result, CliJson.Context.DotNetPublishReleaseArtifact)
+                });
+            }
+            else
+            {
+                logger.Success($"Verified {result.InstallerId} {result.Version}: {result.ArtifactPath}");
+                logger.Info($"SHA-256: {result.Sha256}");
+                logger.Info($"Source: {result.SourceRevision}");
+                logger.Info($"Signer: {result.SignerSubject} ({result.SignerThumbprint})");
+            }
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            if (outputJson)
+            {
+                WriteJson(new CliJsonEnvelope
+                {
+                    SchemaVersion = OutputSchemaVersion,
+                    Command = "dotnet.release-artifact.verify",
+                    Success = false,
+                    ExitCode = 1,
+                    Error = ex.Message
+                });
+            }
+            else
+            {
+                logger.Error(ex.Message);
+            }
+
+            return 1;
+        }
+    }
+}

--- a/PowerForge.Cli/Program.Command.DotNet.ReleaseArtifact.cs
+++ b/PowerForge.Cli/Program.Command.DotNet.ReleaseArtifact.cs
@@ -19,6 +19,10 @@ internal static partial class Program
         var configurationPath = TryGetOptionValue(commandArgs, "--config");
         var installerId = TryGetOptionValue(commandArgs, "--installer");
         var sourceRevision = TryGetOptionValue(commandArgs, "--source-revision");
+        var target = TryGetOptionValue(commandArgs, "--target");
+        var runtime = TryGetOptionValue(commandArgs, "--rid");
+        var framework = TryGetOptionValue(commandArgs, "--framework");
+        var style = TryGetOptionValue(commandArgs, "--style");
         if (string.IsNullOrWhiteSpace(projectRoot) ||
             string.IsNullOrWhiteSpace(manifestPath) ||
             string.IsNullOrWhiteSpace(checksumsPath) ||
@@ -55,7 +59,11 @@ internal static partial class Program
                     ChecksumsPath = checksumsPath,
                     ConfigurationPath = configurationPath,
                     InstallerId = installerId,
-                    ExpectedSourceRevision = sourceRevision
+                    ExpectedSourceRevision = sourceRevision,
+                    Target = target,
+                    Runtime = runtime,
+                    Framework = framework,
+                    Style = style
                 });
             if (outputJson)
             {

--- a/PowerForge.Cli/Program.Command.DotNet.ReleaseArtifact.cs
+++ b/PowerForge.Cli/Program.Command.DotNet.ReleaseArtifact.cs
@@ -28,12 +28,15 @@ internal static partial class Program
         var signProfile = TryGetOptionValue(commandArgs, "--sign-profile");
         var signThumbprint = TryGetOptionValue(commandArgs, "--sign-thumbprint");
         var signSubjectName = TryGetOptionValue(commandArgs, "--sign-subject-name");
+        var enableSigning = commandArgs.Any(value => value.Equals("--sign", StringComparison.OrdinalIgnoreCase));
+        var disableSigning = commandArgs.Any(value => value.Equals("--no-sign", StringComparison.OrdinalIgnoreCase));
         if (string.IsNullOrWhiteSpace(projectRoot) ||
             string.IsNullOrWhiteSpace(manifestPath) ||
             string.IsNullOrWhiteSpace(checksumsPath) ||
             string.IsNullOrWhiteSpace(configurationPath) ||
             string.IsNullOrWhiteSpace(installerId) ||
-            string.IsNullOrWhiteSpace(sourceRevision))
+            string.IsNullOrWhiteSpace(sourceRevision) ||
+            (enableSigning && disableSigning))
         {
             if (outputJson)
             {
@@ -43,7 +46,9 @@ internal static partial class Program
                     Command = "dotnet.release-artifact.verify",
                     Success = false,
                     ExitCode = 2,
-                    Error = "Project root, manifest, checksums, config, installer, and source revision are required."
+                    Error = enableSigning && disableSigning
+                        ? "Use either --sign or --no-sign, not both."
+                        : "Project root, manifest, checksums, config, installer, and source revision are required."
                 });
             }
             else
@@ -73,7 +78,8 @@ internal static partial class Program
                     Profile = profile,
                     SignProfile = signProfile,
                     SignThumbprint = signThumbprint,
-                    SignSubjectName = signSubjectName
+                    SignSubjectName = signSubjectName,
+                    EnableSigning = enableSigning ? true : disableSigning ? false : null
                 });
             if (outputJson)
             {

--- a/PowerForge.Cli/Program.Command.DotNet.cs
+++ b/PowerForge.Cli/Program.Command.DotNet.cs
@@ -14,7 +14,7 @@ internal static partial class Program
     private const string DotNetScaffoldUsage =
         "Usage: powerforge dotnet scaffold [--project-root <path>] [--project <App.csproj>] [--target <Name>] [--framework <tfm>] [--rid <Rid[,Rid...]>] [--style <Portable|PortableCompat|PortableSize|AotSpeed|AotSize>[,...]] [--configuration <Release|Debug>] [--out <powerforge.dotnetpublish.json>] [--overwrite] [--no-schema] [--output json]";
     private const string DotNetReleaseArtifactVerifyUsage =
-        "Usage: powerforge dotnet release-artifact verify --project-root <path> --manifest <manifest.json> --checksums <SHA256SUMS.txt> --config <powerforge.dotnetpublish.json> --installer <id> --source-revision <sha> [--output json]";
+        "Usage: powerforge dotnet release-artifact verify --project-root <path> --manifest <manifest.json> --checksums <SHA256SUMS.txt> --config <powerforge.dotnetpublish.json> --installer <id> --source-revision <sha> [--target <name>] [--rid <rid>] [--framework <tfm>] [--style <style>] [--output json]";
 
     private static int CommandDotNet(string[] filteredArgs, CliOptions cli, ILogger logger)
     {

--- a/PowerForge.Cli/Program.Command.DotNet.cs
+++ b/PowerForge.Cli/Program.Command.DotNet.cs
@@ -14,7 +14,7 @@ internal static partial class Program
     private const string DotNetScaffoldUsage =
         "Usage: powerforge dotnet scaffold [--project-root <path>] [--project <App.csproj>] [--target <Name>] [--framework <tfm>] [--rid <Rid[,Rid...]>] [--style <Portable|PortableCompat|PortableSize|AotSpeed|AotSize>[,...]] [--configuration <Release|Debug>] [--out <powerforge.dotnetpublish.json>] [--overwrite] [--no-schema] [--output json]";
     private const string DotNetReleaseArtifactVerifyUsage =
-        "Usage: powerforge dotnet release-artifact verify --project-root <path> --manifest <manifest.json> --checksums <SHA256SUMS.txt> --config <powerforge.dotnetpublish.json> --installer <id> --source-revision <sha> [--target <name>] [--rid <rid>] [--framework <tfm>] [--style <style>] [--output json]";
+        "Usage: powerforge dotnet release-artifact verify --project-root <path> --manifest <manifest.json> --checksums <SHA256SUMS.txt> --config <powerforge.dotnetpublish.json> --installer <id> --source-revision <sha> [--target <name>] [--rid <rid>] [--framework <tfm>] [--style <style>] [--artifact <manifest-relative-msi>] [--profile <name>] [--sign-profile <name>] [--sign-thumbprint <sha1>] [--sign-subject-name <subject>] [--output json]";
 
     private static int CommandDotNet(string[] filteredArgs, CliOptions cli, ILogger logger)
     {

--- a/PowerForge.Cli/Program.Command.DotNet.cs
+++ b/PowerForge.Cli/Program.Command.DotNet.cs
@@ -14,7 +14,7 @@ internal static partial class Program
     private const string DotNetScaffoldUsage =
         "Usage: powerforge dotnet scaffold [--project-root <path>] [--project <App.csproj>] [--target <Name>] [--framework <tfm>] [--rid <Rid[,Rid...]>] [--style <Portable|PortableCompat|PortableSize|AotSpeed|AotSize>[,...]] [--configuration <Release|Debug>] [--out <powerforge.dotnetpublish.json>] [--overwrite] [--no-schema] [--output json]";
     private const string DotNetReleaseArtifactVerifyUsage =
-        "Usage: powerforge dotnet release-artifact verify --project-root <path> --manifest <manifest.json> --checksums <SHA256SUMS.txt> --config <powerforge.dotnetpublish.json> --installer <id> --source-revision <sha> [--target <name>] [--rid <rid>] [--framework <tfm>] [--style <style>] [--artifact <manifest-relative-msi>] [--profile <name>] [--sign-profile <name>] [--sign-thumbprint <sha1>] [--sign-subject-name <subject>] [--output json]";
+        "Usage: powerforge dotnet release-artifact verify --project-root <path> --manifest <manifest.json> --checksums <SHA256SUMS.txt> --config <powerforge.dotnetpublish-or-release.json> --installer <id> --source-revision <sha> [--target <name>] [--rid <rid>] [--framework <tfm>] [--style <style>] [--artifact <manifest-relative-msi>] [--profile <name>] [--sign|--no-sign] [--sign-profile <name>] [--sign-thumbprint <sha1>] [--sign-subject-name <subject>] [--output json]";
 
     private static int CommandDotNet(string[] filteredArgs, CliOptions cli, ILogger logger)
     {

--- a/PowerForge.Cli/Program.Command.DotNet.cs
+++ b/PowerForge.Cli/Program.Command.DotNet.cs
@@ -13,6 +13,8 @@ internal static partial class Program
         "Usage: powerforge dotnet bundle-postprocess [--config <DotNetPublish.json>] --bundle <Id> --bundle-root <path> [--project-root <path>] [--target <Name>] [--rid <Rid>] [--framework <tfm>] [--style <Portable|PortableCompat|PortableSize|AotSpeed|AotSize>] [--configuration <Release|Debug>] [--zip-path <path>] [--source-output <path>] [--delete-pattern <glob>] [--skip-archive] [--skip-metadata] [--token <name=value>] [--plan] [--output json]";
     private const string DotNetScaffoldUsage =
         "Usage: powerforge dotnet scaffold [--project-root <path>] [--project <App.csproj>] [--target <Name>] [--framework <tfm>] [--rid <Rid[,Rid...]>] [--style <Portable|PortableCompat|PortableSize|AotSpeed|AotSize>[,...]] [--configuration <Release|Debug>] [--out <powerforge.dotnetpublish.json>] [--overwrite] [--no-schema] [--output json]";
+    private const string DotNetReleaseArtifactVerifyUsage =
+        "Usage: powerforge dotnet release-artifact verify --project-root <path> --manifest <manifest.json> --checksums <SHA256SUMS.txt> --config <powerforge.dotnetpublish.json> --installer <id> --source-revision <sha> [--output json]";
 
     private static int CommandDotNet(string[] filteredArgs, CliOptions cli, ILogger logger)
     {
@@ -22,12 +24,15 @@ internal static partial class Program
             Console.WriteLine(DotNetPublishUsage);
             Console.WriteLine(DotNetBundlePostProcessUsage);
             Console.WriteLine(DotNetScaffoldUsage);
+            Console.WriteLine(DotNetReleaseArtifactVerifyUsage);
             return 2;
         }
 
         var sub = argv[0].ToLowerInvariant();
         switch (sub)
         {
+            case "release-artifact":
+                return CommandDotNetReleaseArtifact(argv.Skip(1).ToArray(), cli, logger);
             case "publish":
             {
                 var subArgs = argv.Skip(1).ToArray();

--- a/PowerForge.Tests/DotNetPublishReleaseArtifactVerifierTests.cs
+++ b/PowerForge.Tests/DotNetPublishReleaseArtifactVerifierTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace PowerForge.Tests;
 
@@ -102,6 +103,24 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
     }
 
     [Fact]
+    public void Verify_RejectsInstallerWithoutPrepareFromTarget()
+    {
+        using var fixture = new ReleaseFixture();
+        fixture.WriteConfigurationWithoutDefaults(new
+        {
+            Installers = new[]
+            {
+                new { Id = "Test.MSI", Authoring = ReleaseFixture.AuthoringIdentity, Sign = new { Enabled = true, Thumbprint } }
+            }
+        });
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => fixture.CreateVerifier().Verify(fixture.CreateRequest()));
+
+        Assert.Contains("PrepareFromTarget", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Verify_RejectsAChangedArtifactEvenWhenManifestIdentityStillMatches()
     {
         using var fixture = new ReleaseFixture();
@@ -111,6 +130,105 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
             () => fixture.CreateVerifier().Verify(fixture.CreateRequest()));
 
         Assert.Contains("checksum manifest", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Verify_RejectsAChangedArtifactBeforeOpeningTheMsiDatabase()
+    {
+        using var fixture = new ReleaseFixture();
+        File.AppendAllText(fixture.ArtifactPath, "changed");
+        var packageRead = false;
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            fixture.CreateVerifier(() => packageRead = true).Verify(fixture.CreateRequest()));
+
+        Assert.Contains("checksum manifest", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(packageRead);
+    }
+
+    [Theory]
+    [InlineData("Other", "net8.0", "win-x64", "Portable")]
+    [InlineData("Service", "net9.0", "win-x64", "Portable")]
+    [InlineData("Service", "net8.0", "win-arm64", "Portable")]
+    [InlineData("Service", "net8.0", "win-x64", "FrameworkDependent")]
+    public void Verify_RejectsManifestDimensionsOutsideTheConfiguredInstallerPlan(
+        string target,
+        string framework,
+        string runtime,
+        string style)
+    {
+        using var fixture = new ReleaseFixture();
+        fixture.WriteConfiguration(ReleaseFixture.ConfigurationWithInstallerPlan());
+        fixture.WriteManifest((target, framework, runtime, style));
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => fixture.CreateVerifier().Verify(fixture.CreateRequest()));
+
+        Assert.Contains("configured installer plan", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Verify_AcceptsManifestDimensionsWithinTheConfiguredInstallerPlan()
+    {
+        using var fixture = new ReleaseFixture();
+        fixture.WriteConfiguration(ReleaseFixture.ConfigurationWithInstallerPlan());
+
+        DotNetPublishReleaseArtifact result = fixture.CreateVerifier().Verify(fixture.CreateRequest());
+
+        Assert.Equal("Test.MSI", result.InstallerId);
+    }
+
+    [Fact]
+    public void Verify_RejectsConfiguredAuthoredVersionWhenDynamicVersioningIsDisabled()
+    {
+        using var fixture = new ReleaseFixture();
+        fixture.WriteConfiguration(ReleaseFixture.ConfigurationWithAuthoredVersion("2.0.0", dynamicVersioning: false));
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => fixture.CreateVerifier().Verify(fixture.CreateRequest()));
+
+        Assert.Contains("configured ProductVersion", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Verify_AllowsManifestVersionWhenDynamicVersioningIsEnabled()
+    {
+        using var fixture = new ReleaseFixture();
+        fixture.WriteConfiguration(ReleaseFixture.ConfigurationWithAuthoredVersion("2.0.0", dynamicVersioning: true));
+
+        DotNetPublishReleaseArtifact result = fixture.CreateVerifier().Verify(fixture.CreateRequest());
+
+        Assert.Equal("1.2.3", result.Version);
+    }
+
+    [Fact]
+    public void GetRelativePathViaUri_PreservesCrossVolumeRootedPaths()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        string target = Path.GetFullPath(@"D:\release\SyncSE.msi");
+
+        string result = DotNetPublishReleaseArtifactVerifier.GetRelativePathViaUri(@"C:\source", target);
+
+        Assert.Equal(target, result, StringComparer.OrdinalIgnoreCase);
+        Assert.True(Path.IsPathRooted(result));
+    }
+
+    [Fact]
+    public void GetRelativePathViaUri_PreservesCrossShareUncPaths()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        const string target = @"\\server\release-share\SyncSE.msi";
+
+        string result = DotNetPublishReleaseArtifactVerifier.GetRelativePathViaUri(
+            @"\\server\source-share\repo",
+            target);
+
+        Assert.Equal(target, result, StringComparer.OrdinalIgnoreCase);
+        Assert.True(Path.IsPathRooted(result));
     }
 
     [Fact]
@@ -129,6 +247,32 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
     public void Verify_UsesMatrixSelectorsToIdentifyOneInstallerArtifact()
     {
         using var fixture = new ReleaseFixture();
+        fixture.WriteConfiguration(new
+        {
+            Targets = new[]
+            {
+                new
+                {
+                    Name = "Service",
+                    Publish = new
+                    {
+                        Frameworks = new[] { "net8.0", "net10.0" },
+                        Runtimes = new[] { "win-x64" },
+                        Styles = new[] { "Portable" }
+                    }
+                }
+            },
+            Installers = new[]
+            {
+                new
+                {
+                    Id = "Test.MSI",
+                    PrepareFromTarget = "Service",
+                    Authoring = ReleaseFixture.AuthoringIdentity,
+                    Sign = new { Enabled = true, Thumbprint }
+                }
+            }
+        });
         fixture.WriteManifest(
             ("Service", "net8.0", "win-x64", "Portable"),
             ("Service", "net10.0", "win-x64", "Portable"));
@@ -184,13 +328,21 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
             $$"""
             {
               // PowerForge publish configuration supports comments.
+              "Targets": [
+                {
+                  "Name": "Service",
+                  "Publish": { "Framework": "net8.0", "Runtimes": [ "win-x64" ], "Style": "Portable" },
+                },
+              ],
               "Installers": [
                 {
                   "Id": "Test.MSI",
+                  "PrepareFromTarget": "Service",
                   "Authoring": {
                     "Product": {
                       "Name": "Test Product",
                       "Manufacturer": "Evotec",
+                      "Version": "1.2.3",
                       "UpgradeCode": "{22222222-2222-2222-2222-222222222222}",
                     },
                   },
@@ -366,8 +518,8 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
             },
             Targets = new[]
             {
-                new { Name = "Default" },
-                new { Name = "Release" }
+                new { Name = "Default", Publish = new { Framework = "net8.0", Runtimes = new[] { "win-x64" }, Style = "Portable" } },
+                new { Name = "Release", Publish = new { Framework = "net8.0", Runtimes = new[] { "win-x64" }, Style = "Portable" } }
             },
             Installers = new[]
             {
@@ -380,6 +532,7 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
                 }
             }
         });
+        fixture.WriteManifest(("Release", "net8.0", "win-x64", "Portable"));
         var request = fixture.CreateRequest();
         request.Profile = "release";
         request.SignThumbprint = overrideThumbprint;
@@ -522,7 +675,62 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
             {
                 Name = "Test Product",
                 Manufacturer = "Evotec",
+                Version = "1.2.3",
                 UpgradeCode = "{22222222-2222-2222-2222-222222222222}"
+            }
+        };
+
+        internal static object ConfigurationWithInstallerPlan() => new
+        {
+            DotNet = new { Runtimes = new[] { "win-x64" } },
+            Targets = new[]
+            {
+                new
+                {
+                    Name = "Service",
+                    Publish = new
+                    {
+                        Framework = "net8.0",
+                        Runtimes = new[] { "win-x64" },
+                        Styles = new[] { "Portable" }
+                    }
+                }
+            },
+            Installers = new[]
+            {
+                new
+                {
+                    Id = "Test.MSI",
+                    PrepareFromTarget = "Service",
+                    Runtimes = new[] { "win-x64" },
+                    Frameworks = new[] { "net8.0" },
+                    Styles = new[] { "Portable" },
+                    Authoring = AuthoringIdentity,
+                    Sign = new { Enabled = true, Thumbprint }
+                }
+            }
+        };
+
+        internal static object ConfigurationWithAuthoredVersion(string version, bool dynamicVersioning) => new
+        {
+            Installers = new[]
+            {
+                new
+                {
+                    Id = "Test.MSI",
+                    Authoring = new
+                    {
+                        Product = new
+                        {
+                            Name = "Test Product",
+                            Manufacturer = "Evotec",
+                            Version = version,
+                            UpgradeCode = "{22222222-2222-2222-2222-222222222222}"
+                        }
+                    },
+                    Versioning = new { Enabled = dynamicVersioning },
+                    Sign = new { Enabled = true, Thumbprint }
+                }
             }
         };
 
@@ -534,7 +742,35 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
         internal string Digest { get; }
         internal string SourceRevision { get; } = new string('a', 40);
 
-        internal void WriteConfiguration(object configuration) =>
+        internal void WriteConfiguration(object configuration)
+        {
+            JsonNode root = JsonSerializer.SerializeToNode(configuration)!;
+            JsonObject spec = root["Tools"]?["DotNetPublish"] as JsonObject ?? root.AsObject();
+            if (spec["Targets"] is null)
+            {
+                spec["Targets"] = new JsonArray
+                {
+                    new JsonObject
+                    {
+                        ["Name"] = "Service",
+                        ["Publish"] = new JsonObject
+                        {
+                            ["Framework"] = "net8.0",
+                            ["Runtimes"] = new JsonArray("win-x64"),
+                            ["Style"] = "Portable"
+                        }
+                    }
+                };
+            }
+            if (spec["Installers"] is JsonArray installers)
+            {
+                foreach (JsonObject installer in installers.OfType<JsonObject>())
+                    installer["PrepareFromTarget"] ??= "Service";
+            }
+            File.WriteAllText(ConfigurationPath, root.ToJsonString());
+        }
+
+        internal void WriteConfigurationWithoutDefaults(object configuration) =>
             File.WriteAllText(ConfigurationPath, JsonSerializer.Serialize(configuration));
 
         internal void WriteConfiguration(string configuration) =>
@@ -672,20 +908,35 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
 
         internal DotNetPublishReleaseArtifactVerifier CreateVerifier(string thumbprint = Thumbprint) =>
             new(
-                _ => new DotNetPublishMsiPackageMetadata
-                {
-                    Path = ArtifactPath,
-                    ProductName = "Test Product",
-                    Manufacturer = "Evotec",
-                    ProductVersion = "1.2.3",
-                    ProductCode = "{11111111-1111-1111-1111-111111111111}",
-                    UpgradeCode = "{22222222-2222-2222-2222-222222222222}"
-                },
+                _ => ReadPackageMetadata(),
                 _ => new DotNetPublishReleaseArtifactVerifier.AuthenticodeResult(
                     true,
                     0,
                     "CN=Test Publisher",
                     thumbprint));
+
+        internal DotNetPublishReleaseArtifactVerifier CreateVerifier(Action onReadPackage) =>
+            new(
+                _ =>
+                {
+                    onReadPackage();
+                    return ReadPackageMetadata();
+                },
+                _ => new DotNetPublishReleaseArtifactVerifier.AuthenticodeResult(
+                    true,
+                    0,
+                    "CN=Test Publisher",
+                    Thumbprint));
+
+        private DotNetPublishMsiPackageMetadata ReadPackageMetadata() => new()
+        {
+            Path = ArtifactPath,
+            ProductName = "Test Product",
+            Manufacturer = "Evotec",
+            ProductVersion = "1.2.3",
+            ProductCode = "{11111111-1111-1111-1111-111111111111}",
+            UpgradeCode = "{22222222-2222-2222-2222-222222222222}"
+        };
 
         public void Dispose()
         {

--- a/PowerForge.Tests/DotNetPublishReleaseArtifactVerifierTests.cs
+++ b/PowerForge.Tests/DotNetPublishReleaseArtifactVerifierTests.cs
@@ -368,6 +368,73 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
         Assert.Equal(new string('B', 40), result.SignerThumbprint);
     }
 
+    [Fact]
+    public void Verify_AppliesSigningEnableOverrideUsedByReleaseBuild()
+    {
+        using var fixture = new ReleaseFixture();
+        fixture.WriteConfiguration(new
+        {
+            Installers = new[]
+            {
+                new
+                {
+                    Id = "Test.MSI",
+                    Authoring = ReleaseFixture.AuthoringIdentity,
+                    Sign = new { Enabled = false, Thumbprint }
+                }
+            }
+        });
+        var request = fixture.CreateRequest();
+        request.EnableSigning = true;
+
+        DotNetPublishReleaseArtifact result = fixture.CreateVerifier().Verify(request);
+
+        Assert.Equal(Thumbprint, result.SignerThumbprint);
+    }
+
+    [Fact]
+    public void Verify_ExplicitNoSignWinsOverSignerIdentityOverrides()
+    {
+        using var fixture = new ReleaseFixture();
+        var request = fixture.CreateRequest();
+        request.EnableSigning = false;
+        request.SignThumbprint = Thumbprint;
+        request.SignSubjectName = "Test Publisher";
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => fixture.CreateVerifier().Verify(request));
+
+        Assert.Contains("signing must be enabled", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Verify_AcceptsInlineUnifiedReleaseConfiguration()
+    {
+        using var fixture = new ReleaseFixture();
+        fixture.WriteConfiguration(new
+        {
+            Tools = new
+            {
+                DotNetPublish = new
+                {
+                    Installers = new[]
+                    {
+                        new
+                        {
+                            Id = "Test.MSI",
+                            Authoring = ReleaseFixture.AuthoringIdentity,
+                            Sign = new { Enabled = true, Thumbprint }
+                        }
+                    }
+                }
+            }
+        });
+
+        DotNetPublishReleaseArtifact result = fixture.CreateVerifier().Verify(fixture.CreateRequest());
+
+        Assert.Equal("Test.MSI", result.InstallerId);
+    }
+
     private sealed class ReleaseFixture : IDisposable
     {
         private readonly List<string> _outsideArtifacts = new();

--- a/PowerForge.Tests/DotNetPublishReleaseArtifactVerifierTests.cs
+++ b/PowerForge.Tests/DotNetPublishReleaseArtifactVerifierTests.cs
@@ -38,6 +38,57 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
     }
 
     [Fact]
+    public void Verify_AcceptsAbbreviatedExpectedWorkflowCommit()
+    {
+        using var fixture = new ReleaseFixture();
+        var request = fixture.CreateRequest();
+        request.ExpectedSourceRevision = fixture.SourceRevision[..12];
+
+        DotNetPublishReleaseArtifact result = fixture.CreateVerifier().Verify(request);
+
+        Assert.Equal(fixture.SourceRevision, result.SourceRevision);
+    }
+
+    [Fact]
+    public void Verify_RejectsAbbreviatedManifestSourceRevision()
+    {
+        using var fixture = new ReleaseFixture();
+        fixture.WriteManifestWithSourceRevision(fixture.SourceRevision[..12]);
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => fixture.CreateVerifier().Verify(fixture.CreateRequest()));
+
+        Assert.Contains("full valid source revision", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Verify_RejectsFullSha1AsPrefixOfSha256ManifestRevision()
+    {
+        using var fixture = new ReleaseFixture();
+        fixture.WriteManifestWithSourceRevision(fixture.SourceRevision + new string('b', 24));
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => fixture.CreateVerifier().Verify(fixture.CreateRequest()));
+
+        Assert.Contains("workflow commit", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Verify_AcceptsFullAndAbbreviatedSha256WorkflowCommit()
+    {
+        using var fixture = new ReleaseFixture();
+        string sourceRevision = new string('c', 64);
+        fixture.WriteManifestWithSourceRevision(sourceRevision);
+        var fullRequest = fixture.CreateRequest();
+        fullRequest.ExpectedSourceRevision = sourceRevision;
+        var abbreviatedRequest = fixture.CreateRequest();
+        abbreviatedRequest.ExpectedSourceRevision = sourceRevision[..20];
+
+        Assert.Equal(sourceRevision, fixture.CreateVerifier().Verify(fullRequest).SourceRevision);
+        Assert.Equal(sourceRevision, fixture.CreateVerifier().Verify(abbreviatedRequest).SourceRevision);
+    }
+
+    [Fact]
     public void Verify_RequiresCallerBoundSourceRevision()
     {
         using var fixture = new ReleaseFixture();
@@ -517,6 +568,40 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
                     }
                 }
             })));
+            RefreshChecksums(["Artifacts/Test-1.2.3.msi"]);
+        }
+
+        internal void WriteManifestWithSourceRevision(string sourceRevision)
+        {
+            File.WriteAllText(ManifestPath, JsonSerializer.Serialize(new[]
+            {
+                new
+                {
+                    Category = "Installer",
+                    InstallerId = "Test.MSI",
+                    Target = "Service",
+                    Framework = "net8.0",
+                    Runtime = "win-x64",
+                    Style = "Portable",
+                    OutputFiles = new[] { "Artifacts/Test-1.2.3.msi" },
+                    SignedFiles = 1,
+                    SourceRevision = sourceRevision,
+                    SourceDirty = false,
+                    PackageMetadata = new[]
+                    {
+                        new
+                        {
+                            Path = "Artifacts/Test-1.2.3.msi",
+                            ProductName = "Test Product",
+                            Manufacturer = "Evotec",
+                            ProductVersion = "1.2.3",
+                            ProductCode = "{11111111-1111-1111-1111-111111111111}",
+                            UpgradeCode = "{22222222-2222-2222-2222-222222222222}",
+                            ReadError = (string?)null
+                        }
+                    }
+                }
+            }));
             RefreshChecksums(["Artifacts/Test-1.2.3.msi"]);
         }
 

--- a/PowerForge.Tests/DotNetPublishReleaseArtifactVerifierTests.cs
+++ b/PowerForge.Tests/DotNetPublishReleaseArtifactVerifierTests.cs
@@ -1,0 +1,178 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace PowerForge.Tests;
+
+public sealed class DotNetPublishReleaseArtifactVerifierTests
+{
+    private const string Thumbprint = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    [Fact]
+    public void Verify_ReturnsFactsOnlyAfterAllReleaseEvidenceMatches()
+    {
+        using var fixture = new ReleaseFixture();
+        var verifier = fixture.CreateVerifier();
+
+        DotNetPublishReleaseArtifact result = verifier.Verify(fixture.CreateRequest());
+
+        Assert.Equal("Test.MSI", result.InstallerId);
+        Assert.Equal("1.2.3", result.Version);
+        Assert.Equal("{11111111-1111-1111-1111-111111111111}", result.ProductCode);
+        Assert.Equal("{22222222-2222-2222-2222-222222222222}", result.UpgradeCode);
+        Assert.Equal(fixture.SourceRevision, result.SourceRevision);
+        Assert.Equal(Thumbprint, result.SignerThumbprint);
+        Assert.Equal(fixture.Digest, result.Sha256);
+    }
+
+    [Fact]
+    public void Verify_RejectsManifestFromAnotherWorkflowCommit()
+    {
+        using var fixture = new ReleaseFixture();
+        var request = fixture.CreateRequest();
+        request.ExpectedSourceRevision = new string('b', 40);
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => fixture.CreateVerifier().Verify(request));
+
+        Assert.Contains("workflow commit", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Verify_RequiresCallerBoundSourceRevision()
+    {
+        using var fixture = new ReleaseFixture();
+        var request = fixture.CreateRequest();
+        request.ExpectedSourceRevision = string.Empty;
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => fixture.CreateVerifier().Verify(request));
+
+        Assert.Contains("expected source revision", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Verify_RejectsAChangedArtifactEvenWhenManifestIdentityStillMatches()
+    {
+        using var fixture = new ReleaseFixture();
+        File.AppendAllText(fixture.ArtifactPath, "changed");
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => fixture.CreateVerifier().Verify(fixture.CreateRequest()));
+
+        Assert.Contains("checksum manifest", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Verify_RejectsSignerOutsideTheConfiguredReleaseIdentity()
+    {
+        using var fixture = new ReleaseFixture();
+        var verifier = fixture.CreateVerifier(new string('B', 40));
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => verifier.Verify(fixture.CreateRequest()));
+
+        Assert.Contains("configured release certificate", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class ReleaseFixture : IDisposable
+    {
+        internal ReleaseFixture()
+        {
+            Root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(Root, "Artifacts"));
+            ArtifactPath = Path.Combine(Root, "Artifacts", "Test-1.2.3.msi");
+            File.WriteAllBytes(ArtifactPath, Enumerable.Range(0, 512).Select(value => (byte)value).ToArray());
+            Digest = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(ArtifactPath)));
+            ManifestPath = Path.Combine(Root, "manifest.json");
+            ChecksumsPath = Path.Combine(Root, "SHA256SUMS.txt");
+            ConfigurationPath = Path.Combine(Root, "powerforge.dotnetpublish.json");
+
+            File.WriteAllText(ManifestPath, JsonSerializer.Serialize(new[]
+            {
+                new
+                {
+                    Category = "Installer",
+                    InstallerId = "Test.MSI",
+                    OutputFiles = new[] { "Artifacts/Test-1.2.3.msi" },
+                    SignedFiles = 1,
+                    SourceRevision,
+                    SourceDirty = false,
+                    PackageMetadata = new[]
+                    {
+                        new
+                        {
+                            Path = "Artifacts/Test-1.2.3.msi",
+                            ProductName = "Test Product",
+                            Manufacturer = "Evotec",
+                            ProductVersion = "1.2.3",
+                            ProductCode = "{11111111-1111-1111-1111-111111111111}",
+                            UpgradeCode = "{22222222-2222-2222-2222-222222222222}",
+                            ReadError = (string?)null
+                        }
+                    }
+                }
+            }));
+            File.WriteAllText(ChecksumsPath, $"{Digest.ToLowerInvariant()} *Artifacts/Test-1.2.3.msi{Environment.NewLine}");
+            File.WriteAllText(ConfigurationPath, JsonSerializer.Serialize(new
+            {
+                Installers = new[]
+                {
+                    new
+                    {
+                        Id = "Test.MSI",
+                        Authoring = new
+                        {
+                            Product = new
+                            {
+                                Name = "Test Product",
+                                Manufacturer = "Evotec",
+                                UpgradeCode = "{22222222-2222-2222-2222-222222222222}"
+                            }
+                        },
+                        Sign = new { Enabled = true, Thumbprint }
+                    }
+                }
+            }));
+        }
+
+        internal string Root { get; }
+        internal string ArtifactPath { get; }
+        internal string ManifestPath { get; }
+        internal string ChecksumsPath { get; }
+        internal string ConfigurationPath { get; }
+        internal string Digest { get; }
+        internal string SourceRevision { get; } = new string('a', 40);
+
+        internal DotNetPublishReleaseArtifactVerificationRequest CreateRequest() => new()
+        {
+            ProjectRoot = Root,
+            ManifestPath = ManifestPath,
+            ChecksumsPath = ChecksumsPath,
+            ConfigurationPath = ConfigurationPath,
+            InstallerId = "Test.MSI",
+            ExpectedSourceRevision = SourceRevision
+        };
+
+        internal DotNetPublishReleaseArtifactVerifier CreateVerifier(string thumbprint = Thumbprint) =>
+            new(
+                _ => new DotNetPublishMsiPackageMetadata
+                {
+                    Path = ArtifactPath,
+                    ProductName = "Test Product",
+                    Manufacturer = "Evotec",
+                    ProductVersion = "1.2.3",
+                    ProductCode = "{11111111-1111-1111-1111-111111111111}",
+                    UpgradeCode = "{22222222-2222-2222-2222-222222222222}"
+                },
+                _ => new DotNetPublishReleaseArtifactVerifier.AuthenticodeResult(
+                    true,
+                    0,
+                    "CN=Test Publisher",
+                    thumbprint));
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Root)) Directory.Delete(Root, recursive: true);
+        }
+    }
+}

--- a/PowerForge.Tests/DotNetPublishReleaseArtifactVerifierTests.cs
+++ b/PowerForge.Tests/DotNetPublishReleaseArtifactVerifierTests.cs
@@ -189,8 +189,189 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
         Assert.Equal("{22222222-2222-2222-2222-222222222222}", result.UpgradeCode);
     }
 
+    [Fact]
+    public void Verify_SelectsOneMsiFromAMultiOutputInstallerEntry()
+    {
+        using var fixture = new ReleaseFixture();
+        const string secondArtifact = "Artifacts/Test-Secondary-1.2.3.msi";
+        fixture.CreateArtifact(secondArtifact, 17);
+        fixture.WriteSingleEntryManifest("Artifacts/Test-1.2.3.msi", secondArtifact);
+        var request = fixture.CreateRequest();
+
+        Assert.Throws<InvalidDataException>(() => fixture.CreateVerifier().Verify(request));
+
+        request.ArtifactPath = secondArtifact;
+        DotNetPublishReleaseArtifact result = fixture.CreateVerifier().Verify(request);
+
+        Assert.Equal(Path.GetFullPath(Path.Combine(fixture.Root, secondArtifact)), result.ArtifactPath);
+    }
+
+    [Fact]
+    public void Verify_RespectsConfiguredOutsideRootOutputPolicy()
+    {
+        using var fixture = new ReleaseFixture();
+        string relativeArtifact = "../" + Guid.NewGuid().ToString("N") + ".msi";
+        fixture.CreateArtifact(relativeArtifact, 23);
+        fixture.WriteSingleEntryManifest(relativeArtifact);
+
+        InvalidDataException rejected = Assert.Throws<InvalidDataException>(
+            () => fixture.CreateVerifier().Verify(fixture.CreateRequest()));
+        Assert.Contains("outside", rejected.Message, StringComparison.OrdinalIgnoreCase);
+
+        fixture.WriteConfiguration(new
+        {
+            DotNet = new { AllowOutputOutsideProjectRoot = true },
+            Installers = new[]
+            {
+                new { Id = "Test.MSI", Authoring = ReleaseFixture.AuthoringIdentity, Sign = new { Enabled = true, Thumbprint } }
+            }
+        });
+        DotNetPublishReleaseArtifact result = fixture.CreateVerifier().Verify(fixture.CreateRequest());
+
+        Assert.Equal(Path.GetFullPath(Path.Combine(fixture.Root, relativeArtifact)), result.ArtifactPath);
+    }
+
+    [Fact]
+    public void Verify_AcceptsRootedOutputWhenOutsideRootPolicyIsEnabled()
+    {
+        using var fixture = new ReleaseFixture();
+        string rootedArtifact = Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests.Outside",
+            Guid.NewGuid().ToString("N") + ".msi");
+        fixture.CreateArtifact(rootedArtifact, 29);
+        fixture.WriteSingleEntryManifest(rootedArtifact);
+
+        InvalidDataException rejected = Assert.Throws<InvalidDataException>(
+            () => fixture.CreateVerifier().Verify(fixture.CreateRequest()));
+        Assert.Contains("relative", rejected.Message, StringComparison.OrdinalIgnoreCase);
+
+        fixture.WriteConfiguration(new
+        {
+            DotNet = new { AllowOutputOutsideProjectRoot = true },
+            Installers = new[]
+            {
+                new { Id = "Test.MSI", Authoring = ReleaseFixture.AuthoringIdentity, Sign = new { Enabled = true, Thumbprint } }
+            }
+        });
+
+        DotNetPublishReleaseArtifact result = fixture.CreateVerifier().Verify(fixture.CreateRequest());
+
+        Assert.Equal(Path.GetFullPath(rootedArtifact), result.ArtifactPath);
+    }
+
+    [Fact]
+    public void Verify_AcceptsSubjectSelectedReleaseCertificate()
+    {
+        using var fixture = new ReleaseFixture();
+        fixture.WriteConfiguration(new
+        {
+            Installers = new[]
+            {
+                new
+                {
+                    Id = "Test.MSI",
+                    Authoring = ReleaseFixture.AuthoringIdentity,
+                    Sign = new { Enabled = true, SubjectName = "Test Publisher" }
+                }
+            }
+        });
+
+        DotNetPublishReleaseArtifact result = fixture.CreateVerifier(new string('B', 40))
+            .Verify(fixture.CreateRequest());
+
+        Assert.Equal("CN=Test Publisher", result.SignerSubject);
+    }
+
+    [Fact]
+    public void Verify_AcceptsAutomaticReleaseCertificateSelection()
+    {
+        using var fixture = new ReleaseFixture();
+        fixture.WriteConfiguration(new
+        {
+            Installers = new[]
+            {
+                new { Id = "Test.MSI", Authoring = ReleaseFixture.AuthoringIdentity, Sign = new { Enabled = true } }
+            }
+        });
+
+        DotNetPublishReleaseArtifact result = fixture.CreateVerifier(new string('B', 40))
+            .Verify(fixture.CreateRequest());
+
+        Assert.Equal(new string('B', 40), result.SignerThumbprint);
+    }
+
+    [Fact]
+    public void Verify_AppliesEffectiveProfileAndSigningOverrides()
+    {
+        const string overrideThumbprint = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+        using var fixture = new ReleaseFixture();
+        fixture.WriteConfiguration(new
+        {
+            Profiles = new[]
+            {
+                new { Name = "default", Default = true, Targets = new[] { "Default" } },
+                new { Name = "release", Default = false, Targets = new[] { "Release" } }
+            },
+            Targets = new[]
+            {
+                new { Name = "Default" },
+                new { Name = "Release" }
+            },
+            Installers = new[]
+            {
+                new
+                {
+                    Id = "Test.MSI",
+                    PrepareFromTarget = "Release",
+                    Authoring = ReleaseFixture.AuthoringIdentity,
+                    Sign = new { Enabled = false, Thumbprint }
+                }
+            }
+        });
+        var request = fixture.CreateRequest();
+        request.Profile = "release";
+        request.SignThumbprint = overrideThumbprint;
+
+        DotNetPublishReleaseArtifact result = fixture.CreateVerifier(overrideThumbprint).Verify(request);
+
+        Assert.Equal(overrideThumbprint, result.SignerThumbprint);
+    }
+
+    [Fact]
+    public void Verify_ExplicitSigningProfileAndSubjectOverrideInlineSigningIdentity()
+    {
+        using var fixture = new ReleaseFixture();
+        fixture.WriteConfiguration(new
+        {
+            SigningProfiles = new Dictionary<string, object>
+            {
+                ["release"] = new { Enabled = true, Thumbprint }
+            },
+            Installers = new[]
+            {
+                new
+                {
+                    Id = "Test.MSI",
+                    Authoring = ReleaseFixture.AuthoringIdentity,
+                    Sign = new { Enabled = false, Thumbprint = new string('C', 40) }
+                }
+            }
+        });
+        var request = fixture.CreateRequest();
+        request.SignProfile = "release";
+        request.SignSubjectName = "Test Publisher";
+
+        DotNetPublishReleaseArtifact result = fixture.CreateVerifier(new string('B', 40)).Verify(request);
+
+        Assert.Equal("CN=Test Publisher", result.SignerSubject);
+        Assert.Equal(new string('B', 40), result.SignerThumbprint);
+    }
+
     private sealed class ReleaseFixture : IDisposable
     {
+        private readonly List<string> _outsideArtifacts = new();
+
         internal ReleaseFixture()
         {
             Root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
@@ -269,17 +450,62 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
                     }
                 }
             })));
-            RefreshChecksums();
+            RefreshChecksums(["Artifacts/Test-1.2.3.msi"]);
         }
 
-        private void RefreshChecksums()
+        internal void WriteSingleEntryManifest(params string[] outputFiles)
+        {
+            File.WriteAllText(ManifestPath, JsonSerializer.Serialize(new[]
+            {
+                new
+                {
+                    Category = "Installer",
+                    InstallerId = "Test.MSI",
+                    Target = "Service",
+                    Framework = "net8.0",
+                    Runtime = "win-x64",
+                    Style = "Portable",
+                    OutputFiles = outputFiles,
+                    SignedFiles = outputFiles.Length,
+                    SourceRevision,
+                    SourceDirty = false,
+                    PackageMetadata = outputFiles.Select(path => new
+                    {
+                        Path = path,
+                        ProductName = "Test Product",
+                        Manufacturer = "Evotec",
+                        ProductVersion = "1.2.3",
+                        ProductCode = "{11111111-1111-1111-1111-111111111111}",
+                        UpgradeCode = "{22222222-2222-2222-2222-222222222222}",
+                        ReadError = (string?)null
+                    }).ToArray()
+                }
+            }));
+            RefreshChecksums(outputFiles);
+        }
+
+        internal string CreateArtifact(string relativePath, byte seed)
+        {
+            string path = Path.GetFullPath(Path.Combine(Root, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllBytes(path, Enumerable.Range(0, 512).Select(value => (byte)(value + seed)).ToArray());
+            string rootPrefix = Root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            if (!path.StartsWith(rootPrefix, StringComparison.OrdinalIgnoreCase))
+                _outsideArtifacts.Add(path);
+            return path;
+        }
+
+        private void RefreshChecksums(IReadOnlyList<string> outputFiles)
         {
             string manifestDigest = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(ManifestPath)));
-            File.WriteAllLines(ChecksumsPath,
-            [
-                $"{Digest.ToLowerInvariant()} *Artifacts/Test-1.2.3.msi",
-                $"{manifestDigest.ToLowerInvariant()} *manifest.json"
-            ]);
+            List<string> checksums = outputFiles.Select(relativePath =>
+            {
+                string path = Path.GetFullPath(Path.Combine(Root, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+                string digest = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(path)));
+                return $"{digest.ToLowerInvariant()} *{relativePath.Replace('\\', '/')}";
+            }).ToList();
+            checksums.Add($"{manifestDigest.ToLowerInvariant()} *manifest.json");
+            File.WriteAllLines(ChecksumsPath, checksums);
         }
 
         internal DotNetPublishReleaseArtifactVerificationRequest CreateRequest() => new()
@@ -312,6 +538,10 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
         public void Dispose()
         {
             if (Directory.Exists(Root)) Directory.Delete(Root, recursive: true);
+            foreach (string path in _outsideArtifacts)
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
         }
     }
 }

--- a/PowerForge.Tests/DotNetPublishReleaseArtifactVerifierTests.cs
+++ b/PowerForge.Tests/DotNetPublishReleaseArtifactVerifierTests.cs
@@ -74,6 +74,121 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
         Assert.Contains("configured release certificate", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void Verify_UsesMatrixSelectorsToIdentifyOneInstallerArtifact()
+    {
+        using var fixture = new ReleaseFixture();
+        fixture.WriteManifest(
+            ("Service", "net8.0", "win-x64", "Portable"),
+            ("Service", "net10.0", "win-x64", "Portable"));
+        var request = fixture.CreateRequest();
+
+        InvalidDataException ambiguous = Assert.Throws<InvalidDataException>(
+            () => fixture.CreateVerifier().Verify(request));
+        Assert.Contains("matrix builds", ambiguous.Message, StringComparison.OrdinalIgnoreCase);
+
+        request.Target = "Service";
+        request.Runtime = "win-x64";
+        request.Framework = "net10.0";
+        request.Style = "Portable";
+        DotNetPublishReleaseArtifact result = fixture.CreateVerifier().Verify(request);
+
+        Assert.Equal("1.2.3", result.Version);
+    }
+
+    [Fact]
+    public void Verify_AppliesSigningProfileOverrides()
+    {
+        const string overrideThumbprint = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+        using var fixture = new ReleaseFixture();
+        fixture.WriteConfiguration(new
+        {
+            SigningProfiles = new Dictionary<string, object>
+            {
+                ["release"] = new { Enabled = true, Thumbprint }
+            },
+            Installers = new[]
+            {
+                new
+                {
+                    Id = "Test.MSI",
+                    Authoring = ReleaseFixture.AuthoringIdentity,
+                    SignProfile = "release",
+                    SignOverrides = new { Thumbprint = overrideThumbprint }
+                }
+            }
+        });
+
+        DotNetPublishReleaseArtifact result = fixture.CreateVerifier(overrideThumbprint)
+            .Verify(fixture.CreateRequest());
+
+        Assert.Equal(overrideThumbprint, result.SignerThumbprint);
+    }
+
+    [Fact]
+    public void Verify_AcceptsPublishConfigurationCommentsAndTrailingCommas()
+    {
+        using var fixture = new ReleaseFixture();
+        fixture.WriteConfiguration(
+            $$"""
+            {
+              // PowerForge publish configuration supports comments.
+              "Installers": [
+                {
+                  "Id": "Test.MSI",
+                  "Authoring": {
+                    "Product": {
+                      "Name": "Test Product",
+                      "Manufacturer": "Evotec",
+                      "UpgradeCode": "{22222222-2222-2222-2222-222222222222}",
+                    },
+                  },
+                  "Sign": { "Enabled": true, "Thumbprint": "{{Thumbprint}}", },
+                },
+              ],
+            }
+            """);
+
+        DotNetPublishReleaseArtifact result = fixture.CreateVerifier().Verify(fixture.CreateRequest());
+
+        Assert.Equal("Test.MSI", result.InstallerId);
+    }
+
+    [Fact]
+    public void Verify_RejectsManifestWhoseOwnChecksumChanged()
+    {
+        using var fixture = new ReleaseFixture();
+        File.AppendAllText(fixture.ManifestPath, Environment.NewLine);
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => fixture.CreateVerifier().Verify(fixture.CreateRequest()));
+
+        Assert.Contains("manifest SHA-256", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Verify_SupportsHandAuthoredInstallerProjects()
+    {
+        using var fixture = new ReleaseFixture();
+        fixture.WriteConfiguration(new
+        {
+            Installers = new[]
+            {
+                new
+                {
+                    Id = "Test.MSI",
+                    InstallerProjectPath = "Installer/Test.wixproj",
+                    Sign = new { Enabled = true, Thumbprint }
+                }
+            }
+        });
+
+        DotNetPublishReleaseArtifact result = fixture.CreateVerifier().Verify(fixture.CreateRequest());
+
+        Assert.Equal("Test Product", result.ProductName);
+        Assert.Equal("{22222222-2222-2222-2222-222222222222}", result.UpgradeCode);
+    }
+
     private sealed class ReleaseFixture : IDisposable
     {
         internal ReleaseFixture()
@@ -87,53 +202,30 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
             ChecksumsPath = Path.Combine(Root, "SHA256SUMS.txt");
             ConfigurationPath = Path.Combine(Root, "powerforge.dotnetpublish.json");
 
-            File.WriteAllText(ManifestPath, JsonSerializer.Serialize(new[]
-            {
-                new
-                {
-                    Category = "Installer",
-                    InstallerId = "Test.MSI",
-                    OutputFiles = new[] { "Artifacts/Test-1.2.3.msi" },
-                    SignedFiles = 1,
-                    SourceRevision,
-                    SourceDirty = false,
-                    PackageMetadata = new[]
-                    {
-                        new
-                        {
-                            Path = "Artifacts/Test-1.2.3.msi",
-                            ProductName = "Test Product",
-                            Manufacturer = "Evotec",
-                            ProductVersion = "1.2.3",
-                            ProductCode = "{11111111-1111-1111-1111-111111111111}",
-                            UpgradeCode = "{22222222-2222-2222-2222-222222222222}",
-                            ReadError = (string?)null
-                        }
-                    }
-                }
-            }));
-            File.WriteAllText(ChecksumsPath, $"{Digest.ToLowerInvariant()} *Artifacts/Test-1.2.3.msi{Environment.NewLine}");
-            File.WriteAllText(ConfigurationPath, JsonSerializer.Serialize(new
+            WriteConfiguration(new
             {
                 Installers = new[]
                 {
                     new
                     {
                         Id = "Test.MSI",
-                        Authoring = new
-                        {
-                            Product = new
-                            {
-                                Name = "Test Product",
-                                Manufacturer = "Evotec",
-                                UpgradeCode = "{22222222-2222-2222-2222-222222222222}"
-                            }
-                        },
+                        Authoring = AuthoringIdentity,
                         Sign = new { Enabled = true, Thumbprint }
                     }
                 }
-            }));
+            });
+            WriteManifest(("Service", "net8.0", "win-x64", "Portable"));
         }
+
+        internal static object AuthoringIdentity => new
+        {
+            Product = new
+            {
+                Name = "Test Product",
+                Manufacturer = "Evotec",
+                UpgradeCode = "{22222222-2222-2222-2222-222222222222}"
+            }
+        };
 
         internal string Root { get; }
         internal string ArtifactPath { get; }
@@ -142,6 +234,53 @@ public sealed class DotNetPublishReleaseArtifactVerifierTests
         internal string ConfigurationPath { get; }
         internal string Digest { get; }
         internal string SourceRevision { get; } = new string('a', 40);
+
+        internal void WriteConfiguration(object configuration) =>
+            File.WriteAllText(ConfigurationPath, JsonSerializer.Serialize(configuration));
+
+        internal void WriteConfiguration(string configuration) =>
+            File.WriteAllText(ConfigurationPath, configuration);
+
+        internal void WriteManifest(params (string Target, string Framework, string Runtime, string Style)[] combinations)
+        {
+            File.WriteAllText(ManifestPath, JsonSerializer.Serialize(combinations.Select(combination => new
+            {
+                Category = "Installer",
+                InstallerId = "Test.MSI",
+                combination.Target,
+                combination.Framework,
+                combination.Runtime,
+                combination.Style,
+                OutputFiles = new[] { "Artifacts/Test-1.2.3.msi" },
+                SignedFiles = 1,
+                SourceRevision,
+                SourceDirty = false,
+                PackageMetadata = new[]
+                {
+                    new
+                    {
+                        Path = "Artifacts/Test-1.2.3.msi",
+                        ProductName = "Test Product",
+                        Manufacturer = "Evotec",
+                        ProductVersion = "1.2.3",
+                        ProductCode = "{11111111-1111-1111-1111-111111111111}",
+                        UpgradeCode = "{22222222-2222-2222-2222-222222222222}",
+                        ReadError = (string?)null
+                    }
+                }
+            })));
+            RefreshChecksums();
+        }
+
+        private void RefreshChecksums()
+        {
+            string manifestDigest = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(ManifestPath)));
+            File.WriteAllLines(ChecksumsPath,
+            [
+                $"{Digest.ToLowerInvariant()} *Artifacts/Test-1.2.3.msi",
+                $"{manifestDigest.ToLowerInvariant()} *manifest.json"
+            ]);
+        }
 
         internal DotNetPublishReleaseArtifactVerificationRequest CreateRequest() => new()
         {

--- a/PowerForge.Tests/PowerForgeCliDotNetPublishTests.cs
+++ b/PowerForge.Tests/PowerForgeCliDotNetPublishTests.cs
@@ -6,6 +6,20 @@ namespace PowerForge.Tests;
 public sealed class PowerForgeCliDotNetPublishTests
 {
     [Fact]
+    public async Task ReleaseArtifactVerify_MissingEvidenceReturnsStructuredFailure()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var (exitCode, stdout, stderr) = await RunCliAsync(
+            repoRoot,
+            $"run --project \"{Path.Combine(repoRoot, "PowerForge.Cli", "PowerForge.Cli.csproj")}\" -c Release --framework net10.0 -- dotnet release-artifact verify --output json");
+
+        Assert.True(exitCode == 2, $"CLI exit code {exitCode}\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+        using var document = JsonDocument.Parse(stdout);
+        Assert.False(document.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("dotnet.release-artifact.verify", document.RootElement.GetProperty("command").GetString());
+    }
+
+    [Fact]
     public async Task DotNetPublish_CliProjectRootOverrideWinsOverExplicitConfigRoot()
     {
         var repoRoot = FindRepositoryRoot();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -4290,6 +4290,7 @@ public sealed partial class PowerForgeReleaseServiceTests
                                 ["SafeNetToken"] = new()
                                 {
                                     Enabled = true,
+                                    Thumbprint = new string('B', 40),
                                     Csp = "SafeNet eToken Base Cryptographic Provider",
                                     KeyContainer = "Token Container"
                                 }
@@ -4305,7 +4306,12 @@ public sealed partial class PowerForgeReleaseServiceTests
                                         Framework = "net10.0",
                                         Runtimes = new[] { "win-x64" },
                                         Style = DotNetPublishStyle.PortableCompat,
-                                        SignProfile = "LocalCert"
+                                        SignProfile = "LocalCert",
+                                        Sign = new DotNetPublishSignOptions
+                                        {
+                                            Enabled = false,
+                                            Thumbprint = new string('C', 40)
+                                        }
                                     }
                                 }
                             },
@@ -4316,7 +4322,12 @@ public sealed partial class PowerForgeReleaseServiceTests
                                     Id = "PowerForge.Msi",
                                     PrepareFromTarget = "PowerForge",
                                     InstallerProjectPath = "PowerForge.Installer.wixproj",
-                                    SignProfile = "LocalCert"
+                                    SignProfile = "LocalCert",
+                                    Sign = new DotNetPublishSignOptions
+                                    {
+                                        Enabled = false,
+                                        Thumbprint = new string('C', 40)
+                                    }
                                 }
                             }
                         }
@@ -4328,6 +4339,7 @@ public sealed partial class PowerForgeReleaseServiceTests
                     PlanOnly = true,
                     ToolsOnly = true,
                     SignProfile = "SafeNetToken",
+                    SignSubjectName = "Release Publisher",
                     SignDescription = "Release signing"
                 });
 
@@ -4339,6 +4351,8 @@ public sealed partial class PowerForgeReleaseServiceTests
             Assert.True(target.Publish.Sign!.Enabled);
             Assert.Equal("SafeNet eToken Base Cryptographic Provider", target.Publish.Sign.Csp);
             Assert.Equal("Token Container", target.Publish.Sign.KeyContainer);
+            Assert.Null(target.Publish.Sign.Thumbprint);
+            Assert.Equal("Release Publisher", target.Publish.Sign.SubjectName);
             Assert.Equal("Release signing", target.Publish.Sign.Description);
 
             var installer = Assert.Single(result.DotNetToolPlan.Installers);
@@ -4346,6 +4360,8 @@ public sealed partial class PowerForgeReleaseServiceTests
             Assert.True(installer.Sign!.Enabled);
             Assert.Equal("SafeNet eToken Base Cryptographic Provider", installer.Sign.Csp);
             Assert.Equal("Token Container", installer.Sign.KeyContainer);
+            Assert.Null(installer.Sign.Thumbprint);
+            Assert.Equal("Release Publisher", installer.Sign.SubjectName);
             Assert.Equal("Release signing", installer.Sign.Description);
         }
         finally

--- a/PowerForge/Models/DotNetPublish/DotNetPublishReleaseArtifact.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishReleaseArtifact.cs
@@ -32,6 +32,21 @@ public sealed class DotNetPublishReleaseArtifactVerificationRequest
     /// <summary>Optional publish-style selector used to disambiguate matrix installer entries.</summary>
     public string? Style { get; set; }
 
+    /// <summary>Optional manifest-relative MSI path used to select one output from a multi-output installer build.</summary>
+    public string? ArtifactPath { get; set; }
+
+    /// <summary>Optional active publish profile used by the build.</summary>
+    public string? Profile { get; set; }
+
+    /// <summary>Optional signing profile override used by the build.</summary>
+    public string? SignProfile { get; set; }
+
+    /// <summary>Optional signing thumbprint override used by the build.</summary>
+    public string? SignThumbprint { get; set; }
+
+    /// <summary>Optional signing subject-name override used by the build.</summary>
+    public string? SignSubjectName { get; set; }
+
     /// <summary>Source revision expected by the caller, for example the version-tag workflow commit.</summary>
     public string ExpectedSourceRevision { get; set; } = string.Empty;
 }

--- a/PowerForge/Models/DotNetPublish/DotNetPublishReleaseArtifact.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishReleaseArtifact.cs
@@ -1,0 +1,67 @@
+namespace PowerForge;
+
+/// <summary>
+/// Describes the inputs used to verify a release installer produced by PowerForge.
+/// </summary>
+public sealed class DotNetPublishReleaseArtifactVerificationRequest
+{
+    /// <summary>Repository root used to resolve manifest-relative artifact paths.</summary>
+    public string ProjectRoot { get; set; } = string.Empty;
+
+    /// <summary>Path to the PowerForge JSON artifact manifest.</summary>
+    public string ManifestPath { get; set; } = string.Empty;
+
+    /// <summary>Path to the PowerForge SHA-256 checksum manifest.</summary>
+    public string ChecksumsPath { get; set; } = string.Empty;
+
+    /// <summary>Path to the PowerForge dotnet-publish configuration.</summary>
+    public string ConfigurationPath { get; set; } = string.Empty;
+
+    /// <summary>Installer identifier expected in the manifest and configuration.</summary>
+    public string InstallerId { get; set; } = string.Empty;
+
+    /// <summary>Source revision expected by the caller, for example the version-tag workflow commit.</summary>
+    public string ExpectedSourceRevision { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Trusted local facts for one signed MSI after PowerForge release verification succeeds.
+/// </summary>
+public sealed class DotNetPublishReleaseArtifact
+{
+    /// <summary>Installer identifier from the PowerForge build configuration.</summary>
+    public string InstallerId { get; set; } = string.Empty;
+
+    /// <summary>Absolute path to the verified MSI.</summary>
+    public string ArtifactPath { get; set; } = string.Empty;
+
+    /// <summary>Safe installer file name.</summary>
+    public string FileName { get; set; } = string.Empty;
+
+    /// <summary>Uppercase SHA-256 digest verified against the checksum manifest.</summary>
+    public string Sha256 { get; set; } = string.Empty;
+
+    /// <summary>MSI ProductVersion.</summary>
+    public string Version { get; set; } = string.Empty;
+
+    /// <summary>MSI ProductCode in normalized brace form.</summary>
+    public string ProductCode { get; set; } = string.Empty;
+
+    /// <summary>Stable MSI UpgradeCode in normalized brace form.</summary>
+    public string UpgradeCode { get; set; } = string.Empty;
+
+    /// <summary>MSI ProductName.</summary>
+    public string ProductName { get; set; } = string.Empty;
+
+    /// <summary>MSI Manufacturer.</summary>
+    public string Manufacturer { get; set; } = string.Empty;
+
+    /// <summary>Clean source revision recorded by the PowerForge manifest.</summary>
+    public string SourceRevision { get; set; } = string.Empty;
+
+    /// <summary>Subject of the certificate embedded in the valid Authenticode signature.</summary>
+    public string SignerSubject { get; set; } = string.Empty;
+
+    /// <summary>Normalized certificate thumbprint embedded in the valid Authenticode signature.</summary>
+    public string SignerThumbprint { get; set; } = string.Empty;
+}

--- a/PowerForge/Models/DotNetPublish/DotNetPublishReleaseArtifact.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishReleaseArtifact.cs
@@ -20,6 +20,18 @@ public sealed class DotNetPublishReleaseArtifactVerificationRequest
     /// <summary>Installer identifier expected in the manifest and configuration.</summary>
     public string InstallerId { get; set; } = string.Empty;
 
+    /// <summary>Optional publish target selector used to disambiguate matrix installer entries.</summary>
+    public string? Target { get; set; }
+
+    /// <summary>Optional runtime identifier selector used to disambiguate matrix installer entries.</summary>
+    public string? Runtime { get; set; }
+
+    /// <summary>Optional target-framework selector used to disambiguate matrix installer entries.</summary>
+    public string? Framework { get; set; }
+
+    /// <summary>Optional publish-style selector used to disambiguate matrix installer entries.</summary>
+    public string? Style { get; set; }
+
     /// <summary>Source revision expected by the caller, for example the version-tag workflow commit.</summary>
     public string ExpectedSourceRevision { get; set; } = string.Empty;
 }

--- a/PowerForge/Models/DotNetPublish/DotNetPublishReleaseArtifact.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishReleaseArtifact.cs
@@ -47,6 +47,9 @@ public sealed class DotNetPublishReleaseArtifactVerificationRequest
     /// <summary>Optional signing subject-name override used by the build.</summary>
     public string? SignSubjectName { get; set; }
 
+    /// <summary>Optional signing enable override used by the build.</summary>
+    public bool? EnableSigning { get; set; }
+
     /// <summary>Source revision expected by the caller, for example the version-tag workflow commit.</summary>
     public string ExpectedSourceRevision { get; set; } = string.Empty;
 }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -576,7 +576,7 @@ public sealed partial class DotNetPublishPipelineRunner
         };
     }
 
-    private static DotNetPublishSpec ResolveProfile(DotNetPublishSpec spec)
+    internal static DotNetPublishSpec ResolveProfile(DotNetPublishSpec spec)
     {
         var profiles = (spec.Profiles ?? Array.Empty<DotNetPublishProfile>())
             .Where(p => p is not null && !string.IsNullOrWhiteSpace(p.Name))

--- a/PowerForge/Services/DotNetPublishReleaseArtifactVerifier.cs
+++ b/PowerForge/Services/DotNetPublishReleaseArtifactVerifier.cs
@@ -41,6 +41,7 @@ public sealed class DotNetPublishReleaseArtifactVerifier
         var checksumsPath = RequireFile(request.ChecksumsPath, nameof(request.ChecksumsPath));
         var configurationPath = RequireFile(request.ConfigurationPath, nameof(request.ConfigurationPath));
         var installerId = RequireText(request.InstallerId, nameof(request.InstallerId));
+        var expected = ReadExpectedInstaller(configurationPath, installerId, request);
 
         var manifestRelativePath = GetRelativePath(projectRoot, manifestPath).Replace('\\', '/');
         var manifestDigest = ComputeSha256(manifestPath);
@@ -80,28 +81,47 @@ public sealed class DotNetPublishReleaseArtifactVerifier
             throw Invalid("PowerForge manifest source revision does not match the release workflow commit.");
         }
 
-        var outputFiles = ReadStringArray(entry, "OutputFiles");
+        var outputFiles = ReadStringArray(entry, "OutputFiles")
+            .Select(NormalizeRelativePath)
+            .ToArray();
         var packageMetadata = ReadArray(entry, "PackageMetadata");
-        if (outputFiles.Length != 1 || packageMetadata.Length != 1)
-            throw Invalid("PowerForge installer entry must contain exactly one output and one package metadata record.");
+        if (outputFiles.Length == 0 || packageMetadata.Length == 0)
+            throw Invalid("PowerForge installer entry does not contain an output with package metadata.");
 
-        var relativePath = NormalizeRelativePath(outputFiles[0]);
-        var artifactPath = ResolveWithinRoot(projectRoot, relativePath);
+        string relativePath;
+        if (string.IsNullOrWhiteSpace(request.ArtifactPath))
+        {
+            if (outputFiles.Length != 1)
+                throw Invalid("PowerForge installer entry contains multiple MSI outputs; select one with --artifact.");
+            relativePath = outputFiles[0];
+        }
+        else
+        {
+            var selectedPath = NormalizeRelativePath(request.ArtifactPath);
+            var selectedOutputs = outputFiles
+                .Where(path => string.Equals(path, selectedPath, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            if (selectedOutputs.Length != 1)
+                throw Invalid("The requested MSI artifact path does not identify exactly one manifest output.");
+            relativePath = selectedOutputs[0];
+        }
+
+        var artifactPath = ResolveArtifactPath(projectRoot, relativePath, expected.AllowOutputOutsideProjectRoot);
         if (!File.Exists(artifactPath))
             throw new FileNotFoundException("PowerForge installer output was not found.", artifactPath);
 
-        var manifestPackage = packageMetadata[0];
-        if (!string.Equals(
-                NormalizeRelativePath(ReadString(manifestPackage, "Path")),
+        var matchingPackageMetadata = packageMetadata
+            .Where(package => string.Equals(
+                NormalizeRelativePath(ReadString(package, "Path")),
                 relativePath,
                 StringComparison.OrdinalIgnoreCase))
-        {
-            throw Invalid("PowerForge package metadata does not describe the installer output.");
-        }
+            .ToArray();
+        if (matchingPackageMetadata.Length != 1)
+            throw Invalid("PowerForge package metadata does not uniquely describe the selected installer output.");
+        var manifestPackage = matchingPackageMetadata[0];
         if (!string.IsNullOrWhiteSpace(ReadString(manifestPackage, "ReadError")))
             throw Invalid("PowerForge manifest reports that MSI package metadata could not be read.");
 
-        var expected = ReadExpectedInstaller(configurationPath, installerId);
         var actual = _readPackage(artifactPath);
         ValidatePackage(manifestPackage, actual, expected);
 
@@ -112,8 +132,15 @@ public sealed class DotNetPublishReleaseArtifactVerifier
         var signature = _verifyAuthenticode(artifactPath);
         if (!signature.IsValid)
             throw Invalid($"Installer Authenticode signature is not valid (0x{signature.StatusCode:X8}).");
-        if (!string.Equals(signature.Thumbprint, expected.SignerThumbprint, StringComparison.OrdinalIgnoreCase))
+        if (expected.SignerThumbprint is not null &&
+            !string.Equals(signature.Thumbprint, expected.SignerThumbprint, StringComparison.OrdinalIgnoreCase))
             throw Invalid("Installer signature does not use the configured release certificate.");
+        if (expected.SignerThumbprint is null &&
+            expected.SignerSubjectName is not null &&
+            signature.Subject.IndexOf(expected.SignerSubjectName, StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            throw Invalid("Installer signature does not match the configured release certificate subject.");
+        }
 
         return new DotNetPublishReleaseArtifact
         {
@@ -132,12 +159,17 @@ public sealed class DotNetPublishReleaseArtifactVerifier
         };
     }
 
-    private static ExpectedInstaller ReadExpectedInstaller(string configurationPath, string installerId)
+    private static ExpectedInstaller ReadExpectedInstaller(
+        string configurationPath,
+        string installerId,
+        DotNetPublishReleaseArtifactVerificationRequest request)
     {
         var configuration = JsonSerializer.Deserialize<DotNetPublishSpec>(
                 File.ReadAllText(configurationPath),
                 ConfigurationJsonOptions)
             ?? throw Invalid("PowerForge configuration could not be deserialized.");
+        if (!string.IsNullOrWhiteSpace(request.Profile))
+            configuration.Profile = request.Profile!.Trim();
         configuration = DotNetPublishPipelineRunner.ResolveProfile(configuration);
         var installers = (configuration.Installers ?? Array.Empty<DotNetPublishInstaller>())
             .Where(installer => string.Equals(installer.Id, installerId, StringComparison.OrdinalIgnoreCase))
@@ -146,12 +178,28 @@ public sealed class DotNetPublishReleaseArtifactVerifier
             throw Invalid($"PowerForge configuration must define exactly one '{installerId}' installer.");
 
         var installer = installers[0];
+        var hasRequestedSignProfile = !string.IsNullOrWhiteSpace(request.SignProfile);
         var sign = DotNetPublishSigningProfileResolver.ResolveConfiguredSignOptions(
             configuration.SigningProfiles,
-            installer.SignProfile,
-            installer.Sign,
+            hasRequestedSignProfile ? request.SignProfile : installer.SignProfile,
+            hasRequestedSignProfile ? null : installer.Sign,
             installer.SignOverrides,
             $"Installer '{installerId}'");
+        if (!string.IsNullOrWhiteSpace(request.SignThumbprint) ||
+            !string.IsNullOrWhiteSpace(request.SignSubjectName))
+        {
+            sign = DotNetPublishSigningProfileResolver.CloneSignOptions(sign) ?? new DotNetPublishSignOptions();
+            sign.Enabled = true;
+            if (string.IsNullOrWhiteSpace(request.SignThumbprint) &&
+                !string.IsNullOrWhiteSpace(request.SignSubjectName))
+            {
+                sign.Thumbprint = null;
+            }
+            if (!string.IsNullOrWhiteSpace(request.SignThumbprint))
+                sign.Thumbprint = request.SignThumbprint!.Trim();
+            if (!string.IsNullOrWhiteSpace(request.SignSubjectName))
+                sign.SubjectName = request.SignSubjectName!.Trim();
+        }
         if (sign is null || !sign.Enabled)
             throw Invalid("PowerForge installer signing must be enabled for a release artifact.");
 
@@ -163,12 +211,20 @@ public sealed class DotNetPublishReleaseArtifactVerifier
         }
 
         var product = installer.Authoring?.Product;
+        var signerThumbprint = string.IsNullOrWhiteSpace(sign.Thumbprint)
+            ? null
+            : NormalizeThumbprint(sign.Thumbprint);
+        var signerSubjectName = signerThumbprint is not null || string.IsNullOrWhiteSpace(sign.SubjectName)
+            ? null
+            : sign.SubjectName!.Trim();
 
         return new ExpectedInstaller(
             product is null ? null : RequireText(product.Name, "Product.Name"),
             product is null ? null : RequireText(product.Manufacturer, "Product.Manufacturer"),
             product is null ? null : NormalizeGuid(product.UpgradeCode, "Product.UpgradeCode"),
-            NormalizeThumbprint(sign.Thumbprint));
+            signerThumbprint,
+            signerSubjectName,
+            configuration.DotNet.AllowOutputOutsideProjectRoot);
     }
 
     private static void ValidatePackage(
@@ -284,13 +340,16 @@ public sealed class DotNetPublishReleaseArtifactVerifier
         return options;
     }
 
-    private static string ResolveWithinRoot(string root, string relativePath)
+    private static string ResolveArtifactPath(string root, string relativePath, bool allowOutsideProjectRoot)
     {
-        if (Path.IsPathRooted(relativePath))
+        var platformPath = relativePath.Replace('/', Path.DirectorySeparatorChar);
+        if (Path.IsPathRooted(platformPath) && !allowOutsideProjectRoot)
             throw Invalid("PowerForge manifest installer path must be relative to the repository.");
-        var candidate = Path.GetFullPath(Path.Combine(root, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var candidate = Path.GetFullPath(Path.IsPathRooted(platformPath)
+            ? platformPath
+            : Path.Combine(root, platformPath));
         var prefix = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
-        if (!candidate.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        if (!allowOutsideProjectRoot && !candidate.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             throw Invalid("PowerForge manifest installer path resolves outside the repository.");
         return candidate;
     }
@@ -323,7 +382,7 @@ public sealed class DotNetPublishReleaseArtifactVerifier
 
     private static string NormalizeRelativePath(string? value)
     {
-        var normalized = RequireText(value, "manifest artifact path").Replace('\\', '/').TrimStart('/');
+        var normalized = RequireText(value, "manifest artifact path").Replace('\\', '/');
         return normalized;
     }
 
@@ -412,17 +471,27 @@ public sealed class DotNetPublishReleaseArtifactVerifier
 
     private sealed class ExpectedInstaller
     {
-        internal ExpectedInstaller(string? productName, string? manufacturer, string? upgradeCode, string signerThumbprint)
+        internal ExpectedInstaller(
+            string? productName,
+            string? manufacturer,
+            string? upgradeCode,
+            string? signerThumbprint,
+            string? signerSubjectName,
+            bool allowOutputOutsideProjectRoot)
         {
             ProductName = productName;
             Manufacturer = manufacturer;
             UpgradeCode = upgradeCode;
             SignerThumbprint = signerThumbprint;
+            SignerSubjectName = signerSubjectName;
+            AllowOutputOutsideProjectRoot = allowOutputOutsideProjectRoot;
         }
 
         internal string? ProductName { get; }
         internal string? Manufacturer { get; }
         internal string? UpgradeCode { get; }
-        internal string SignerThumbprint { get; }
+        internal string? SignerThumbprint { get; }
+        internal string? SignerSubjectName { get; }
+        internal bool AllowOutputOutsideProjectRoot { get; }
     }
 }

--- a/PowerForge/Services/DotNetPublishReleaseArtifactVerifier.cs
+++ b/PowerForge/Services/DotNetPublishReleaseArtifactVerifier.cs
@@ -164,10 +164,7 @@ public sealed class DotNetPublishReleaseArtifactVerifier
         string installerId,
         DotNetPublishReleaseArtifactVerificationRequest request)
     {
-        var configuration = JsonSerializer.Deserialize<DotNetPublishSpec>(
-                File.ReadAllText(configurationPath),
-                ConfigurationJsonOptions)
-            ?? throw Invalid("PowerForge configuration could not be deserialized.");
+        var configuration = ReadConfiguredPublishSpec(configurationPath);
         if (!string.IsNullOrWhiteSpace(request.Profile))
             configuration.Profile = request.Profile!.Trim();
         configuration = DotNetPublishPipelineRunner.ResolveProfile(configuration);
@@ -200,6 +197,11 @@ public sealed class DotNetPublishReleaseArtifactVerifier
             if (!string.IsNullOrWhiteSpace(request.SignSubjectName))
                 sign.SubjectName = request.SignSubjectName!.Trim();
         }
+        if (request.EnableSigning.HasValue)
+        {
+            sign = DotNetPublishSigningProfileResolver.CloneSignOptions(sign) ?? new DotNetPublishSignOptions();
+            sign.Enabled = request.EnableSigning.Value;
+        }
         if (sign is null || !sign.Enabled)
             throw Invalid("PowerForge installer signing must be enabled for a release artifact.");
 
@@ -225,6 +227,49 @@ public sealed class DotNetPublishReleaseArtifactVerifier
             signerThumbprint,
             signerSubjectName,
             configuration.DotNet.AllowOutputOutsideProjectRoot);
+    }
+
+    private static DotNetPublishSpec ReadConfiguredPublishSpec(string configurationPath)
+    {
+        var json = File.ReadAllText(configurationPath);
+        using var document = JsonDocument.Parse(json, new JsonDocumentOptions
+        {
+            CommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true
+        });
+        if (!TryGet(document.RootElement, "Tools", out _))
+        {
+            return JsonSerializer.Deserialize<DotNetPublishSpec>(json, ConfigurationJsonOptions)
+                ?? throw Invalid("PowerForge dotnet-publish configuration could not be deserialized.");
+        }
+
+        var release = JsonSerializer.Deserialize<PowerForgeReleaseSpec>(json, ConfigurationJsonOptions)
+            ?? throw Invalid("PowerForge release configuration could not be deserialized.");
+        var tools = release.Tools
+            ?? throw Invalid("PowerForge release configuration does not define Tools.DotNetPublish.");
+        if (tools.DotNetPublish is not null && !string.IsNullOrWhiteSpace(tools.DotNetPublishConfigPath))
+            throw Invalid("Tools.DotNetPublish and Tools.DotNetPublishConfigPath are mutually exclusive.");
+
+        DotNetPublishSpec configuration;
+        if (tools.DotNetPublish is not null)
+        {
+            configuration = tools.DotNetPublish;
+        }
+        else
+        {
+            var configuredPath = RequireText(tools.DotNetPublishConfigPath, "Tools.DotNetPublishConfigPath");
+            var root = Path.GetDirectoryName(configurationPath) ?? Directory.GetCurrentDirectory();
+            var path = Path.GetFullPath(Path.IsPathRooted(configuredPath)
+                ? configuredPath
+                : Path.Combine(root, configuredPath));
+            var externalJson = File.ReadAllText(RequireFile(path, "Tools.DotNetPublishConfigPath"));
+            configuration = JsonSerializer.Deserialize<DotNetPublishSpec>(externalJson, ConfigurationJsonOptions)
+                ?? throw Invalid("Referenced PowerForge dotnet-publish configuration could not be deserialized.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(tools.DotNetPublishProfile))
+            configuration.Profile = tools.DotNetPublishProfile!.Trim();
+        return configuration;
     }
 
     private static void ValidatePackage(

--- a/PowerForge/Services/DotNetPublishReleaseArtifactVerifier.cs
+++ b/PowerForge/Services/DotNetPublishReleaseArtifactVerifier.cs
@@ -69,6 +69,7 @@ public sealed class DotNetPublishReleaseArtifactVerifier
                 "specify target, RID, framework, and style for matrix builds.");
 
         var entry = entries[0];
+        ValidateManifestDimensions(entry, expected);
         if (ReadInt32(entry, "SignedFiles") < 1)
             throw Invalid("PowerForge manifest does not attest that the installer was signed.");
         if (!TryGet(entry, "SourceDirty", out var sourceDirty) || sourceDirty.ValueKind != JsonValueKind.False)
@@ -126,12 +127,12 @@ public sealed class DotNetPublishReleaseArtifactVerifier
         if (!string.IsNullOrWhiteSpace(ReadString(manifestPackage, "ReadError")))
             throw Invalid("PowerForge manifest reports that MSI package metadata could not be read.");
 
-        var actual = _readPackage(artifactPath);
-        ValidatePackage(manifestPackage, actual, expected);
-
         var digest = ComputeSha256(artifactPath);
         if (!ChecksumContains(checksumsPath, relativePath, digest))
             throw Invalid("Installer SHA-256 does not match the PowerForge checksum manifest.");
+
+        var actual = _readPackage(artifactPath);
+        ValidatePackage(manifestPackage, actual, expected);
 
         var signature = _verifyAuthenticode(artifactPath);
         if (!signature.IsValid)
@@ -217,6 +218,7 @@ public sealed class DotNetPublishReleaseArtifactVerifier
         }
 
         var product = installer.Authoring?.Product;
+        var expectedCombinations = ResolveExpectedCombinations(configuration, installer);
         var signerThumbprint = string.IsNullOrWhiteSpace(sign.Thumbprint)
             ? null
             : NormalizeThumbprint(sign.Thumbprint);
@@ -228,6 +230,8 @@ public sealed class DotNetPublishReleaseArtifactVerifier
             product is null ? null : RequireText(product.Name, "Product.Name"),
             product is null ? null : RequireText(product.Manufacturer, "Product.Manufacturer"),
             product is null ? null : NormalizeGuid(product.UpgradeCode, "Product.UpgradeCode"),
+            product is null || installer.Versioning?.Enabled == true ? null : NormalizeVersion(product.Version),
+            expectedCombinations,
             signerThumbprint,
             signerSubjectName,
             configuration.DotNet.AllowOutputOutsideProjectRoot);
@@ -292,7 +296,107 @@ public sealed class DotNetPublishReleaseArtifactVerifier
             ValidateEqual(expected.Manufacturer, actual.Manufacturer, "configured Manufacturer");
         if (expected.UpgradeCode is not null)
             ValidateEqual(expected.UpgradeCode, NormalizeGuid(actual.UpgradeCode, "UpgradeCode"), "configured UpgradeCode");
+        if (expected.ProductVersion is not null)
+            ValidateEqual(expected.ProductVersion, NormalizeVersion(actual.ProductVersion), "configured ProductVersion");
         _ = NormalizeVersion(actual.ProductVersion);
+    }
+
+    private static void ValidateManifestDimensions(JsonElement entry, ExpectedInstaller expected)
+    {
+        if (expected.Combinations.Length == 0)
+            return;
+
+        var target = ReadString(entry, "Target");
+        var runtime = ReadString(entry, "Runtime");
+        var framework = ReadString(entry, "Framework");
+        var style = ReadString(entry, "Style");
+        if (!expected.Combinations.Any(combination =>
+                string.Equals(combination.Target, target, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(combination.Runtime, runtime, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(combination.Framework, framework, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(combination.Style, style, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw Invalid("PowerForge manifest installer dimensions do not match the configured installer plan.");
+        }
+    }
+
+    private static ExpectedCombination[] ResolveExpectedCombinations(
+        DotNetPublishSpec configuration,
+        DotNetPublishInstaller installer)
+    {
+        var targetName = installer.PrepareFromTarget?.Trim() ?? string.Empty;
+        if (targetName.Length == 0)
+            throw Invalid($"PowerForge installer '{installer.Id}' must define PrepareFromTarget for release verification.");
+
+        var matchingTargets = (configuration.Targets ?? Array.Empty<DotNetPublishTarget>())
+            .Where(target => string.Equals(target?.Name?.Trim(), targetName, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (matchingTargets.Length != 1 || matchingTargets[0].Publish is null)
+            throw Invalid($"PowerForge configuration does not define the installer target '{targetName}'.");
+
+        var publish = matchingTargets[0].Publish;
+        var frameworks = NormalizeConfiguredStrings(publish.Frameworks);
+        if (frameworks.Length == 0 && !string.IsNullOrWhiteSpace(publish.Framework))
+            frameworks = new[] { publish.Framework.Trim() };
+        if (frameworks.Length == 0)
+            frameworks = NormalizeConfiguredStrings(configuration.Matrix?.Frameworks);
+
+        var runtimes = NormalizeConfiguredStrings(publish.Runtimes);
+        if (runtimes.Length == 0)
+            runtimes = NormalizeConfiguredStrings(configuration.Matrix?.Runtimes);
+        if (runtimes.Length == 0)
+            runtimes = NormalizeConfiguredStrings(configuration.DotNet.Runtimes);
+
+        var styles = (publish.Styles ?? Array.Empty<DotNetPublishStyle>()).Distinct().ToArray();
+        if (styles.Length == 0)
+            styles = (configuration.Matrix?.Styles ?? Array.Empty<DotNetPublishStyle>()).Distinct().ToArray();
+        if (styles.Length == 0)
+            styles = new[] { publish.Style };
+        if (frameworks.Length == 0 || runtimes.Length == 0)
+            throw Invalid($"PowerForge configuration does not resolve publish dimensions for installer target '{targetName}'.");
+
+        var combinations = (from framework in frameworks
+                            from runtime in runtimes
+                            from style in styles
+                            select new ExpectedCombination(targetName, runtime, framework, style.ToString()))
+            .ToArray();
+        var include = configuration.Matrix?.Include ?? Array.Empty<DotNetPublishMatrixRule>();
+        if (include.Length > 0)
+            combinations = combinations.Where(combination => include.Any(rule => RuleMatches(combination, rule))).ToArray();
+        var exclude = configuration.Matrix?.Exclude ?? Array.Empty<DotNetPublishMatrixRule>();
+        if (exclude.Length > 0)
+            combinations = combinations.Where(combination => !exclude.Any(rule => RuleMatches(combination, rule))).ToArray();
+
+        var installerRuntimes = NormalizeConfiguredStrings(installer.Runtimes);
+        var installerFrameworks = NormalizeConfiguredStrings(installer.Frameworks);
+        var installerStyles = (installer.Styles ?? Array.Empty<DotNetPublishStyle>())
+            .Select(style => style.ToString())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        combinations = combinations.Where(combination =>
+            (installerRuntimes.Length == 0 || installerRuntimes.Contains(combination.Runtime, StringComparer.OrdinalIgnoreCase)) &&
+            (installerFrameworks.Length == 0 || installerFrameworks.Contains(combination.Framework, StringComparer.OrdinalIgnoreCase)) &&
+            (installerStyles.Count == 0 || installerStyles.Contains(combination.Style))).ToArray();
+        if (combinations.Length == 0)
+            throw Invalid($"PowerForge installer '{installer.Id}' does not match a configured publish combination.");
+        return combinations;
+    }
+
+    private static string[] NormalizeConfiguredStrings(IEnumerable<string>? values) =>
+        (values ?? Array.Empty<string>())
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private static bool RuleMatches(ExpectedCombination combination, DotNetPublishMatrixRule? rule)
+    {
+        if (rule is null)
+            return false;
+        var targets = NormalizeConfiguredStrings(rule.Targets);
+        return (targets.Length == 0 || targets.Any(pattern => DotNetPublishPipelineRunner.WildcardMatch(combination.Target, pattern))) &&
+               (string.IsNullOrWhiteSpace(rule.Runtime) || DotNetPublishPipelineRunner.WildcardMatch(combination.Runtime, rule.Runtime!.Trim())) &&
+               (string.IsNullOrWhiteSpace(rule.Framework) || DotNetPublishPipelineRunner.WildcardMatch(combination.Framework, rule.Framework!.Trim())) &&
+               (string.IsNullOrWhiteSpace(rule.Style) || DotNetPublishPipelineRunner.WildcardMatch(combination.Style, rule.Style!.Trim()));
     }
 
     private static void ValidateEqual(string? expected, string? actual, string name)
@@ -365,16 +469,29 @@ public sealed class DotNetPublishReleaseArtifactVerifier
     private static string GetRelativePath(string root, string path)
     {
 #if NET472
-        var basePath = Path.GetFullPath(root)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-            + Path.DirectorySeparatorChar;
-        var baseUri = new Uri(basePath);
-        var targetUri = new Uri(Path.GetFullPath(path));
-        return Uri.UnescapeDataString(baseUri.MakeRelativeUri(targetUri).ToString())
-            .Replace('/', Path.DirectorySeparatorChar);
+        return GetRelativePathViaUri(root, path);
 #else
         return Path.GetRelativePath(root, path);
 #endif
+    }
+
+    internal static string GetRelativePathViaUri(string root, string path)
+    {
+        var fullRoot = Path.GetFullPath(root);
+        var fullPath = Path.GetFullPath(path);
+        if (!string.Equals(Path.GetPathRoot(fullRoot), Path.GetPathRoot(fullPath), StringComparison.OrdinalIgnoreCase))
+            return fullPath;
+
+        var basePath = fullRoot
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        var baseUri = new Uri(basePath);
+        var targetUri = new Uri(fullPath);
+        var relativeUri = baseUri.MakeRelativeUri(targetUri);
+        if (relativeUri.IsAbsoluteUri)
+            return fullPath;
+        return Uri.UnescapeDataString(relativeUri.ToString())
+            .Replace('/', Path.DirectorySeparatorChar);
     }
 
     private static JsonSerializerOptions CreateConfigurationJsonOptions()
@@ -532,6 +649,8 @@ public sealed class DotNetPublishReleaseArtifactVerifier
             string? productName,
             string? manufacturer,
             string? upgradeCode,
+            string? productVersion,
+            ExpectedCombination[] combinations,
             string? signerThumbprint,
             string? signerSubjectName,
             bool allowOutputOutsideProjectRoot)
@@ -539,6 +658,8 @@ public sealed class DotNetPublishReleaseArtifactVerifier
             ProductName = productName;
             Manufacturer = manufacturer;
             UpgradeCode = upgradeCode;
+            ProductVersion = productVersion;
+            Combinations = combinations;
             SignerThumbprint = signerThumbprint;
             SignerSubjectName = signerSubjectName;
             AllowOutputOutsideProjectRoot = allowOutputOutsideProjectRoot;
@@ -547,8 +668,26 @@ public sealed class DotNetPublishReleaseArtifactVerifier
         internal string? ProductName { get; }
         internal string? Manufacturer { get; }
         internal string? UpgradeCode { get; }
+        internal string? ProductVersion { get; }
+        internal ExpectedCombination[] Combinations { get; }
         internal string? SignerThumbprint { get; }
         internal string? SignerSubjectName { get; }
         internal bool AllowOutputOutsideProjectRoot { get; }
+    }
+
+    private sealed class ExpectedCombination
+    {
+        internal ExpectedCombination(string target, string runtime, string framework, string style)
+        {
+            Target = target;
+            Runtime = runtime;
+            Framework = framework;
+            Style = style;
+        }
+
+        internal string Target { get; }
+        internal string Runtime { get; }
+        internal string Framework { get; }
+        internal string Style { get; }
     }
 }

--- a/PowerForge/Services/DotNetPublishReleaseArtifactVerifier.cs
+++ b/PowerForge/Services/DotNetPublishReleaseArtifactVerifier.cs
@@ -74,9 +74,13 @@ public sealed class DotNetPublishReleaseArtifactVerifier
         if (!TryGet(entry, "SourceDirty", out var sourceDirty) || sourceDirty.ValueKind != JsonValueKind.False)
             throw Invalid("PowerForge manifest must come from a clean source checkout.");
 
-        var sourceRevision = RequireHex(ReadString(entry, "SourceRevision"), 7, 64, "source revision");
+        var sourceRevision = RequireFullGitObjectId(ReadString(entry, "SourceRevision"), "source revision");
         var expectedRevision = RequireHex(request.ExpectedSourceRevision, 7, 64, "expected source revision");
-        if (!string.Equals(sourceRevision, expectedRevision, StringComparison.OrdinalIgnoreCase))
+        var abbreviatedExpected = expectedRevision.Length < 40;
+        if (abbreviatedExpected
+                ? !sourceRevision.StartsWith(expectedRevision, StringComparison.OrdinalIgnoreCase)
+                : sourceRevision.Length != expectedRevision.Length ||
+                  !string.Equals(sourceRevision, expectedRevision, StringComparison.OrdinalIgnoreCase))
         {
             throw Invalid("PowerForge manifest source revision does not match the release workflow commit.");
         }
@@ -422,6 +426,14 @@ public sealed class DotNetPublishReleaseArtifactVerifier
         var normalized = RequireText(value, name);
         if (normalized.Length < minimum || normalized.Length > maximum || normalized.Any(ch => !Uri.IsHexDigit(ch)))
             throw Invalid($"PowerForge manifest does not contain a valid {name}.");
+        return normalized;
+    }
+
+    private static string RequireFullGitObjectId(string? value, string name)
+    {
+        var normalized = RequireText(value, name);
+        if ((normalized.Length != 40 && normalized.Length != 64) || normalized.Any(ch => !Uri.IsHexDigit(ch)))
+            throw Invalid($"PowerForge manifest does not contain a full valid {name}.");
         return normalized;
     }
 

--- a/PowerForge/Services/DotNetPublishReleaseArtifactVerifier.cs
+++ b/PowerForge/Services/DotNetPublishReleaseArtifactVerifier.cs
@@ -1,0 +1,377 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+
+namespace PowerForge;
+
+/// <summary>
+/// Verifies that a signed MSI still matches the PowerForge build manifest, checksum catalog,
+/// source provenance, package identity, and signing configuration that produced it.
+/// </summary>
+public sealed class DotNetPublishReleaseArtifactVerifier
+{
+    private readonly Func<string, DotNetPublishMsiPackageMetadata> _readPackage;
+    private readonly Func<string, AuthenticodeResult> _verifyAuthenticode;
+
+    /// <summary>Creates a verifier backed by Windows Installer and WinTrust.</summary>
+    public DotNetPublishReleaseArtifactVerifier()
+        : this(
+            path => new MsiPackageMetadataReader().Read(path),
+            VerifyAuthenticode)
+    {
+    }
+
+    internal DotNetPublishReleaseArtifactVerifier(
+        Func<string, DotNetPublishMsiPackageMetadata> readPackage,
+        Func<string, AuthenticodeResult> verifyAuthenticode)
+    {
+        _readPackage = readPackage ?? throw new ArgumentNullException(nameof(readPackage));
+        _verifyAuthenticode = verifyAuthenticode ?? throw new ArgumentNullException(nameof(verifyAuthenticode));
+    }
+
+    /// <summary>Verifies one configured installer and returns trusted local release metadata.</summary>
+    public DotNetPublishReleaseArtifact Verify(DotNetPublishReleaseArtifactVerificationRequest request)
+    {
+        if (request is null) throw new ArgumentNullException(nameof(request));
+
+        var projectRoot = RequireDirectory(request.ProjectRoot, nameof(request.ProjectRoot));
+        var manifestPath = RequireFile(request.ManifestPath, nameof(request.ManifestPath));
+        var checksumsPath = RequireFile(request.ChecksumsPath, nameof(request.ChecksumsPath));
+        var configurationPath = RequireFile(request.ConfigurationPath, nameof(request.ConfigurationPath));
+        var installerId = RequireText(request.InstallerId, nameof(request.InstallerId));
+
+        using var manifest = JsonDocument.Parse(File.ReadAllText(manifestPath));
+        if (manifest.RootElement.ValueKind != JsonValueKind.Array)
+            throw Invalid("PowerForge manifest must contain a JSON array.");
+
+        var entries = manifest.RootElement.EnumerateArray()
+            .Where(entry => Is(entry, "Category", "Installer") && Is(entry, "InstallerId", installerId))
+            .ToArray();
+        if (entries.Length != 1)
+            throw Invalid($"PowerForge manifest must contain exactly one '{installerId}' installer.");
+
+        var entry = entries[0];
+        if (ReadInt32(entry, "SignedFiles") < 1)
+            throw Invalid("PowerForge manifest does not attest that the installer was signed.");
+        if (!TryGet(entry, "SourceDirty", out var sourceDirty) || sourceDirty.ValueKind != JsonValueKind.False)
+            throw Invalid("PowerForge manifest must come from a clean source checkout.");
+
+        var sourceRevision = RequireHex(ReadString(entry, "SourceRevision"), 7, 64, "source revision");
+        var expectedRevision = RequireHex(request.ExpectedSourceRevision, 7, 64, "expected source revision");
+        if (!string.Equals(sourceRevision, expectedRevision, StringComparison.OrdinalIgnoreCase))
+        {
+            throw Invalid("PowerForge manifest source revision does not match the release workflow commit.");
+        }
+
+        var outputFiles = ReadStringArray(entry, "OutputFiles");
+        var packageMetadata = ReadArray(entry, "PackageMetadata");
+        if (outputFiles.Length != 1 || packageMetadata.Length != 1)
+            throw Invalid("PowerForge installer entry must contain exactly one output and one package metadata record.");
+
+        var relativePath = NormalizeRelativePath(outputFiles[0]);
+        var artifactPath = ResolveWithinRoot(projectRoot, relativePath);
+        if (!File.Exists(artifactPath))
+            throw new FileNotFoundException("PowerForge installer output was not found.", artifactPath);
+
+        var manifestPackage = packageMetadata[0];
+        if (!string.Equals(
+                NormalizeRelativePath(ReadString(manifestPackage, "Path")),
+                relativePath,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw Invalid("PowerForge package metadata does not describe the installer output.");
+        }
+        if (!string.IsNullOrWhiteSpace(ReadString(manifestPackage, "ReadError")))
+            throw Invalid("PowerForge manifest reports that MSI package metadata could not be read.");
+
+        var expected = ReadExpectedInstaller(configurationPath, installerId);
+        var actual = _readPackage(artifactPath);
+        ValidatePackage(manifestPackage, actual, expected);
+
+        var digest = ComputeSha256(artifactPath);
+        if (!ChecksumContains(checksumsPath, relativePath, digest))
+            throw Invalid("Installer SHA-256 does not match the PowerForge checksum manifest.");
+
+        var signature = _verifyAuthenticode(artifactPath);
+        if (!signature.IsValid)
+            throw Invalid($"Installer Authenticode signature is not valid (0x{signature.StatusCode:X8}).");
+        if (!string.Equals(signature.Thumbprint, expected.SignerThumbprint, StringComparison.OrdinalIgnoreCase))
+            throw Invalid("Installer signature does not use the configured release certificate.");
+
+        return new DotNetPublishReleaseArtifact
+        {
+            InstallerId = installerId,
+            ArtifactPath = artifactPath,
+            FileName = Path.GetFileName(artifactPath),
+            Sha256 = digest,
+            Version = NormalizeVersion(actual.ProductVersion),
+            ProductCode = NormalizeGuid(actual.ProductCode, "ProductCode"),
+            UpgradeCode = NormalizeGuid(actual.UpgradeCode, "UpgradeCode"),
+            ProductName = RequireText(actual.ProductName, "ProductName"),
+            Manufacturer = RequireText(actual.Manufacturer, "Manufacturer"),
+            SourceRevision = sourceRevision.ToLowerInvariant(),
+            SignerSubject = signature.Subject,
+            SignerThumbprint = signature.Thumbprint
+        };
+    }
+
+    private static ExpectedInstaller ReadExpectedInstaller(string configurationPath, string installerId)
+    {
+        using var configuration = JsonDocument.Parse(File.ReadAllText(configurationPath));
+        var installers = ReadArray(configuration.RootElement, "Installers")
+            .Where(installer => Is(installer, "Id", installerId))
+            .ToArray();
+        if (installers.Length != 1)
+            throw Invalid($"PowerForge configuration must define exactly one '{installerId}' installer.");
+
+        var installer = installers[0];
+        if (!TryGet(installer, "Authoring", out var authoring) ||
+            !TryGet(authoring, "Product", out var product))
+        {
+            throw Invalid("PowerForge installer authoring identity is required for release verification.");
+        }
+
+        JsonElement sign;
+        if (TryGet(installer, "Sign", out sign))
+        {
+            // Inline signing policy is already resolved.
+        }
+        else
+        {
+            var profileName = ReadString(installer, "SignProfile");
+            if (string.IsNullOrWhiteSpace(profileName) ||
+                !TryGet(configuration.RootElement, "SigningProfiles", out var profiles) ||
+                profiles.ValueKind != JsonValueKind.Object ||
+                !TryGet(profiles, profileName, out sign))
+            {
+                throw Invalid("PowerForge installer signing configuration is required for release verification.");
+            }
+        }
+
+        if (!ReadBoolean(sign, "Enabled"))
+            throw Invalid("PowerForge installer signing must be enabled for a release artifact.");
+
+        return new ExpectedInstaller(
+            RequireText(ReadString(product, "Name"), "Product.Name"),
+            RequireText(ReadString(product, "Manufacturer"), "Product.Manufacturer"),
+            NormalizeGuid(ReadString(product, "UpgradeCode"), "Product.UpgradeCode"),
+            NormalizeThumbprint(ReadString(sign, "Thumbprint")));
+    }
+
+    private static void ValidatePackage(
+        JsonElement manifestPackage,
+        DotNetPublishMsiPackageMetadata actual,
+        ExpectedInstaller expected)
+    {
+        ValidateEqual(ReadString(manifestPackage, "ProductName"), actual.ProductName, "ProductName");
+        ValidateEqual(ReadString(manifestPackage, "Manufacturer"), actual.Manufacturer, "Manufacturer");
+        ValidateEqual(ReadString(manifestPackage, "ProductVersion"), actual.ProductVersion, "ProductVersion");
+        ValidateEqual(NormalizeGuid(ReadString(manifestPackage, "ProductCode"), "ProductCode"), NormalizeGuid(actual.ProductCode, "ProductCode"), "ProductCode");
+        ValidateEqual(NormalizeGuid(ReadString(manifestPackage, "UpgradeCode"), "UpgradeCode"), NormalizeGuid(actual.UpgradeCode, "UpgradeCode"), "UpgradeCode");
+        ValidateEqual(expected.ProductName, actual.ProductName, "configured ProductName");
+        ValidateEqual(expected.Manufacturer, actual.Manufacturer, "configured Manufacturer");
+        ValidateEqual(expected.UpgradeCode, NormalizeGuid(actual.UpgradeCode, "UpgradeCode"), "configured UpgradeCode");
+        _ = NormalizeVersion(actual.ProductVersion);
+    }
+
+    private static void ValidateEqual(string? expected, string? actual, string name)
+    {
+        if (!string.Equals(expected?.Trim(), actual?.Trim(), StringComparison.OrdinalIgnoreCase))
+            throw Invalid($"PowerForge manifest or configuration does not match MSI {name}.");
+    }
+
+    private static AuthenticodeResult VerifyAuthenticode(string path)
+    {
+        var status = WindowsAuthenticodeSignatureInspector.Verify(path);
+        if (status != 0)
+            return new AuthenticodeResult(false, status, string.Empty, string.Empty);
+
+        try
+        {
+#pragma warning disable SYSLIB0057 // The certificate is embedded in a signed file, not loaded from certificate bytes.
+            using var signedCertificate = X509Certificate.CreateFromSignedFile(path);
+            using var certificate = new X509Certificate2(signedCertificate);
+#pragma warning restore SYSLIB0057
+            return new AuthenticodeResult(
+                true,
+                status,
+                certificate.Subject,
+                NormalizeThumbprint(certificate.Thumbprint));
+        }
+        catch (CryptographicException)
+        {
+            return new AuthenticodeResult(false, unchecked((int)0x800B0100), string.Empty, string.Empty);
+        }
+    }
+
+    private static string ComputeSha256(string path)
+    {
+        using var input = File.OpenRead(path);
+        using var hash = SHA256.Create();
+        return BitConverter.ToString(hash.ComputeHash(input)).Replace("-", string.Empty);
+    }
+
+    private static bool ChecksumContains(string path, string relativePath, string digest)
+    {
+        var expected = relativePath.Replace('\\', '/');
+        foreach (var line in File.ReadLines(path))
+        {
+            var separator = line.IndexOf(" *", StringComparison.Ordinal);
+            if (separator <= 0) continue;
+            var listedDigest = line.Substring(0, separator).Trim();
+            var listedPath = line.Substring(separator + 2).Trim().Replace('\\', '/');
+            if (string.Equals(listedDigest, digest, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(listedPath, expected, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string ResolveWithinRoot(string root, string relativePath)
+    {
+        if (Path.IsPathRooted(relativePath))
+            throw Invalid("PowerForge manifest installer path must be relative to the repository.");
+        var candidate = Path.GetFullPath(Path.Combine(root, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var prefix = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        if (!candidate.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            throw Invalid("PowerForge manifest installer path resolves outside the repository.");
+        return candidate;
+    }
+
+    private static string RequireDirectory(string? path, string name)
+    {
+        var full = Path.GetFullPath(RequireText(path, name));
+        return Directory.Exists(full) ? full : throw new DirectoryNotFoundException($"Directory was not found: {full}");
+    }
+
+    private static string RequireFile(string? path, string name)
+    {
+        var full = Path.GetFullPath(RequireText(path, name));
+        return File.Exists(full) ? full : throw new FileNotFoundException($"File was not found: {full}", full);
+    }
+
+    private static string RequireText(string? value, string name)
+    {
+        var normalized = value?.Trim() ?? string.Empty;
+        return normalized.Length > 0 ? normalized : throw new InvalidDataException($"{name} is required.");
+    }
+
+    private static string RequireHex(string? value, int minimum, int maximum, string name)
+    {
+        var normalized = RequireText(value, name);
+        if (normalized.Length < minimum || normalized.Length > maximum || normalized.Any(ch => !Uri.IsHexDigit(ch)))
+            throw Invalid($"PowerForge manifest does not contain a valid {name}.");
+        return normalized;
+    }
+
+    private static string NormalizeRelativePath(string? value)
+    {
+        var normalized = RequireText(value, "manifest artifact path").Replace('\\', '/').TrimStart('/');
+        return normalized;
+    }
+
+    private static string NormalizeVersion(string? value)
+    {
+        var normalized = RequireText(value, "ProductVersion");
+        if (!Version.TryParse(normalized, out _))
+            throw Invalid("MSI ProductVersion is not a numeric version.");
+        return normalized;
+    }
+
+    private static string NormalizeGuid(string? value, string name)
+    {
+        if (!Guid.TryParse(value, out var parsed))
+            throw Invalid($"MSI {name} is not a valid GUID.");
+        return parsed.ToString("B").ToUpperInvariant();
+    }
+
+    private static string NormalizeThumbprint(string? value)
+    {
+        var normalized = RequireText(value, "signing certificate thumbprint")
+            .Replace(" ", string.Empty)
+            .ToUpperInvariant();
+        if (normalized.Length < 40 || normalized.Any(ch => !Uri.IsHexDigit(ch)))
+            throw Invalid("PowerForge signing certificate thumbprint is invalid.");
+        return normalized;
+    }
+
+    private static bool Is(JsonElement element, string name, string expected) =>
+        string.Equals(ReadString(element, name), expected, StringComparison.OrdinalIgnoreCase);
+
+    private static string ReadString(JsonElement element, string name) =>
+        TryGet(element, name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString() ?? string.Empty
+            : string.Empty;
+
+    private static int ReadInt32(JsonElement element, string name) =>
+        TryGet(element, name, out var value) && value.TryGetInt32(out var result) ? result : 0;
+
+    private static bool ReadBoolean(JsonElement element, string name) =>
+        TryGet(element, name, out var value) && value.ValueKind == JsonValueKind.True;
+
+    private static string[] ReadStringArray(JsonElement element, string name) =>
+        ReadArray(element, name)
+            .Where(value => value.ValueKind == JsonValueKind.String)
+            .Select(value => value.GetString() ?? string.Empty)
+            .ToArray();
+
+    private static JsonElement[] ReadArray(JsonElement element, string name) =>
+        TryGet(element, name, out var value) && value.ValueKind == JsonValueKind.Array
+            ? value.EnumerateArray().ToArray()
+            : Array.Empty<JsonElement>();
+
+    private static bool TryGet(JsonElement element, string name, out JsonElement value)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = property.Value;
+                    return true;
+                }
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static InvalidDataException Invalid(string message) => new(message);
+
+    internal sealed class AuthenticodeResult
+    {
+        internal AuthenticodeResult(bool isValid, int statusCode, string subject, string thumbprint)
+        {
+            IsValid = isValid;
+            StatusCode = statusCode;
+            Subject = subject;
+            Thumbprint = thumbprint;
+        }
+
+        internal bool IsValid { get; }
+        internal int StatusCode { get; }
+        internal string Subject { get; }
+        internal string Thumbprint { get; }
+    }
+
+    private sealed class ExpectedInstaller
+    {
+        internal ExpectedInstaller(string productName, string manufacturer, string upgradeCode, string signerThumbprint)
+        {
+            ProductName = productName;
+            Manufacturer = manufacturer;
+            UpgradeCode = upgradeCode;
+            SignerThumbprint = signerThumbprint;
+        }
+
+        internal string ProductName { get; }
+        internal string Manufacturer { get; }
+        internal string UpgradeCode { get; }
+        internal string SignerThumbprint { get; }
+    }
+}

--- a/PowerForge/Services/DotNetPublishReleaseArtifactVerifier.cs
+++ b/PowerForge/Services/DotNetPublishReleaseArtifactVerifier.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace PowerForge;
 
@@ -10,6 +11,7 @@ namespace PowerForge;
 /// </summary>
 public sealed class DotNetPublishReleaseArtifactVerifier
 {
+    private static readonly JsonSerializerOptions ConfigurationJsonOptions = CreateConfigurationJsonOptions();
     private readonly Func<string, DotNetPublishMsiPackageMetadata> _readPackage;
     private readonly Func<string, AuthenticodeResult> _verifyAuthenticode;
 
@@ -40,15 +42,30 @@ public sealed class DotNetPublishReleaseArtifactVerifier
         var configurationPath = RequireFile(request.ConfigurationPath, nameof(request.ConfigurationPath));
         var installerId = RequireText(request.InstallerId, nameof(request.InstallerId));
 
-        using var manifest = JsonDocument.Parse(File.ReadAllText(manifestPath));
+        var manifestRelativePath = GetRelativePath(projectRoot, manifestPath).Replace('\\', '/');
+        var manifestDigest = ComputeSha256(manifestPath);
+        if (!ChecksumContains(checksumsPath, manifestRelativePath, manifestDigest))
+            throw Invalid("PowerForge manifest SHA-256 does not match the checksum manifest.");
+
+        using var manifest = JsonDocument.Parse(File.ReadAllText(manifestPath), new JsonDocumentOptions
+        {
+            AllowTrailingCommas = true,
+            CommentHandling = JsonCommentHandling.Skip
+        });
         if (manifest.RootElement.ValueKind != JsonValueKind.Array)
             throw Invalid("PowerForge manifest must contain a JSON array.");
 
         var entries = manifest.RootElement.EnumerateArray()
             .Where(entry => Is(entry, "Category", "Installer") && Is(entry, "InstallerId", installerId))
             .ToArray();
+        entries = FilterEntries(entries, "Target", request.Target);
+        entries = FilterEntries(entries, "Runtime", request.Runtime);
+        entries = FilterEntries(entries, "Framework", request.Framework);
+        entries = FilterEntries(entries, "Style", request.Style);
         if (entries.Length != 1)
-            throw Invalid($"PowerForge manifest must contain exactly one '{installerId}' installer.");
+            throw Invalid(
+                $"PowerForge manifest selectors must identify exactly one '{installerId}' installer; " +
+                "specify target, RID, framework, and style for matrix builds.");
 
         var entry = entries[0];
         if (ReadInt32(entry, "SignedFiles") < 1)
@@ -117,45 +134,41 @@ public sealed class DotNetPublishReleaseArtifactVerifier
 
     private static ExpectedInstaller ReadExpectedInstaller(string configurationPath, string installerId)
     {
-        using var configuration = JsonDocument.Parse(File.ReadAllText(configurationPath));
-        var installers = ReadArray(configuration.RootElement, "Installers")
-            .Where(installer => Is(installer, "Id", installerId))
+        var configuration = JsonSerializer.Deserialize<DotNetPublishSpec>(
+                File.ReadAllText(configurationPath),
+                ConfigurationJsonOptions)
+            ?? throw Invalid("PowerForge configuration could not be deserialized.");
+        configuration = DotNetPublishPipelineRunner.ResolveProfile(configuration);
+        var installers = (configuration.Installers ?? Array.Empty<DotNetPublishInstaller>())
+            .Where(installer => string.Equals(installer.Id, installerId, StringComparison.OrdinalIgnoreCase))
             .ToArray();
         if (installers.Length != 1)
             throw Invalid($"PowerForge configuration must define exactly one '{installerId}' installer.");
 
         var installer = installers[0];
-        if (!TryGet(installer, "Authoring", out var authoring) ||
-            !TryGet(authoring, "Product", out var product))
-        {
-            throw Invalid("PowerForge installer authoring identity is required for release verification.");
-        }
-
-        JsonElement sign;
-        if (TryGet(installer, "Sign", out sign))
-        {
-            // Inline signing policy is already resolved.
-        }
-        else
-        {
-            var profileName = ReadString(installer, "SignProfile");
-            if (string.IsNullOrWhiteSpace(profileName) ||
-                !TryGet(configuration.RootElement, "SigningProfiles", out var profiles) ||
-                profiles.ValueKind != JsonValueKind.Object ||
-                !TryGet(profiles, profileName, out sign))
-            {
-                throw Invalid("PowerForge installer signing configuration is required for release verification.");
-            }
-        }
-
-        if (!ReadBoolean(sign, "Enabled"))
+        var sign = DotNetPublishSigningProfileResolver.ResolveConfiguredSignOptions(
+            configuration.SigningProfiles,
+            installer.SignProfile,
+            installer.Sign,
+            installer.SignOverrides,
+            $"Installer '{installerId}'");
+        if (sign is null || !sign.Enabled)
             throw Invalid("PowerForge installer signing must be enabled for a release artifact.");
 
+        if (installer.Authoring is null &&
+            string.IsNullOrWhiteSpace(installer.InstallerProjectId) &&
+            string.IsNullOrWhiteSpace(installer.InstallerProjectPath))
+        {
+            throw Invalid("PowerForge installer authoring or a hand-authored installer project is required for release verification.");
+        }
+
+        var product = installer.Authoring?.Product;
+
         return new ExpectedInstaller(
-            RequireText(ReadString(product, "Name"), "Product.Name"),
-            RequireText(ReadString(product, "Manufacturer"), "Product.Manufacturer"),
-            NormalizeGuid(ReadString(product, "UpgradeCode"), "Product.UpgradeCode"),
-            NormalizeThumbprint(ReadString(sign, "Thumbprint")));
+            product is null ? null : RequireText(product.Name, "Product.Name"),
+            product is null ? null : RequireText(product.Manufacturer, "Product.Manufacturer"),
+            product is null ? null : NormalizeGuid(product.UpgradeCode, "Product.UpgradeCode"),
+            NormalizeThumbprint(sign.Thumbprint));
     }
 
     private static void ValidatePackage(
@@ -168,9 +181,12 @@ public sealed class DotNetPublishReleaseArtifactVerifier
         ValidateEqual(ReadString(manifestPackage, "ProductVersion"), actual.ProductVersion, "ProductVersion");
         ValidateEqual(NormalizeGuid(ReadString(manifestPackage, "ProductCode"), "ProductCode"), NormalizeGuid(actual.ProductCode, "ProductCode"), "ProductCode");
         ValidateEqual(NormalizeGuid(ReadString(manifestPackage, "UpgradeCode"), "UpgradeCode"), NormalizeGuid(actual.UpgradeCode, "UpgradeCode"), "UpgradeCode");
-        ValidateEqual(expected.ProductName, actual.ProductName, "configured ProductName");
-        ValidateEqual(expected.Manufacturer, actual.Manufacturer, "configured Manufacturer");
-        ValidateEqual(expected.UpgradeCode, NormalizeGuid(actual.UpgradeCode, "UpgradeCode"), "configured UpgradeCode");
+        if (expected.ProductName is not null)
+            ValidateEqual(expected.ProductName, actual.ProductName, "configured ProductName");
+        if (expected.Manufacturer is not null)
+            ValidateEqual(expected.Manufacturer, actual.Manufacturer, "configured Manufacturer");
+        if (expected.UpgradeCode is not null)
+            ValidateEqual(expected.UpgradeCode, NormalizeGuid(actual.UpgradeCode, "UpgradeCode"), "configured UpgradeCode");
         _ = NormalizeVersion(actual.ProductVersion);
     }
 
@@ -228,6 +244,44 @@ public sealed class DotNetPublishReleaseArtifactVerifier
         }
 
         return false;
+    }
+
+    private static JsonElement[] FilterEntries(JsonElement[] entries, string propertyName, string? selector)
+    {
+        if (string.IsNullOrWhiteSpace(selector))
+            return entries;
+
+        var expected = selector!.Trim();
+        return entries
+            .Where(entry => Is(entry, propertyName, expected))
+            .ToArray();
+    }
+
+    private static string GetRelativePath(string root, string path)
+    {
+#if NET472
+        var basePath = Path.GetFullPath(root)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        var baseUri = new Uri(basePath);
+        var targetUri = new Uri(Path.GetFullPath(path));
+        return Uri.UnescapeDataString(baseUri.MakeRelativeUri(targetUri).ToString())
+            .Replace('/', Path.DirectorySeparatorChar);
+#else
+        return Path.GetRelativePath(root, path);
+#endif
+    }
+
+    private static JsonSerializerOptions CreateConfigurationJsonOptions()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true
+        };
+        options.Converters.Add(new JsonStringEnumConverter());
+        return options;
     }
 
     private static string ResolveWithinRoot(string root, string relativePath)
@@ -309,9 +363,6 @@ public sealed class DotNetPublishReleaseArtifactVerifier
     private static int ReadInt32(JsonElement element, string name) =>
         TryGet(element, name, out var value) && value.TryGetInt32(out var result) ? result : 0;
 
-    private static bool ReadBoolean(JsonElement element, string name) =>
-        TryGet(element, name, out var value) && value.ValueKind == JsonValueKind.True;
-
     private static string[] ReadStringArray(JsonElement element, string name) =>
         ReadArray(element, name)
             .Where(value => value.ValueKind == JsonValueKind.String)
@@ -361,7 +412,7 @@ public sealed class DotNetPublishReleaseArtifactVerifier
 
     private sealed class ExpectedInstaller
     {
-        internal ExpectedInstaller(string productName, string manufacturer, string upgradeCode, string signerThumbprint)
+        internal ExpectedInstaller(string? productName, string? manufacturer, string? upgradeCode, string signerThumbprint)
         {
             ProductName = productName;
             Manufacturer = manufacturer;
@@ -369,9 +420,9 @@ public sealed class DotNetPublishReleaseArtifactVerifier
             SignerThumbprint = signerThumbprint;
         }
 
-        internal string ProductName { get; }
-        internal string Manufacturer { get; }
-        internal string UpgradeCode { get; }
+        internal string? ProductName { get; }
+        internal string? Manufacturer { get; }
+        internal string? UpgradeCode { get; }
         internal string SignerThumbprint { get; }
     }
 }

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -4201,10 +4201,11 @@ internal sealed partial class PowerForgeReleaseService
             foreach (var target in spec.Targets ?? Array.Empty<DotNetPublishTarget>())
             {
                 target.Publish ??= new DotNetPublishPublishOptions();
+                var hasRequestedSignProfile = !string.IsNullOrWhiteSpace(request.SignProfile);
                 var baseSign = DotNetPublishSigningProfileResolver.ResolveConfiguredSignOptions(
                     spec.SigningProfiles,
-                    !string.IsNullOrWhiteSpace(request.SignProfile) ? request.SignProfile : target.Publish.SignProfile,
-                    target.Publish.Sign,
+                    hasRequestedSignProfile ? request.SignProfile : target.Publish.SignProfile,
+                    hasRequestedSignProfile ? null : target.Publish.Sign,
                     target.Publish.SignOverrides,
                     $"Target '{target.Name}'");
                 target.Publish.Sign = ApplySigningOverrides(baseSign, request);
@@ -4217,10 +4218,11 @@ internal sealed partial class PowerForgeReleaseService
 
             foreach (var installer in spec.Installers ?? Array.Empty<DotNetPublishInstaller>())
             {
+                var hasRequestedSignProfile = !string.IsNullOrWhiteSpace(request.SignProfile);
                 var baseSign = DotNetPublishSigningProfileResolver.ResolveConfiguredSignOptions(
                     spec.SigningProfiles,
-                    !string.IsNullOrWhiteSpace(request.SignProfile) ? request.SignProfile : installer.SignProfile,
-                    installer.Sign,
+                    hasRequestedSignProfile ? request.SignProfile : installer.SignProfile,
+                    hasRequestedSignProfile ? null : installer.Sign,
                     installer.SignOverrides,
                     $"Installer '{installer.Id}'");
                 installer.Sign = ApplySigningOverrides(baseSign, request);
@@ -5504,6 +5506,8 @@ internal sealed partial class PowerForgeReleaseService
             sign.ToolPath = request.SignToolPath!.Trim();
         if (!string.IsNullOrWhiteSpace(request.SignThumbprint))
             sign.Thumbprint = request.SignThumbprint!.Trim();
+        else if (!string.IsNullOrWhiteSpace(request.SignSubjectName))
+            sign.Thumbprint = null;
         if (!string.IsNullOrWhiteSpace(request.SignSubjectName))
             sign.SubjectName = request.SignSubjectName!.Trim();
         if (request.SignOnMissingTool.HasValue)

--- a/PowerForge/Services/WindowsAuthenticodeSignatureInspector.cs
+++ b/PowerForge/Services/WindowsAuthenticodeSignatureInspector.cs
@@ -68,6 +68,55 @@ internal static class WindowsAuthenticodeSignatureInspector
         }
     }
 
+    internal static int Verify(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath) || !IsWindows())
+            return TrustENoSignature;
+
+        var fileInfoPointer = IntPtr.Zero;
+        var trustDataPointer = IntPtr.Zero;
+        try
+        {
+            var fileInfo = new WinTrustFileInfo
+            {
+                StructSize = (uint)Marshal.SizeOf<WinTrustFileInfo>(),
+                FilePath = filePath,
+                FileHandle = IntPtr.Zero,
+                KnownSubject = IntPtr.Zero
+            };
+            fileInfoPointer = Marshal.AllocHGlobal(Marshal.SizeOf<WinTrustFileInfo>());
+            Marshal.StructureToPtr(fileInfo, fileInfoPointer, fDeleteOld: false);
+
+            var trustData = new WinTrustData
+            {
+                StructSize = (uint)Marshal.SizeOf<WinTrustData>(),
+                UiChoice = 2,
+                RevocationChecks = 1,
+                UnionChoice = 1,
+                FileInfo = fileInfoPointer,
+                StateAction = 0,
+                ProviderFlags = 0x00000040,
+                UiContext = 0
+            };
+            trustDataPointer = Marshal.AllocHGlobal(Marshal.SizeOf<WinTrustData>());
+            Marshal.StructureToPtr(trustData, trustDataPointer, fDeleteOld: false);
+            return WinVerifyTrust(new IntPtr(-1), GenericVerifyV2, trustDataPointer);
+        }
+        finally
+        {
+            if (trustDataPointer != IntPtr.Zero)
+            {
+                Marshal.DestroyStructure<WinTrustData>(trustDataPointer);
+                Marshal.FreeHGlobal(trustDataPointer);
+            }
+            if (fileInfoPointer != IntPtr.Zero)
+            {
+                Marshal.DestroyStructure<WinTrustFileInfo>(fileInfoPointer);
+                Marshal.FreeHGlobal(fileInfoPointer);
+            }
+        }
+    }
+
     internal static bool IsNoSignatureStatus(int status)
         => status == TrustENoSignature ||
            status == TrustEProviderUnknown ||


### PR DESCRIPTION
## Summary

- add a reusable verifier for signed MSI release artifacts
- bind publication to a clean source revision and the PowerForge manifest, effective build target/runtime/framework/style plan, checksum catalog, MSI identity/version, Authenticode signature, and configured publisher certificate
- verify artifact integrity before invoking the native MSI parser and preserve permitted rooted outputs on .NET Framework across drives and UNC shares
- require full 40- or 64-character manifest provenance; permit prefix matching only for explicitly abbreviated caller revisions and require equal-length exact matching for full object IDs
- accept standalone dotnet-publish configuration or unified release configuration with inline/external `Tools.DotNetPublish`, preserving release-build profile precedence
- support matrix and multi-output artifact selectors, publish-compatible JSON, hand-authored installer projects, and explicitly permitted outside-root outputs including rooted cross-volume and UNC identities
- apply signing profile, identity, and explicit `--sign`/`--no-sign` overrides with the same precedence as the release builder; explicit disable cannot be re-enabled by inherited signer selectors
- support thumbprint, subject-name, or automatic valid-certificate selection without inherited configuration shadowing explicit overrides
- expose structured JSON through `powerforge dotnet release-artifact verify` for downstream release workflows

## Validation

- focused verifier/release-builder tests: 35/35 passed on the final candidate
- `dotnet build PowerForge/PowerForge.csproj -c Release --no-restore`: .NET Framework 4.7.2, .NET 8, and .NET 10 passed
- `dotnet build PowerForge.Cli/PowerForge.Cli.csproj -c Release --no-restore`: .NET 8 and .NET 10 passed
- independent owner-level closure review plus targeted confirmations found no unresolved P0-P2 issue in artifact path identity, unified configuration loading, effective signing precedence, or revision binding
- full PowerForge test run was attempted; unrelated existing Windows failures remain in Apple, web/xref, and visual suites outside this change

## Release state

No package was published by this PR. Downstream reusable workflows must pin a future published PowerForge.Build version containing this verifier.
