### PR TITLE
Coordinate complete PSPublishModule public releases

### DIFF
--- a/Build/Build-Project.ps1
+++ b/Build/Build-Project.ps1
@@ -66,11 +66,13 @@ if ([string]::IsNullOrWhiteSpace($ConfigPath)) {
     $ConfigPath = Join-Path $PSScriptRoot 'release.json'
 }
 
+$publishRequested = $Publish -or $RunMode -eq 'Publish'
+$fullPublishRequested = $Publish -or ($RunMode -eq 'Publish' -and -not $ModuleOnly)
 $operation = if ($Plan) {
     'Plan unified PowerForge release'
 } elseif ($Validate) {
     'Validate unified PowerForge release'
-} elseif ($Publish -or $RunMode -eq 'Publish' -or $PublishNuget -or $PublishProjectGitHub -or $PublishToolGitHub) {
+} elseif ($publishRequested -or $PublishNuget -or $PublishProjectGitHub -or $PublishToolGitHub) {
     'Publish unified PowerForge release'
 } else {
     'Build unified PowerForge release'
@@ -103,11 +105,20 @@ $moduleProject = Join-Path $repoRoot 'PSPublishModule\PSPublishModule.csproj'
 $moduleBinary = Join-Path $repoRoot "PSPublishModule\bin\$Configuration\$importFramework\PSPublishModule.dll"
 
 try {
-    if ($Publish -and $PackagesOnly) {
-        throw 'The full -Publish switch cannot be combined with -PackagesOnly. Use -PackagesOnly -PublishNuget for a package-only publication.'
+    if ($Publish -and $ModuleOnly) {
+        throw 'The full -Publish switch cannot be combined with -ModuleOnly. Use -ModuleOnly -RunMode Publish for an intentional module-only publication.'
     }
-    if ($Publish -and $ToolsOnly) {
-        throw 'The full -Publish switch cannot be combined with -ToolsOnly. Use -ToolsOnly -PublishToolGitHub for a tool-only publication.'
+    if ($publishRequested -and $PackagesOnly) {
+        throw 'A full publish request cannot be combined with -PackagesOnly. Use -PackagesOnly -PublishNuget for a package-only publication.'
+    }
+    if ($publishRequested -and $ToolsOnly) {
+        throw 'A full publish request cannot be combined with -ToolsOnly. Use -ToolsOnly -PublishToolGitHub for a tool-only publication.'
+    }
+    $hasLaneSpecificGitHubOverride =
+        $PSBoundParameters.ContainsKey('PublishProjectGitHub') -or
+        $PSBoundParameters.ContainsKey('PublishToolGitHub')
+    if ($fullPublishRequested -and $hasLaneSpecificGitHubOverride) {
+        throw 'A full publish request cannot be combined with lane-specific GitHub publication switches. The unified GitHub release is published last automatically.'
     }
 
     foreach ($framework in $bootstrapFrameworks) {
@@ -146,10 +157,12 @@ try {
     }
     $invokeParams.ConfigPath = $ConfigPath
     $invokeParams.Configuration = $Configuration
-    $invokeParams.ModuleRunMode = if ($Publish) { 'Publish' } else { $RunMode }
+    $invokeParams.ModuleRunMode = if ($publishRequested) { 'Publish' } else { $RunMode }
     $invokeParams.ErrorAction = 'Stop'
-    if ($Publish) {
+    if ($fullPublishRequested) {
         $invokeParams.PublishNuget = $true
+    }
+    if ($publishRequested) {
         if (-not $ModuleNoSign) {
             $invokeParams.ModuleSignModule = $true
         }

--- a/Docs/PSPublishModule.UnifiedModuleProjectRelease.md
+++ b/Docs/PSPublishModule.UnifiedModuleProjectRelease.md
@@ -44,6 +44,13 @@ The complete repository release uses the same entry point:
 .\Build\Build-Project.ps1 -Publish
 ```
 
+For compatibility, an unscoped `-RunMode Publish` request is normalized to the same complete release. It publishes
+the coordinated PowerForge package train to NuGet, publishes PSPublishModule to PowerShell Gallery, and creates the
+unified GitHub release only after those prerequisite lanes succeed. Use the explicit lane selectors for an
+intentional partial operation: `-ModuleOnly -RunMode Publish`, `-PackagesOnly -PublishNuget`, or
+`-ToolsOnly -PublishToolGitHub`. Full publication rejects those lane selectors and the lane-specific GitHub
+publication switches so a partial public release cannot become visible before the coordinated registries succeed.
+
 `Build/Build-Project.ps1` loads `Build/release.json`, which coordinates the module recipe in `powerforge.json`
 with packages, tools, signing, and the unified GitHub release. External module repositories can continue using
 the `Build-Module {}` DSL; both entry-point styles run the same shared module and release engines.

--- a/PowerForge.Tests/PSPublishModuleManifestContractTests.cs
+++ b/PowerForge.Tests/PSPublishModuleManifestContractTests.cs
@@ -208,13 +208,22 @@ public sealed class PSPublishModuleManifestContractTests
 
         Assert.Contains("$invokeParams.PublishNuget = $true", projectWrapperScript, StringComparison.Ordinal);
         Assert.Contains("$invokeParams.ModuleSignModule = $true", projectWrapperScript, StringComparison.Ordinal);
-        Assert.Contains("if ($Publish -and $PackagesOnly)", projectWrapperScript, StringComparison.Ordinal);
+        Assert.Contains("$publishRequested = $Publish -or $RunMode -eq 'Publish'", projectWrapperScript, StringComparison.Ordinal);
+        Assert.Contains("$fullPublishRequested = $Publish -or ($RunMode -eq 'Publish' -and -not $ModuleOnly)", projectWrapperScript, StringComparison.Ordinal);
+        Assert.Contains("if ($Publish -and $ModuleOnly)", projectWrapperScript, StringComparison.Ordinal);
+        Assert.Contains("Use -ModuleOnly -RunMode Publish", projectWrapperScript, StringComparison.Ordinal);
+        Assert.Contains("if ($publishRequested -and $PackagesOnly)", projectWrapperScript, StringComparison.Ordinal);
         Assert.Contains("Use -PackagesOnly -PublishNuget", projectWrapperScript, StringComparison.Ordinal);
-        Assert.Contains("if ($Publish -and $ToolsOnly)", projectWrapperScript, StringComparison.Ordinal);
+        Assert.Contains("if ($publishRequested -and $ToolsOnly)", projectWrapperScript, StringComparison.Ordinal);
         Assert.Contains("Use -ToolsOnly -PublishToolGitHub", projectWrapperScript, StringComparison.Ordinal);
+        Assert.Contains("$PSBoundParameters.ContainsKey('PublishProjectGitHub')", projectWrapperScript, StringComparison.Ordinal);
+        Assert.Contains("$PSBoundParameters.ContainsKey('PublishToolGitHub')", projectWrapperScript, StringComparison.Ordinal);
+        Assert.Contains("if ($fullPublishRequested -and $hasLaneSpecificGitHubOverride)", projectWrapperScript, StringComparison.Ordinal);
+        Assert.Contains("The unified GitHub release is published last automatically", projectWrapperScript, StringComparison.Ordinal);
         Assert.Contains("[switch] $ModuleNoDotnetBuild", projectWrapperScript, StringComparison.Ordinal);
-        Assert.Contains("$invokeParams.ModuleRunMode = if ($Publish) { 'Publish' } else { $RunMode }", projectWrapperScript, StringComparison.Ordinal);
-        Assert.Contains("$Publish -or $RunMode -eq 'Publish' -or $PublishNuget", projectWrapperScript, StringComparison.Ordinal);
+        Assert.Contains("$invokeParams.ModuleRunMode = if ($publishRequested) { 'Publish' } else { $RunMode }", projectWrapperScript, StringComparison.Ordinal);
+        Assert.Contains("if ($fullPublishRequested)", projectWrapperScript, StringComparison.Ordinal);
+        Assert.Contains("$publishRequested -or $PublishNuget", projectWrapperScript, StringComparison.Ordinal);
         Assert.DoesNotContain(
             "$invokeParams.ModuleRunMode = if ($Publish -or $PublishNuget -or $PublishProjectGitHub)",
             projectWrapperScript,


### PR DESCRIPTION
## Summary

- treat unscoped `-RunMode Publish` as the complete PSPublishModule/PowerForge public release
- publish the coordinated six-package NuGet train before PSPublishModule and the final unified GitHub release
- reject mixed full/partial modes, including explicitly bound false GitHub switches that could suppress or reorder the unified release
- document the explicit module-, package-, and tool-only publication forms

## Why

The 3.0.105 GitHub release and PSPublishModule Gallery package were published while the six PowerForge NuGet packages remained at 1.0.9. The wrapper classified `-RunMode Publish` as a publication but did not enable NuGet publication. This change makes the complete release meaning consistent and prevents partial public state from being mistaken for a unified release.

## Validation

- PowerShell parser validation passes
- release-mode guard matrix passes for true and explicitly bound false switches
- focused release entry-point contract test passes
- credential-free public-release plan resolves PSPublishModule, all six NuGet packages, and both CLI artifact families to 3.0.106
- `git diff --check` passes

No package, module, tool, tag, or GitHub release was published while validating this PR.