### PR TITLE
Share one version across product release installers

### DIFF
--- a/Module/Docs/Readme.md
+++ b/Module/Docs/Readme.md
@@ -2,7 +2,7 @@
 Module Name: PSPublishModule
 Module Guid: eb76426a-1992-40a5-82cd-6480f883ef4d
 Download Help Link: https://github.com/EvotecIT/PSPublishModule
-Help Version: 3.0.106
+Help Version: 3.0.107
 Locale: en-US
 ---
 # PSPublishModule Module

--- a/Module/PSPublishModule.psd1
+++ b/Module/PSPublishModule.psd1
@@ -9,7 +9,7 @@
     DotNetFrameworkVersion = '4.5.2'
     FunctionsToExport      = @()
     GUID                   = 'eb76426a-1992-40a5-82cd-6480f883ef4d'
-    ModuleVersion          = '3.0.106'
+    ModuleVersion          = '3.0.107'
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{

--- a/PowerForge.Blazor/PowerForge.Blazor.csproj
+++ b/PowerForge.Blazor/PowerForge.Blazor.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>3.0.106</VersionPrefix>
+    <VersionPrefix>3.0.107</VersionPrefix>
 
     <!-- Package metadata -->
     <PackageId>PowerForge.Blazor</PackageId>

--- a/PowerForge.Cli/PowerForge.Cli.csproj
+++ b/PowerForge.Cli/PowerForge.Cli.csproj
@@ -11,7 +11,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>powerforge</ToolCommandName>
     <Description>PowerForge command-line interface for building and publishing PowerShell modules.</Description>
-    <VersionPrefix>3.0.106</VersionPrefix>
+    <VersionPrefix>3.0.107</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Przemyslaw Klys</Authors>
     <Company>Evotec Services sp. z o.o.</Company>

--- a/PowerForge.PowerShell/PowerForge.PowerShell.csproj
+++ b/PowerForge.PowerShell/PowerForge.PowerShell.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsAsErrors>CS1591</WarningsAsErrors>
-    <VersionPrefix>3.0.106</VersionPrefix>
+    <VersionPrefix>3.0.107</VersionPrefix>
     <PackageId>PowerForge.PowerShell</PackageId>
     <Description>PowerForge PowerShell-hosted module pipeline services.</Description>
     <AssemblyName>PowerForge.PowerShell</AssemblyName>

--- a/PowerForge.Tests/DotNetPublishMsiGitAuthorityTests.cs
+++ b/PowerForge.Tests/DotNetPublishMsiGitAuthorityTests.cs
@@ -12,6 +12,7 @@ public sealed class DotNetPublishMsiGitAuthorityTests
         const string json = """
             {
               "Enabled": true,
+              "ReleaseGroup": "product-release",
               "Monotonic": true,
               "StatePath": "Build/versioning/app.json",
               "Authority": "GitTags",
@@ -26,7 +27,8 @@ public sealed class DotNetPublishMsiGitAuthorityTests
         var versioning = JsonSerializer.Deserialize<DotNetPublishMsiVersionOptions>(json, options);
 
         Assert.NotNull(versioning);
-        Assert.Equal(DotNetPublishMsiVersionAuthorityKind.GitTags, versioning!.Authority);
+        Assert.Equal("product-release", versioning!.ReleaseGroup);
+        Assert.Equal(DotNetPublishMsiVersionAuthorityKind.GitTags, versioning.Authority);
         Assert.Equal("syncse", versioning.AuthorityKey);
         Assert.Equal("origin", versioning.GitRemote);
         Assert.Equal("powerforge-msi", versioning.GitTagPrefix);

--- a/PowerForge.Tests/DotNetPublishMsiGitAuthorityTests.cs
+++ b/PowerForge.Tests/DotNetPublishMsiGitAuthorityTests.cs
@@ -152,6 +152,69 @@ public sealed class DotNetPublishMsiGitAuthorityTests
     }
 
     [Fact]
+    public void GitTagAuthority_RejectsSharedStatePathAcrossDifferentAuthorities()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var remote = Path.Combine(root, "authority.git");
+            var seed = Path.Combine(root, "seed");
+            InitializeRepository(remote, seed);
+            var spec = CreateSpec(seed);
+            var first = spec.Installers[0];
+            first.Versioning!.ReleaseGroup = "suite-a";
+            var second = CreateSpec(seed).Installers[0];
+            second.Id = "agent";
+            second.Versioning!.AuthorityKey = "agent";
+            second.Versioning.ReleaseGroup = "suite-b";
+            spec.Installers = new[] { first, second };
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new DotNetPublishPipelineRunner(new NullLogger()).Plan(
+                    spec,
+                    Path.Combine(seed, "powerforge.json")));
+
+            Assert.Contains("one canonical authority and ReleaseGroup per state path", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GitTagAuthority_RejectsGroupedAndUngroupedOwnersRegardlessOfOrdering(bool groupedFirst)
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var remote = Path.Combine(root, "authority.git");
+            var seed = Path.Combine(root, "seed");
+            InitializeRepository(remote, seed);
+            var spec = CreateSpec(seed);
+            var grouped = spec.Installers[0];
+            grouped.Versioning!.ReleaseGroup = "suite";
+            var ungrouped = CreateSpec(seed).Installers[0];
+            ungrouped.Id = "agent";
+            ungrouped.Versioning!.StatePath = "Build/versioning/agent.msi.state.json";
+            spec.Installers = groupedFirst ? new[] { grouped, ungrouped } : new[] { ungrouped, grouped };
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new DotNetPublishPipelineRunner(new NullLogger()).Plan(
+                    spec,
+                    Path.Combine(seed, "powerforge.json")));
+
+            Assert.Contains("Every installer sharing an authority with a release group", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Authority_RejectsMajorMinorRegression()
     {
         var root = CreateTempRoot();

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -749,6 +749,62 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
     }
 
     [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Plan_StatePathRejectsGroupedAndUngroupedOwnership(bool groupedFirst)
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var app = CreateProject(root, "App/App.csproj");
+            var spec = CreateBaseSpec(root, app);
+            var grouped = CreateReleaseGroupInstaller("monitoring.msi", "MonitoringFiles");
+            var ungrouped = CreateReleaseGroupInstaller("standalone.msi", "StandaloneFiles");
+            ungrouped.Versioning!.ReleaseGroup = null;
+            spec.Installers = groupedFirst ? new[] { grouped, ungrouped } : new[] { ungrouped, grouped };
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null));
+
+            Assert.Contains("one canonical authority and ReleaseGroup per state path", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Plan_MsiVersionStateUsesFileSystemCaseSemantics()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var app = CreateProject(root, "App/App.csproj");
+            var spec = CreateBaseSpec(root, app);
+            var first = CreateReleaseGroupInstaller("monitoring.msi", "MonitoringFiles");
+            var second = CreateReleaseGroupInstaller("agent.msi", "AgentFiles");
+            first.Versioning!.ReleaseGroup = null;
+            second.Versioning!.ReleaseGroup = null;
+            first.Versioning.StatePath = "Build/versioning/Product.state.json";
+            second.Versioning.StatePath = "Build/versioning/product.state.json";
+            spec.Installers = new[] { first, second };
+
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null);
+            var distinctVersions = plan.MsiVersions.Values
+                .Select(version => version.Version)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Count();
+
+            Assert.Equal(OperatingSystem.IsWindows() ? 2 : 1, distinctVersions);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Theory]
     [InlineData(null, "app-1.0.1")]
     [InlineData("output", null)]
     public void VersionedMsiOutput_RequiresUnambiguousTarget(string? outputDirectory, string? outputName)

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -537,6 +537,126 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
         }
     }
 
+    [Fact]
+    public void Plan_ReleaseGroupSharesOneVersionAndReservationAcrossInstallers()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var app = CreateProject(root, "App/App.csproj");
+            var spec = CreateBaseSpec(root, app);
+            spec.Installers = new[]
+            {
+                CreateReleaseGroupInstaller("monitoring.msi", "MonitoringFiles"),
+                CreateReleaseGroupInstaller("agent.msi", "AgentFiles")
+            };
+
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null);
+
+            Assert.Equal(2, plan.MsiVersions.Count);
+            var versions = plan.MsiVersions.Values.ToArray();
+            Assert.Single(versions.Select(version => version.Version).Distinct(StringComparer.OrdinalIgnoreCase));
+            Assert.Single(versions.Select(version => version.StatePath).Distinct(StringComparer.OrdinalIgnoreCase));
+
+            const string reservationOwner = "shared-release-owner";
+            foreach (var version in versions)
+            {
+                DotNetPublishPipelineRunner.ReserveMsiVersionState(
+                    version,
+                    "shared release group test",
+                    reservationOwner);
+            }
+
+            var state = File.ReadAllText(versions[0].StatePath!);
+            Assert.Contains($"\"ReservationOwner\": \"{reservationOwner}\"", state, StringComparison.Ordinal);
+            Assert.True(DotNetPublishPipelineRunner.ReleaseMsiVersionStateReservation(versions[0], reservationOwner));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Plan_ReleaseGroupRejectsDifferentVersionAuthorities()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var app = CreateProject(root, "App/App.csproj");
+            var spec = CreateBaseSpec(root, app);
+            var monitoring = CreateReleaseGroupInstaller("monitoring.msi", "MonitoringFiles");
+            var agent = CreateReleaseGroupInstaller("agent.msi", "AgentFiles");
+            agent.Versioning!.StatePath = "Build/versioning/agent.state.json";
+            spec.Installers = new[] { monitoring, agent };
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null));
+
+            Assert.Contains("release group 'product-release'", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("resolved authority differs", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void Plan_ReleaseGroupRequiresMonotonicPublishVersioning(bool monotonic, bool applyToPublish)
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var app = CreateProject(root, "App/App.csproj");
+            var spec = CreateBaseSpec(root, app);
+            var installer = CreateReleaseGroupInstaller("app.msi", "ProductFiles");
+            installer.Versioning!.Monotonic = monotonic;
+            installer.Versioning.ApplyToPublish = applyToPublish;
+            spec.Installers = new[] { installer };
+
+            var exception = Assert.Throws<ArgumentException>(() =>
+                new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null));
+
+            Assert.Contains("ReleaseGroup requires Monotonic=true and ApplyToPublish=true", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Plan_ReleaseGroupExcludesDisabledInstallersRegardlessOfOrdering(bool disabledFirst)
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var app = CreateProject(root, "App/App.csproj");
+            var spec = CreateBaseSpec(root, app);
+            var enabled = CreateReleaseGroupInstaller("enabled.msi", "EnabledFiles");
+            var disabled = CreateReleaseGroupInstaller("disabled.msi", "DisabledFiles");
+            disabled.Versioning!.Enabled = false;
+            spec.Installers = disabledFirst
+                ? new[] { disabled, enabled }
+                : new[] { enabled, disabled };
+
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null);
+
+            var version = Assert.Single(plan.MsiVersions);
+            Assert.StartsWith("enabled.msi|", version.Key, StringComparison.OrdinalIgnoreCase);
+            Assert.False(string.IsNullOrWhiteSpace(version.Value.Version));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
     [Theory]
     [InlineData(null, "app-1.0.1")]
     [InlineData("output", null)]
@@ -2649,6 +2769,27 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
             CompanyFolderName = "Evotec",
             InstallDirectoryName = "App",
             PayloadComponentGroupId = payloadComponentGroupId
+        };
+    }
+
+    private static DotNetPublishInstaller CreateReleaseGroupInstaller(string id, string payloadComponentGroupId)
+    {
+        return new DotNetPublishInstaller
+        {
+            Id = id,
+            PrepareFromTarget = "app",
+            Authoring = CreateSimpleAuthoring(payloadComponentGroupId),
+            Versioning = new DotNetPublishMsiVersionOptions
+            {
+                ReleaseGroup = "product-release",
+                Enabled = true,
+                Major = 27,
+                Minor = 0,
+                FloorDateUtc = "2026-08-01",
+                Monotonic = true,
+                StatePath = "Build/versioning/product-release.state.json",
+                ApplyToPublish = true
+            }
         };
     }
 

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -657,6 +657,97 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
         }
     }
 
+    [Fact]
+    public void Plan_ReleaseGroupAllowsOverwriteForOnePlanPerInstaller()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var app = CreateProject(root, "App/App.csproj");
+            var spec = CreateBaseSpec(root, app);
+            var monitoring = CreateReleaseGroupInstaller("monitoring.msi", "MonitoringFiles");
+            var agent = CreateReleaseGroupInstaller("agent.msi", "AgentFiles");
+            monitoring.Versioning!.AllowOutputOverwrite = true;
+            agent.Versioning!.AllowOutputOverwrite = true;
+            spec.Installers = new[] { monitoring, agent };
+
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null);
+
+            Assert.Equal(2, plan.MsiVersions.Count);
+            Assert.All(plan.MsiVersions.Values, version => Assert.True(version.AllowOutputOverwrite));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Plan_ReleaseGroupCanonicalizesEquivalentDatesAndPublishProperties()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var app = CreateProject(root, "App/App.csproj");
+            var spec = CreateBaseSpec(root, app);
+            var monitoring = CreateReleaseGroupInstaller("monitoring.msi", "MonitoringFiles");
+            var agent = CreateReleaseGroupInstaller("agent.msi", "AgentFiles");
+            monitoring.Versioning!.FloorDateUtc = "2026-08-01";
+            monitoring.Versioning.PublishProperties = Array.Empty<string>();
+            agent.Versioning!.FloorDateUtc = "20260801";
+            agent.Versioning.PublishProperties = new[]
+            {
+                "InformationalVersion",
+                "AssemblyVersion",
+                "Version",
+                "FileVersion",
+                "PackageVersion"
+            };
+            spec.Installers = new[] { monitoring, agent };
+
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null);
+
+            Assert.Equal(2, plan.MsiVersions.Count);
+            Assert.Single(plan.MsiVersions.Values.Select(version => version.Version).Distinct(StringComparer.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Plan_ReleaseGroupComparesStatePathsUsingFileSystemSemantics()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var app = CreateProject(root, "App/App.csproj");
+            var spec = CreateBaseSpec(root, app);
+            var monitoring = CreateReleaseGroupInstaller("monitoring.msi", "MonitoringFiles");
+            var agent = CreateReleaseGroupInstaller("agent.msi", "AgentFiles");
+            monitoring.Versioning!.StatePath = "Build/versioning/Product.state.json";
+            agent.Versioning!.StatePath = "Build/versioning/product.state.json";
+            spec.Installers = new[] { monitoring, agent };
+
+            if (OperatingSystem.IsWindows())
+            {
+                var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null);
+                Assert.Equal(2, plan.MsiVersions.Count);
+            }
+            else
+            {
+                var exception = Assert.Throws<InvalidOperationException>(() =>
+                    new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null));
+                Assert.Contains("resolved authority differs", exception.Message, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
     [Theory]
     [InlineData(null, "app-1.0.1")]
     [InlineData("output", null)]

--- a/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj
+++ b/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj
@@ -11,7 +11,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>powerforge-web</ToolCommandName>
     <Description>PowerForge.Web command-line interface for building and serving static sites.</Description>
-    <VersionPrefix>3.0.106</VersionPrefix>
+    <VersionPrefix>3.0.107</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Przemyslaw Klys</Authors>
     <Company>Evotec Services sp. z o.o.</Company>

--- a/PowerForge.Web/PowerForge.Web.csproj
+++ b/PowerForge.Web/PowerForge.Web.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <VersionPrefix>3.0.106</VersionPrefix>
+    <VersionPrefix>3.0.107</VersionPrefix>
     <PackageId>PowerForge.Web</PackageId>
     <RootNamespace>PowerForge.Web</RootNamespace>
     <Description>PowerForge.Web static-site engine and reusable website build components.</Description>

--- a/PowerForge/Models/DotNetPublish/DotNetPublishSpec.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishSpec.cs
@@ -690,6 +690,13 @@ public sealed class DotNetPublishBundleMetadataOptions
 public sealed class DotNetPublishMsiVersionOptions
 {
     /// <summary>
+    /// Optional release-level version group shared by multiple installers.
+    /// Installers in the same group resolve and reserve one version atomically.
+    /// Their version authority settings must be identical after template expansion.
+    /// </summary>
+    public string? ReleaseGroup { get; set; }
+
+    /// <summary>
     /// Enables MSI version policy.
     /// </summary>
     public bool Enabled { get; set; }

--- a/PowerForge/PowerForge.csproj
+++ b/PowerForge/PowerForge.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsAsErrors>CS1591</WarningsAsErrors>
-    <VersionPrefix>3.0.106</VersionPrefix>
+    <VersionPrefix>3.0.107</VersionPrefix>
     <PackageId>PowerForge</PackageId>
     <Description>PowerForge core library: reusable engine for building, formatting, packaging and publishing PowerShell modules.</Description>
     <AssemblyName>PowerForge</AssemblyName>

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -1372,6 +1372,7 @@ public sealed partial class DotNetPublishPipelineRunner
         if (versioning is null) return null;
         return new DotNetPublishMsiVersionOptions
         {
+            ReleaseGroup = versioning.ReleaseGroup,
             Enabled = versioning.Enabled,
             Pattern = versioning.Pattern,
             Major = versioning.Major,
@@ -1997,6 +1998,7 @@ public sealed partial class DotNetPublishPipelineRunner
             Configuration = configuration
         };
         var plannedStates = new Dictionary<string, MsiVersionState>(StringComparer.OrdinalIgnoreCase);
+        var releaseGroups = new Dictionary<string, MsiReleaseGroupPlan>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var target in targets ?? Array.Empty<DotNetPublishTargetPlan>())
         {
@@ -2004,7 +2006,7 @@ public sealed partial class DotNetPublishPipelineRunner
             {
                 foreach (var installer in installers.Where(i => string.Equals(i.PrepareFromTarget, target.Name, StringComparison.OrdinalIgnoreCase)))
                 {
-                    if (installer.Versioning?.ApplyToPublish != true)
+                    if (installer.Versioning is not { Enabled: true, ApplyToPublish: true })
                         continue;
 
                     if (!InstallerMatchesCombo(installer, combo))
@@ -2018,7 +2020,37 @@ public sealed partial class DotNetPublishPipelineRunner
                         Runtime = combo.Runtime,
                         Style = combo.Style
                     };
-                    var resolved = ResolveMsiVersion(probePlan, installer, step, plannedStates);
+                    var releaseGroup = installer.Versioning?.ReleaseGroup;
+                    MsiVersionResolution resolved;
+                    if (string.IsNullOrWhiteSpace(releaseGroup))
+                    {
+                        resolved = ResolveMsiVersion(probePlan, installer, step, plannedStates);
+                    }
+                    else
+                    {
+                        var normalizedGroup = releaseGroup!.Trim();
+                        var compatibilityKey = BuildMsiReleaseGroupCompatibilityKey(probePlan, installer, step);
+                        if (releaseGroups.TryGetValue(normalizedGroup, out var existingGroup))
+                        {
+                            if (!string.Equals(existingGroup.CompatibilityKey, compatibilityKey, StringComparison.OrdinalIgnoreCase))
+                            {
+                                throw new InvalidOperationException(
+                                    $"Installer '{installer.Id}' cannot join MSI release group '{normalizedGroup}' because its " +
+                                    $"version policy or resolved authority differs from installer '{existingGroup.InstallerId}'. " +
+                                    "Use the same version line, state path, authority key, Git remote, tag prefix, patch cap, and overwrite policy for every installer in the group.");
+                            }
+
+                            resolved = existingGroup.Resolution;
+                        }
+                        else
+                        {
+                            resolved = ResolveMsiVersion(probePlan, installer, step, plannedStates);
+                            releaseGroups[normalizedGroup] = new MsiReleaseGroupPlan(
+                                installer.Id,
+                                compatibilityKey,
+                                resolved);
+                        }
+                    }
                     if (string.IsNullOrWhiteSpace(resolved.Version))
                         continue;
 
@@ -2035,12 +2067,12 @@ public sealed partial class DotNetPublishPipelineRunner
                         GitRemote = resolved.GitRemote,
                         GitTagPrefix = resolved.GitTagPrefix,
                         AuthorityWorkingDirectory = projectRoot,
-                        AllowOutputOverwrite = installer.Versioning.AllowOutputOverwrite
+                        AllowOutputOverwrite = installer.Versioning!.AllowOutputOverwrite
                     };
 
                     if (!string.IsNullOrWhiteSpace(resolved.CoordinationKey) && resolved.Patch.HasValue)
                     {
-                        if (installer.Versioning.AllowOutputOverwrite
+                        if (installer.Versioning!.AllowOutputOverwrite
                             && plannedStates.ContainsKey(resolved.CoordinationKey!))
                         {
                             throw new InvalidOperationException(
@@ -2062,6 +2094,66 @@ public sealed partial class DotNetPublishPipelineRunner
         }
 
         return versions;
+    }
+
+    private static string BuildMsiReleaseGroupCompatibilityKey(
+        DotNetPublishPlan plan,
+        DotNetPublishInstallerPlan installer,
+        DotNetPublishStep step)
+    {
+        var versioning = installer.Versioning
+            ?? throw new InvalidOperationException($"Installer '{installer.Id}' has no MSI version policy.");
+        var tokens = BuildMsiVersionTemplateTokens(plan, installer, step);
+        var statePath = versioning.Monotonic
+            ? ResolveMsiVersionStatePath(plan, installer, tokens)
+            : string.Empty;
+        var authorityKey = versioning.Authority == DotNetPublishMsiVersionAuthorityKind.GitTags
+            ? NormalizeMsiGitRefPath(
+                ApplyTemplate(
+                    string.IsNullOrWhiteSpace(versioning.AuthorityKey) ? installer.Id : versioning.AuthorityKey!,
+                    tokens),
+                "MSI version authority key")
+            : string.Empty;
+        var remote = versioning.Authority == DotNetPublishMsiVersionAuthorityKind.GitTags
+            ? NormalizeMsiGitRemote(versioning.GitRemote)
+            : string.Empty;
+        var tagPrefix = versioning.Authority == DotNetPublishMsiVersionAuthorityKind.GitTags
+            ? NormalizeMsiGitRefPath(versioning.GitTagPrefix, "MSI version Git tag prefix", "powerforge-msi")
+            : string.Empty;
+
+        return string.Join(
+            "\n",
+            versioning.Pattern,
+            versioning.Major.ToString(CultureInfo.InvariantCulture),
+            versioning.Minor.ToString(CultureInfo.InvariantCulture),
+            versioning.FloorDateUtc?.Trim() ?? string.Empty,
+            versioning.Monotonic,
+            statePath,
+            versioning.Authority,
+            authorityKey,
+            remote,
+            tagPrefix,
+            versioning.PatchCap.ToString(CultureInfo.InvariantCulture),
+            versioning.AllowOutputOverwrite,
+            versioning.PropertyName?.Trim() ?? string.Empty,
+            string.Join(",", versioning.PublishProperties ?? Array.Empty<string>()));
+    }
+
+    private sealed class MsiReleaseGroupPlan
+    {
+        public string InstallerId { get; }
+        public string CompatibilityKey { get; }
+        public MsiVersionResolution Resolution { get; }
+
+        public MsiReleaseGroupPlan(
+            string installerId,
+            string compatibilityKey,
+            MsiVersionResolution resolution)
+        {
+            InstallerId = installerId;
+            CompatibilityKey = compatibilityKey;
+            Resolution = resolution;
+        }
     }
 
     private static DotNetPublishInstallerPlan[] BuildInstallerPlans(
@@ -2827,6 +2919,15 @@ public sealed partial class DotNetPublishPipelineRunner
         var clone = CloneMsiVersionOptions(versioning);
         if (clone is null) return null;
         if (!clone.Enabled) return clone;
+
+        clone.ReleaseGroup = string.IsNullOrWhiteSpace(clone.ReleaseGroup)
+            ? null
+            : clone.ReleaseGroup!.Trim();
+        if (clone.ReleaseGroup is not null && (!clone.Monotonic || !clone.ApplyToPublish))
+        {
+            throw new ArgumentException(
+                $"Installer '{installerId}' Versioning.ReleaseGroup requires Monotonic=true and ApplyToPublish=true.");
+        }
 
         if (!Enum.IsDefined(typeof(DotNetPublishMsiVersionPattern), clone.Pattern))
             throw new ArgumentException($"Installer '{installerId}' Versioning.Pattern is not supported.");

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -2021,6 +2021,7 @@ public sealed partial class DotNetPublishPipelineRunner
                         Style = combo.Style
                     };
                     var releaseGroup = installer.Versioning?.ReleaseGroup;
+                    var isFirstPlanForInstallerInReleaseGroup = false;
                     MsiVersionResolution resolved;
                     if (string.IsNullOrWhiteSpace(releaseGroup))
                     {
@@ -2029,10 +2030,10 @@ public sealed partial class DotNetPublishPipelineRunner
                     else
                     {
                         var normalizedGroup = releaseGroup!.Trim();
-                        var compatibilityKey = BuildMsiReleaseGroupCompatibilityKey(probePlan, installer, step);
+                        var compatibility = BuildMsiReleaseGroupCompatibility(probePlan, installer, step);
                         if (releaseGroups.TryGetValue(normalizedGroup, out var existingGroup))
                         {
-                            if (!string.Equals(existingGroup.CompatibilityKey, compatibilityKey, StringComparison.OrdinalIgnoreCase))
+                            if (!existingGroup.Compatibility.Matches(compatibility))
                             {
                                 throw new InvalidOperationException(
                                     $"Installer '{installer.Id}' cannot join MSI release group '{normalizedGroup}' because its " +
@@ -2041,14 +2042,16 @@ public sealed partial class DotNetPublishPipelineRunner
                             }
 
                             resolved = existingGroup.Resolution;
+                            isFirstPlanForInstallerInReleaseGroup = existingGroup.InstallerIds.Add(installer.Id);
                         }
                         else
                         {
                             resolved = ResolveMsiVersion(probePlan, installer, step, plannedStates);
                             releaseGroups[normalizedGroup] = new MsiReleaseGroupPlan(
                                 installer.Id,
-                                compatibilityKey,
+                                compatibility,
                                 resolved);
+                            isFirstPlanForInstallerInReleaseGroup = true;
                         }
                     }
                     if (string.IsNullOrWhiteSpace(resolved.Version))
@@ -2073,7 +2076,8 @@ public sealed partial class DotNetPublishPipelineRunner
                     if (!string.IsNullOrWhiteSpace(resolved.CoordinationKey) && resolved.Patch.HasValue)
                     {
                         if (installer.Versioning!.AllowOutputOverwrite
-                            && plannedStates.ContainsKey(resolved.CoordinationKey!))
+                            && plannedStates.ContainsKey(resolved.CoordinationKey!)
+                            && !isFirstPlanForInstallerInReleaseGroup)
                         {
                             throw new InvalidOperationException(
                                 $"Installer '{installer.Id}' enables Versioning.AllowOutputOverwrite, but multiple publish " +
@@ -2096,7 +2100,7 @@ public sealed partial class DotNetPublishPipelineRunner
         return versions;
     }
 
-    private static string BuildMsiReleaseGroupCompatibilityKey(
+    private static MsiReleaseGroupCompatibility BuildMsiReleaseGroupCompatibility(
         DotNetPublishPlan plan,
         DotNetPublishInstallerPlan installer,
         DotNetPublishStep step)
@@ -2120,38 +2124,95 @@ public sealed partial class DotNetPublishPipelineRunner
         var tagPrefix = versioning.Authority == DotNetPublishMsiVersionAuthorityKind.GitTags
             ? NormalizeMsiGitRefPath(versioning.GitTagPrefix, "MSI version Git tag prefix", "powerforge-msi")
             : string.Empty;
+        var floorDate = string.Empty;
+        if (!string.IsNullOrWhiteSpace(versioning.FloorDateUtc))
+        {
+            if (!TryParseUtcDate(versioning.FloorDateUtc!, out var parsedFloorDate))
+                throw new InvalidOperationException($"Invalid MSI floor date '{versioning.FloorDateUtc}'.");
+            floorDate = parsedFloorDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        }
+        var publishProperties = ResolvePublishVersionProperties(versioning)
+            .OrderBy(value => value, StringComparer.OrdinalIgnoreCase);
 
-        return string.Join(
-            "\n",
-            versioning.Pattern,
-            versioning.Major.ToString(CultureInfo.InvariantCulture),
-            versioning.Minor.ToString(CultureInfo.InvariantCulture),
-            versioning.FloorDateUtc?.Trim() ?? string.Empty,
-            versioning.Monotonic,
+        return new MsiReleaseGroupCompatibility(
             statePath,
-            versioning.Authority,
+            string.Join(
+                "\n",
+                versioning.Pattern,
+                versioning.Major.ToString(CultureInfo.InvariantCulture),
+                versioning.Minor.ToString(CultureInfo.InvariantCulture),
+                floorDate,
+                versioning.Monotonic,
+                versioning.Authority,
+                versioning.PatchCap.ToString(CultureInfo.InvariantCulture),
+                versioning.AllowOutputOverwrite),
             authorityKey,
             remote,
             tagPrefix,
-            versioning.PatchCap.ToString(CultureInfo.InvariantCulture),
-            versioning.AllowOutputOverwrite,
-            versioning.PropertyName?.Trim() ?? string.Empty,
-            string.Join(",", versioning.PublishProperties ?? Array.Empty<string>()));
+            versioning.PropertyName?.Trim() ?? "ProductVersion",
+            string.Join(",", publishProperties));
+    }
+
+    private sealed class MsiReleaseGroupCompatibility
+    {
+        public string StatePath { get; }
+        public string PolicyKey { get; }
+        public string AuthorityKey { get; }
+        public string GitRemote { get; }
+        public string GitTagPrefix { get; }
+        public string PropertyName { get; }
+        public string PublishPropertiesKey { get; }
+
+        public MsiReleaseGroupCompatibility(
+            string statePath,
+            string policyKey,
+            string authorityKey,
+            string gitRemote,
+            string gitTagPrefix,
+            string propertyName,
+            string publishPropertiesKey)
+        {
+            StatePath = statePath;
+            PolicyKey = policyKey;
+            AuthorityKey = authorityKey;
+            GitRemote = gitRemote;
+            GitTagPrefix = gitTagPrefix;
+            PropertyName = propertyName;
+            PublishPropertiesKey = publishPropertiesKey;
+        }
+
+        public bool Matches(MsiReleaseGroupCompatibility other)
+        {
+            var leftComparison = FrameworkCompatibility.GetPathStringComparisonForPath(StatePath);
+            var rightComparison = FrameworkCompatibility.GetPathStringComparisonForPath(other.StatePath);
+            var pathComparison = leftComparison == StringComparison.Ordinal || rightComparison == StringComparison.Ordinal
+                ? StringComparison.Ordinal
+                : StringComparison.OrdinalIgnoreCase;
+            return string.Equals(StatePath, other.StatePath, pathComparison)
+                   && string.Equals(PolicyKey, other.PolicyKey, StringComparison.Ordinal)
+                   && string.Equals(AuthorityKey, other.AuthorityKey, StringComparison.Ordinal)
+                   && string.Equals(GitRemote, other.GitRemote, StringComparison.Ordinal)
+                   && string.Equals(GitTagPrefix, other.GitTagPrefix, StringComparison.Ordinal)
+                   && string.Equals(PropertyName, other.PropertyName, StringComparison.OrdinalIgnoreCase)
+                   && string.Equals(PublishPropertiesKey, other.PublishPropertiesKey, StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     private sealed class MsiReleaseGroupPlan
     {
         public string InstallerId { get; }
-        public string CompatibilityKey { get; }
+        public HashSet<string> InstallerIds { get; }
+        public MsiReleaseGroupCompatibility Compatibility { get; }
         public MsiVersionResolution Resolution { get; }
 
         public MsiReleaseGroupPlan(
             string installerId,
-            string compatibilityKey,
+            MsiReleaseGroupCompatibility compatibility,
             MsiVersionResolution resolution)
         {
             InstallerId = installerId;
-            CompatibilityKey = compatibilityKey;
+            InstallerIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { installerId };
+            Compatibility = compatibility;
             Resolution = resolution;
         }
     }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -1997,8 +1997,10 @@ public sealed partial class DotNetPublishPipelineRunner
             AllowOutputOutsideProjectRoot = allowOutputOutsideProjectRoot,
             Configuration = configuration
         };
-        var plannedStates = new Dictionary<string, MsiVersionState>(StringComparer.OrdinalIgnoreCase);
+        var plannedStates = new Dictionary<string, MsiVersionState>(MsiVersionCoordinationKeyComparer.Instance);
         var releaseGroups = new Dictionary<string, MsiReleaseGroupPlan>(StringComparer.OrdinalIgnoreCase);
+        var authorityReleaseGroups = new List<MsiVersionAuthorityUsage>();
+        var statePathAuthorities = new List<MsiVersionAuthorityUsage>();
 
         foreach (var target in targets ?? Array.Empty<DotNetPublishTargetPlan>())
         {
@@ -2020,7 +2022,9 @@ public sealed partial class DotNetPublishPipelineRunner
                         Runtime = combo.Runtime,
                         Style = combo.Style
                     };
-                    var releaseGroup = installer.Versioning?.ReleaseGroup;
+                    var releaseGroup = string.IsNullOrWhiteSpace(installer.Versioning?.ReleaseGroup)
+                        ? null
+                        : installer.Versioning!.ReleaseGroup!.Trim();
                     var isFirstPlanForInstallerInReleaseGroup = false;
                     MsiVersionResolution resolved;
                     if (string.IsNullOrWhiteSpace(releaseGroup))
@@ -2029,7 +2033,7 @@ public sealed partial class DotNetPublishPipelineRunner
                     }
                     else
                     {
-                        var normalizedGroup = releaseGroup!.Trim();
+                        var normalizedGroup = releaseGroup!;
                         var compatibility = BuildMsiReleaseGroupCompatibility(probePlan, installer, step);
                         if (releaseGroups.TryGetValue(normalizedGroup, out var existingGroup))
                         {
@@ -2056,6 +2060,40 @@ public sealed partial class DotNetPublishPipelineRunner
                     }
                     if (string.IsNullOrWhiteSpace(resolved.Version))
                         continue;
+
+                    if (!string.IsNullOrWhiteSpace(resolved.CoordinationKey))
+                    {
+                        var authorityOwner = releaseGroup ?? string.Empty;
+                        if (!string.IsNullOrWhiteSpace(resolved.StatePath))
+                        {
+                            var existingStatePath = statePathAuthorities.FirstOrDefault(usage => usage.MatchesStatePath(resolved.StatePath!));
+                            if (existingStatePath is not null
+                                && (!MsiVersionCoordinationKeyComparer.Instance.Equals(existingStatePath.CoordinationKey, resolved.CoordinationKey!)
+                                    || !string.Equals(existingStatePath.ReleaseGroup, authorityOwner, StringComparison.OrdinalIgnoreCase)))
+                            {
+                                throw new InvalidOperationException(
+                                    $"Installer '{installer.Id}' cannot use MSI version state path '{resolved.StatePath}' because it is already " +
+                                    "assigned to a different version authority or ReleaseGroup. Use one canonical authority and ReleaseGroup per state path.");
+                            }
+
+                            if (existingStatePath is null)
+                                statePathAuthorities.Add(new MsiVersionAuthorityUsage(resolved, authorityOwner));
+                        }
+
+                        var existingAuthority = authorityReleaseGroups.FirstOrDefault(usage => usage.Matches(resolved));
+                        if (existingAuthority is not null
+                            && !string.Equals(existingAuthority.ReleaseGroup, authorityOwner, StringComparison.OrdinalIgnoreCase)
+                            && (!string.IsNullOrWhiteSpace(existingAuthority.ReleaseGroup) || !string.IsNullOrWhiteSpace(authorityOwner)))
+                        {
+                            throw new InvalidOperationException(
+                                $"Installer '{installer.Id}' cannot use version authority '{resolved.CoordinationKey}' because it is already " +
+                                $"assigned to {(string.IsNullOrWhiteSpace(existingAuthority.ReleaseGroup) ? "an ungrouped installer" : $"release group '{existingAuthority.ReleaseGroup}'")}. " +
+                                "Every installer sharing an authority with a release group must use that same ReleaseGroup.");
+                        }
+
+                        if (existingAuthority is null)
+                            authorityReleaseGroups.Add(new MsiVersionAuthorityUsage(resolved, authorityOwner));
+                    }
 
                     var key = BuildMsiVersionKey(installer.Id, target.Name, combo.Framework, combo.Runtime, combo.Style);
                     versions[key] = new DotNetPublishMsiVersionPlan
@@ -2086,12 +2124,14 @@ public sealed partial class DotNetPublishPipelineRunner
                                 "or Versioning.AuthorityKey so every completed output has an authoritative version to reuse.");
                         }
 
-                        plannedStates[resolved.CoordinationKey!] = new MsiVersionState
+                        var candidateState = new MsiVersionState
                         {
                             LastPatch = resolved.Patch.Value,
                             Version = resolved.Version!,
                             UpdatedUtc = DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture)
                         };
+                        plannedStates.TryGetValue(resolved.CoordinationKey!, out var currentState);
+                        plannedStates[resolved.CoordinationKey!] = SelectLatestMsiVersionState(currentState, candidateState)!;
                     }
                 }
             }
@@ -2214,6 +2254,76 @@ public sealed partial class DotNetPublishPipelineRunner
             InstallerIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { installerId };
             Compatibility = compatibility;
             Resolution = resolution;
+        }
+    }
+
+    private sealed class MsiVersionAuthorityUsage
+    {
+        public DotNetPublishMsiVersionAuthorityKind Authority { get; }
+        public string CoordinationKey { get; }
+        public string ReleaseGroup { get; }
+        public string? StatePath { get; }
+
+        public MsiVersionAuthorityUsage(MsiVersionResolution resolution, string releaseGroup)
+        {
+            Authority = resolution.Authority;
+            CoordinationKey = resolution.CoordinationKey!;
+            ReleaseGroup = releaseGroup;
+            StatePath = resolution.StatePath;
+        }
+
+        public bool Matches(MsiVersionResolution resolution)
+        {
+            if (Authority != resolution.Authority || string.IsNullOrWhiteSpace(resolution.CoordinationKey))
+                return false;
+
+            return MsiVersionCoordinationKeyComparer.Instance.Equals(CoordinationKey, resolution.CoordinationKey!);
+        }
+
+        public bool MatchesStatePath(string statePath)
+        {
+            if (string.IsNullOrWhiteSpace(StatePath))
+                return false;
+
+            var leftComparison = FrameworkCompatibility.GetPathStringComparisonForPath(StatePath!);
+            var rightComparison = FrameworkCompatibility.GetPathStringComparisonForPath(statePath);
+            var comparison = leftComparison == StringComparison.Ordinal || rightComparison == StringComparison.Ordinal
+                ? StringComparison.Ordinal
+                : StringComparison.OrdinalIgnoreCase;
+            return string.Equals(StatePath, statePath, comparison);
+        }
+    }
+
+    private sealed class MsiVersionCoordinationKeyComparer : IEqualityComparer<string>
+    {
+        public static MsiVersionCoordinationKeyComparer Instance { get; } = new();
+
+        public bool Equals(string? left, string? right)
+        {
+            if (ReferenceEquals(left, right))
+                return true;
+            if (left is null || right is null)
+                return false;
+
+            var leftIsGit = left.StartsWith("git:", StringComparison.Ordinal);
+            var rightIsGit = right.StartsWith("git:", StringComparison.Ordinal);
+            if (leftIsGit || rightIsGit)
+                return leftIsGit && rightIsGit && string.Equals(left, right, StringComparison.Ordinal);
+
+            var leftComparison = FrameworkCompatibility.GetPathStringComparisonForPath(left);
+            var rightComparison = FrameworkCompatibility.GetPathStringComparisonForPath(right);
+            var comparison = leftComparison == StringComparison.Ordinal || rightComparison == StringComparison.Ordinal
+                ? StringComparison.Ordinal
+                : StringComparison.OrdinalIgnoreCase;
+            return string.Equals(left, right, comparison);
+        }
+
+        public int GetHashCode(string value)
+        {
+            if (value.StartsWith("git:", StringComparison.Ordinal))
+                return StringComparer.Ordinal.GetHashCode(value);
+
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(value);
         }
     }
 

--- a/Schemas/powerforge.dotnetpublish.schema.json
+++ b/Schemas/powerforge.dotnetpublish.schema.json
@@ -125,6 +125,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "ReleaseGroup": { "type": ["string", "null"], "minLength": 1 },
         "Enabled": { "type": "boolean" },
         "Pattern": { "$ref": "#/$defs/DotNetPublishMsiVersionPattern" },
         "Major": { "type": "integer", "minimum": 0, "maximum": 255 },


### PR DESCRIPTION
## What changed

- add `Versioning.ReleaseGroup` so several MSI installers resolve and reserve one release version
- require grouped installers to share the same effective version line, state path, Git-tag authority, overwrite policy, and publish-version properties
- bind every state path and coordination authority to one compatible release-group owner
- compare filesystem authorities using host filesystem case semantics while preserving exact Git authority identities
- preserve the newest planned authority state, support one overwrite-enabled plan per installer, and exclude disabled policies before group participation
- expose the setting in the JSON schema and advance PSPublishModule plus every PowerForge NuGet/tool package to `3.0.107`

## Why

A TestimoX release contains Monitoring and Agent installers. Separate monotonic version ledgers could drift permanently after a partial build. The owning PowerForge planner now allocates the product release version once and reuses it across every named installer artifact without allowing another authority or group to share the same state ledger incorrectly.

## Validation

- focused MSI versioning and Git-authority suite: 76/76 passed on net10.0
- PowerForge net472 library build passed
- `Build/Build-Project.ps1 -RunMode Documentation -ModuleVersion 3.0.107 -ModuleNoSign -ModuleSkipInstall -Json` built the module, all NuGet packages, both CLI tools, and runtime archives at the unified version
- a live local TestimoX plan resolved Monitoring and Agent to the same `27.0.9721` version, state path, and Git authority
- owner-level review confirmed disabled-policy exclusion, state-path ownership, Git authority ownership, platform-aware planning, and latest-state preservation

## Release note

Downstream release workflows must wait until the complete `3.0.107` package set is publicly available. This PR does not publish packages or installers.