### PR TITLE
Preserve LLMS package publication channels

### DIFF
--- a/PowerForge.Tests/WebLlmsPublicationCatalogTests.cs
+++ b/PowerForge.Tests/WebLlmsPublicationCatalogTests.cs
@@ -93,6 +93,29 @@ public sealed class WebLlmsPublicationCatalogTests
     }
 
     [Fact]
+    public void VerifiedCatalog_OmitsCommandWhenTheSourceVersionIsUnknown()
+    {
+        using var fixture = new PublicationFixture();
+        var project = fixture.WriteFile(
+            "Unknown.csproj",
+            "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><PackageId>Unknown.Package</PackageId></PropertyGroup></Project>");
+        var catalog = fixture.WriteCatalog("Evotec", ["Unknown.Package"]);
+
+        var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+        {
+            SiteRoot = fixture.Root,
+            ProjectFile = project,
+            InstallCommandPolicy = WebLlmsInstallCommandPolicy.VerifiedCatalog,
+            PublicationCatalogPath = catalog,
+            NuGetOwner = "Evotec"
+        });
+
+        Assert.Equal("unknown", result.Version);
+        Assert.Equal(0, result.InstallCommandCount);
+        Assert.DoesNotContain("## Install", File.ReadAllText(result.LlmsTxtPath), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void VerifiedCatalog_RejectsStalePublicationProof()
     {
         using var fixture = new PublicationFixture();
@@ -198,6 +221,68 @@ public sealed class WebLlmsPublicationCatalogTests
     }
 
     [Fact]
+    public void VerifiedCatalog_PreservesNuGetAndPowerShellPackagesWithTheSameIdentifier()
+    {
+        using var fixture = new PublicationFixture();
+        var project = fixture.WriteProject("Shared.Package");
+        var module = fixture.WriteModule("Shared.Package");
+        var catalog = fixture.WriteCatalog(
+            "Evotec",
+            ["Shared.Package"],
+            powerShellGalleryOwner: "Przemyslaw.Klys",
+            powerShellModules: ["Shared.Package"]);
+
+        var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+        {
+            SiteRoot = fixture.Root,
+            PackageFiles = [project, module],
+            InstallCommandPolicy = WebLlmsInstallCommandPolicy.VerifiedCatalog,
+            PublicationCatalogPath = catalog,
+            NuGetOwner = "Evotec",
+            PowerShellGalleryOwner = "Przemyslaw.Klys"
+        });
+
+        Assert.Equal(2, result.PackageCount);
+        Assert.Equal(2, result.InstallCommandCount);
+        var llmsTxt = File.ReadAllText(result.LlmsTxtPath);
+        var llmsJson = File.ReadAllText(result.LlmsJsonPath);
+        Assert.Contains("dotnet add package Shared.Package", llmsTxt, StringComparison.Ordinal);
+        Assert.Contains("Install-Module Shared.Package", llmsTxt, StringComparison.Ordinal);
+        Assert.Contains("\"source\": \"nuget\"", llmsJson, StringComparison.Ordinal);
+        Assert.Contains("\"source\": \"powerShellGallery\"", llmsJson, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void VerifiedCatalog_OmitsInstallSectionsWhenNoPackageInAMultiChannelSuiteIsCurrent()
+    {
+        using var fixture = new PublicationFixture();
+        var project = fixture.WriteProject("Shared.Package");
+        var module = fixture.WriteModule("Shared.Package");
+        var catalog = fixture.WriteCatalog(
+            "Evotec",
+            ["Shared.Package"],
+            powerShellGalleryOwner: "Przemyslaw.Klys",
+            powerShellModules: ["Shared.Package"],
+            packageVersion: "1.2.2");
+
+        var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+        {
+            SiteRoot = fixture.Root,
+            PackageFiles = [project, module],
+            InstallCommandPolicy = WebLlmsInstallCommandPolicy.VerifiedCatalog,
+            PublicationCatalogPath = catalog,
+            NuGetOwner = "Evotec",
+            PowerShellGalleryOwner = "Przemyslaw.Klys"
+        });
+
+        Assert.Equal(2, result.PackageCount);
+        Assert.Equal(0, result.InstallCommandCount);
+        Assert.DoesNotContain("## Install", File.ReadAllText(result.LlmsTxtPath), StringComparison.Ordinal);
+        Assert.DoesNotContain("## Installation", File.ReadAllText(result.LlmsFullPath), StringComparison.Ordinal);
+        Assert.DoesNotContain("\"install\"", File.ReadAllText(result.LlmsJsonPath), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void NonePolicy_OmitsDeclaredInstallationCommandsWithoutARegistryCatalog()
     {
         using var fixture = new PublicationFixture();
@@ -294,6 +379,46 @@ public sealed class WebLlmsPublicationCatalogTests
 
         Assert.Equal("Targeted.Package", result.PackageId);
         Assert.Equal("1.2.3", result.Version);
+    }
+
+    [Fact]
+    public void PackageMetadata_ResolvesProvableProjectNameConditions()
+    {
+        using var fixture = new PublicationFixture();
+        fixture.WriteFile(
+            "Directory.Build.props",
+            "<Project><PropertyGroup Condition=\"'$(MSBuildProjectName)' == 'Different'\"><PackageId>Wrong.Package</PackageId></PropertyGroup><PropertyGroup Condition=\"'$(MSBuildProjectName)' == 'Conditional'\"><PackageId>Conditional.Package</PackageId></PropertyGroup></Project>");
+        var project = fixture.WriteFile(
+            "Conditional.csproj",
+            "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><Version>1.2.3</Version></PropertyGroup></Project>");
+
+        var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+        {
+            SiteRoot = fixture.Root,
+            ProjectFile = project
+        });
+
+        Assert.Equal("Conditional.Package", result.PackageId);
+        Assert.Equal("1.2.3", result.Version);
+    }
+
+    [Theory]
+    [InlineData("@(Flavor)")]
+    [InlineData("%(Flavor.Identity)")]
+    public void PackageMetadata_RejectsUnresolvedItemExpressionsInConditions(string expression)
+    {
+        using var fixture = new PublicationFixture();
+        var project = fixture.WriteFile(
+            "Conditional.csproj",
+            $"<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><Version>1.2.3</Version><PackageId Condition=\"'{expression}' != ''\">Conditional.Package</PackageId></PropertyGroup></Project>");
+
+        var exception = Assert.Throws<InvalidDataException>(() => WebLlmsGenerator.Generate(new WebLlmsOptions
+        {
+            SiteRoot = fixture.Root,
+            ProjectFile = project
+        }));
+
+        Assert.Contains("Cannot resolve MSBuild property 'PackageId'", exception.Message, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/PowerForge.Web/Services/WebLlmsGenerator.Output.cs
+++ b/PowerForge.Web/Services/WebLlmsGenerator.Output.cs
@@ -44,7 +44,7 @@ public static partial class WebLlmsGenerator
             if (typeCount.HasValue) lines.Add($"- API types: {typeCount.Value}");
             if (apiCatalogs.Count > 1) lines.Add($"- API catalogs: {apiCatalogs.Count}");
             lines.Add(string.Empty);
-            if (!string.IsNullOrWhiteSpace(legacyInstallCommand) || packages.Any(HasInstallCommand))
+            if (HasAnyInstallCommand(legacyInstallCommand, packages))
             {
                 lines.Add("## Install");
                 if (packages.Count == 0)
@@ -167,8 +167,7 @@ public static partial class WebLlmsGenerator
         if (!string.IsNullOrWhiteSpace(options.License)) lines.Add($"- License: {options.License}");
         if (!string.IsNullOrWhiteSpace(options.Targets)) lines.Add($"- Targets: {options.Targets}");
 
-        if (includePackageContent &&
-            (!string.IsNullOrWhiteSpace(legacyInstallCommand) || packages.Any(HasInstallCommand)))
+        if (includePackageContent && HasAnyInstallCommand(legacyInstallCommand, packages))
         {
             lines.Add(string.Empty);
             lines.Add("## Installation");
@@ -244,12 +243,20 @@ public static partial class WebLlmsGenerator
     private static bool HasInstallCommand(PackageInfo package)
         => !string.IsNullOrWhiteSpace(package.InstallCommand);
 
+    private static bool HasAnyInstallCommand(
+        string? legacyInstallCommand,
+        IReadOnlyList<PackageInfo> packages)
+        => packages.Count == 0
+            ? !string.IsNullOrWhiteSpace(legacyInstallCommand)
+            : packages.Any(HasInstallCommand);
+
     private static Dictionary<string, object?> CreatePackagePayload(PackageInfo package)
     {
         var payload = new Dictionary<string, object?>
         {
             ["id"] = package.Id,
-            ["version"] = package.Version
+            ["version"] = package.Version,
+            ["source"] = package.IsPowerShellModule ? "powerShellGallery" : "nuget"
         };
         if (HasInstallCommand(package))
             payload["install"] = package.InstallCommand;

--- a/PowerForge.Web/Services/WebLlmsGenerator.PackageMetadata.cs
+++ b/PowerForge.Web/Services/WebLlmsGenerator.PackageMetadata.cs
@@ -40,7 +40,8 @@ public static partial class WebLlmsGenerator
         }
 
         return packages
-            .GroupBy(static package => package.Id, StringComparer.OrdinalIgnoreCase)
+            .GroupBy(
+                static package => (package.Id.ToUpperInvariant(), package.IsPowerShellModule))
             .Select(static group => group.First())
             .ToList();
     }
@@ -278,19 +279,68 @@ public static partial class WebLlmsGenerator
 
     private static void EvaluatePropertyGroup(XElement group, MsBuildPropertySet properties)
     {
-        var groupConditional = !string.IsNullOrWhiteSpace(group.Attribute("Condition")?.Value);
+        var groupConditionKnown = TryEvaluateSimpleMsBuildCondition(
+            group.Attribute("Condition")?.Value,
+            properties,
+            out var groupApplies);
+        if (groupConditionKnown && !groupApplies)
+            return;
+
         foreach (var property in group.Elements())
         {
             var name = property.Name.LocalName;
-            if (groupConditional || !string.IsNullOrWhiteSpace(property.Attribute("Condition")?.Value))
+            if (!groupConditionKnown ||
+                !TryEvaluateSimpleMsBuildCondition(
+                    property.Attribute("Condition")?.Value,
+                    properties,
+                    out var propertyApplies))
             {
                 properties.ConditionalNames.Add(name);
                 continue;
             }
+            if (!propertyApplies)
+                continue;
 
             properties.Values[name] = ExpandMsBuildPropertyAtAssignment(property.Value.Trim(), properties);
             properties.ConditionalNames.Remove(name);
         }
+    }
+
+    private static bool TryEvaluateSimpleMsBuildCondition(
+        string? condition,
+        MsBuildPropertySet properties,
+        out bool result)
+    {
+        if (string.IsNullOrWhiteSpace(condition))
+        {
+            result = true;
+            return true;
+        }
+
+        var expanded = ExpandMsBuildPropertyAtAssignment(condition, properties);
+        if (expanded.Contains("$(", StringComparison.Ordinal) ||
+            expanded.Contains("@(", StringComparison.Ordinal) ||
+            expanded.Contains("%(", StringComparison.Ordinal))
+        {
+            result = false;
+            return false;
+        }
+
+        var match = Regex.Match(
+            expanded,
+            "^\\s*(?<left>'[^']*'|\\\"[^\\\"]*\\\")\\s*(?<operator>==|!=)\\s*(?<right>'[^']*'|\\\"[^\\\"]*\\\")\\s*$",
+            RegexOptions.CultureInvariant);
+        if (!match.Success)
+        {
+            result = false;
+            return false;
+        }
+
+        var left = match.Groups["left"].Value[1..^1];
+        var right = match.Groups["right"].Value[1..^1];
+        var equal = string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+        result = match.Groups["operator"].Value == "==" ? equal : !equal;
+        return true;
     }
 
     private static void EvaluateImport(XElement import, string importingFile, MsBuildPropertySet properties, string? inheritedCondition = null)

--- a/PowerForge.Web/Services/WebLlmsGenerator.PublicationCatalog.cs
+++ b/PowerForge.Web/Services/WebLlmsGenerator.PublicationCatalog.cs
@@ -194,14 +194,14 @@ public static partial class WebLlmsGenerator
 
             if (!section.Packages.TryGetValue(packageId, out var publishedVersion))
                 return false;
-            if (!RequiresExactPublicationVersion(expectedVersion))
-                return true;
+            if (!HasExactSourceVersion(expectedVersion))
+                return false;
 
             return string.Equals(publishedVersion, expectedVersion!.Trim(), StringComparison.OrdinalIgnoreCase);
         }
     }
 
-    private static bool RequiresExactPublicationVersion(string? version)
+    private static bool HasExactSourceVersion(string? version)
         => !string.IsNullOrWhiteSpace(version) &&
            !string.Equals(version, "unknown", StringComparison.OrdinalIgnoreCase) &&
            !string.Equals(version, "varies by package", StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
## Summary

- preserve NuGet and PowerShell Gallery packages as separate LLMS publication channels when they share an identifier
- emit install headings only when the rendered package set contains a verified command
- require an exact known source version before owner-catalog verification can authorize an install command
- resolve only provable simple MSBuild string conditions while keeping unresolved property, item, and metadata expressions fail-closed
- identify each package's publication source in `llms.json`

## Why

Website consumers can describe both a .NET package and PowerShell module with the same name. Collapsing those records could discard one publication channel and produce an empty installation section. Installation guidance must also remain absent when the exact source version cannot be verified against the expected registry owner.

## Validation

- focused LLMS and pipeline contract suite: 101 passed
- PowerForge.Web CLI Release build: 0 warnings, 0 errors
- real DomainDetective and TestimoX artifacts preserve separate NuGet/PowerShell Gallery entries and omit unverified commands
- real OfficeIMO artifact emits exact-version commands for owner-catalog matches across 94 packages
- independent local review found two P1 fail-closed gaps; both were fixed and targeted confirmation found no remaining P0-P2 findings