### PR TITLE
Fix Cloudflare discovery paths on Linux

### DIFF
--- a/.github/workflows/BuildModule.yml
+++ b/.github/workflows/BuildModule.yml
@@ -322,6 +322,14 @@ jobs:
         timeout-minutes: 10
         run: .\Build\Build-Project.ps1 -ModuleOnly
 
+      - name: Test cross-platform Cloudflare website contracts
+        shell: pwsh
+        timeout-minutes: 10
+        run: >
+          dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj
+          -c Release --nologo
+          --filter 'FullyQualifiedName~WebPipelineRunnerCloudflareTests'
+
       - name: Test Linux website deployment state machine
         shell: bash
         run: sudo bash Deployment/Linux/tests/powerforge-site-deploy-fixture.sh

--- a/PowerForge.Tests/WebPipelineRunnerCloudflareTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerCloudflareTests.cs
@@ -273,6 +273,33 @@ public class WebPipelineRunnerCloudflareTests
     }
 
     [Fact]
+    public void CloudflareHtmlAssetResolver_RejectsNetworkPathDiscoverySource()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() => CloudflareHtmlAssetResolver.Resolve(
+            "https://example.test/",
+            ["//outside.example/apps/converter/"],
+            ["/apps/converter/_framework/*.js"],
+            timeoutMs: 5000));
+
+        Assert.Contains("must resolve under", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("/../admin/")]
+    [InlineData("/%2e%2e/admin/")]
+    [InlineData("/%252e%252e/admin/")]
+    public void CloudflareHtmlAssetResolver_RejectsDeploymentBaseTraversal(string source)
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() => CloudflareHtmlAssetResolver.Resolve(
+            "https://example.test/project/",
+            [source],
+            ["/project/_framework/*.js"],
+            timeoutMs: 5000));
+
+        Assert.Contains("must resolve under", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task RunPipeline_CloudflareVerify_RejectsCachedErrorResponse()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-cloudflare-cached-error-" + Guid.NewGuid().ToString("N"));
@@ -374,7 +401,7 @@ public class WebPipelineRunnerCloudflareTests
                       "baseUrl": "http://127.0.0.1:{{port}}/project/",
                       "warmupRequests": 0,
                       "allowStatuses": "HIT",
-                      "discoverAssetsFrom": "/",
+                      "discoverAssetsFrom": "/?next=/../admin#section/../next",
                       "assetPathPatterns": "{{assetPath}}"
                     }
                   ]
@@ -385,7 +412,7 @@ public class WebPipelineRunnerCloudflareTests
 
             Assert.True(result.Success, result.Steps.Single().Message);
             Assert.NotNull(requestCounter);
-            Assert.Contains(appPath, requestCounter!.Paths);
+            Assert.Contains("/project/?next=/../admin", requestCounter!.Paths);
             Assert.Contains(assetPath, requestCounter.Paths);
             Assert.DoesNotContain("/", requestCounter.Paths);
         }

--- a/PowerForge.Tests/WebPipelineRunnerCloudflareTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerCloudflareTests.cs
@@ -286,8 +286,13 @@ public class WebPipelineRunnerCloudflareTests
 
     [Theory]
     [InlineData("/../admin/")]
+    [InlineData("/safe/../../admin/")]
+    [InlineData("/..\\admin/")]
     [InlineData("/%2e%2e/admin/")]
+    [InlineData("/%2e%2e%2fadmin/")]
+    [InlineData("/..%5cadmin/")]
     [InlineData("/%252e%252e/admin/")]
+    [InlineData("/%252e%252e%252fadmin/")]
     public void CloudflareHtmlAssetResolver_RejectsDeploymentBaseTraversal(string source)
     {
         var exception = Assert.Throws<InvalidOperationException>(() => CloudflareHtmlAssetResolver.Resolve(
@@ -373,8 +378,14 @@ public class WebPipelineRunnerCloudflareTests
         }
     }
 
-    [Fact]
-    public async Task RunPipeline_CloudflareVerify_ResolvesRootDiscoveryPathUnderConfiguredSiteBase()
+    [Theory]
+    [InlineData("/?next=/../admin#section/../next", "/project/?next=/../admin")]
+    [InlineData("./", "/project/")]
+    [InlineData("docs/../", "/project/")]
+    [InlineData("docs/./../", "/project/")]
+    public async Task RunPipeline_CloudflareVerify_ResolvesSafeRelativeDiscoveryPathUnderConfiguredSiteBase(
+        string discoverySource,
+        string expectedRequestPath)
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-cloudflare-base-path-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
@@ -401,7 +412,7 @@ public class WebPipelineRunnerCloudflareTests
                       "baseUrl": "http://127.0.0.1:{{port}}/project/",
                       "warmupRequests": 0,
                       "allowStatuses": "HIT",
-                      "discoverAssetsFrom": "/?next=/../admin#section/../next",
+                      "discoverAssetsFrom": "{{discoverySource}}",
                       "assetPathPatterns": "{{assetPath}}"
                     }
                   ]
@@ -412,7 +423,7 @@ public class WebPipelineRunnerCloudflareTests
 
             Assert.True(result.Success, result.Steps.Single().Message);
             Assert.NotNull(requestCounter);
-            Assert.Contains("/project/?next=/../admin", requestCounter!.Paths);
+            Assert.Contains(expectedRequestPath, requestCounter!.Paths);
             Assert.Contains(assetPath, requestCounter.Paths);
             Assert.DoesNotContain("/", requestCounter.Paths);
         }

--- a/PowerForge.Web.Cli/CloudflareHtmlAssetResolver.cs
+++ b/PowerForge.Web.Cli/CloudflareHtmlAssetResolver.cs
@@ -124,22 +124,56 @@ internal static class CloudflareHtmlAssetResolver
     {
         var candidate = value.Trim();
         Uri? resolved;
-        if (Uri.TryCreate(candidate, UriKind.Absolute, out var absolute))
+        if (candidate.StartsWith("//", StringComparison.Ordinal))
+            throw new InvalidOperationException($"cloudflare: {label} '{value}' must resolve under {siteBase.GetLeftPart(UriPartial.Authority)}.");
+
+        var deploymentRelative = false;
+        // Unix treats leading-slash paths as absolute file URIs. Pipeline paths
+        // are deployment-relative on every platform, so classify them before
+        // asking Uri to detect absolute HTTP(S) URLs.
+        if (!candidate.StartsWith("/", StringComparison.Ordinal) &&
+            Uri.TryCreate(candidate, UriKind.Absolute, out var absolute))
         {
             resolved = absolute;
         }
         else
         {
+            deploymentRelative = true;
             // Pipeline paths are site-relative: a leading slash means the root of
             // the configured deployment, not the hostname root. This matters for
             // GitHub Pages project sites such as https://host/project/.
             var relative = candidate.TrimStart('/');
+            var pathEnd = relative.IndexOfAny(['?', '#']);
+            var relativePath = pathEnd < 0 ? relative : relative[..pathEnd];
+            if (ContainsDotSegment(relativePath))
+                throw new InvalidOperationException($"cloudflare: {label} '{value}' must resolve under {siteBase.GetLeftPart(UriPartial.Authority)}.");
             resolved = relative.Length == 0 ? siteBase : new Uri(siteBase, relative);
         }
 
-        if (!HasSameOrigin(siteBase, resolved))
+        if (!HasSameOrigin(siteBase, resolved) || (deploymentRelative && !HasDeploymentBasePath(siteBase, resolved)))
             throw new InvalidOperationException($"cloudflare: {label} '{value}' must resolve under {siteBase.GetLeftPart(UriPartial.Authority)}.");
         return resolved;
+    }
+
+    private static bool ContainsDotSegment(string value)
+    {
+        var decoded = value.Replace('\\', '/');
+        while (true)
+        {
+            if (decoded.Split('/').Any(static segment => segment is "." or ".."))
+                return true;
+
+            var unescaped = Uri.UnescapeDataString(decoded);
+            if (string.Equals(decoded, unescaped, StringComparison.Ordinal))
+                return false;
+            decoded = unescaped.Replace('\\', '/');
+        }
+    }
+
+    private static bool HasDeploymentBasePath(Uri siteBase, Uri candidate)
+    {
+        var basePath = EnsureDirectoryUri(siteBase).AbsolutePath;
+        return basePath == "/" || candidate.AbsolutePath.StartsWith(basePath, StringComparison.Ordinal);
     }
 
     private static Uri EnsureDirectoryUri(Uri value)

--- a/PowerForge.Web.Cli/CloudflareHtmlAssetResolver.cs
+++ b/PowerForge.Web.Cli/CloudflareHtmlAssetResolver.cs
@@ -145,7 +145,7 @@ internal static class CloudflareHtmlAssetResolver
             var relative = candidate.TrimStart('/');
             var pathEnd = relative.IndexOfAny(['?', '#']);
             var relativePath = pathEnd < 0 ? relative : relative[..pathEnd];
-            if (ContainsDotSegment(relativePath))
+            if (!StaysWithinDeploymentBase(siteBase, relativePath))
                 throw new InvalidOperationException($"cloudflare: {label} '{value}' must resolve under {siteBase.GetLeftPart(UriPartial.Authority)}.");
             resolved = relative.Length == 0 ? siteBase : new Uri(siteBase, relative);
         }
@@ -155,19 +155,37 @@ internal static class CloudflareHtmlAssetResolver
         return resolved;
     }
 
-    private static bool ContainsDotSegment(string value)
+    private static bool StaysWithinDeploymentBase(Uri siteBase, string relativePath)
     {
-        var decoded = value.Replace('\\', '/');
+        var decoded = relativePath.Replace('\\', '/');
         while (true)
         {
-            if (decoded.Split('/').Any(static segment => segment is "." or ".."))
-                return true;
-
             var unescaped = Uri.UnescapeDataString(decoded);
             if (string.Equals(decoded, unescaped, StringComparison.Ordinal))
-                return false;
+                break;
             decoded = unescaped.Replace('\\', '/');
         }
+
+        var baseDepth = EnsureDirectoryUri(siteBase).AbsolutePath
+            .Split('/', StringSplitOptions.RemoveEmptyEntries)
+            .Length;
+        var depth = baseDepth;
+        foreach (var segment in decoded.Split('/', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (segment == ".")
+                continue;
+            if (segment == "..")
+            {
+                if (depth == baseDepth)
+                    return false;
+                depth--;
+                continue;
+            }
+
+            depth++;
+        }
+
+        return true;
     }
 
     private static bool HasDeploymentBasePath(Uri siteBase, Uri candidate)


### PR DESCRIPTION
## Summary

- resolve leading-slash Cloudflare HTML discovery sources relative to the configured deployment base on every platform
- preserve safe relative dot-segment paths while rejecting literal, encoded, and repeatedly encoded traversal outside a subpath deployment
- keep query and fragment content out of path traversal validation
- run the focused Cloudflare website pipeline contracts in the Linux build lane

## Why

OfficeIMO's managed Cloudflare policy applied successfully, but its Linux post-deploy verifier interpreted `/apps/officeimo-converter/` as an absolute file URI. This keeps the documented deployment-relative path contract consistent across Linux and Windows and adds a permanent Linux regression gate.