### PR TITLE
Accept unchanged Xcode archive manifest signals

### DIFF
--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleIntegrityClosureRegressions.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleIntegrityClosureRegressions.cs
@@ -336,6 +336,25 @@ public sealed partial class PowerForgeReleaseServiceTests {
     }
 
     [Fact]
+    public void AppleArchiveUploadSnapshot_allows_xcode_changed_signal_for_unchanged_archive_info_plist() {
+        var root = CreateSandbox();
+        try {
+            var archive = Directory.CreateDirectory(Path.Combine(root, "approved.xcarchive"));
+            var infoPlist = Path.Combine(archive.FullName, "Info.plist");
+            File.WriteAllText(infoPlist, "approved bytes");
+            var expectedSha256 = AppleNotarizationService.ComputeArtifactSha256(archive.FullName);
+
+            using var snapshot = AppleArchiveUploadSnapshot.Create(archive.FullName, expectedSha256);
+
+            Assert.True(snapshot.IsExpectedXcodeExportMutation(
+                new FileSystemEventArgs(WatcherChangeTypes.Changed, snapshot.ArchivePath, "Info.plist")));
+            snapshot.ValidateUnchanged(expectedSha256);
+        } finally {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_ApplePreparePlan_reuses_remote_screenshots_without_local_approval_or_pixels() {
         var root = CreateSandbox();
         try {

--- a/PowerForge/Services/AppleArchiveUploadSnapshot.cs
+++ b/PowerForge/Services/AppleArchiveUploadSnapshot.cs
@@ -65,7 +65,7 @@ internal sealed class AppleArchiveUploadSnapshot : IDisposable
             "private Apple upload archive snapshot",
             "xcodebuild exportArchive",
             "Discard the upload/export result and inspect remote state before retrying.",
-            ignoredMutation: IsExpectedXcodeExportScratchMutation);
+            ignoredMutation: IsExpectedXcodeExportMutation);
 
     internal void ValidateUnchanged(string expectedSha256)
     {
@@ -113,11 +113,29 @@ internal sealed class AppleArchiveUploadSnapshot : IDisposable
             new HashSet<string>(identities.Keys, GetPathComparer(archivePath)));
     }
 
-    private bool IsExpectedXcodeExportScratchMutation(FileSystemEventArgs args)
+    internal bool IsExpectedXcodeExportMutation(FileSystemEventArgs args)
     {
         if (args is RenamedEventArgs)
             return false;
-        return IsExpectedXcodeExportScratchPath(args.FullPath);
+
+        var path = Path.GetFullPath(args.FullPath);
+        var archiveInfoPlist = Path.Combine(ArchivePath, "Info.plist");
+        if (args.ChangeType == WatcherChangeTypes.Changed &&
+            path.Equals(
+                archiveInfoPlist,
+                Path.DirectorySeparatorChar == '\\'
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal) &&
+            _identity.ApprovedFiles.Contains("Info.plist"))
+        {
+            // xcodebuild exportArchive emits a Changed notification while reading the
+            // approved top-level archive manifest. The complete content and physical
+            // mutation identities are revalidated after export, so a real write,
+            // replacement, or transient hard-link alias still fails closed.
+            return true;
+        }
+
+        return IsExpectedXcodeExportScratchPath(path);
     }
 
     private bool IsExpectedXcodeExportScratchPath(string path)


### PR DESCRIPTION
## Summary

- allow the exact `Changed` notification Xcode emits for an approved top-level archive `Info.plist` during export
- keep renames, malformed scratch paths, other files, writes, replacements, hard-link aliases, and changed final identities fail-closed
- cover the accepted signal alongside the existing archive-integrity regression suite

## Release impact

This prevents a successful App Store upload from being reported as failed when Xcode only emits the benign manifest notification. Consumers must repin PowerForge to the merged commit before retrying an affected platform upload.