### PR TITLE
Fix cross-host signing certificate lookup

### DIFF
--- a/PowerForge.Tests/SigningScriptRetryTests.cs
+++ b/PowerForge.Tests/SigningScriptRetryTests.cs
@@ -66,10 +66,52 @@ public sealed class SigningScriptRetryTests
             StringComparison.Ordinal));
     }
 
-    private static (ModuleSigningResult Summary, int SigningCallCount, string[] PackageFilePaths)
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void CertificateLookupFallsBackToLocalMachineWhenCurrentUserCopyIsUnsuitable(
+        bool currentUserHasPrivateKey,
+        bool currentUserHasCodeSigningEku)
+    {
+        if (Path.DirectorySeparatorChar != '\\')
+            return;
+
+        var evidence = RunSigningProviderFailureHarness(
+            includePrecheckFailure: false,
+            includeNonCompatibilitySigningFailure: false,
+            currentUserHasPrivateKey,
+            currentUserHasCodeSigningEku,
+            currentUserHasEkuRestriction: true);
+
+        Assert.Equal(2, evidence.CertificateLookupPaths.Length);
+        Assert.Contains("Cert:\\CurrentUser\\My", evidence.CertificateLookupPaths[0], StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Cert:\\LocalMachine\\My", evidence.CertificateLookupPaths[1], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CertificateLookupAcceptsCurrentUserCopyWithoutEkuRestriction()
+    {
+        if (Path.DirectorySeparatorChar != '\\')
+            return;
+
+        var evidence = RunSigningProviderFailureHarness(
+            includePrecheckFailure: false,
+            includeNonCompatibilitySigningFailure: false,
+            currentUserHasPrivateKey: true,
+            currentUserHasCodeSigningEku: false,
+            currentUserHasEkuRestriction: false);
+
+        var lookupPath = Assert.Single(evidence.CertificateLookupPaths);
+        Assert.Contains("Cert:\\CurrentUser\\My", lookupPath, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static (ModuleSigningResult Summary, int SigningCallCount, string[] PackageFilePaths, string[] CertificateLookupPaths)
         RunSigningProviderFailureHarness(
             bool includePrecheckFailure,
-            bool includeNonCompatibilitySigningFailure)
+            bool includeNonCompatibilitySigningFailure,
+            bool currentUserHasPrivateKey = true,
+            bool currentUserHasCodeSigningEku = true,
+            bool currentUserHasEkuRestriction = true)
     {
         var rootPath = Directory.CreateDirectory(Path.Combine(
             Path.GetTempPath(),
@@ -77,6 +119,7 @@ public sealed class SigningScriptRetryTests
             Guid.NewGuid().ToString("N"))).FullName;
         var packageFileListPath = Path.Combine(rootPath, "package-files.txt");
         var callLogPath = Path.Combine(rootPath, "signing-calls.txt");
+        var certificateLookupLogPath = Path.Combine(rootPath, "certificate-lookups.txt");
         try
         {
             var packageFilePaths = Enumerable.Range(1, 12)
@@ -94,16 +137,34 @@ public sealed class SigningScriptRetryTests
                 $rootPath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(rootPath))}}'))
                 $packageFileListPath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(packageFileListPath))}}'))
                 $callLogPath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(callLogPath))}}'))
+                $certificateLookupLogPath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(certificateLookupLogPath))}}'))
                 $precheckFailurePath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(precheckFailurePath))}}'))
                 $includeNonCompatibilitySigningFailure = [Convert]::ToBoolean('{{includeNonCompatibilitySigningFailure}}')
+                $currentUserHasPrivateKey = [Convert]::ToBoolean('{{currentUserHasPrivateKey}}')
+                $currentUserHasCodeSigningEku = [Convert]::ToBoolean('{{currentUserHasCodeSigningEku}}')
+                $currentUserHasEkuRestriction = [Convert]::ToBoolean('{{currentUserHasEkuRestriction}}')
                 $script:firstSigningCall = $true
-                function Get-ChildItem {
+                function Get-Item {
                   [CmdletBinding()]
-                  param([string]$Path, [switch]$CodeSigningCert)
+                  param([string]$LiteralPath)
+                  [IO.File]::AppendAllText($certificateLookupLogPath, $LiteralPath + [Environment]::NewLine)
+                  $isCurrentUser = $LiteralPath -like 'Cert:\CurrentUser\My\*'
                   [pscustomobject]@{
                     Thumbprint = '0123456789ABCDEF'
                     NotBefore = [DateTime]::Now.AddDays(-1)
                     NotAfter = [DateTime]::Now.AddDays(1)
+                    HasPrivateKey = if ($isCurrentUser) { $currentUserHasPrivateKey } else { $true }
+                    Extensions = if ($isCurrentUser -and -not $currentUserHasEkuRestriction) {
+                      @()
+                    } else {
+                      @([pscustomobject]@{
+                        EnhancedKeyUsages = if (-not $isCurrentUser -or $currentUserHasCodeSigningEku) {
+                          @([pscustomobject]@{ Value = '1.3.6.1.5.5.7.3.3' })
+                        } else {
+                          @([pscustomobject]@{ Value = '1.3.6.1.5.5.7.3.1' })
+                        }
+                      })
+                    }
                   }
                 }
                 function Get-AuthenticodeSignature {
@@ -153,7 +214,11 @@ public sealed class SigningScriptRetryTests
                 new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
             Assert.NotNull(summary);
-            return (summary!, File.ReadAllText(callLogPath).Length, packageFilePaths);
+            return (
+                summary!,
+                File.ReadAllText(callLogPath).Length,
+                packageFilePaths,
+                File.ReadAllLines(certificateLookupLogPath));
         }
         finally
         {

--- a/PowerForge/Scripts/Signing/Sign-Module.ps1
+++ b/PowerForge/Scripts/Signing/Sign-Module.ps1
@@ -19,6 +19,32 @@ function DecodeLines([string]$b64) {
   return $text -split "`n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | ForEach-Object { $_.Trim() }
 }
 
+function Test-CodeSigningCertificate([object]$certificate) {
+  if ($null -eq $certificate -or -not $certificate.HasPrivateKey) { return $false }
+
+  $hasEnhancedKeyUsageRestriction = $false
+  foreach ($extension in @($certificate.Extensions)) {
+    if ($null -eq $extension -or $null -eq $extension.PSObject.Properties['EnhancedKeyUsages']) { continue }
+    $usages = @($extension.EnhancedKeyUsages)
+    if ($usages.Count -eq 0) { continue }
+    $hasEnhancedKeyUsageRestriction = $true
+    foreach ($usage in $usages) {
+      if ([string]$usage.Value -eq '1.3.6.1.5.5.7.3.3') { return $true }
+    }
+  }
+
+  return -not $hasEnhancedKeyUsageRestriction
+}
+
+function Get-CodeSigningCertificateByThumbprint([string]$thumbprint) {
+  foreach ($storeRoot in @('Cert:\CurrentUser\My', 'Cert:\LocalMachine\My')) {
+    $candidate = Get-Item -LiteralPath ("{0}\{1}" -f $storeRoot, $thumbprint) -ErrorAction SilentlyContinue
+    if (Test-CodeSigningCertificate -certificate $candidate) { return $candidate }
+  }
+
+  return $null
+}
+
 function Test-ExcludedPackagePath([string]$relativePath, [string[]]$exclusions) {
   if ([string]::IsNullOrWhiteSpace($relativePath) -or -not $exclusions -or $exclusions.Count -eq 0) {
     return $false
@@ -180,14 +206,7 @@ try {
     $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($pfxFull, $PfxPassword, $flags)
   } elseif (-not [string]::IsNullOrWhiteSpace($Thumbprint)) {
     $tp = ($Thumbprint -replace '\s','').ToUpperInvariant()
-    $cert = Get-ChildItem -Path Cert:\CurrentUser\My -CodeSigningCert -ErrorAction SilentlyContinue |
-      Where-Object { ($_.Thumbprint -replace '\s','').ToUpperInvariant() -eq $tp } |
-      Select-Object -First 1
-    if (-not $cert) {
-      $cert = Get-ChildItem -Path Cert:\LocalMachine\My -CodeSigningCert -ErrorAction SilentlyContinue |
-        Where-Object { ($_.Thumbprint -replace '\s','').ToUpperInvariant() -eq $tp } |
-        Select-Object -First 1
-    }
+    $cert = Get-CodeSigningCertificateByThumbprint -thumbprint $tp
   }
 
   if (-not $cert) {


### PR DESCRIPTION
## Summary

- replace the provider-specific certificate-store filter with exact thumbprint lookup that works in PowerShell 7 and Windows PowerShell 5.1
- keep certificate suitability checks, CurrentUser-to-LocalMachine fallback, and support for certificates without an EKU restriction
- add regression coverage for missing private keys, incompatible EKUs, unrestricted certificates, and hardware-provider fallback behavior

## Why

A module build could sign its unpacked files successfully and then fail while producing the packed artifact. PowerShell 7 correctly requested a compatibility retry after the hardware-backed provider returned an error, but Windows PowerShell could fail during certificate lookup before it attempted signing. This left a newly signed unpacked artifact alongside an older ZIP.

## Validation

Focused signing, runner, and fallback tests pass, the Release solution builds cleanly, and the real EFLegacyReporting artifacts validate in both PowerShell hosts without being re-signed.

The fix requires a PSPublishModule rebuild or release before installed consumers receive it.