### PR TITLE
Accept Xcode SwiftPM mirrors in exact-source archives

### DIFF
--- a/PowerForge.Tests/AppleAppArchiveServiceTests.ExactSourcePackages.cs
+++ b/PowerForge.Tests/AppleAppArchiveServiceTests.ExactSourcePackages.cs
@@ -58,6 +58,112 @@ public sealed partial class AppleAppArchiveServiceTests
     }
 
     [Fact]
+    public async Task CreateArchiveAsync_exact_source_accepts_xcode_private_repository_mirror_origins()
+    {
+        if (!OperatingSystem.IsMacOS()) return;
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(root.FullName, "App.xcodeproj"));
+            File.WriteAllText(Path.Combine(project.FullName, "project.pbxproj"), string.Empty);
+            RunGit(root.FullName, "init", "--quiet");
+            var runner = new ExactPackageProcessRunner(root.FullName, materializeXcodeMirrorOrigin: true);
+            WritePackageLock(root.FullName, runner.RemoteUrl, runner.ApprovedRevision);
+            CommitApprovedInputs(root.FullName);
+
+            var result = await new AppleAppArchiveService(runner).CreateArchiveAsync(new AppleAppArchiveRequest
+            {
+                ProjectPath = project.FullName,
+                Scheme = "App",
+                ArchivePath = Path.Combine(root.FullName, "App.xcarchive"),
+                RequireExactPackageSnapshot = true
+            });
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(2, runner.Requests.Count);
+            Assert.False(Directory.Exists(runner.SourcePackagesRoot));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task CreateArchiveAsync_exact_source_rejects_linked_xcode_repository_mirror_config()
+    {
+        if (!OperatingSystem.IsMacOS()) return;
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(root.FullName, "App.xcodeproj"));
+            File.WriteAllText(Path.Combine(project.FullName, "project.pbxproj"), string.Empty);
+            RunGit(root.FullName, "init", "--quiet");
+            var runner = new ExactPackageProcessRunner(
+                root.FullName,
+                materializeXcodeMirrorOrigin: true,
+                linkXcodeMirrorConfig: true);
+            WritePackageLock(root.FullName, runner.RemoteUrl, runner.ApprovedRevision);
+            CommitApprovedInputs(root.FullName);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                new AppleAppArchiveService(runner).CreateArchiveAsync(new AppleAppArchiveRequest
+                {
+                    ProjectPath = project.FullName,
+                    Scheme = "App",
+                    ArchivePath = Path.Combine(root.FullName, "App.xcarchive"),
+                    RequireExactPackageSnapshot = true
+                }));
+
+            Assert.Contains("symbolic link", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Theory]
+    [InlineData(true, false, "include external Git configuration")]
+    [InlineData(false, true, "symbolic link")]
+    public async Task CreateArchiveAsync_exact_source_rejects_xcode_repository_mirror_indirections(
+        bool includeExternalConfig,
+        bool linkObjectsInfo,
+        string expectedMessage)
+    {
+        if (!OperatingSystem.IsMacOS()) return;
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(root.FullName, "App.xcodeproj"));
+            File.WriteAllText(Path.Combine(project.FullName, "project.pbxproj"), string.Empty);
+            RunGit(root.FullName, "init", "--quiet");
+            var runner = new ExactPackageProcessRunner(
+                root.FullName,
+                materializeXcodeMirrorOrigin: true,
+                includeExternalXcodeMirrorConfig: includeExternalConfig,
+                linkXcodeMirrorObjectsInfo: linkObjectsInfo);
+            WritePackageLock(root.FullName, runner.RemoteUrl, runner.ApprovedRevision);
+            CommitApprovedInputs(root.FullName);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                new AppleAppArchiveService(runner).CreateArchiveAsync(new AppleAppArchiveRequest
+                {
+                    ProjectPath = project.FullName,
+                    Scheme = "App",
+                    ArchivePath = Path.Combine(root.FullName, "App.xcarchive"),
+                    RequireExactPackageSnapshot = true
+                }));
+
+            Assert.Contains(expectedMessage, exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public async Task CreateArchiveAsync_exact_source_rejects_transient_package_checkout_mutation()
     {
         if (!OperatingSystem.IsMacOS()) return;
@@ -228,6 +334,10 @@ public sealed partial class AppleAppArchiveServiceTests
         private readonly bool _mutateBinaryArtifactDuringArchive;
         private readonly bool _replaceBinaryArtifactAfterResolveCompletion;
         private readonly bool _mutatePackageViaHardLinkDuringArchive;
+        private readonly bool _materializeXcodeMirrorOrigin;
+        private readonly bool _linkXcodeMirrorConfig;
+        private readonly bool _includeExternalXcodeMirrorConfig;
+        private readonly bool _linkXcodeMirrorObjectsInfo;
         private readonly string _fixtureRoot;
         private readonly string _remoteSourceRoot;
 
@@ -238,7 +348,11 @@ public sealed partial class AppleAppArchiveServiceTests
             bool materializeBinaryArtifact = false,
             bool mutateBinaryArtifactDuringArchive = false,
             bool replaceBinaryArtifactAfterResolveCompletion = false,
-            bool mutatePackageViaHardLinkDuringArchive = false)
+            bool mutatePackageViaHardLinkDuringArchive = false,
+            bool materializeXcodeMirrorOrigin = false,
+            bool linkXcodeMirrorConfig = false,
+            bool includeExternalXcodeMirrorConfig = false,
+            bool linkXcodeMirrorObjectsInfo = false)
         {
             _fixtureRoot = fixtureRoot;
             _mutateDuringArchive = mutateDuringArchive;
@@ -247,6 +361,10 @@ public sealed partial class AppleAppArchiveServiceTests
             _mutateBinaryArtifactDuringArchive = mutateBinaryArtifactDuringArchive;
             _replaceBinaryArtifactAfterResolveCompletion = replaceBinaryArtifactAfterResolveCompletion;
             _mutatePackageViaHardLinkDuringArchive = mutatePackageViaHardLinkDuringArchive;
+            _materializeXcodeMirrorOrigin = materializeXcodeMirrorOrigin;
+            _linkXcodeMirrorConfig = linkXcodeMirrorConfig;
+            _includeExternalXcodeMirrorConfig = includeExternalXcodeMirrorConfig;
+            _linkXcodeMirrorObjectsInfo = linkXcodeMirrorObjectsInfo;
             _remoteSourceRoot = Directory.CreateDirectory(Path.Combine(fixtureRoot, "RemoteShared")).FullName;
             RunGit(_remoteSourceRoot, "init", "--quiet");
             RunGit(_remoteSourceRoot, "config", "user.name", "PowerForge Tests");
@@ -281,7 +399,42 @@ public sealed partial class AppleAppArchiveServiceTests
                 var checkouts = Directory.CreateDirectory(Path.Combine(SourcePackagesRoot, "checkouts")).FullName;
                 var checkout = Path.Combine(checkouts, "Shared");
                 RunGit(checkouts, "clone", "--quiet", "--no-hardlinks", _remoteSourceRoot, checkout);
-                RunGit(checkout, "remote", "set-url", "origin", RemoteUrl);
+                if (_materializeXcodeMirrorOrigin)
+                {
+                    var repositories = Directory.CreateDirectory(Path.Combine(SourcePackagesRoot, "repositories")).FullName;
+                    var mirror = Path.Combine(repositories, "Shared-12345678");
+                    RunGit(repositories, "clone", "--quiet", "--mirror", "--no-hardlinks", _remoteSourceRoot, mirror);
+                    RunGit(mirror, "remote", "set-url", "origin", RemoteUrl);
+                    if (_linkXcodeMirrorConfig)
+                    {
+                        var config = Path.Combine(mirror, "config");
+                        var externalConfig = Path.Combine(_fixtureRoot, "linked-mirror-config");
+                        File.Copy(config, externalConfig);
+                        File.Delete(config);
+                        File.CreateSymbolicLink(config, externalConfig);
+                    }
+                    if (_includeExternalXcodeMirrorConfig)
+                    {
+                        var externalConfig = Path.Combine(_fixtureRoot, "included-mirror-config");
+                        File.WriteAllText(externalConfig, "[core]\n\tbare = true\n");
+                        File.AppendAllText(
+                            Path.Combine(mirror, "config"),
+                            $"\n[include]\n\tpath = {externalConfig}\n");
+                    }
+                    if (_linkXcodeMirrorObjectsInfo)
+                    {
+                        var objectsInfo = Path.Combine(mirror, "objects", "info");
+                        var externalObjectsInfo = Directory.CreateDirectory(
+                            Path.Combine(_fixtureRoot, "linked-objects-info")).FullName;
+                        Directory.Delete(objectsInfo, recursive: true);
+                        Directory.CreateSymbolicLink(objectsInfo, externalObjectsInfo);
+                    }
+                    RunGit(checkout, "remote", "set-url", "origin", mirror);
+                }
+                else
+                {
+                    RunGit(checkout, "remote", "set-url", "origin", RemoteUrl);
+                }
                 if (_materializeWrongRevision)
                 {
                     RunGit(checkout, "config", "user.name", "PowerForge Tests");

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleHostedReviewRegressions.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleHostedReviewRegressions.cs
@@ -507,6 +507,9 @@ public sealed partial class PowerForgeReleaseServiceTests
             File.WriteAllText(
                 Path.Combine(root, "Package.swift"),
                 "// swift-tools-version: 6.0\nimport PackageDescription\nlet package = Package(name: \"CasaRay\")\n");
+            var trackedSwiftPackageMetadata = Path.Combine(root, ".swiftpm", "configuration", "mirrors.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(trackedSwiftPackageMetadata)!);
+            File.WriteAllText(trackedSwiftPackageMetadata, "{\"object\":{\"pins\":[]},\"version\":1}");
             var sourceFile = Path.Combine(root, "CasaRay.xcodeproj", "project.pbxproj");
             var committedContents = File.ReadAllText(sourceFile);
             var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
@@ -526,6 +529,9 @@ public sealed partial class PowerForgeReleaseServiceTests
                     var snapshotRoot = Path.GetDirectoryName(request.ProjectPath)!;
                     Assert.True(Directory.Exists(Path.Combine(snapshotRoot, ".swiftpm", "configuration")));
                     Assert.True(Directory.Exists(Path.Combine(snapshotRoot, ".swiftpm", "xcode")));
+                    Assert.Equal(
+                        File.ReadAllText(trackedSwiftPackageMetadata),
+                        File.ReadAllText(Path.Combine(snapshotRoot, ".swiftpm", "configuration", "mirrors.json")));
                     File.AppendAllText(sourceFile, "\n// concurrent original-worktree mutation");
                     Assert.Equal(committedContents, File.ReadAllText(Path.Combine(request.ProjectPath, "project.pbxproj")));
                     var archive = Directory.CreateDirectory(request.ArchivePath!);

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleHostedReviewRegressions.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleHostedReviewRegressions.cs
@@ -504,6 +504,9 @@ public sealed partial class PowerForgeReleaseServiceTests
         try
         {
             CreateXcodeProject(root, "CasaRay.xcodeproj", "1.2.0", "9");
+            File.WriteAllText(
+                Path.Combine(root, "Package.swift"),
+                "// swift-tools-version: 6.0\nimport PackageDescription\nlet package = Package(name: \"CasaRay\")\n");
             var sourceFile = Path.Combine(root, "CasaRay.xcodeproj", "project.pbxproj");
             var committedContents = File.ReadAllText(sourceFile);
             var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
@@ -520,6 +523,9 @@ public sealed partial class PowerForgeReleaseServiceTests
                 archiveAppleApp: request =>
                 {
                     archivedProjectPath = request.ProjectPath;
+                    var snapshotRoot = Path.GetDirectoryName(request.ProjectPath)!;
+                    Assert.True(Directory.Exists(Path.Combine(snapshotRoot, ".swiftpm", "configuration")));
+                    Assert.True(Directory.Exists(Path.Combine(snapshotRoot, ".swiftpm", "xcode")));
                     File.AppendAllText(sourceFile, "\n// concurrent original-worktree mutation");
                     Assert.Equal(committedContents, File.ReadAllText(Path.Combine(request.ProjectPath, "project.pbxproj")));
                     var archive = Directory.CreateDirectory(request.ArchivePath!);

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleIntegrityClosureRegressions.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleIntegrityClosureRegressions.cs
@@ -70,7 +70,7 @@ public sealed partial class PowerForgeReleaseServiceTests {
 
             var exception = Assert.Throws<InvalidOperationException>(() => snapshot.MonitorChanges());
 
-            Assert.Contains("must be empty", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("untracked state", exception.Message, StringComparison.OrdinalIgnoreCase);
         } finally {
             TryDelete(root);
         }

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleIntegrityClosureRegressions.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleIntegrityClosureRegressions.cs
@@ -2,6 +2,123 @@ namespace PowerForge.Tests;
 
 public sealed partial class PowerForgeReleaseServiceTests {
     [Fact]
+    public void Execute_AppleCheckpoint_rejects_linked_swiftpm_metadata_root() {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var root = CreateSandbox();
+        var outside = root + "-swiftpm-metadata";
+        try {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.2.0", "9");
+            File.WriteAllText(
+                Path.Combine(root, "Package.swift"),
+                "// swift-tools-version: 6.0\nimport PackageDescription\nlet package = Package(name: \"CasaRay\")\n");
+            Directory.CreateDirectory(outside);
+            Directory.CreateSymbolicLink(Path.Combine(root, ".swiftpm"), outside);
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            RunSnapshotGit(root, "init", "--quiet");
+            RunSnapshotGit(root, "config", "user.name", "PowerForge Tests");
+            RunSnapshotGit(root, "config", "user.email", "powerforge-tests@example.invalid");
+            RunSnapshotGit(root, "add", ".");
+            RunSnapshotGit(root, "commit", "--quiet", "-m", "exact source");
+            var sourceCommit = RunSnapshotGit(root, "rev-parse", "HEAD").Trim();
+
+            var result = CreateAppleAutomationService(
+                    _ => throw new InvalidOperationException("Archive-only checkpoint must not query App Store Connect."),
+                    archiveAppleApp: _ => throw new InvalidOperationException("Linked SwiftPM metadata must fail before archive."))
+                .Execute(CreateAppleAutomationSpec(root, keyPath), new PowerForgeReleaseRequest {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    AppleAction = PowerForgeAppleReleaseAction.Archive,
+                    AppleSourceCommit = sourceCommit,
+                    RequireImmutableAppleSourceSnapshot = true
+                });
+
+            Assert.False(result.Success);
+            Assert.Contains("symbolic link", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            TryDelete(root);
+            TryDelete(outside);
+        }
+    }
+
+    [Fact]
+    public void AppleReleaseSourceSnapshot_revalidates_prepared_swiftpm_state_when_monitoring_begins() {
+        var root = CreateSandbox();
+        try {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.2.0", "9");
+            File.WriteAllText(
+                Path.Combine(root, "Package.swift"),
+                "// swift-tools-version: 6.0\nimport PackageDescription\nlet package = Package(name: \"CasaRay\")\n");
+            RunSnapshotGit(root, "init", "--quiet");
+            RunSnapshotGit(root, "config", "user.name", "PowerForge Tests");
+            RunSnapshotGit(root, "config", "user.email", "powerforge-tests@example.invalid");
+            RunSnapshotGit(root, "add", ".");
+            RunSnapshotGit(root, "commit", "--quiet", "-m", "exact source");
+            var sourceCommit = RunSnapshotGit(root, "rev-parse", "HEAD").Trim();
+
+            using var snapshot = AppleReleaseSourceSnapshot.CreateIfRequired(new PowerForgeAppleReleasePlan {
+                ProjectRoot = root,
+                SourceCommit = sourceCommit,
+                RequireImmutableSourceSnapshot = true,
+                Archive = true
+            });
+            Assert.NotNull(snapshot);
+            File.WriteAllText(
+                Path.Combine(snapshot!.RootPath, ".swiftpm", "configuration", "workspace-state.json"),
+                "unbound state inserted after snapshot preflight");
+
+            var exception = Assert.Throws<InvalidOperationException>(() => snapshot.MonitorChanges());
+
+            Assert.Contains("must be empty", exception.Message, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleCheckpoint_rejects_files_created_in_prepared_swiftpm_directories() {
+        var root = CreateSandbox();
+        try {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.2.0", "9");
+            File.WriteAllText(
+                Path.Combine(root, "Package.swift"),
+                "// swift-tools-version: 6.0\nimport PackageDescription\nlet package = Package(name: \"CasaRay\")\n");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            RunSnapshotGit(root, "init", "--quiet");
+            RunSnapshotGit(root, "config", "user.name", "PowerForge Tests");
+            RunSnapshotGit(root, "config", "user.email", "powerforge-tests@example.invalid");
+            RunSnapshotGit(root, "add", ".");
+            RunSnapshotGit(root, "commit", "--quiet", "-m", "exact source");
+            var sourceCommit = RunSnapshotGit(root, "rev-parse", "HEAD").Trim();
+
+            var result = CreateAppleAutomationService(
+                    _ => throw new InvalidOperationException("Archive-only checkpoint must not query App Store Connect."),
+                    archiveAppleApp: request => {
+                        var snapshotRoot = Path.GetDirectoryName(request.ProjectPath)!;
+                        File.WriteAllText(
+                            Path.Combine(snapshotRoot, ".swiftpm", "configuration", "workspace-state.json"),
+                            "untrusted state");
+                        var archive = Directory.CreateDirectory(request.ArchivePath!);
+                        File.WriteAllText(Path.Combine(archive.FullName, "payload"), "untrusted archive");
+                        return CreateSuccessfulArchive(request);
+                    })
+                .Execute(CreateAppleAutomationSpec(root, keyPath), new PowerForgeReleaseRequest {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    AppleAction = PowerForgeAppleReleaseAction.Archive,
+                    AppleSourceCommit = sourceCommit,
+                    RequireImmutableAppleSourceSnapshot = true
+                });
+
+            Assert.False(result.Success);
+            Assert.Contains("snapshot changed while xcodebuild", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_AppleCheckpoint_rejects_transient_exact_source_snapshot_mutation() {
         var root = CreateSandbox();
         try {

--- a/PowerForge/Services/AppleReleaseSourceSnapshot.cs
+++ b/PowerForge/Services/AppleReleaseSourceSnapshot.cs
@@ -17,7 +17,8 @@ internal sealed class AppleReleaseSourceSnapshot : IDisposable
         new Dictionary<string, string>(StringComparer.Ordinal);
     private string? _snapshotConfigPath;
     private string? _expectedConfigSha256;
-    private readonly List<string> _preparedSwiftPackageMetadataRoots = new();
+    private readonly Dictionary<string, AppleArchiveUploadSnapshot.SnapshotIdentity> _preparedSwiftPackageMetadata =
+        new(GetPathComparer());
     private bool _disposed;
 
     private AppleReleaseSourceSnapshot(
@@ -184,64 +185,113 @@ internal sealed class AppleReleaseSourceSnapshot : IDisposable
                 relativePath.Replace('/', Path.DirectorySeparatorChar)));
             EnsureContained(RootPath, packageManifest, "Apple snapshot Swift package manifest");
             var metadataRoot = Path.Combine(Path.GetDirectoryName(packageManifest)!, ".swiftpm");
-            EnsureEmptyRealDirectory(metadataRoot, "Apple snapshot Swift package metadata root");
-            _preparedSwiftPackageMetadataRoots.Add(metadataRoot);
+            EnsureRealDirectory(metadataRoot, "Apple snapshot Swift package metadata root", createIfMissing: true);
             foreach (var name in new[] { "configuration", "xcode" })
             {
                 var directory = Path.Combine(metadataRoot, name);
-                EnsureEmptyRealDirectory(directory, $"Apple snapshot Swift package {name} directory");
+                EnsureRealDirectory(directory, $"Apple snapshot Swift package {name} directory", createIfMissing: true);
             }
+            ValidateSwiftPackageMetadataTree(metadataRoot);
+            _preparedSwiftPackageMetadata[metadataRoot] = AppleArchiveUploadSnapshot.CaptureCompleteIdentity(
+                metadataRoot,
+                "prepared Apple snapshot Swift package metadata");
         }
     }
 
     private void ValidatePreparedSwiftPackageWorkingDirectories()
     {
-        foreach (var metadataRoot in _preparedSwiftPackageMetadataRoots)
+        foreach (var pair in _preparedSwiftPackageMetadata)
         {
+            var metadataRoot = pair.Key;
             EnsureRealDirectory(metadataRoot, "Apple snapshot Swift package metadata root");
-            var expectedChildren = new HashSet<string>(new[] { "configuration", "xcode" }, StringComparer.Ordinal);
-            foreach (var entry in Directory.EnumerateFileSystemEntries(metadataRoot))
+            foreach (var name in new[] { "configuration", "xcode" })
             {
-                if (!expectedChildren.Remove(Path.GetFileName(entry)))
-                {
-                    throw new InvalidOperationException(
-                        $"Apple snapshot Swift package metadata root contains unbound state before the Apple build starts: {entry}");
-                }
+                EnsureRealDirectory(
+                    Path.Combine(metadataRoot, name),
+                    $"Apple snapshot Swift package {name} directory");
             }
-            if (expectedChildren.Count > 0)
+            ValidateSwiftPackageMetadataTree(metadataRoot);
+            var current = AppleArchiveUploadSnapshot.CaptureCompleteIdentity(
+                metadataRoot,
+                "prepared Apple snapshot Swift package metadata");
+            if (!pair.Value.Equals(current))
             {
                 throw new InvalidOperationException(
-                    $"Apple snapshot Swift package metadata root is incomplete before the Apple build starts: {metadataRoot}");
+                    $"Apple snapshot Swift package metadata changed before the Apple build started: {metadataRoot}");
             }
-            EnsureEmptyRealDirectory(
-                Path.Combine(metadataRoot, "configuration"),
-                "Apple snapshot Swift package configuration directory");
-            EnsureEmptyRealDirectory(
-                Path.Combine(metadataRoot, "xcode"),
-                "Apple snapshot Swift package xcode directory");
         }
     }
 
-    private void EnsureEmptyRealDirectory(string directory, string name)
+    private void ValidateSwiftPackageMetadataTree(string metadataRoot)
+    {
+        var relativeRoot = FrameworkCompatibility.GetRelativePath(RootPath, metadataRoot).Replace('\\', '/');
+        var trackedFiles = Run(
+                _git,
+                RootPath,
+                new[] { "ls-files", "-z", "--", relativeRoot + "/" },
+                "enumerate tracked Swift package metadata")
+            .StdOut.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(path => Path.GetFullPath(Path.Combine(RootPath, path.Replace('/', Path.DirectorySeparatorChar))))
+            .ToHashSet(GetPathComparer());
+        var allowedDirectories = new HashSet<string>(GetPathComparer())
+        {
+            metadataRoot,
+            Path.Combine(metadataRoot, "configuration"),
+            Path.Combine(metadataRoot, "xcode")
+        };
+        foreach (var trackedFile in trackedFiles)
+        {
+            EnsureContained(metadataRoot, trackedFile, "tracked Apple snapshot Swift package metadata");
+            for (var directory = Path.GetDirectoryName(trackedFile);
+                 directory is not null && !directory.Equals(metadataRoot, GetPathComparison());
+                 directory = Path.GetDirectoryName(directory))
+            {
+                allowedDirectories.Add(directory);
+            }
+        }
+        var pending = new Stack<string>();
+        pending.Push(metadataRoot);
+        while (pending.Count > 0)
+        {
+            var directory = pending.Pop();
+            foreach (var entry in Directory.EnumerateFileSystemEntries(directory))
+            {
+                var attributes = File.GetAttributes(entry);
+                if ((attributes & FileAttributes.ReparsePoint) != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Apple snapshot Swift package metadata must not contain a symbolic link or reparse point: {entry}");
+                }
+                if ((attributes & FileAttributes.Directory) != 0)
+                {
+                    if (!allowedDirectories.Contains(Path.GetFullPath(entry)))
+                    {
+                        throw new InvalidOperationException(
+                            $"Apple snapshot Swift package metadata contains an untracked directory: {entry}");
+                    }
+                    pending.Push(entry);
+                    continue;
+                }
+                var fullPath = Path.GetFullPath(entry);
+                if (!trackedFiles.Contains(fullPath))
+                {
+                    throw new InvalidOperationException(
+                        $"Apple snapshot Swift package metadata contains untracked state: {entry}");
+                }
+            }
+        }
+    }
+
+    private void EnsureRealDirectory(string directory, string name, bool createIfMissing = false)
     {
         EnsureContained(RootPath, directory, name);
         if (!Directory.Exists(directory))
         {
-            if (File.Exists(directory))
-                throw new InvalidOperationException($"{name} must be an ordinary empty directory: {directory}");
+            if (!createIfMissing || File.Exists(directory))
+                throw new InvalidOperationException($"{name} must be an ordinary directory: {directory}");
             Directory.CreateDirectory(directory);
             return;
         }
-        EnsureRealDirectory(directory, name);
-        if (Directory.EnumerateFileSystemEntries(directory).Any())
-            throw new InvalidOperationException($"{name} must be empty before the Apple build starts: {directory}");
-    }
-
-    private void EnsureRealDirectory(string directory, string name)
-    {
-        EnsureContained(RootPath, directory, name);
-        if (!Directory.Exists(directory))
-            throw new InvalidOperationException($"{name} must be an ordinary directory: {directory}");
         if ((File.GetAttributes(directory) & FileAttributes.ReparsePoint) != 0)
         {
             throw new InvalidOperationException(
@@ -452,6 +502,9 @@ internal sealed class AppleReleaseSourceSnapshot : IDisposable
 
     private static StringComparer GetPathComparer()
         => Path.DirectorySeparatorChar == '\\' ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+    private static StringComparison GetPathComparison()
+        => Path.DirectorySeparatorChar == '\\' ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
     public void Dispose()
     {

--- a/PowerForge/Services/AppleReleaseSourceSnapshot.cs
+++ b/PowerForge/Services/AppleReleaseSourceSnapshot.cs
@@ -17,6 +17,7 @@ internal sealed class AppleReleaseSourceSnapshot : IDisposable
         new Dictionary<string, string>(StringComparer.Ordinal);
     private string? _snapshotConfigPath;
     private string? _expectedConfigSha256;
+    private readonly List<string> _preparedSwiftPackageMetadataRoots = new();
     private bool _disposed;
 
     private AppleReleaseSourceSnapshot(
@@ -80,6 +81,7 @@ internal sealed class AppleReleaseSourceSnapshot : IDisposable
                 snapshotRoot,
                 snapshotProjectRoot,
                 sourceCommit);
+            snapshot.PrepareSwiftPackageWorkingDirectories();
             snapshot._trackedFileMutationIdentities = snapshot.CaptureTrackedFileMutationIdentities();
             snapshot.ValidateUnchanged();
             if (!string.IsNullOrWhiteSpace(plan.ExactSourceConfigPath))
@@ -148,7 +150,104 @@ internal sealed class AppleReleaseSourceSnapshot : IDisposable
 
     /// <summary>Begins monitoring the detached source tree for transient changes during xcodebuild.</summary>
     internal AppleReleaseSourceMutationMonitor MonitorChanges()
-        => new(RootPath);
+    {
+        var monitor = new AppleReleaseSourceMutationMonitor(RootPath);
+        try
+        {
+            ValidatePreparedSwiftPackageWorkingDirectories();
+            return monitor;
+        }
+        catch
+        {
+            monitor.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Prepares the empty package-local directories that Xcode creates while resolving a tracked
+    /// local Swift package. Files and later mutations remain observable by the snapshot monitor.
+    /// </summary>
+    private void PrepareSwiftPackageWorkingDirectories()
+    {
+        var trackedPaths = Run(
+                _git,
+                RootPath,
+                new[] { "ls-files", "-z" },
+                "enumerate local Swift package roots")
+            .StdOut.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var relativePath in trackedPaths.Where(path =>
+                     Path.GetFileName(path).Equals("Package.swift", StringComparison.Ordinal)))
+        {
+            var packageManifest = Path.GetFullPath(Path.Combine(
+                RootPath,
+                relativePath.Replace('/', Path.DirectorySeparatorChar)));
+            EnsureContained(RootPath, packageManifest, "Apple snapshot Swift package manifest");
+            var metadataRoot = Path.Combine(Path.GetDirectoryName(packageManifest)!, ".swiftpm");
+            EnsureEmptyRealDirectory(metadataRoot, "Apple snapshot Swift package metadata root");
+            _preparedSwiftPackageMetadataRoots.Add(metadataRoot);
+            foreach (var name in new[] { "configuration", "xcode" })
+            {
+                var directory = Path.Combine(metadataRoot, name);
+                EnsureEmptyRealDirectory(directory, $"Apple snapshot Swift package {name} directory");
+            }
+        }
+    }
+
+    private void ValidatePreparedSwiftPackageWorkingDirectories()
+    {
+        foreach (var metadataRoot in _preparedSwiftPackageMetadataRoots)
+        {
+            EnsureRealDirectory(metadataRoot, "Apple snapshot Swift package metadata root");
+            var expectedChildren = new HashSet<string>(new[] { "configuration", "xcode" }, StringComparer.Ordinal);
+            foreach (var entry in Directory.EnumerateFileSystemEntries(metadataRoot))
+            {
+                if (!expectedChildren.Remove(Path.GetFileName(entry)))
+                {
+                    throw new InvalidOperationException(
+                        $"Apple snapshot Swift package metadata root contains unbound state before the Apple build starts: {entry}");
+                }
+            }
+            if (expectedChildren.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    $"Apple snapshot Swift package metadata root is incomplete before the Apple build starts: {metadataRoot}");
+            }
+            EnsureEmptyRealDirectory(
+                Path.Combine(metadataRoot, "configuration"),
+                "Apple snapshot Swift package configuration directory");
+            EnsureEmptyRealDirectory(
+                Path.Combine(metadataRoot, "xcode"),
+                "Apple snapshot Swift package xcode directory");
+        }
+    }
+
+    private void EnsureEmptyRealDirectory(string directory, string name)
+    {
+        EnsureContained(RootPath, directory, name);
+        if (!Directory.Exists(directory))
+        {
+            if (File.Exists(directory))
+                throw new InvalidOperationException($"{name} must be an ordinary empty directory: {directory}");
+            Directory.CreateDirectory(directory);
+            return;
+        }
+        EnsureRealDirectory(directory, name);
+        if (Directory.EnumerateFileSystemEntries(directory).Any())
+            throw new InvalidOperationException($"{name} must be empty before the Apple build starts: {directory}");
+    }
+
+    private void EnsureRealDirectory(string directory, string name)
+    {
+        EnsureContained(RootPath, directory, name);
+        if (!Directory.Exists(directory))
+            throw new InvalidOperationException($"{name} must be an ordinary directory: {directory}");
+        if ((File.GetAttributes(directory) & FileAttributes.ReparsePoint) != 0)
+        {
+            throw new InvalidOperationException(
+                $"{name} must not be a symbolic link or reparse point: {directory}");
+        }
+    }
 
     private string MapRepositoryPath(string sourcePath)
     {

--- a/PowerForge/Services/AppleReleaseSourceTrustService.RemotePackages.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.RemotePackages.cs
@@ -131,7 +131,7 @@ internal sealed partial class AppleReleaseSourceTrustService
             var originResult = RunGitAllowFailure(entry, "remote", "get-url", "origin");
             if (!originResult.Succeeded || string.IsNullOrWhiteSpace(originResult.StdOut))
                 throw new InvalidOperationException($"Xcode materialized Swift package checkout has no approved origin: {entry}");
-            var origin = originResult.StdOut.Trim();
+            var origin = ResolveMaterializedPackageOrigin(root, entry, originResult.StdOut.Trim());
             var normalizedOrigin = NormalizePackageLocation(origin);
             if (!approvedRevisions.TryGetValue(normalizedOrigin, out var approvedRevision))
                 throw new InvalidOperationException($"Xcode materialized an additional Swift package checkout outside the approved graph: {origin}");
@@ -148,6 +148,126 @@ internal sealed partial class AppleReleaseSourceTrustService
         var missing = approvedRevisions.Keys.FirstOrDefault(key => !observed.Contains(key));
         if (missing is not null)
             throw new InvalidOperationException($"Xcode did not materialize approved Swift package checkout '{missing}'.");
+    }
+
+    private string ResolveMaterializedPackageOrigin(
+        string sourcePackagesRoot,
+        string checkoutPath,
+        string origin)
+    {
+        if (origin.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ||
+            origin.StartsWith("ssh://", StringComparison.OrdinalIgnoreCase) ||
+            origin.StartsWith("git@", StringComparison.OrdinalIgnoreCase))
+        {
+            return origin;
+        }
+
+        var resolvedOrigin = Path.IsPathRooted(origin)
+            ? Path.GetFullPath(origin)
+            : Path.GetFullPath(Path.Combine(checkoutPath, origin));
+        var repositories = Path.Combine(sourcePackagesRoot, "repositories");
+        var directMirror = Directory.Exists(repositories) &&
+                           Directory.Exists(resolvedOrigin) &&
+                           GetPathComparer().Equals(Path.GetDirectoryName(resolvedOrigin), repositories);
+        if (!directMirror)
+            return origin;
+
+        ValidateXcodeRepositoryMirrorMetadata(repositories, resolvedOrigin);
+        var canonicalOrigin = RunGitAllowFailure(resolvedOrigin, "remote", "get-url", "origin");
+        if (!canonicalOrigin.Succeeded || string.IsNullOrWhiteSpace(canonicalOrigin.StdOut))
+        {
+            throw new InvalidOperationException(
+                $"Xcode materialized Swift package repository mirror has no approved origin: {resolvedOrigin}");
+        }
+
+        return canonicalOrigin.StdOut.Trim();
+    }
+
+    private void ValidateXcodeRepositoryMirrorMetadata(string repositoriesRoot, string mirrorPath)
+    {
+        EnsureNoLinkedTraversal(repositoriesRoot, mirrorPath, "Xcode materialized Swift package repository mirror");
+
+        var configPath = Path.Combine(mirrorPath, "config");
+        if (!File.Exists(configPath))
+        {
+            throw new InvalidOperationException(
+                $"Xcode materialized Swift package repository mirror config was not found: {configPath}");
+        }
+        EnsureNoLinkedTraversal(mirrorPath, configPath, "Xcode materialized Swift package repository mirror config");
+        var includes = RunGitAllowFailure(
+            mirrorPath,
+            "config",
+            "--file",
+            configPath,
+            "--no-includes",
+            "--get-regexp",
+            "^include");
+        if (includes.Succeeded)
+        {
+            throw new InvalidOperationException(
+                $"Xcode materialized Swift package repository mirror config must not include external Git configuration: {configPath}");
+        }
+        if (includes.ExitCode != 1)
+        {
+            throw new InvalidOperationException(
+                $"Xcode materialized Swift package repository mirror config could not be inspected safely: {configPath}");
+        }
+
+        var objectsPath = Path.Combine(mirrorPath, "objects");
+        var objectsInfoPath = Path.Combine(objectsPath, "info");
+        EnsureDirectoryWithinRepository(mirrorPath, objectsPath, "Xcode materialized Swift package repository mirror object database");
+        EnsureDirectoryWithinRepository(mirrorPath, objectsInfoPath, "Xcode materialized Swift package repository mirror object metadata");
+        foreach (var alternateName in new[] { "alternates", "http-alternates" })
+        {
+            var alternatesPath = Path.Combine(objectsInfoPath, alternateName);
+            if (PathEntryExistsOrIsLink(alternatesPath))
+            {
+                throw new InvalidOperationException(
+                    $"Xcode materialized Swift package repository mirror must not use Git object alternates: {alternatesPath}");
+            }
+        }
+
+        var bare = RunGitAllowFailure(mirrorPath, "rev-parse", "--is-bare-repository");
+        if (!bare.Succeeded || !bare.StdOut.Trim().Equals("true", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Xcode materialized Swift package repository mirror is not a self-contained bare repository: {mirrorPath}");
+        }
+
+        var gitDirectory = RunGitAllowFailure(mirrorPath, "rev-parse", "--git-dir");
+        var commonDirectory = RunGitAllowFailure(mirrorPath, "rev-parse", "--git-common-dir");
+        if (!gitDirectory.Succeeded || !commonDirectory.Succeeded)
+        {
+            throw new InvalidOperationException(
+                $"Xcode materialized Swift package repository mirror has unresolved Git metadata: {mirrorPath}");
+        }
+
+        if (!gitDirectory.StdOut.Trim().Equals(".", StringComparison.Ordinal) ||
+            !commonDirectory.StdOut.Trim().Equals(".", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Xcode materialized Swift package repository mirror Git metadata must be self-contained: {mirrorPath}");
+        }
+
+    }
+
+    private static bool PathEntryExistsOrIsLink(string path)
+    {
+        if (File.Exists(path) || Directory.Exists(path))
+            return true;
+#if NET8_0_OR_GREATER
+        try
+        {
+            return !string.IsNullOrWhiteSpace(new FileInfo(path).LinkTarget) ||
+                   !string.IsNullOrWhiteSpace(new DirectoryInfo(path).LinkTarget);
+        }
+        catch (IOException)
+        {
+            return true;
+        }
+#else
+        return false;
+#endif
     }
 
     private void EnsureRemotePackageHasNoGitLinks(string checkoutPath, string repositoryUrl)


### PR DESCRIPTION
## Summary

- bind direct Xcode private SwiftPM repository mirrors back to the canonical origin approved by Package.resolved
- require those mirrors to be bare, self-contained, link-free, and free of config includes or object alternates
- create only missing Xcode-owned .swiftpm working directories while preserving committed metadata as immutable source input
- revalidate the complete metadata identity at the archive-start boundary
- cover legitimate mirrors, tracked metadata, links, indirection, and late mutation with regression tests

This unblocks exact-source Apple archives that previously rejected Xcode private mirror paths and then treated expected .swiftpm directory creation as source mutation. No public API changes are introduced.

## Validation

Focused exact-source and Apple checkpoint contracts pass, and PowerForge builds cleanly for net8.0.