### PR TITLE
Preserve web-relative discovery URLs on Linux

### DIFF
--- a/PowerForge.Tests/CloudflareResponseHeaderPolicyTests.cs
+++ b/PowerForge.Tests/CloudflareResponseHeaderPolicyTests.cs
@@ -84,7 +84,7 @@ public sealed class CloudflareResponseHeaderPolicyTests
         {
             Enabled = true,
             ApiCatalog = new AgentApiCatalogSpec { Enabled = true, OutputPath = "discovery/catalog.json" },
-            AgentSkills = new AgentSkillsDiscoverySpec { Enabled = true, IndexPath = "/skills/index.json" },
+            AgentSkills = new AgentSkillsDiscoverySpec { Enabled = true, IndexPath = "skills/index.json" },
             AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = false },
             A2AAgentCard = new AgentA2ACardSpec { Enabled = true },
             McpServerCard = new AgentMcpServerCardSpec { Enabled = true, OutputPath = "cards/mcp.json" }
@@ -182,6 +182,39 @@ public sealed class CloudflareResponseHeaderPolicyTests
             rule!["description"]!.GetValue<string>().EndsWith("security headers", StringComparison.Ordinal)));
         Assert.Contains("starts_with(http.request.uri.path, \"/product%20docs/\")",
             securityRule["expression"]!.GetValue<string>(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildManagedRules_ShouldPreserveRootRelativeDiscoveryLinksAcrossPlatforms()
+    {
+        var rules = CloudflareResponseHeaderPolicyBuilder.BuildManagedRules(
+            "example.com",
+            "Root",
+            new AgentSecurityHeadersSpec { Enabled = true, Hsts = false },
+            basePath: "/",
+            agentReadiness: new AgentReadinessSpec
+            {
+                Enabled = true,
+                ApiCatalog = new AgentApiCatalogSpec
+                {
+                    Enabled = true,
+                    OutputPath = ".well-known/api-catalog"
+                },
+                AgentSkills = new AgentSkillsDiscoverySpec { Enabled = false },
+                AgentsJson = new AgentDiscoveryDocumentSpec
+                {
+                    Enabled = true,
+                    OutputPath = "agents.json"
+                }
+            });
+
+        var linkRule = Assert.IsType<JsonObject>(rules.Single(rule =>
+            rule!["description"]!.GetValue<string>().EndsWith("discovery Link headers", StringComparison.Ordinal)));
+        var link = linkRule["action_parameters"]!["headers"]!["Link"]!["value"]!.GetValue<string>();
+
+        Assert.Contains("</.well-known/api-catalog>; rel=\"api-catalog\"", link, StringComparison.Ordinal);
+        Assert.Contains("</agents.json>; rel=\"describedby\"", link, StringComparison.Ordinal);
+        Assert.DoesNotContain("file:", link, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -832,6 +832,30 @@ public partial class WebAgentReadinessTests
         Assert.Equal("https://example.test/agent.md", url);
     }
 
+    [Theory]
+    [InlineData("file:///tmp/agent.md")]
+    [InlineData("ftp://outside.example/agent.md")]
+    public void ResolveMarkdownAlternateUrl_RejectsNonHttpTargets(string href)
+    {
+        var linkHeader = $"<{href}>; rel=\"alternate\"; type=\"text/markdown\"";
+
+        var url = WebAgentReadiness.ResolveMarkdownAlternateUrl("https://example.test", linkHeader);
+
+        Assert.Null(url);
+    }
+
+    [Fact]
+    public void ResolveMarkdownAlternateUrl_SkipsRejectedTargetAndUsesLaterHttpTarget()
+    {
+        const string linkHeader =
+            "<file:///tmp/agent.md>; rel=\"alternate\"; type=\"text/markdown\", " +
+            "</agent.md>; rel=\"alternate\"; type=\"text/markdown\"";
+
+        var url = WebAgentReadiness.ResolveMarkdownAlternateUrl("https://example.test", linkHeader);
+
+        Assert.Equal("https://example.test/agent.md", url);
+    }
+
     [Fact]
     public void Prepare_ReplacesExistingApacheManagedBlock()
     {
@@ -2214,6 +2238,85 @@ public partial class WebAgentReadinessTests
 
         Assert.Contains("must be relative", exception.Message, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain(handler.Requests, path => path.Contains("outside", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("/skills/index.json")]
+    [InlineData("\\skills\\index.json")]
+    public async Task Scan_RejectsRootedOutputPathsAcrossPlatforms(string outputPath)
+    {
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => WebAgentReadiness.ScanAsync(new WebAgentReadinessScanOptions
+        {
+            BaseUrl = "https://example.test",
+            HttpMessageHandler = new AgentReadinessScanHandler(),
+            AgentReadiness = new AgentReadinessSpec
+            {
+                Enabled = true,
+                Robots = false,
+                LinkHeaders = false,
+                SecurityHeaders = new AgentSecurityHeadersSpec { Enabled = false },
+                ContentSignals = new AgentContentSignalsSpec { Enabled = false },
+                ApiCatalog = new AgentApiCatalogSpec { Enabled = false },
+                AgentSkills = new AgentSkillsDiscoverySpec { Enabled = true, IndexPath = outputPath },
+                AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = false },
+                MarkdownNegotiation = false
+            }
+        }));
+
+        Assert.Contains("must be relative", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("safe/%2e%2e/agents.json")]
+    [InlineData("safe/a%20b/agents.json")]
+    public async Task Scan_RejectsPercentEncodedOutputPathSegments(string outputPath)
+    {
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => WebAgentReadiness.ScanAsync(new WebAgentReadinessScanOptions
+        {
+            BaseUrl = "https://example.test",
+            HttpMessageHandler = new AgentReadinessScanHandler(),
+            AgentReadiness = new AgentReadinessSpec
+            {
+                Enabled = true,
+                Robots = false,
+                LinkHeaders = false,
+                SecurityHeaders = new AgentSecurityHeadersSpec { Enabled = false },
+                ContentSignals = new AgentContentSignalsSpec { Enabled = false },
+                ApiCatalog = new AgentApiCatalogSpec { Enabled = false },
+                AgentSkills = new AgentSkillsDiscoverySpec { Enabled = true, IndexPath = outputPath },
+                AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = false },
+                MarkdownNegotiation = false
+            }
+        }));
+
+        Assert.Contains("unescaped filesystem characters", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("%2e%2emd")]
+    [InlineData("md/path")]
+    public async Task Scan_RejectsMarkdownExtensionsWithUriOrPathSyntax(string extension)
+    {
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => WebAgentReadiness.ScanAsync(new WebAgentReadinessScanOptions
+        {
+            BaseUrl = "https://example.test",
+            HttpMessageHandler = new AgentReadinessScanHandler(),
+            AgentReadiness = new AgentReadinessSpec
+            {
+                Enabled = true,
+                Robots = false,
+                LinkHeaders = false,
+                SecurityHeaders = new AgentSecurityHeadersSpec { Enabled = false },
+                ContentSignals = new AgentContentSignalsSpec { Enabled = false },
+                ApiCatalog = new AgentApiCatalogSpec { Enabled = false },
+                AgentSkills = new AgentSkillsDiscoverySpec { Enabled = false },
+                AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = false },
+                MarkdownArtifacts = new AgentMarkdownArtifactsSpec { Enabled = true, Extension = extension },
+                MarkdownNegotiation = false
+            }
+        }));
+
+        Assert.Contains("without path or URI syntax", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     private sealed class AgentReadinessScanHandler(string? body = null) : HttpMessageHandler

--- a/PowerForge.Web.Cli/CloudflareResponseHeaderPolicyBuilder.cs
+++ b/PowerForge.Web.Cli/CloudflareResponseHeaderPolicyBuilder.cs
@@ -149,9 +149,10 @@ internal static class CloudflareResponseHeaderPolicyBuilder
         {
             var value = string.IsNullOrWhiteSpace(configured) ? fallback : configured.Trim();
             string target;
-            if (Uri.TryCreate(value, UriKind.Absolute, out var absolute))
+            if (Uri.TryCreate(value, UriKind.Absolute, out var absolute) &&
+                (absolute.Scheme == Uri.UriSchemeHttp || absolute.Scheme == Uri.UriSchemeHttps))
             {
-                if ((absolute.Scheme != Uri.UriSchemeHttp && absolute.Scheme != Uri.UriSchemeHttps) || value.Any(char.IsControl))
+                if (value.Any(char.IsControl))
                     throw new ArgumentException($"Invalid Cloudflare discovery resource URL '{configured}'.", nameof(configured));
                 target = absolute.AbsoluteUri;
             }
@@ -193,7 +194,8 @@ internal static class CloudflareResponseHeaderPolicyBuilder
 
     private static string EscapeLinkUriReference(string value)
     {
-        if (Uri.TryCreate(value, UriKind.Absolute, out var absolute))
+        if (Uri.TryCreate(value, UriKind.Absolute, out var absolute) &&
+            (absolute.Scheme == Uri.UriSchemeHttp || absolute.Scheme == Uri.UriSchemeHttps))
             return absolute.AbsoluteUri;
 
         return CloudflareCachePolicyBuilder.EncodeUriPathForExpression(value);

--- a/PowerForge.Web/Services/WebAgentReadiness.RemoteMarkdown.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.RemoteMarkdown.cs
@@ -16,7 +16,7 @@ public static partial class WebAgentReadiness
         var url = expected
             ? ResolveRemoteOutputUrl(
                 baseUrl,
-                "/index" + NormalizeMarkdownExtension(spec.MarkdownArtifacts!.Extension),
+                "index" + NormalizeMarkdownExtension(spec.MarkdownArtifacts!.Extension),
                 "/index.md")
             : ResolveMarkdownAlternateUrl(baseUrl, linkHeader) ?? CombineUrl(baseUrl, "/index.md");
         var result = expected || !markdownNegotiated

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -555,6 +555,8 @@ public static partial class WebAgentReadiness
                 resolved.AgentSkills ??= new AgentSkillsDiscoverySpec();
                 resolved.AgentsJson ??= new AgentDiscoveryDocumentSpec();
                 ValidateDiscoveryOutputPaths(resolved);
+                if (resolved.MarkdownArtifacts?.Enabled == true)
+                    _ = NormalizeMarkdownExtension(resolved.MarkdownArtifacts.Extension);
             }
 
             return resolved;
@@ -581,7 +583,9 @@ public static partial class WebAgentReadiness
         void Add(string displayName, string resourceOwner, string? configured, string fallback)
         {
             var value = string.IsNullOrWhiteSpace(configured) ? fallback : configured.Trim();
-            if (Uri.TryCreate(value, UriKind.Absolute, out _))
+            if (value.StartsWith("/", StringComparison.Ordinal) ||
+                value.StartsWith("\\", StringComparison.Ordinal) ||
+                Uri.TryCreate(value, UriKind.Absolute, out _))
                 throw new ArgumentException($"Agent-readiness output path '{configured}' must be relative to the site root.");
 
             var normalized = NormalizeDiscoveryOutputPath(value);
@@ -612,6 +616,22 @@ public static partial class WebAgentReadiness
 
     private static string NormalizeDiscoveryOutputPath(string value)
     {
+        string decoded;
+        try
+        {
+            decoded = Uri.UnescapeDataString(value);
+        }
+        catch (UriFormatException ex)
+        {
+            throw new ArgumentException($"Agent-readiness output path '{value}' contains invalid percent encoding.", ex);
+        }
+
+        if (!string.Equals(decoded, value, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Agent-readiness output path '{value}' must use unescaped filesystem characters instead of percent-encoded URI segments.");
+        }
+
         var segments = new List<string>();
         foreach (var segment in value.Replace('\\', '/').Split('/', StringSplitOptions.RemoveEmptyEntries))
         {
@@ -861,7 +881,7 @@ public static partial class WebAgentReadiness
 
     private static string NormalizeApiCatalogAnchorKey(string value)
     {
-        var normalized = Uri.TryCreate(value, UriKind.Absolute, out var uri)
+        var normalized = TryCreateAbsoluteHttpUri(value, out var uri)
             ? uri.AbsoluteUri
             : NormalizeRoute(value);
         // Treat /api and /api/ as the same catalog anchor for explicit-vs-inferred de-duplication.
@@ -881,7 +901,7 @@ public static partial class WebAgentReadiness
 
     private static bool IsLocalProjectApiRoute(string? value)
         => !string.IsNullOrWhiteSpace(value) &&
-           !Uri.TryCreate(value, UriKind.Absolute, out _) &&
+           !TryCreateAbsoluteHttpUri(value!, out _) &&
            NormalizeRoute(value!).StartsWith("/projects/", StringComparison.OrdinalIgnoreCase);
 
     private static string? GetJsonString(JsonElement element, string propertyName)
@@ -1130,12 +1150,33 @@ public static partial class WebAgentReadiness
                relative.StartsWith("api-fragments/", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string NormalizeMarkdownExtension(string? extension)
+    internal static string NormalizeMarkdownExtension(string? extension)
     {
         var value = string.IsNullOrWhiteSpace(extension) ? ".md" : extension!.Trim();
         if (!value.StartsWith(".", StringComparison.Ordinal))
             value = "." + value;
-        return value.Equals(".", StringComparison.Ordinal) ? ".md" : value;
+        if (value.Equals(".", StringComparison.Ordinal))
+            return ".md";
+
+        string decoded;
+        try
+        {
+            decoded = Uri.UnescapeDataString(value);
+        }
+        catch (UriFormatException ex)
+        {
+            throw new ArgumentException($"Markdown artifact extension '{extension}' contains invalid percent encoding.", ex);
+        }
+
+        if (!string.Equals(decoded, value, StringComparison.Ordinal) ||
+            value.IndexOfAny(['/', '\\', '?', '#', '*']) >= 0 ||
+            value.Any(char.IsControl))
+        {
+            throw new ArgumentException(
+                $"Markdown artifact extension '{extension}' must be an unescaped file extension without path or URI syntax.");
+        }
+
+        return value;
     }
 
     private static string ConvertHtmlDocumentToMarkdown(string html, AgentMarkdownArtifactsSpec spec)
@@ -1649,7 +1690,7 @@ public static partial class WebAgentReadiness
     private static string EscapeLinkUriReference(string value)
     {
         var sanitized = StripHeaderControlCharacters(value);
-        if (Uri.TryCreate(sanitized, UriKind.Absolute, out var absolute))
+        if (TryCreateAbsoluteHttpUri(sanitized, out var absolute))
             return absolute.AbsoluteUri;
 
         return string.Join("/", sanitized.Split('/').Select(EscapeLinkPathSegment));
@@ -2261,7 +2302,7 @@ public static partial class WebAgentReadiness
         if (!string.IsNullOrWhiteSpace(spec?.Path))
         {
             var configured = spec.Path!.Trim();
-            if (Uri.TryCreate(configured, UriKind.Absolute, out _))
+            if (TryCreateAbsoluteHttpUri(configured, out _))
                 return configured;
             return File.Exists(ResolveSitePath(siteRoot, configured)) ? NormalizeRoute(configured) : null;
         }
@@ -2298,16 +2339,25 @@ public static partial class WebAgentReadiness
     private static string ResolveRemoteUrl(string baseUrl, string? configuredPath, string defaultPath)
     {
         var value = string.IsNullOrWhiteSpace(configuredPath) ? defaultPath : configuredPath!.Trim();
-        return Uri.TryCreate(value, UriKind.Absolute, out var absolute)
+        return TryCreateAbsoluteHttpUri(value, out var absolute)
             ? absolute.AbsoluteUri
             : CombineUrl(baseUrl, NormalizeRoute(value));
     }
 
     private static string ResolveRemoteOutputUrl(string baseUrl, string? configuredPath, string defaultPath)
     {
+        if (!string.IsNullOrWhiteSpace(configuredPath))
+        {
+            var configured = configuredPath!.Trim();
+            if (configured.StartsWith("/", StringComparison.Ordinal) ||
+                configured.StartsWith("\\", StringComparison.Ordinal) ||
+                Uri.TryCreate(configured, UriKind.Absolute, out _))
+            {
+                throw new ArgumentException($"Agent-readiness output path '{configuredPath}' must be relative to the site root.", nameof(configuredPath));
+            }
+        }
+
         var value = string.IsNullOrWhiteSpace(configuredPath) ? defaultPath : configuredPath!.Trim();
-        if (Uri.TryCreate(value, UriKind.Absolute, out _))
-            throw new ArgumentException($"Agent-readiness output path '{configuredPath}' must be relative to the site root.", nameof(configuredPath));
         return CombineUrl(baseUrl, NormalizeRoute(value));
     }
 
@@ -2347,7 +2397,7 @@ public static partial class WebAgentReadiness
         }
         if (spec.MarkdownArtifacts?.Enabled == true)
             expectationGroups.Add([new RemoteLinkExpectation(
-                ResolveRemoteOutputUrl(baseUrl, "/index" + NormalizeMarkdownExtension(spec.MarkdownArtifacts.Extension), "/index.md"), "alternate")]);
+                ResolveRemoteOutputUrl(baseUrl, "index" + NormalizeMarkdownExtension(spec.MarkdownArtifacts.Extension), "/index.md"), "alternate")]);
 
         return expectationGroups.All(group => group.Any(expectation => LinkHeaderContainsTarget(linkHeader, baseUrl, expectation)));
     }
@@ -2382,11 +2432,18 @@ public static partial class WebAgentReadiness
 
     private static string ResolveLinkTargetUrl(string baseUrl, string href)
     {
-        if (Uri.TryCreate(href, UriKind.Absolute, out var absolute))
+        if (TryCreateAbsoluteHttpUri(href, out var absolute))
             return absolute.AbsoluteUri;
 
-        if (Uri.TryCreate(baseUrl.TrimEnd('/') + "/", UriKind.Absolute, out var homepage) &&
-            Uri.TryCreate(homepage, href, out var resolved))
+        if (!href.StartsWith("/", StringComparison.Ordinal) &&
+            Uri.TryCreate(href, UriKind.Absolute, out _))
+        {
+            return string.Empty;
+        }
+
+        if (TryCreateAbsoluteHttpUri(baseUrl.TrimEnd('/') + "/", out var homepage) &&
+            Uri.TryCreate(homepage, href, out var resolved) &&
+            (resolved.Scheme == Uri.UriSchemeHttp || resolved.Scheme == Uri.UriSchemeHttps))
             return resolved.AbsoluteUri;
 
         return ResolveRemoteUrl(baseUrl, href, "/");
@@ -2541,9 +2598,10 @@ public static partial class WebAgentReadiness
             if (string.IsNullOrWhiteSpace(href))
                 continue;
 
-            return Uri.TryCreate(href, UriKind.Absolute, out _)
-                ? href
-                : CombineUrl(baseUrl, href);
+            var resolved = ResolveLinkTargetUrl(baseUrl, href);
+            if (string.IsNullOrWhiteSpace(resolved))
+                continue;
+            return resolved;
         }
 
         return null;
@@ -2730,7 +2788,7 @@ public static partial class WebAgentReadiness
             return EscapeLinkUriReference(NormalizeRoute(route));
 
         var combined = baseUrl.TrimEnd('/') + "/" + NormalizeRoute(route).TrimStart('/');
-        return Uri.TryCreate(combined, UriKind.Absolute, out var absolute)
+        return TryCreateAbsoluteHttpUri(combined, out var absolute)
             ? absolute.AbsoluteUri
             : combined;
     }
@@ -2739,9 +2797,22 @@ public static partial class WebAgentReadiness
     {
         if (string.IsNullOrWhiteSpace(value))
             return string.Empty;
-        if (Uri.TryCreate(value, UriKind.Absolute, out var absolute))
+        if (TryCreateAbsoluteHttpUri(value, out var absolute))
             return absolute.AbsoluteUri;
         return string.IsNullOrWhiteSpace(baseUrl) ? NormalizeRoute(value) : CombineUrl(baseUrl!, value);
+    }
+
+    private static bool TryCreateAbsoluteHttpUri(string value, out Uri uri)
+    {
+        if (Uri.TryCreate(value, UriKind.Absolute, out var candidate) &&
+            (candidate.Scheme == Uri.UriSchemeHttp || candidate.Scheme == Uri.UriSchemeHttps))
+        {
+            uri = candidate;
+            return true;
+        }
+
+        uri = null!;
+        return false;
     }
 
     private static string NormalizeRoute(string value)


### PR DESCRIPTION
## Summary

- keep root-relative discovery references as web paths on Linux instead of converting them to file URLs
- centralize HTTP/HTTPS absolute-URL classification across agent-readiness generation and remote verification
- reject rooted, percent-encoded, and path-like output values that would make generated artifacts disagree with advertised URLs
- ignore non-HTTP Markdown alternates while continuing to later valid Link candidates

## Why

The post-deploy OfficeIMO probe found that its otherwise healthy Cloudflare policy emitted file-scheme targets in the homepage Link header on Linux. .NET treats leading-slash paths as absolute file URIs on Unix, so platform-neutral web paths must be distinguished from HTTP/HTTPS URLs explicitly.

## Validation

- Windows: 208 focused Cloudflare and agent-readiness tests passed
- WSL/Linux: the same 208 tests passed
- one independent local review found two URI-boundary issues; its targeted confirmation found two adjacent cases; all four were fixed and covered
- HSTS behavior is unchanged; OfficeIMO remains configured with HSTS disabled

## Deployment note

OfficeIMO should repin its reusable website workflows to this exact head after this PR settles so the managed Cloudflare policy is regenerated with corrected Link values.