### PR TITLE
Handle Markdown-wrapped package commands in agent audits

### DIFF
--- a/PowerForge.Tests/WebLlmsPublicationCatalogTests.cs
+++ b/PowerForge.Tests/WebLlmsPublicationCatalogTests.cs
@@ -8,6 +8,40 @@ namespace PowerForge.Tests;
 public sealed class WebLlmsPublicationCatalogTests
 {
     [Fact]
+    public void VerifiedCatalog_MultiPackageMarkdownPassesFinalArtifactAudit()
+    {
+        using var fixture = new PublicationFixture();
+        var firstProject = fixture.WriteProject("Published.First");
+        var secondProject = fixture.WriteProject("Published.Second");
+        var catalog = fixture.WriteCatalog("Evotec", ["Published.First", "Published.Second"]);
+
+        var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+        {
+            SiteRoot = fixture.Root,
+            PackageFiles = [firstProject, secondProject],
+            InstallCommandPolicy = WebLlmsInstallCommandPolicy.VerifiedCatalog,
+            PublicationCatalogPath = catalog,
+            NuGetOwner = "Evotec"
+        });
+
+        Assert.Equal(2, result.InstallCommandCount);
+        var llmsText = File.ReadAllText(result.LlmsTxtPath);
+        Assert.Contains("`dotnet add package Published.First --version 1.2.3` — source version `1.2.3`", llmsText, StringComparison.Ordinal);
+
+        using var scanner = new WebAgentContentSecurityScanner();
+        var scan = scanner.Scan(new WebAgentContentSecurityOptions
+        {
+            SiteRoot = fixture.Root,
+            Files = ["llms.txt", "llms-full.txt", "llms.json"],
+            PublicationCatalogPath = catalog,
+            NuGetOwner = "Evotec",
+            RequireOwnerVerification = ["nuget:*"]
+        });
+        Assert.True(scan.Success, string.Join(" | ", scan.Findings.Select(static finding => finding.Message)));
+        Assert.Equal(2, scan.VerifiedPackageCount);
+    }
+
+    [Fact]
     public void VerifiedCatalog_AcceptsUtf8BomFromExistingCatalogs()
     {
         using var fixture = new PublicationFixture();

--- a/PowerForge.Web/Services/WebAgentContentSecurityScanner.Commands.cs
+++ b/PowerForge.Web/Services/WebAgentContentSecurityScanner.Commands.cs
@@ -41,7 +41,10 @@ public sealed partial class WebAgentContentSecurityScanner
         ScanDynamicExecutableInvocations(content, path, lineOffset, countLogicalLines, findings);
         foreach (Match match in CommandSegmentRegex.Matches(content))
         {
-            var matchedCommand = match.Groups["command"].Value;
+            var matchedCommand = TrimMarkdownInlineCodeCommand(
+                content,
+                match.Index,
+                match.Groups["command"].Value);
             var commandForValidation = StripShellComment(matchedCommand);
             if (IsUntrustedExecutableReference(content, match.Index))
             {
@@ -192,6 +195,40 @@ public sealed partial class WebAgentContentSecurityScanner
             flowState.RemoteExecutionContextChanged = true;
 
         return references;
+    }
+
+    private static string TrimMarkdownInlineCodeCommand(
+        string content,
+        int commandIndex,
+        string matchedCommand)
+    {
+        var openingStart = commandIndex;
+        while (openingStart > 0 && content[openingStart - 1] == '`')
+            openingStart--;
+
+        var delimiterLength = commandIndex - openingStart;
+        if (delimiterLength == 0)
+            return matchedCommand;
+
+        var lineEnd = content.IndexOfAny(['\r', '\n'], commandIndex);
+        if (lineEnd < 0)
+            lineEnd = content.Length;
+
+        for (var index = commandIndex; index < lineEnd; index++)
+        {
+            if (content[index] != '`')
+                continue;
+
+            var runLength = 1;
+            while (index + runLength < lineEnd && content[index + runLength] == '`')
+                runLength++;
+            if (runLength == delimiterLength)
+                return content.Substring(commandIndex, index - commandIndex);
+
+            index += runLength - 1;
+        }
+
+        return matchedCommand;
     }
 
     private static bool HasShellExpansionInOptionValue(string[] tokens)


### PR DESCRIPTION
## Summary

- recognize generated package commands inside Markdown inline-code delimiters without treating the closing delimiter as shell construction
- preserve detection of real backtick construction inside commands that require longer Markdown delimiters
- add a multi-package end-to-end regression covering generation and final audit of llms.txt, llms-full.txt, and llms.json

## Why

Multi-package LLMS output appends source-version metadata after an inline-code command. The scanner previously consumed the closing Markdown backtick as part of the shell command and rejected truthful generated artifacts with PFAGENT.PACKAGE.OBFUSCATED_COMMAND.

## Validation

- focused LLMS generator/publication tests: 81/81 passing
- Release PowerForge.Web.Cli build: 0 warnings, 0 errors
- git diff --check