### PR TITLE
Fix UTF-8 publication catalog compatibility

### DIFF
--- a/PowerForge.Tests/WebEcosystemStatsGeneratorTests.cs
+++ b/PowerForge.Tests/WebEcosystemStatsGeneratorTests.cs
@@ -36,6 +36,9 @@ public sealed partial class WebEcosystemStatsGeneratorTests
             Assert.Empty(result.Warnings);
             Assert.True(File.Exists(outPath));
 
+            var outputBytes = File.ReadAllBytes(outPath);
+            Assert.False(outputBytes.AsSpan().StartsWith(Encoding.UTF8.Preamble));
+
             using var document = JsonDocument.Parse(File.ReadAllText(outPath));
             var rootElement = document.RootElement;
             var summary = rootElement.GetProperty("summary");

--- a/PowerForge.Tests/WebLlmsPublicationCatalogTests.cs
+++ b/PowerForge.Tests/WebLlmsPublicationCatalogTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using PowerForge.Web;
 using PowerForge.Web.Cli;
@@ -6,6 +7,26 @@ namespace PowerForge.Tests;
 
 public sealed class WebLlmsPublicationCatalogTests
 {
+    [Fact]
+    public void VerifiedCatalog_AcceptsUtf8BomFromExistingCatalogs()
+    {
+        using var fixture = new PublicationFixture();
+        var project = fixture.WriteProject("Published.Package");
+        var catalog = fixture.WriteCatalog("Evotec", ["Published.Package"]);
+        File.WriteAllText(catalog, File.ReadAllText(catalog), new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+
+        var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+        {
+            SiteRoot = fixture.Root,
+            ProjectFile = project,
+            InstallCommandPolicy = WebLlmsInstallCommandPolicy.VerifiedCatalog,
+            PublicationCatalogPath = catalog,
+            NuGetOwner = "Evotec"
+        });
+
+        Assert.Equal(1, result.InstallCommandCount);
+    }
+
     [Fact]
     public void VerifiedCatalog_EmitsNuGetCommandForPackageOwnedByExpectedProfile()
     {

--- a/PowerForge.Web/Services/WebEcosystemStatsGenerator.cs
+++ b/PowerForge.Web/Services/WebEcosystemStatsGenerator.cs
@@ -83,7 +83,10 @@ public static partial class WebEcosystemStatsGenerator
         var outputDir = Path.GetDirectoryName(outputPath);
         if (!string.IsNullOrWhiteSpace(outputDir))
             Directory.CreateDirectory(outputDir);
-        File.WriteAllText(outputPath, JsonSerializer.Serialize(document, WebJson.Options), Encoding.UTF8);
+        File.WriteAllText(
+            outputPath,
+            JsonSerializer.Serialize(document, WebJson.Options),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
 
         return new WebEcosystemStatsResult
         {

--- a/PowerForge.Web/Services/WebPublicationCatalog.cs
+++ b/PowerForge.Web/Services/WebPublicationCatalog.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
@@ -75,7 +76,11 @@ internal sealed class WebPublicationCatalog
             }
             memory.Write(buffer[..read]);
         }
-        return memory.ToArray();
+        var bytes = memory.ToArray();
+        var preamble = Encoding.UTF8.Preamble;
+        return bytes.AsSpan().StartsWith(preamble)
+            ? bytes.AsMemory(preamble.Length)
+            : bytes;
     }
 
     public bool ContainsExactOwnedPackage(


### PR DESCRIPTION
## Summary
- write generated ecosystem publication catalogs as UTF-8 without a byte-order mark
- accept existing UTF-8 BOM catalogs at the bounded catalog reader boundary
- cover both generated output and backward-compatible catalog consumption

## Why
Linux website CI exposed that ecosystem catalogs generated with a BOM could not be consumed by the LLMS generator/scanner, blocking the final-artifact security gate before it ran.

## Validation
- focused publication/catalog tests: 33/33
- Release PowerForge.Web.Cli build: 0 warnings, 0 errors
- git diff check clean