### PR TITLE
Allow Xcode export scratch in Apple upload snapshots

### DIFF
--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleIntegrityClosureRegressions.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleIntegrityClosureRegressions.cs
@@ -292,6 +292,92 @@ public sealed partial class PowerForgeReleaseServiceTests {
     }
 
     [Fact]
+    public void Execute_AppleUpload_allows_transient_xcode_sandbox_scratch_for_approved_archive_file() {
+        const string sourceCommit = "0123456789abcdef0123456789abcdef01234567";
+        var root = CreateSandbox();
+        try {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.2.0", "9");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.MinimumFreeSpaceGB = 0;
+            spec.AppleApps.Automation.CleanupBeforeArchive = false;
+            spec.AppleApps.Automation.WaitForProcessing = false;
+
+            var result = CreateAppleAutomationService(
+                    request => CreateReleaseState(request, processingState: null),
+                    archiveAppleApp: request => {
+                        var archive = Directory.CreateDirectory(request.ArchivePath!);
+                        File.WriteAllText(Path.Combine(archive.FullName, "Info.plist"), "approved bytes");
+                        return CreateSuccessfulArchive(request);
+                    },
+                    uploadAppleApp: request => {
+                        var scratch = Path.Combine(
+                            request.ArchivePath!,
+                            "Info.plist.sb-2f65fadd-rg00hz");
+                        File.WriteAllText(scratch, "xcode scratch bytes");
+                        Thread.Sleep(1000);
+                        File.Delete(scratch);
+                        return CreateSuccessfulUpload(request);
+                    })
+                .Execute(spec, new PowerForgeReleaseRequest {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    AppleAction = PowerForgeAppleReleaseAction.Upload,
+                    AppleSourceCommit = sourceCommit
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.True(Assert.Single(result.AppleApps).Upload?.Succeeded);
+        } finally {
+            TryDelete(root);
+        }
+    }
+
+    [Theory]
+    [InlineData("Unapproved.plist.sb-2f65fadd-rg00hz")]
+    [InlineData("Products/Info.plist.sb-2f65fadd-rg00hz")]
+    public void Execute_AppleUpload_rejects_xcode_sandbox_scratch_outside_exact_archive_info_plist(string scratchRelativePath) {
+        const string sourceCommit = "0123456789abcdef0123456789abcdef01234567";
+        var root = CreateSandbox();
+        try {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.2.0", "9");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.MinimumFreeSpaceGB = 0;
+            spec.AppleApps.Automation.CleanupBeforeArchive = false;
+            spec.AppleApps.Automation.WaitForProcessing = false;
+
+            var result = CreateAppleAutomationService(
+                    request => CreateReleaseState(request, processingState: null),
+                    archiveAppleApp: request => {
+                        var archive = Directory.CreateDirectory(request.ArchivePath!);
+                        File.WriteAllText(Path.Combine(archive.FullName, "Info.plist"), "approved bytes");
+                        var products = Directory.CreateDirectory(Path.Combine(archive.FullName, "Products"));
+                        File.WriteAllText(Path.Combine(products.FullName, "Info.plist"), "approved nested bytes");
+                        return CreateSuccessfulArchive(request);
+                    },
+                    uploadAppleApp: request => {
+                        var scratch = Path.Combine(request.ArchivePath!, scratchRelativePath);
+                        File.WriteAllText(scratch, "unapproved scratch bytes");
+                        Thread.Sleep(1000);
+                        File.Delete(scratch);
+                        return CreateSuccessfulUpload(request);
+                    })
+                .Execute(spec, new PowerForgeReleaseRequest {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    AppleAction = PowerForgeAppleReleaseAction.Upload,
+                    AppleSourceCommit = sourceCommit
+                });
+
+            Assert.False(result.Success);
+            Assert.Contains("private Apple upload archive snapshot changed", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_AppleUpload_rejects_transient_private_archive_hard_link_alias_mutation() {
         const string sourceCommit = "0123456789abcdef0123456789abcdef01234567";
         var root = CreateSandbox();

--- a/PowerForge/Services/AppleArchiveUploadSnapshot.cs
+++ b/PowerForge/Services/AppleArchiveUploadSnapshot.cs
@@ -54,6 +54,19 @@ internal sealed class AppleArchiveUploadSnapshot : IDisposable
         }
     }
 
+    /// <summary>
+    /// Monitors the private archive while allowing only Xcode's transient sandbox scratch files.
+    /// The scratch name must correspond to an approved archive file, and the complete archive
+    /// identity is still revalidated after export so a retained scratch file or base-file change fails.
+    /// </summary>
+    internal AppleReleaseSourceMutationMonitor MonitorChanges()
+        => new(
+            RootPath,
+            "private Apple upload archive snapshot",
+            "xcodebuild exportArchive",
+            "Discard the upload/export result and inspect remote state before retrying.",
+            ignoredMutation: IsExpectedXcodeExportScratchMutation);
+
     internal void ValidateUnchanged(string expectedSha256)
     {
         var current = CaptureCompleteIdentity(ArchivePath);
@@ -80,7 +93,8 @@ internal sealed class AppleArchiveUploadSnapshot : IDisposable
         {
             return new SnapshotIdentity(
                 sha256,
-                ExistingFilePathIdentityResolver.CapturePrivateFileMutationIdentity(archivePath, description));
+                ExistingFilePathIdentityResolver.CapturePrivateFileMutationIdentity(archivePath, description),
+                new HashSet<string>(GetPathComparer(archivePath)));
         }
         var identities = CaptureFileMutationIdentities(archivePath, description);
         var canonical = new System.Text.StringBuilder();
@@ -93,7 +107,60 @@ internal sealed class AppleArchiveUploadSnapshot : IDisposable
         var digest = BitConverter.ToString(hash.ComputeHash(System.Text.Encoding.UTF8.GetBytes(canonical.ToString())))
             .Replace("-", string.Empty)
             .ToLowerInvariant();
-        return new SnapshotIdentity(sha256, digest);
+        return new SnapshotIdentity(
+            sha256,
+            digest,
+            new HashSet<string>(identities.Keys, GetPathComparer(archivePath)));
+    }
+
+    private bool IsExpectedXcodeExportScratchMutation(FileSystemEventArgs args)
+    {
+        if (args is RenamedEventArgs)
+            return false;
+        return IsExpectedXcodeExportScratchPath(args.FullPath);
+    }
+
+    private bool IsExpectedXcodeExportScratchPath(string path)
+    {
+        var scratchPath = Path.GetFullPath(path);
+        var archiveRoot = Path.GetFullPath(ArchivePath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var comparison = Path.DirectorySeparatorChar == '\\'
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        var prefix = archiveRoot + Path.DirectorySeparatorChar;
+        if (!scratchPath.StartsWith(prefix, comparison))
+            return false;
+
+        var relativePath = FrameworkCompatibility.GetRelativePath(archiveRoot, scratchPath)
+            .Replace('\\', '/');
+        if (relativePath.IndexOf('/') >= 0)
+            return false;
+        var fileName = Path.GetFileName(relativePath);
+        var marker = fileName.LastIndexOf(".sb-", StringComparison.Ordinal);
+        if (marker <= 0)
+            return false;
+
+        var firstTokenStart = marker + 4;
+        var separator = fileName.IndexOf('-', firstTokenStart);
+        if (separator != firstTokenStart + 8 || fileName.Length != separator + 7)
+            return false;
+        for (var index = firstTokenStart; index < separator; index++)
+        {
+            var character = fileName[index];
+            if (!((character >= '0' && character <= '9') || (character >= 'a' && character <= 'f')))
+                return false;
+        }
+        for (var index = separator + 1; index < fileName.Length; index++)
+        {
+            var character = fileName[index];
+            if (!((character >= '0' && character <= '9') || (character >= 'a' && character <= 'z')))
+                return false;
+        }
+
+        var approvedFileName = fileName.Substring(0, marker);
+        return string.Equals(approvedFileName, "Info.plist", StringComparison.Ordinal) &&
+               _identity.ApprovedFiles.Contains(approvedFileName);
     }
 
     private static IReadOnlyDictionary<string, string> CaptureFileMutationIdentities(
@@ -165,15 +232,21 @@ internal sealed class AppleArchiveUploadSnapshot : IDisposable
 
     internal sealed class SnapshotIdentity : IEquatable<SnapshotIdentity>
     {
-        internal SnapshotIdentity(string sha256, string mutationDigest)
+        internal SnapshotIdentity(
+            string sha256,
+            string mutationDigest,
+            HashSet<string> approvedFiles)
         {
             Sha256 = sha256;
             MutationDigest = mutationDigest;
+            ApprovedFiles = approvedFiles;
         }
 
         internal string Sha256 { get; }
 
         internal string MutationDigest { get; }
+
+        internal HashSet<string> ApprovedFiles { get; }
 
         public bool Equals(SnapshotIdentity? other)
             => other is not null &&

--- a/PowerForge/Services/AppleReleaseSourceMutationMonitor.cs
+++ b/PowerForge/Services/AppleReleaseSourceMutationMonitor.cs
@@ -11,6 +11,7 @@ internal sealed class AppleReleaseSourceMutationMonitor : IDisposable {
     private readonly string _failureInstruction;
     private readonly string? _exactPath;
     private readonly bool _includeExactPathDescendants;
+    private readonly Func<FileSystemEventArgs, bool>? _ignoredMutation;
     private int _enforceMutations;
     private long _mutationSequence;
     private string? _firstMutation;
@@ -24,12 +25,14 @@ internal sealed class AppleReleaseSourceMutationMonitor : IDisposable {
         string failureInstruction = "Discard the archive and rebuild from a new snapshot.",
         bool enableImmediately = true,
         string? exactPath = null,
-        bool includeExactPathDescendants = false) {
+        bool includeExactPathDescendants = false,
+        Func<FileSystemEventArgs, bool>? ignoredMutation = null) {
         _scopeDescription = scopeDescription;
         _readerDescription = readerDescription;
         _failureInstruction = failureInstruction;
         _exactPath = string.IsNullOrWhiteSpace(exactPath) ? null : Path.GetFullPath(exactPath);
         _includeExactPathDescendants = includeExactPathDescendants;
+        _ignoredMutation = ignoredMutation;
         _watcher = new FileSystemWatcher(rootPath) {
             IncludeSubdirectories = true,
             InternalBufferSize = 64 * 1024,
@@ -60,7 +63,8 @@ internal sealed class AppleReleaseSourceMutationMonitor : IDisposable {
         _watcher.EnableRaisingEvents = false;
         if (_watcherError is not null) {
             throw new InvalidOperationException(
-                $"The {_scopeDescription} mutation monitor failed; its output cannot be trusted. {_failureInstruction}",
+                $"The {_scopeDescription} mutation monitor failed; its output cannot be trusted. " +
+                $"{_watcherError.Message} {_failureInstruction}",
                 _watcherError);
         }
         if (!string.IsNullOrWhiteSpace(_firstMutation)) {
@@ -75,7 +79,8 @@ internal sealed class AppleReleaseSourceMutationMonitor : IDisposable {
             throw new ArgumentNullException(nameof(capture));
         if (_watcherError is not null) {
             throw new InvalidOperationException(
-                $"The {_scopeDescription} mutation monitor failed at the {producerDescription} completion boundary. {_failureInstruction}",
+                $"The {_scopeDescription} mutation monitor failed at the {producerDescription} completion boundary. " +
+                $"{_watcherError.Message} {_failureInstruction}",
                 _watcherError);
         }
 
@@ -140,7 +145,8 @@ internal sealed class AppleReleaseSourceMutationMonitor : IDisposable {
         Thread.Sleep(250);
         if (_watcherError is not null) {
             throw new InvalidOperationException(
-                $"The {_scopeDescription} changed while its {producerDescription} output was being bound. {_failureInstruction}",
+                $"The {_scopeDescription} changed while its {producerDescription} output was being bound. " +
+                $"{_watcherError.Message} {_failureInstruction}",
                 _watcherError);
         }
         var currentOutput = capture();
@@ -160,6 +166,19 @@ internal sealed class AppleReleaseSourceMutationMonitor : IDisposable {
     {
         if (_exactPath is not null && !MutationTouchesExactPath(args, _exactPath, _includeExactPathDescendants))
             return;
+        if (_ignoredMutation is not null)
+        {
+            try
+            {
+                if (_ignoredMutation(args))
+                    return;
+            }
+            catch (Exception exception)
+            {
+                Interlocked.CompareExchange(ref _watcherError, exception, null);
+                return;
+            }
+        }
         Interlocked.Increment(ref _mutationSequence);
         if (Volatile.Read(ref _enforceMutations) != 0)
             Interlocked.CompareExchange(ref _firstMutation, args.FullPath, null);

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -2349,11 +2349,7 @@ internal sealed partial class PowerForgeReleaseService
                 using var directExportSnapshot = direct ? AppleDirectExportSnapshot.Create() : null;
                 using var uploadMutationMonitor = uploadSnapshot is null
                     ? null
-                    : new AppleReleaseSourceMutationMonitor(
-                        uploadSnapshot.RootPath,
-                        "private Apple upload archive snapshot",
-                        "xcodebuild exportArchive",
-                        "Discard the upload/export result and inspect remote state before retrying.");
+                    : uploadSnapshot.MonitorChanges();
                 AppleAppArchiveUploadResult upload;
                 var uploadRemoteMutationStarted = false;
                 try


### PR DESCRIPTION
## Summary

Xcode export creates and removes a top-level `Info.plist.sb-<token>` file inside the private archive. PowerForge treated that expected lifecycle as a source mutation after a successful upload.

This change narrowly recognizes the exact top-level Xcode scratch pattern only when the corresponding `Info.plist` was part of the approved archive snapshot. Renames, nested paths, malformed names, and unapproved base files remain rejected, and the complete archive hash and physical identity are still revalidated after export.

## Validation

- 28 focused Apple upload integrity tests passed
- PowerForge builds cleanly for `net8.0` and `net472` with warnings as errors
- `git diff --check` passed