### PR TITLE
Handle GitHub deployment response arrays

### DIFF
--- a/.github/actions/powerforge-cloudflare-site-policy/Resolve-PowerForgeCloudflareBaselineOrder.ps1
+++ b/.github/actions/powerforge-cloudflare-site-policy/Resolve-PowerForgeCloudflareBaselineOrder.ps1
@@ -53,11 +53,12 @@ function Get-PagesDeployments {
     $historyComplete = $false
     do {
         $uri = "$script:ApiUrl/repos/$script:Repository/deployments?environment=github-pages&per_page=100&page=$page"
-        $current = @(Invoke-GitHubGet -Uri $uri)
+        [object[]] $current = Invoke-GitHubGet -Uri $uri
         foreach ($deployment in $current) {
             $deploymentId = Get-PositiveInt64 -Name 'deployment id' -Value ([string]$deployment.id)
             $statusesUri = "$script:ApiUrl/repos/$script:Repository/deployments/$deploymentId/statuses?per_page=100"
-            $status = @(Invoke-GitHubGet -Uri $statusesUri) | Where-Object {
+            [object[]] $statuses = Invoke-GitHubGet -Uri $statusesUri
+            $status = $statuses | Where-Object {
                 [string]$_.state -eq 'success' -and [string]$_.environment_url -match '^https?://' -and [string]$_.log_url -match '/actions/runs/(?<run>[0-9]+)/job/(?<job>[0-9]+)'
             } | Sort-Object -Property @{ Expression = { [DateTimeOffset]$_.created_at }; Descending = $true } | Select-Object -First 1
             if ($null -ne $status) {
@@ -78,7 +79,9 @@ function Get-PagesDeployments {
     if (-not $historyComplete) {
         throw 'GitHub Pages deployment history exceeded the 2,000-deployment safety bound.'
     }
-    @($deployments)
+    foreach ($deployment in $deployments) {
+        $deployment
+    }
 }
 
 if ([string]::IsNullOrWhiteSpace($env:GITHUB_OUTPUT)) { throw 'GITHUB_OUTPUT is required.' }

--- a/PowerForge.Tests/CloudflareIncrementalCachePurgeTests.DeploymentOrder.cs
+++ b/PowerForge.Tests/CloudflareIncrementalCachePurgeTests.DeploymentOrder.cs
@@ -124,9 +124,15 @@ public sealed partial class CloudflareIncrementalCachePurgeTests
                     throw "Unexpected GitHub test URI: $Uri"
                 }
                 if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { throw "Missing GitHub test response: $path" }
-                Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+                $response = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+                Write-Output -NoEnumerate $response
             }
-            & $env:POWERFORGE_TEST_SCRIPT
+            try {
+                & $env:POWERFORGE_TEST_SCRIPT
+            } catch {
+                [Console]::Error.WriteLine($_.ScriptStackTrace)
+                throw
+            }
             """);
         var startInfo = new ProcessStartInfo("pwsh")
         {


### PR DESCRIPTION
## Summary
- normalize GitHub deployment and status responses at the real `Invoke-RestMethod` boundary
- preserve fail-closed deployment continuity checks when GitHub returns top-level JSON arrays
- make the deployment-order fixture reproduce PowerShell 7's non-enumerated array response shape

## Why
OfficeIMO's first incremental-cache deployment reached GitHub Pages successfully, but the Cloudflare policy job stopped before applying or purging because a real top-level deployments array was wrapped as one nested object. The deployment id validator then received the array instead of a scalar id.

## Validation
- 207/207 Cloudflare-focused tests passed on Windows
- 33/33 incremental purge tests passed on Windows after rebasing onto current `main`
- 33/33 incremental purge tests passed under WSL/Linux after rebasing
- PowerShell 7 and Windows PowerShell 5.1 parse checks passed
- independent local review found no actionable P0-P3 issues