### PR TITLE
Fix Windows PowerShell architecture fallback

### DIFF
--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -11,9 +11,7 @@ public class ModuleBootstrapperGeneratorTests
         string environmentArchitecture,
         string expectedRuntimeFolder)
     {
-        var resolver = string.Join(
-                "\r\n",
-                ModuleBootstrapperGenerator.BuildWindowsRuntimeArchitectureResolverLines("$Arch", "$ArchFolder"))
+        var resolver = ModuleBootstrapperGenerator.RenderWindowsRuntimeArchitectureResolver("$Arch", "$ArchFolder")
             .Replace(
                 "[string][System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture",
                 "[string]$null",
@@ -36,9 +34,7 @@ public class ModuleBootstrapperGeneratorTests
     [Fact]
     public void WindowsRuntimeArchitectureResolver_UsesProcessBitnessForMissingSignalsWithoutWarning()
     {
-        var resolver = string.Join(
-                "\r\n",
-                ModuleBootstrapperGenerator.BuildWindowsRuntimeArchitectureResolverLines("$Arch", "$ArchFolder"))
+        var resolver = ModuleBootstrapperGenerator.RenderWindowsRuntimeArchitectureResolver("$Arch", "$ArchFolder")
             .Replace(
                 "[string][System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture",
                 "[string]$null",
@@ -61,9 +57,7 @@ public class ModuleBootstrapperGeneratorTests
     [Fact]
     public void WindowsRuntimeArchitectureResolver_WarnsForUnrecognizedNonEmptyArchitecture()
     {
-        var resolver = string.Join(
-                "\r\n",
-                ModuleBootstrapperGenerator.BuildWindowsRuntimeArchitectureResolverLines("$Arch", "$ArchFolder"))
+        var resolver = ModuleBootstrapperGenerator.RenderWindowsRuntimeArchitectureResolver("$Arch", "$ArchFolder")
             .Replace(
                 "[string][System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture",
                 "[string]'RISCV64'",

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -2,6 +2,85 @@ using PowerForge;
 
 public class ModuleBootstrapperGeneratorTests
 {
+    [Theory]
+    [InlineData("AMD64", "win-x64")]
+    [InlineData("X86", "win-x86")]
+    [InlineData("ARM64", "win-arm64")]
+    [InlineData("ARM", "win-arm")]
+    public void WindowsRuntimeArchitectureResolver_UsesEnvironmentFallbackWithoutWarning(
+        string environmentArchitecture,
+        string expectedRuntimeFolder)
+    {
+        var resolver = string.Join(
+                "\r\n",
+                ModuleBootstrapperGenerator.BuildWindowsRuntimeArchitectureResolverLines("$Arch", "$ArchFolder"))
+            .Replace(
+                "[string][System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture",
+                "[string]$null",
+                StringComparison.Ordinal)
+            .Replace(
+                "[string]$env:PROCESSOR_ARCHITECTURE",
+                $"[string]'{environmentArchitecture}'",
+                StringComparison.Ordinal);
+
+        using var powerShell = System.Management.Automation.PowerShell.Create();
+        powerShell.AddScript(resolver + "\r\n$ArchFolder");
+
+        var output = powerShell.Invoke();
+
+        Assert.False(powerShell.HadErrors);
+        Assert.Empty(powerShell.Streams.Warning);
+        Assert.Equal(expectedRuntimeFolder, Assert.Single(output).BaseObject);
+    }
+
+    [Fact]
+    public void WindowsRuntimeArchitectureResolver_UsesProcessBitnessForMissingSignalsWithoutWarning()
+    {
+        var resolver = string.Join(
+                "\r\n",
+                ModuleBootstrapperGenerator.BuildWindowsRuntimeArchitectureResolverLines("$Arch", "$ArchFolder"))
+            .Replace(
+                "[string][System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture",
+                "[string]$null",
+                StringComparison.Ordinal)
+            .Replace(
+                "[string]$env:PROCESSOR_ARCHITECTURE",
+                "[string]$null",
+                StringComparison.Ordinal);
+
+        using var powerShell = System.Management.Automation.PowerShell.Create();
+        powerShell.AddScript(resolver + "\r\n$ArchFolder");
+
+        var output = powerShell.Invoke();
+
+        Assert.False(powerShell.HadErrors);
+        Assert.Empty(powerShell.Streams.Warning);
+        Assert.Equal(IntPtr.Size == 4 ? "win-x86" : "win-x64", Assert.Single(output).BaseObject);
+    }
+
+    [Fact]
+    public void WindowsRuntimeArchitectureResolver_WarnsForUnrecognizedNonEmptyArchitecture()
+    {
+        var resolver = string.Join(
+                "\r\n",
+                ModuleBootstrapperGenerator.BuildWindowsRuntimeArchitectureResolverLines("$Arch", "$ArchFolder"))
+            .Replace(
+                "[string][System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture",
+                "[string]'RISCV64'",
+                StringComparison.Ordinal);
+
+        using var powerShell = System.Management.Automation.PowerShell.Create();
+        powerShell.AddScript(resolver + "\r\n$ArchFolder");
+
+        var output = powerShell.Invoke();
+
+        Assert.False(powerShell.HadErrors);
+        Assert.Contains(
+            powerShell.Streams.Warning,
+            warning => warning.Message.Contains("Unknown Windows architecture 'RISCV64'", StringComparison.Ordinal));
+        Assert.Equal(IntPtr.Size == 4 ? "win-x86" : "win-x64", Assert.Single(output).BaseObject);
+    }
+
     [Fact]
     public void Generate_WithLibLayout_WritesLibrariesAndBootstrapperFromTemplates()
     {
@@ -120,6 +199,10 @@ public class ModuleBootstrapperGeneratorTests
             Assert.Contains("Lib\\{0}\\runtimes\\{1}\\native", bootstrapper);
             Assert.Contains("$PathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }", bootstrapper);
             Assert.Contains("($PathEntries -notcontains $NativePath)", bootstrapper);
+            Assert.Contains("$Arch = [string][System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture", bootstrapper);
+            Assert.Contains("$Arch = [string]$env:PROCESSOR_ARCHITECTURE", bootstrapper);
+            Assert.Contains("'AMD64' { 'win-x64' }", bootstrapper);
+            Assert.Contains("if ([IntPtr]::Size -eq 4) { 'win-x86' } else { 'win-x64' }", bootstrapper);
             Assert.Contains("Unknown Windows architecture", bootstrapper);
             Assert.DoesNotContain("\r\n\r\ntry {", bootstrapper);
         }
@@ -878,6 +961,10 @@ public class ModuleBootstrapperGeneratorTests
                 developmentBinaries: developmentOptions);
 
             var bootstrapper = File.ReadAllText(Path.Combine(moduleRoot, "DemoModule.psm1"));
+            Assert.Contains("$PowerForgeDevelopmentArch = [string][System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture", bootstrapper);
+            Assert.Contains("$PowerForgeDevelopmentArch = [string]$env:PROCESSOR_ARCHITECTURE", bootstrapper);
+            Assert.Contains("'AMD64' { 'win-x64' }", bootstrapper);
+            Assert.Contains("if ([IntPtr]::Size -eq 4) { 'win-x86' } else { 'win-x64' }", bootstrapper);
             Assert.Contains("$PowerForgeDevelopmentLibFolder = [IO.Path]::GetDirectoryName($PowerForgeDevelopmentBinaryPath)", bootstrapper);
             Assert.Contains("Join-Path -Path $PowerForgeDevelopmentLibFolder -ChildPath (\"runtimes\\{0}\\native\" -f $PowerForgeDevelopmentArchFolder)", bootstrapper);
             Assert.Contains("$PowerForgeDevelopmentPathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH))", bootstrapper);

--- a/PowerForge/Scripts/ModuleBootstrapper/DevelopmentRuntimeHandler.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/DevelopmentRuntimeHandler.Template.ps1
@@ -1,0 +1,17 @@
+# Ensure native runtime libraries are discoverable for the selected development binary.
+$PowerForgeDevelopmentIsWindowsPlatform = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
+if ($PowerForgeDevelopmentIsWindowsPlatform) {
+{{ArchitectureResolverBlock}}
+    $PowerForgeDevelopmentLibFolder = [IO.Path]::GetDirectoryName($PowerForgeDevelopmentBinaryPath)
+    if ($PowerForgeDevelopmentLibFolder) {
+        $PowerForgeDevelopmentNativePath = Join-Path -Path $PowerForgeDevelopmentLibFolder -ChildPath ("runtimes\{0}\native" -f $PowerForgeDevelopmentArchFolder)
+        $PowerForgeDevelopmentPathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }
+        if ((Test-Path -LiteralPath $PowerForgeDevelopmentNativePath) -and ($PowerForgeDevelopmentPathEntries -notcontains $PowerForgeDevelopmentNativePath)) {
+            if ([string]::IsNullOrWhiteSpace($env:PATH)) {
+                $env:PATH = $PowerForgeDevelopmentNativePath
+            } else {
+                $env:PATH = "$PowerForgeDevelopmentNativePath$([IO.Path]::PathSeparator)$env:PATH"
+            }
+        }
+    }
+}

--- a/PowerForge/Scripts/ModuleBootstrapper/RuntimeHandler.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/RuntimeHandler.Template.ps1
@@ -1,0 +1,17 @@
+# Ensure native runtime libraries are discoverable on Windows
+$IsWindowsPlatform = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
+# Skip probing when the current host cannot resolve a Windows-facing Lib folder (for example Desktop + Core-only payloads).
+if ($IsWindowsPlatform -and $LibFolder) {
+{{ArchitectureResolverBlock}}
+
+    $NativePath = Join-Path -Path $PSScriptRoot -ChildPath ("Lib\{0}\runtimes\{1}\native" -f $LibFolder, $ArchFolder)
+    $PathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }
+    if ((Test-Path -LiteralPath $NativePath) -and ($PathEntries -notcontains $NativePath)) {
+        # Prepend the module-native runtime path so the packaged payload wins over unrelated machine-wide copies.
+        if ([string]::IsNullOrWhiteSpace($env:PATH)) {
+            $env:PATH = $NativePath
+        } else {
+            $env:PATH = "$NativePath$([IO.Path]::PathSeparator)$env:PATH"
+        }
+    }
+}

--- a/PowerForge/Scripts/ModuleBootstrapper/WindowsRuntimeArchitectureResolver.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/WindowsRuntimeArchitectureResolver.Template.ps1
@@ -1,0 +1,20 @@
+{{ArchitectureVariable}} = [string][System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
+if ([string]::IsNullOrWhiteSpace({{ArchitectureVariable}})) {
+    {{ArchitectureVariable}} = [string]$env:PROCESSOR_ARCHITECTURE
+}
+{{ArchitectureFolderVariable}} = switch ({{ArchitectureVariable}}) {
+    'X64'   { 'win-x64' }
+    'AMD64' { 'win-x64' }
+    'X86'   { 'win-x86' }
+    'I386'  { 'win-x86' }
+    'Arm64' { 'win-arm64' }
+    'Arm'   { 'win-arm' }
+    Default {
+        if ([string]::IsNullOrWhiteSpace({{ArchitectureVariable}})) {
+            {{FallbackFolderExpression}}
+        } else {
+            Write-Warning -Message ("Unknown Windows architecture '{0}'. Falling back to process-bitness native runtime probing." -f {{ArchitectureVariable}})
+            {{FallbackFolderExpression}}
+        }
+    }
+}

--- a/PowerForge/Services/ModuleBootstrapperGenerator.Architecture.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.Architecture.cs
@@ -2,34 +2,20 @@ namespace PowerForge;
 
 internal static partial class ModuleBootstrapperGenerator
 {
-    internal static IEnumerable<string> BuildWindowsRuntimeArchitectureResolverLines(
+    internal static string RenderWindowsRuntimeArchitectureResolver(
         string architectureVariable,
         string architectureFolderVariable)
     {
         var fallbackFolderExpression = $"if ([IntPtr]::Size -eq 4) {{ 'win-x86' }} else {{ 'win-x64' }}";
 
-        return new[]
-        {
-            $"    {architectureVariable} = [string][System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture",
-            $"    if ([string]::IsNullOrWhiteSpace({architectureVariable})) {{",
-            $"        {architectureVariable} = [string]$env:PROCESSOR_ARCHITECTURE",
-            "    }",
-            $"    {architectureFolderVariable} = switch ({architectureVariable}) {{",
-            "        'X64'   { 'win-x64' }",
-            "        'AMD64' { 'win-x64' }",
-            "        'X86'   { 'win-x86' }",
-            "        'I386'  { 'win-x86' }",
-            "        'Arm64' { 'win-arm64' }",
-            "        'Arm'   { 'win-arm' }",
-            "        Default {",
-            $"            if ([string]::IsNullOrWhiteSpace({architectureVariable})) {{",
-            $"                {fallbackFolderExpression}",
-            "            } else {",
-            $"                Write-Warning -Message (\"Unknown Windows architecture '{{0}}'. Falling back to process-bitness native runtime probing.\" -f {architectureVariable})",
-            $"                {fallbackFolderExpression}",
-            "            }",
-            "        }",
-            "    }"
-        };
+        return RenderModuleBootstrapperTemplate(
+            "WindowsRuntimeArchitectureResolver",
+            "Scripts/ModuleBootstrapper/WindowsRuntimeArchitectureResolver.Template.ps1",
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ArchitectureVariable"] = architectureVariable,
+                ["ArchitectureFolderVariable"] = architectureFolderVariable,
+                ["FallbackFolderExpression"] = fallbackFolderExpression
+            });
     }
 }

--- a/PowerForge/Services/ModuleBootstrapperGenerator.Architecture.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.Architecture.cs
@@ -1,0 +1,35 @@
+namespace PowerForge;
+
+internal static partial class ModuleBootstrapperGenerator
+{
+    internal static IEnumerable<string> BuildWindowsRuntimeArchitectureResolverLines(
+        string architectureVariable,
+        string architectureFolderVariable)
+    {
+        var fallbackFolderExpression = $"if ([IntPtr]::Size -eq 4) {{ 'win-x86' }} else {{ 'win-x64' }}";
+
+        return new[]
+        {
+            $"    {architectureVariable} = [string][System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture",
+            $"    if ([string]::IsNullOrWhiteSpace({architectureVariable})) {{",
+            $"        {architectureVariable} = [string]$env:PROCESSOR_ARCHITECTURE",
+            "    }",
+            $"    {architectureFolderVariable} = switch ({architectureVariable}) {{",
+            "        'X64'   { 'win-x64' }",
+            "        'AMD64' { 'win-x64' }",
+            "        'X86'   { 'win-x86' }",
+            "        'I386'  { 'win-x86' }",
+            "        'Arm64' { 'win-arm64' }",
+            "        'Arm'   { 'win-arm' }",
+            "        Default {",
+            $"            if ([string]::IsNullOrWhiteSpace({architectureVariable})) {{",
+            $"                {fallbackFolderExpression}",
+            "            } else {",
+            $"                Write-Warning -Message (\"Unknown Windows architecture '{{0}}'. Falling back to process-bitness native runtime probing.\" -f {architectureVariable})",
+            $"                {fallbackFolderExpression}",
+            "            }",
+            "        }",
+            "    }"
+        };
+    }
+}

--- a/PowerForge/Services/ModuleBootstrapperGenerator.Development.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.Development.cs
@@ -148,33 +148,15 @@ if ($null -ne $AddExportedCmdlet) {{
 
     private static string BuildDevelopmentRuntimeHandlerBlock()
     {
-        var lines = new List<string>
-        {
-            "# Ensure native runtime libraries are discoverable for the selected development binary.",
-            "$PowerForgeDevelopmentIsWindowsPlatform = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)",
-            "if ($PowerForgeDevelopmentIsWindowsPlatform) {"
-        };
-        lines.AddRange(BuildWindowsRuntimeArchitectureResolverLines("$PowerForgeDevelopmentArch", "$PowerForgeDevelopmentArchFolder"));
-        lines.AddRange(
-            new[]
+        return RenderModuleBootstrapperTemplate(
+            "DevelopmentRuntimeHandler",
+            "Scripts/ModuleBootstrapper/DevelopmentRuntimeHandler.Template.ps1",
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
-                "    $PowerForgeDevelopmentLibFolder = [IO.Path]::GetDirectoryName($PowerForgeDevelopmentBinaryPath)",
-                "    if ($PowerForgeDevelopmentLibFolder) {",
-                "        $PowerForgeDevelopmentNativePath = Join-Path -Path $PowerForgeDevelopmentLibFolder -ChildPath (\"runtimes\\{0}\\native\" -f $PowerForgeDevelopmentArchFolder)",
-                "        $PowerForgeDevelopmentPathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }",
-                "        if ((Test-Path -LiteralPath $PowerForgeDevelopmentNativePath) -and ($PowerForgeDevelopmentPathEntries -notcontains $PowerForgeDevelopmentNativePath)) {",
-                "            if ([string]::IsNullOrWhiteSpace($env:PATH)) {",
-                "                $env:PATH = $PowerForgeDevelopmentNativePath",
-                "            } else {",
-                "                $env:PATH = \"$PowerForgeDevelopmentNativePath$([IO.Path]::PathSeparator)$env:PATH\"",
-                "            }",
-                "        }",
-                "    }",
-                "}",
-                string.Empty
+                ["ArchitectureResolverBlock"] = IndentPowerShell(
+                    RenderWindowsRuntimeArchitectureResolver("$PowerForgeDevelopmentArch", "$PowerForgeDevelopmentArchFolder").TrimEnd(),
+                    4)
             });
-
-        return string.Join("\r\n", lines);
     }
 
     private static string BuildPowerShellPathExpression(string moduleRoot, string targetPath)

--- a/PowerForge/Services/ModuleBootstrapperGenerator.Development.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.Development.cs
@@ -147,24 +147,17 @@ if ($null -ne $AddExportedCmdlet) {{
     }
 
     private static string BuildDevelopmentRuntimeHandlerBlock()
-        => string.Join(
-            "\r\n",
+    {
+        var lines = new List<string>
+        {
+            "# Ensure native runtime libraries are discoverable for the selected development binary.",
+            "$PowerForgeDevelopmentIsWindowsPlatform = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)",
+            "if ($PowerForgeDevelopmentIsWindowsPlatform) {"
+        };
+        lines.AddRange(BuildWindowsRuntimeArchitectureResolverLines("$PowerForgeDevelopmentArch", "$PowerForgeDevelopmentArchFolder"));
+        lines.AddRange(
             new[]
             {
-                "# Ensure native runtime libraries are discoverable for the selected development binary.",
-                "$PowerForgeDevelopmentIsWindowsPlatform = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)",
-                "if ($PowerForgeDevelopmentIsWindowsPlatform) {",
-                "    $PowerForgeDevelopmentArch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture",
-                "    $PowerForgeDevelopmentArchFolder = switch ($PowerForgeDevelopmentArch) {",
-                "        'X64'   { 'win-x64' }",
-                "        'X86'   { 'win-x86' }",
-                "        'Arm64' { 'win-arm64' }",
-                "        'Arm'   { 'win-arm' }",
-                "        Default {",
-                "            Write-Warning -Message (\"Unknown Windows architecture '{0}'. Falling back to win-x64 native runtime probing.\" -f $PowerForgeDevelopmentArch)",
-                "            'win-x64'",
-                "        }",
-                "    }",
                 "    $PowerForgeDevelopmentLibFolder = [IO.Path]::GetDirectoryName($PowerForgeDevelopmentBinaryPath)",
                 "    if ($PowerForgeDevelopmentLibFolder) {",
                 "        $PowerForgeDevelopmentNativePath = Join-Path -Path $PowerForgeDevelopmentLibFolder -ChildPath (\"runtimes\\{0}\\native\" -f $PowerForgeDevelopmentArchFolder)",
@@ -180,6 +173,9 @@ if ($null -ne $AddExportedCmdlet) {{
                 "}",
                 string.Empty
             });
+
+        return string.Join("\r\n", lines);
+    }
 
     private static string BuildPowerShellPathExpression(string moduleRoot, string targetPath)
     {

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -1116,40 +1116,33 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
 
     private static string BuildRuntimeHandlerBlock()
     {
-        return string.Join(
-                   "\r\n",
-                   new[]
-                   {
-                       "# Ensure native runtime libraries are discoverable on Windows",
-                       "$IsWindowsPlatform = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)",
-                       "# Skip probing when the current host cannot resolve a Windows-facing Lib folder (for example Desktop + Core-only payloads).",
-                       "if ($IsWindowsPlatform -and $LibFolder) {",
-                       "    $Arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture",
-                       "    # PowerShell switch matches the Architecture enum by its string representation here.",
-                       "    $ArchFolder = switch ($Arch) {",
-                       "        'X64'   { 'win-x64' }",
-                       "        'X86'   { 'win-x86' }",
-                       "        'Arm64' { 'win-arm64' }",
-                       "        'Arm'   { 'win-arm' }",
-                       "        Default {",
-                       "            Write-Warning -Message (\"Unknown Windows architecture '{0}'. Falling back to win-x64 native runtime probing.\" -f $Arch)",
-                       "            'win-x64'",
-                       "        }",
-                       "    }",
-                       string.Empty,
-                       "    $NativePath = Join-Path -Path $PSScriptRoot -ChildPath (\"Lib\\{0}\\runtimes\\{1}\\native\" -f $LibFolder, $ArchFolder)",
-                       "    $PathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }",
-                       "    if ((Test-Path -LiteralPath $NativePath) -and ($PathEntries -notcontains $NativePath)) {",
-                       "        # Prepend the module-native runtime path so the packaged payload wins over unrelated machine-wide copies.",
-                       "        if ([string]::IsNullOrWhiteSpace($env:PATH)) {",
-                       "            $env:PATH = $NativePath",
-                       "        } else {",
-                       "            $env:PATH = \"$NativePath$([IO.Path]::PathSeparator)$env:PATH\"",
-                       "        }",
-                       "    }",
-                       "}",
-                       string.Empty
-                   });
+        var lines = new List<string>
+        {
+            "# Ensure native runtime libraries are discoverable on Windows",
+            "$IsWindowsPlatform = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)",
+            "# Skip probing when the current host cannot resolve a Windows-facing Lib folder (for example Desktop + Core-only payloads).",
+            "if ($IsWindowsPlatform -and $LibFolder) {"
+        };
+        lines.AddRange(BuildWindowsRuntimeArchitectureResolverLines("$Arch", "$ArchFolder"));
+        lines.AddRange(
+            new[]
+            {
+                string.Empty,
+                "    $NativePath = Join-Path -Path $PSScriptRoot -ChildPath (\"Lib\\{0}\\runtimes\\{1}\\native\" -f $LibFolder, $ArchFolder)",
+                "    $PathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }",
+                "    if ((Test-Path -LiteralPath $NativePath) -and ($PathEntries -notcontains $NativePath)) {",
+                "        # Prepend the module-native runtime path so the packaged payload wins over unrelated machine-wide copies.",
+                "        if ([string]::IsNullOrWhiteSpace($env:PATH)) {",
+                "            $env:PATH = $NativePath",
+                "        } else {",
+                "            $env:PATH = \"$NativePath$([IO.Path]::PathSeparator)$env:PATH\"",
+                "        }",
+                "    }",
+                "}",
+                string.Empty
+            });
+
+        return string.Join("\r\n", lines);
     }
 
     private static string BuildDesktopAssemblyResolverBlock()

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -1116,33 +1116,15 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
 
     private static string BuildRuntimeHandlerBlock()
     {
-        var lines = new List<string>
-        {
-            "# Ensure native runtime libraries are discoverable on Windows",
-            "$IsWindowsPlatform = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)",
-            "# Skip probing when the current host cannot resolve a Windows-facing Lib folder (for example Desktop + Core-only payloads).",
-            "if ($IsWindowsPlatform -and $LibFolder) {"
-        };
-        lines.AddRange(BuildWindowsRuntimeArchitectureResolverLines("$Arch", "$ArchFolder"));
-        lines.AddRange(
-            new[]
+        return RenderModuleBootstrapperTemplate(
+            "RuntimeHandler",
+            "Scripts/ModuleBootstrapper/RuntimeHandler.Template.ps1",
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
-                string.Empty,
-                "    $NativePath = Join-Path -Path $PSScriptRoot -ChildPath (\"Lib\\{0}\\runtimes\\{1}\\native\" -f $LibFolder, $ArchFolder)",
-                "    $PathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }",
-                "    if ((Test-Path -LiteralPath $NativePath) -and ($PathEntries -notcontains $NativePath)) {",
-                "        # Prepend the module-native runtime path so the packaged payload wins over unrelated machine-wide copies.",
-                "        if ([string]::IsNullOrWhiteSpace($env:PATH)) {",
-                "            $env:PATH = $NativePath",
-                "        } else {",
-                "            $env:PATH = \"$NativePath$([IO.Path]::PathSeparator)$env:PATH\"",
-                "        }",
-                "    }",
-                "}",
-                string.Empty
+                ["ArchitectureResolverBlock"] = IndentPowerShell(
+                    RenderWindowsRuntimeArchitectureResolver("$Arch", "$ArchFolder").TrimEnd(),
+                    4)
             });
-
-        return string.Join("\r\n", lines);
     }
 
     private static string BuildDesktopAssemblyResolverBlock()


### PR DESCRIPTION
## Summary

- make generated Windows bootstrap code fall back from `RuntimeInformation.ProcessArchitecture` to `PROCESSOR_ARCHITECTURE`, then process bitness
- keep warnings for genuinely unknown non-empty architecture values while avoiding false warnings when Windows PowerShell reports an empty value
- use one embedded PowerShell resolver template from both packaged-runtime and development-bootstrap handlers
- keep runtime handler script structure in embedded `.Template.ps1` resources while C# supplies only tokens and composition
- cover x64, x86, ARM64, ARM, missing-signal, and unknown-signal behavior

## Consumer impact

Modules such as DbaClientX will receive the corrected bootstrapper when rebuilt with a PSPublishModule release containing this change.