### PR TITLE
Add resumable Apple Ship intent

### DIFF
--- a/Docs/PSPublishModule.AppleRelease.md
+++ b/Docs/PSPublishModule.AppleRelease.md
@@ -262,6 +262,7 @@ Use the same entry point for each transition:
 | `Screenshots` | Validates and syncs configured screenshot sets as a separate, deliberate transition. |
 | `TestFlight` | Assigns the processed build to configured groups and testers. |
 | `Advance` | Resumes versioning, archive, upload, preparation, metadata, readiness, configured TestFlight distribution, and screenshots only when `SyncScreenshots` is explicitly enabled; then stops before any review or public-release action. |
+| `Ship` | Runs one resumable intent across versioning, upload, internal TestFlight, preparation, and App Review for explicitly selected targets. It reuses remote screenshots by default and stops at a reviewed source-version checkpoint when needed. |
 | `SubmitTestFlightReview` | Submits external TestFlight distribution for Beta App Review. |
 | `SubmitAppReview` | Submits a ready App Store version for App Review. |
 | `Release` | Publishes a version waiting for developer release. |
@@ -332,6 +333,51 @@ uses a separate plan receipt, checks the exact version/build remotely, and stops
 `SubmitTestFlightReview`, `SubmitAppReview`, or `Release`.
 Screenshot replacement is opt-in during `Advance`. Keep `SyncScreenshots=false` when the
 protected `powerforge-apple-screenshots.yml` lane owns capture, approval, and immediate sync.
+
+### Ship an Apple release with one intent
+
+Use `Ship` for the normal end-to-end path. Declare where each configured target
+should go; PowerForge owns the required sequence and binds the complete intent to
+one reviewable plan hash. A target may appear in both sets when it should be sent
+to internal TestFlight and App Review.
+
+```text
+# iOS App Review plus internal TestFlight; Mac internal TestFlight only
+powerforge apple-release Ship --config powerforge.release.json --apple-version 1.X --apple-source-commit <exact-commit> \
+  --apple-testflight-target "CasaRay iOS,CasaRay Mac" \
+  --apple-app-store-target "CasaRay iOS" --plan --summary --output json
+
+powerforge apple-release Ship --config powerforge.release.json --apple-version 1.X --apple-source-commit <exact-commit> \
+  --apple-testflight-target "CasaRay iOS,CasaRay Mac" \
+  --apple-app-store-target "CasaRay iOS" \
+  --apple-expected-plan-sha256 <reviewed-plan-sha256> \
+  --confirm-apple-action --summary --output json
+```
+
+The same command supports iOS-only, Mac-only, or both platforms in internal
+TestFlight. PowerForge never adds groups or testers that are not already configured,
+requires each selected target to declare `TestFlightPolicy: Internal`, and an
+internal-TestFlight-only target does not receive an App Store version or review
+submission.
+
+Remote App Store screenshots are reused by default. Add
+`--apple-sync-screenshots` only when reviewed local screenshot inputs should replace
+the remote sets.
+
+When the selected marketing version/build is not yet present in the checked-in
+version source, the first plan has `shipPhase: VersionCheckpoint`. Confirming it
+changes only the version source and regenerates configured Xcode projects; it does
+not archive, upload, or mutate App Store Connect. Review and merge that source change,
+then rerun the identical intent from the exact merged commit. The new plan has
+`shipPhase: Release` and can be confirmed to resume the remaining steps.
+If that confirmed run is interrupted after an upload, rerun the exact confirmed
+command with the same plan hash. PowerForge uses its exact-source, route, and upload
+attestations to skip completed uploads; it never silently adopts an unrelated build.
+
+The compiled PowerShell surface exposes the same intent through
+`Invoke-PowerForgeRelease -AppleAction Ship`,
+`-AppleShipTestFlightTarget`, `-AppleShipAppStoreTarget`, and the opt-in
+`-AppleShipSyncScreenshots` switch.
 
 ### Receipts and recovery
 

--- a/PSPublishModule/Cmdlets/InvokePowerForgeReleaseCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokePowerForgeReleaseCommand.cs
@@ -266,6 +266,18 @@ public sealed partial class InvokePowerForgeReleaseCommand : PSCmdlet
     [Parameter]
     public string? AppleExpectedPlanSha256 { get; set; }
 
+    /// <summary>Apple target names or schemes that should receive the Ship build through internal TestFlight.</summary>
+    [Parameter]
+    public string[]? AppleShipTestFlightTarget { get; set; }
+
+    /// <summary>Apple target names or schemes that should be submitted to App Store Review by Ship.</summary>
+    [Parameter]
+    public string[]? AppleShipAppStoreTarget { get; set; }
+
+    /// <summary>Publishes reviewed local screenshot bytes during Ship instead of reusing complete remote screenshots.</summary>
+    [Parameter]
+    public SwitchParameter AppleShipSyncScreenshots { get; set; }
+
     /// <summary>
     /// Explicitly confirms a risky Apple screenshot replacement, review submission, or public release action.
     /// </summary>
@@ -817,6 +829,9 @@ public sealed partial class InvokePowerForgeReleaseCommand : PSCmdlet
             AppleMarketingVersion = NormalizeNullable(AppleVersion),
             AppleSourceCommit = NormalizeNullable(AppleSourceCommit),
             AppleExpectedPlanSha256 = NormalizeNullable(AppleExpectedPlanSha256),
+            AppleShipTestFlightTargets = NormalizeStrings(AppleShipTestFlightTarget),
+            AppleShipAppStoreTargets = NormalizeStrings(AppleShipAppStoreTarget),
+            AppleShipReuseRemoteScreenshots = !AppleShipSyncScreenshots.IsPresent,
             AppleActionConfirmed = ConfirmAppleAction.IsPresent,
             AppleAdoptExistingBuild = AdoptExistingAppleBuild.IsPresent,
             AppleResume = ResolveMutuallyExclusiveFlag(

--- a/PSPublishModule/Cmdlets/PowerForgeReleaseInvocationOptions.cs
+++ b/PSPublishModule/Cmdlets/PowerForgeReleaseInvocationOptions.cs
@@ -168,6 +168,12 @@ internal sealed class PowerForgeReleaseInvocationOptions
 
     public string? AppleExpectedPlanSha256 { get; set; }
 
+    public string[] AppleShipTestFlightTargets { get; set; } = Array.Empty<string>();
+
+    public string[] AppleShipAppStoreTargets { get; set; } = Array.Empty<string>();
+
+    public bool AppleShipReuseRemoteScreenshots { get; set; } = true;
+
     public bool AppleActionConfirmed { get; set; }
 
     public bool AppleAdoptExistingBuild { get; set; }

--- a/PSPublishModule/Cmdlets/PowerForgeReleaseRequestMapper.cs
+++ b/PSPublishModule/Cmdlets/PowerForgeReleaseRequestMapper.cs
@@ -49,6 +49,11 @@ internal static class PowerForgeReleaseRequestMapper
         request.RequireImmutableAppleSourceSnapshot = request.RequireImmutableAppleSourceSnapshot ||
                                                       !string.IsNullOrWhiteSpace(request.AppleSourceCommit);
         request.AppleExpectedPlanSha256 = ChooseString(request.AppleExpectedPlanSha256, options.AppleExpectedPlanSha256);
+        if (options.AppleShipTestFlightTargets.Length > 0)
+            request.AppleShipTestFlightTargets = NormalizeStrings(options.AppleShipTestFlightTargets);
+        if (options.AppleShipAppStoreTargets.Length > 0)
+            request.AppleShipAppStoreTargets = NormalizeStrings(options.AppleShipAppStoreTargets);
+        request.AppleShipReuseRemoteScreenshots = options.AppleShipReuseRemoteScreenshots;
 
         request.SkipWorkspaceValidation = request.SkipWorkspaceValidation || options.SkipWorkspaceValidation;
         request.SkipRestore = request.SkipRestore || options.SkipRestore;
@@ -218,6 +223,9 @@ internal static class PowerForgeReleaseRequestMapper
             AppleSourceCommit = source.AppleSourceCommit,
             RequireImmutableAppleSourceSnapshot = source.RequireImmutableAppleSourceSnapshot,
             AppleExpectedPlanSha256 = source.AppleExpectedPlanSha256,
+            AppleShipTestFlightTargets = source.AppleShipTestFlightTargets.ToArray(),
+            AppleShipAppStoreTargets = source.AppleShipAppStoreTargets.ToArray(),
+            AppleShipReuseRemoteScreenshots = source.AppleShipReuseRemoteScreenshots,
             AppleActionConfirmed = source.AppleActionConfirmed,
             AppleAdoptExistingBuild = source.AppleAdoptExistingBuild,
             AppleResume = source.AppleResume,
@@ -233,4 +241,11 @@ internal static class PowerForgeReleaseRequestMapper
 
     private static bool? ChooseBool(bool? currentValue, bool? overrideValue)
         => overrideValue.HasValue ? overrideValue : currentValue;
+
+    private static string[] NormalizeStrings(IEnumerable<string>? values)
+        => (values ?? Array.Empty<string>())
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
 }

--- a/PowerForge.Cli/AppleReleaseCliSummary.cs
+++ b/PowerForge.Cli/AppleReleaseCliSummary.cs
@@ -18,6 +18,10 @@ internal sealed class AppleReleaseCliPlanSummary
 
     public bool AdoptExistingBuild { get; set; }
 
+    public PowerForgeAppleShipPhase? ShipPhase { get; set; }
+
+    public bool ReuseRemoteScreenshots { get; set; }
+
     public bool WaitForProcessing { get; set; }
 
     public int ProcessingTimeoutSeconds { get; set; }
@@ -46,6 +50,10 @@ internal sealed class AppleReleaseCliTargetSummary
     public string[] Capabilities { get; set; } = Array.Empty<string>();
 
     public AppleTestFlightPolicy TestFlightPolicy { get; set; }
+
+    public bool ShipToTestFlight { get; set; }
+
+    public bool ShipToAppStoreReview { get; set; }
 
     public string? BundleId { get; set; }
 

--- a/PowerForge.Cli/Program.Command.AppleRelease.cs
+++ b/PowerForge.Cli/Program.Command.AppleRelease.cs
@@ -4,10 +4,11 @@ using PowerForge.Cli;
 internal static partial class Program
 {
     private const string AppleReleaseUsage =
-        "Usage: powerforge apple-release <Status|Doctor|Version|Archive|Rehearse|Upload|UploadExisting|Prepare|Screenshots|TestFlight|Advance|SubmitTestFlightReview|SubmitAppReview|Release|Cleanup> " +
+        "Usage: powerforge apple-release <Status|Doctor|Version|Archive|Rehearse|Upload|UploadExisting|Prepare|Screenshots|TestFlight|Advance|Ship|SubmitTestFlightReview|SubmitAppReview|Release|Cleanup> " +
         "[--config <release.json>] [--plan] [--validate] [--confirm-apple-action] " +
         "[--apple-version <marketing-version-or-X-pattern>] [--apple-source-commit <sha>] [--apple-expected-plan-sha256 <sha256>] " +
         "[--apple-adopt-existing-build] " +
+        "[--apple-testflight-target <Name[,Name...]>] [--apple-app-store-target <Name[,Name...]>] [--apple-sync-screenshots] " +
         "[--apple-resume|--no-apple-resume] [--apple-wait|--no-apple-wait] " +
         "[--apple-timeout-seconds <seconds>] [--apple-poll-seconds <seconds>] " +
         "[--target <Name[,Name...]>] [--summary] [--output json]";
@@ -79,7 +80,8 @@ internal static partial class Program
             "--no-apple-resume",
             "--apple-wait",
             "--no-apple-wait",
-            "--summary"
+            "--summary",
+            "--apple-sync-screenshots"
         };
         var options = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -90,6 +92,8 @@ internal static partial class Program
             "--apple-version",
             "--apple-source-commit",
             "--apple-expected-plan-sha256",
+            "--apple-testflight-target",
+            "--apple-app-store-target",
             "--output"
         };
 

--- a/PowerForge.Cli/Program.Command.Release.cs
+++ b/PowerForge.Cli/Program.Command.Release.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 internal static partial class Program
 {
     private const string ReleaseUsageBase =
-        "Usage: powerforge release [--config <release.json>] [--plan] [--validate] [--packages-only] [--module-only] [--tools-only] [--apple-action <Configured|Status|Doctor|Version|Archive|Rehearse|Upload|UploadExisting|Prepare|Screenshots|TestFlight|Advance|SubmitTestFlightReview|SubmitAppReview|Release|Cleanup>] [--apple-version <marketing-version-or-X-pattern>] [--apple-source-commit <sha>] [--apple-expected-plan-sha256 <sha256>] [--confirm-apple-action] [--apple-adopt-existing-build] [--apple-resume|--no-apple-resume] [--apple-wait|--no-apple-wait] [--apple-timeout-seconds <seconds>] [--apple-poll-seconds <seconds>] [--summary] [--configuration <Release|Debug>] [--module-framework <auto|net10.0|net8.0>] [--module-run-mode <Manifest|Documentation|Build|Publish>] [--module-timeout-seconds <seconds>] [--module-no-dotnet-build] [--module-version <version>] [--module-prerelease-tag <tag>] [--module-no-sign] [--module-sign] [--module-certificate-thumbprint <sha1>] [--module-sign-include-binaries|--module-no-sign-include-binaries] [--module-sign-include-internals|--module-no-sign-include-internals] [--module-sign-include-exe|--module-no-sign-include-exe] [--module-diagnostics-baseline <path>] [--module-diagnostics-baseline-generate|--module-no-diagnostics-baseline-generate] [--module-diagnostics-baseline-update|--module-no-diagnostics-baseline-update] [--module-fail-on-new-diagnostics|--module-no-fail-on-new-diagnostics] [--module-fail-on-diagnostics-severity <Warning|Error>] [--skip-workspace-validation] [--workspace-config <workspace.validation.json>] [--workspace-profile <name>] [--workspace-testimox-root <path>] [--workspace-enable-feature <name[,name...]>] [--workspace-disable-feature <name[,name...]>] [--publish-nuget] [--publish-project-github] [--publish-tool-github] [--submit-winget] [--skip-winget-submit] [--winget-submit-mode <Manifest|Update>] [--winget-tool-path <path>] [--winget-token-env <name>] [--winget-token-file <path>] [--winget-pr-title <text>] [--winget-open-browser] [--winget-replace [version]] [--winget-allow-interactive-auth] [--winget-timeout-seconds <seconds>] [--skip-restore] [--skip-build] [--output-root <path>] [--stage-root <path>] [--manifest-json <path>] [--allow-output-outside-project-root] [--allow-manifest-outside-project-root] [--checksums-path <path>] [--skip-release-checksums] [--keep-symbols] [--sign] [--sign-profile <name>] [--sign-tool-path <path>] [--sign-thumbprint <sha1>] [--sign-subject-name <name>] [--sign-on-missing-tool <Warn|Fail|Skip>] [--sign-on-failure <Warn|Fail|Skip>] [--sign-timeout-seconds <seconds>] [--sign-timestamp-url <url>] [--sign-description <text>] [--sign-url <url>] [--sign-csp <name>] [--sign-key-container <name>] [--package-sign-thumbprint <sha1>] [--package-sign-store <CurrentUser|LocalMachine>] [--package-sign-timestamp-url <url>] [--installer-property <Name=Value>] [--tool-output <Tool|Portable|Installer|Store>[,<...>]] [--skip-tool-output <...>] [--target <Name[,Name...]>] [--rid <Rid[,Rid...]>] [--framework <tfm[,tfm...]>] [--style <Portable|PortableCompat|PortableSize|FrameworkDependent|AotSpeed|AotSize>[,<...>]] [--flavor <SingleContained|SingleFx|Portable|Fx>[,<...>]] [--output json]";
+        "Usage: powerforge release [--config <release.json>] [--plan] [--validate] [--packages-only] [--module-only] [--tools-only] [--apple-action <Configured|Status|Doctor|Version|Archive|Rehearse|Upload|UploadExisting|Prepare|Screenshots|TestFlight|Advance|Ship|SubmitTestFlightReview|SubmitAppReview|Release|Cleanup>] [--apple-version <marketing-version-or-X-pattern>] [--apple-source-commit <sha>] [--apple-expected-plan-sha256 <sha256>] [--confirm-apple-action] [--apple-adopt-existing-build] [--apple-testflight-target <Name[,Name...]>] [--apple-app-store-target <Name[,Name...]>] [--apple-sync-screenshots] [--apple-resume|--no-apple-resume] [--apple-wait|--no-apple-wait] [--apple-timeout-seconds <seconds>] [--apple-poll-seconds <seconds>] [--summary] [--configuration <Release|Debug>] [--module-framework <auto|net10.0|net8.0>] [--module-run-mode <Manifest|Documentation|Build|Publish>] [--module-timeout-seconds <seconds>] [--module-no-dotnet-build] [--module-version <version>] [--module-prerelease-tag <tag>] [--module-no-sign] [--module-sign] [--module-certificate-thumbprint <sha1>] [--module-sign-include-binaries|--module-no-sign-include-binaries] [--module-sign-include-internals|--module-no-sign-include-internals] [--module-sign-include-exe|--module-no-sign-include-exe] [--module-diagnostics-baseline <path>] [--module-diagnostics-baseline-generate|--module-no-diagnostics-baseline-generate] [--module-diagnostics-baseline-update|--module-no-diagnostics-baseline-update] [--module-fail-on-new-diagnostics|--module-no-fail-on-new-diagnostics] [--module-fail-on-diagnostics-severity <Warning|Error>] [--skip-workspace-validation] [--workspace-config <workspace.validation.json>] [--workspace-profile <name>] [--workspace-testimox-root <path>] [--workspace-enable-feature <name[,name...]>] [--workspace-disable-feature <name[,name...]>] [--publish-nuget] [--publish-project-github] [--publish-tool-github] [--submit-winget] [--skip-winget-submit] [--winget-submit-mode <Manifest|Update>] [--winget-tool-path <path>] [--winget-token-env <name>] [--winget-token-file <path>] [--winget-pr-title <text>] [--winget-open-browser] [--winget-replace [version]] [--winget-allow-interactive-auth] [--winget-timeout-seconds <seconds>] [--skip-restore] [--skip-build] [--output-root <path>] [--stage-root <path>] [--manifest-json <path>] [--allow-output-outside-project-root] [--allow-manifest-outside-project-root] [--checksums-path <path>] [--skip-release-checksums] [--keep-symbols] [--sign] [--sign-profile <name>] [--sign-tool-path <path>] [--sign-thumbprint <sha1>] [--sign-subject-name <name>] [--sign-on-missing-tool <Warn|Fail|Skip>] [--sign-on-failure <Warn|Fail|Skip>] [--sign-timeout-seconds <seconds>] [--sign-timestamp-url <url>] [--sign-description <text>] [--sign-url <url>] [--sign-csp <name>] [--sign-key-container <name>] [--package-sign-thumbprint <sha1>] [--package-sign-store <CurrentUser|LocalMachine>] [--package-sign-timestamp-url <url>] [--installer-property <Name=Value>] [--tool-output <Tool|Portable|Installer|Store>[,<...>]] [--skip-tool-output <...>] [--target <Name[,Name...]>] [--rid <Rid[,Rid...]>] [--framework <tfm[,tfm...]>] [--style <Portable|PortableCompat|PortableSize|FrameworkDependent|AotSpeed|AotSize>[,<...>]] [--flavor <SingleContained|SingleFx|Portable|Fx>[,<...>]] [--output json]";
 
     private const string ReleaseUsage = ReleaseUsageBase + " Tool-only version override: --release-version <x.y.z>.";
 
@@ -381,6 +381,14 @@ internal static partial class Program
         request.RequireImmutableAppleSourceSnapshot = request.RequireImmutableAppleSourceSnapshot ||
                                                       !string.IsNullOrWhiteSpace(request.AppleSourceCommit);
         request.AppleExpectedPlanSha256 = ChooseString(request.AppleExpectedPlanSha256, TryGetOptionValue(argv, "--apple-expected-plan-sha256"));
+        var appleShipTestFlightTargets = ParseCsvOptionValues(argv, "--apple-testflight-target");
+        if (appleShipTestFlightTargets.Length > 0)
+            request.AppleShipTestFlightTargets = appleShipTestFlightTargets;
+        var appleShipAppStoreTargets = ParseCsvOptionValues(argv, "--apple-app-store-target");
+        if (appleShipAppStoreTargets.Length > 0)
+            request.AppleShipAppStoreTargets = appleShipAppStoreTargets;
+        request.AppleShipReuseRemoteScreenshots = !argv.Any(a =>
+            a.Equals("--apple-sync-screenshots", StringComparison.OrdinalIgnoreCase));
         request.AppleActionConfirmed = argv.Any(a => a.Equals("--confirm-apple-action", StringComparison.OrdinalIgnoreCase));
         request.AppleAdoptExistingBuild = argv.Any(a => a.Equals("--apple-adopt-existing-build", StringComparison.OrdinalIgnoreCase));
         request.AppleResume = ResolveBooleanOverride(argv, "--apple-resume", "--no-apple-resume", request.AppleResume);
@@ -552,20 +560,29 @@ internal static partial class Program
 
         var plan = result.AppleAppPlan;
         var enabledSteps = new List<string>();
-        AddEnabledStep(enabledSteps, plan.Archive, "archive");
-        AddEnabledStep(enabledSteps, plan.Rehearse, "localExportValidation");
-        AddEnabledStep(enabledSteps, plan.Upload, "upload");
-        AddEnabledStep(enabledSteps, plan.PrepareDistribution, "prepareDistribution");
-        AddEnabledStep(enabledSteps, plan.SelectBuildForDistribution, "selectBuild");
-        AddEnabledStep(enabledSteps, plan.SyncMetadata, "syncMetadata");
-        AddEnabledStep(enabledSteps, plan.SyncAppInfo, "syncAppInfo");
-        AddEnabledStep(enabledSteps, plan.SyncScreenshots, "syncScreenshots");
-        AddEnabledStep(enabledSteps, plan.CheckGovernance, "checkGovernance");
-        AddEnabledStep(enabledSteps, plan.CheckReleaseReadiness, "checkReadiness");
-        AddEnabledStep(enabledSteps, plan.DistributeTestFlight, "testFlight");
-        AddEnabledStep(enabledSteps, plan.SubmitTestFlightBetaReview, "submitTestFlightReview");
-        AddEnabledStep(enabledSteps, plan.SubmitForReview, "submitAppReview");
-        AddEnabledStep(enabledSteps, plan.ReleaseApprovedVersion, "release");
+        var versionCheckpoint = plan.Action == PowerForgeAppleReleaseAction.Ship &&
+                                plan.ShipPhase == PowerForgeAppleShipPhase.VersionCheckpoint;
+        if (versionCheckpoint)
+        {
+            enabledSteps.Add("versionCheckpoint");
+        }
+        else
+        {
+            AddEnabledStep(enabledSteps, plan.Archive, "archive");
+            AddEnabledStep(enabledSteps, plan.Rehearse, "localExportValidation");
+            AddEnabledStep(enabledSteps, plan.Upload, "upload");
+            AddEnabledStep(enabledSteps, plan.PrepareDistribution, "prepareDistribution");
+            AddEnabledStep(enabledSteps, plan.SelectBuildForDistribution, "selectBuild");
+            AddEnabledStep(enabledSteps, plan.SyncMetadata, "syncMetadata");
+            AddEnabledStep(enabledSteps, plan.SyncAppInfo, "syncAppInfo");
+            AddEnabledStep(enabledSteps, plan.SyncScreenshots, "syncScreenshots");
+            AddEnabledStep(enabledSteps, plan.CheckGovernance, "checkGovernance");
+            AddEnabledStep(enabledSteps, plan.CheckReleaseReadiness, "checkReadiness");
+            AddEnabledStep(enabledSteps, plan.DistributeTestFlight, "testFlight");
+            AddEnabledStep(enabledSteps, plan.SubmitTestFlightBetaReview, "submitTestFlightReview");
+            AddEnabledStep(enabledSteps, plan.SubmitForReview, "submitAppReview");
+            AddEnabledStep(enabledSteps, plan.ReleaseApprovedVersion, "release");
+        }
         if (plan.Action == PowerForgeAppleReleaseAction.Status)
             enabledSteps.Add("status");
         if (plan.Action == PowerForgeAppleReleaseAction.Doctor)
@@ -588,6 +605,8 @@ internal static partial class Program
             PlanSha256 = result.AppleReceipt?.PlanSha256,
             Resume = plan.Automation.Resume,
             AdoptExistingBuild = plan.AdoptExistingBuild,
+            ShipPhase = plan.ShipPhase,
+            ReuseRemoteScreenshots = plan.ShipReuseRemoteScreenshots,
             WaitForProcessing = plan.Automation.WaitForProcessing,
             ProcessingTimeoutSeconds = plan.Automation.ProcessingTimeoutSeconds,
             PollIntervalSeconds = plan.Automation.PollIntervalSeconds,
@@ -602,6 +621,8 @@ internal static partial class Program
                 ParentTarget = app.ParentTarget,
                 Capabilities = app.Capabilities,
                 TestFlightPolicy = app.TestFlightPolicy,
+                ShipToTestFlight = app.ShipToTestFlight,
+                ShipToAppStoreReview = app.ShipToAppStoreReview,
                 BundleId = app.BundleId,
                 AppId = app.AppStoreConnectAppId,
                 AppIdDiscovered = app.AppStoreConnectAppIdDiscovered,
@@ -628,6 +649,7 @@ internal static partial class Program
              (plan.SyncScreenshots && plan.ReplaceScreenshots))) ||
            plan.Action == PowerForgeAppleReleaseAction.SubmitTestFlightReview ||
            plan.Action == PowerForgeAppleReleaseAction.Advance ||
+           plan.Action == PowerForgeAppleReleaseAction.Ship ||
            plan.Action == PowerForgeAppleReleaseAction.Version ||
            plan.Action == PowerForgeAppleReleaseAction.SubmitAppReview ||
            plan.Action == PowerForgeAppleReleaseAction.Release ||

--- a/PowerForge.Cli/Program.Helpers.cs
+++ b/PowerForge.Cli/Program.Helpers.cs
@@ -33,8 +33,8 @@ internal static partial class Program
                         [--package-sign-thumbprint <sha1>] [--package-sign-store <CurrentUser|LocalMachine>] [--package-sign-timestamp-url <url>]
                         [--tool-output <Tool|Portable|Installer|Store>[,<...>]] [--skip-tool-output <Tool|Portable|Installer|Store>[,<...>]]
                         [--target <Name[,Name...]>] [--rid <Rid[,Rid...]>] [--framework <tfm[,tfm...]>] [--style <Portable|PortableCompat|PortableSize|FrameworkDependent|AotSpeed|AotSize>[,<...>]] [--flavor <SingleContained|SingleFx|Portable|Fx>[,<...>]] [--output json]
-      powerforge apple-release <Status|Doctor|Version|Archive|Rehearse|Upload|UploadExisting|Prepare|Screenshots|TestFlight|Advance|SubmitTestFlightReview|SubmitAppReview|Release|Cleanup>
-                        [--config <release.json>] [--plan] [--validate] [--confirm-apple-action] [--apple-expected-plan-sha256 <sha256>] [--apple-resume|--no-apple-resume]
+      powerforge apple-release <Status|Doctor|Version|Archive|Rehearse|Upload|UploadExisting|Prepare|Screenshots|TestFlight|Advance|Ship|SubmitTestFlightReview|SubmitAppReview|Release|Cleanup>
+                        [--config <release.json>] [--plan] [--validate] [--confirm-apple-action] [--apple-expected-plan-sha256 <sha256>] [--apple-testflight-target <Name[,Name...]>] [--apple-app-store-target <Name[,Name...]>] [--apple-sync-screenshots] [--apple-resume|--no-apple-resume]
                         [--apple-wait|--no-apple-wait] [--apple-timeout-seconds <seconds>] [--apple-poll-seconds <seconds>]
                                 [--target <Name[,Name...]>] [--summary] [--output json]
       powerforge apple-deploy [--config <powerforge.release.json>] [--platform <iOS|iPadOS|watchOS|macOS|tvOS|visionOS>] [--target <name-or-scheme>] [--device <name>|--device-id <id>] [--profile <name>] [--configuration <Debug|Release>] [--install-root </Applications>] [--build-mirror|--no-build-mirror] [--launch|--no-launch] [--plan] [--output json]

--- a/PowerForge.Tests/AppStoreConnectClientTests.AppInfoMetadata.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.AppInfoMetadata.cs
@@ -119,6 +119,21 @@ public sealed partial class AppStoreConnectClientTests
                 {
                   "data": [
                     {
+                      "id": "info-loc-live",
+                      "type": "appInfoLocalizations",
+                      "attributes": {
+                        "locale": "en-US",
+                        "privacyPolicyUrl": "https://tactra.dev/privacy/"
+                      }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
                       "id": "info-loc-1",
                       "type": "appInfoLocalizations",
                       "attributes": {
@@ -163,7 +178,7 @@ public sealed partial class AppStoreConnectClientTests
         Assert.Equal("https://old.example/privacy/", result.Before.PrivacyPolicyUrl);
         Assert.Equal("https://tactra.dev/privacy/", result.After.PrivacyPolicyUrl);
         Assert.Equal(new[] { "privacyPolicyUrl" }, result.UpdatedFields);
-        Assert.Contains("appInfos/info-editable/appInfoLocalizations", handler.RequestUris[1].ToString(), StringComparison.Ordinal);
+        Assert.Contains("appInfos/info-editable/appInfoLocalizations", handler.RequestUris[2].ToString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -199,6 +214,206 @@ public sealed partial class AppStoreConnectClientTests
 
         Assert.Contains("does not belong to app 'app-1'", exception.Message, StringComparison.Ordinal);
         Assert.Single(handler.RequestUris);
+    }
+
+    [Fact]
+    public async Task AppInfoMetadataSyncService_AcceptsConvergedLockedResourcesWithoutMutation()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    { "id": "info-live", "type": "appInfos", "attributes": { "state": "READY_FOR_DISTRIBUTION" } },
+                    { "id": "info-review", "type": "appInfos", "attributes": { "state": "IN_REVIEW" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    { "id": "loc-live", "type": "appInfoLocalizations", "attributes": { "locale": "en-US", "privacyPolicyUrl": "https://casaray.dev/privacy/" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    { "id": "loc-review", "type": "appInfoLocalizations", "attributes": { "locale": "en-US", "privacyPolicyUrl": "https://casaray.dev/privacy/" } }
+                  ]
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var result = await new AppStoreConnectAppInfoMetadataSyncService(client).SyncAsync(
+            new AppStoreConnectAppInfoMetadataSyncRequest
+            {
+                Spec = new AppStoreConnectAppInfoMetadataSpec
+                {
+                    AppId = "app-1",
+                    Locale = "en-US",
+                    Metadata = new AppStoreConnectAppInfoLocalizationUpdate
+                    {
+                        PrivacyPolicyUrl = "https://casaray.dev/privacy/"
+                    }
+                }
+            });
+
+        Assert.Empty(result.UpdatedFields);
+        Assert.Equal(result.Before.Id, result.After.Id);
+        Assert.Equal(3, handler.RequestUris.Count);
+        Assert.All(handler.Methods, method => Assert.Equal(HttpMethod.Get, method));
+    }
+
+    [Fact]
+    public async Task AppInfoMetadataSyncService_RejectsChangedMetadataWhenResourcesAreLocked()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    { "id": "info-review", "type": "appInfos", "attributes": { "state": "IN_REVIEW" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    { "id": "loc-review", "type": "appInfoLocalizations", "attributes": { "locale": "en-US", "privacyPolicyUrl": "https://old.example/privacy/" } }
+                  ]
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            new AppStoreConnectAppInfoMetadataSyncService(client).SyncAsync(
+                new AppStoreConnectAppInfoMetadataSyncRequest
+                {
+                    Spec = new AppStoreConnectAppInfoMetadataSpec
+                    {
+                        AppId = "app-1",
+                        Locale = "en-US",
+                        Metadata = new AppStoreConnectAppInfoLocalizationUpdate
+                        {
+                            PrivacyPolicyUrl = "https://casaray.dev/privacy/"
+                        }
+                    }
+                }));
+
+        Assert.Contains("locked resources do not already match", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(2, handler.RequestUris.Count);
+        Assert.All(handler.Methods, method => Assert.Equal(HttpMethod.Get, method));
+    }
+
+    [Fact]
+    public async Task AppInfoMetadataSyncService_RejectsMismatchedLockedResourceAlongsideEditableResource()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    { "id": "info-editable", "type": "appInfos", "attributes": { "state": "PREPARE_FOR_SUBMISSION" } },
+                    { "id": "info-review", "type": "appInfos", "attributes": { "state": "IN_REVIEW" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    { "id": "loc-editable", "type": "appInfoLocalizations", "attributes": { "locale": "en-US", "privacyPolicyUrl": "https://casaray.dev/privacy/" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    { "id": "loc-review", "type": "appInfoLocalizations", "attributes": { "locale": "en-US", "privacyPolicyUrl": "https://old.example/privacy/" } }
+                  ]
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            new AppStoreConnectAppInfoMetadataSyncService(client).SyncAsync(
+                new AppStoreConnectAppInfoMetadataSyncRequest
+                {
+                    Spec = new AppStoreConnectAppInfoMetadataSpec
+                    {
+                        AppId = "app-1",
+                        Locale = "en-US",
+                        Metadata = new AppStoreConnectAppInfoLocalizationUpdate
+                        {
+                            PrivacyPolicyUrl = "https://casaray.dev/privacy/"
+                        }
+                    }
+                }));
+
+        Assert.Contains("locked resources do not already match", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(3, handler.RequestUris.Count);
+        Assert.All(handler.Methods, method => Assert.Equal(HttpMethod.Get, method));
+    }
+
+    [Fact]
+    public async Task AppInfoMetadataSyncService_ExplicitLockedIdStillChecksEveryLockedResource()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    { "id": "info-live", "type": "appInfos", "attributes": { "state": "READY_FOR_DISTRIBUTION" } },
+                    { "id": "info-review", "type": "appInfos", "attributes": { "state": "IN_REVIEW" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    { "id": "loc-live", "type": "appInfoLocalizations", "attributes": { "locale": "en-US", "privacyPolicyUrl": "https://casaray.dev/privacy/" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    { "id": "loc-review", "type": "appInfoLocalizations", "attributes": { "locale": "en-US", "privacyPolicyUrl": "https://old.example/privacy/" } }
+                  ]
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            new AppStoreConnectAppInfoMetadataSyncService(client).SyncAsync(
+                new AppStoreConnectAppInfoMetadataSyncRequest
+                {
+                    Spec = new AppStoreConnectAppInfoMetadataSpec
+                    {
+                        AppId = "app-1",
+                        AppInfoId = "info-live",
+                        Locale = "en-US",
+                        Metadata = new AppStoreConnectAppInfoLocalizationUpdate
+                        {
+                            PrivacyPolicyUrl = "https://casaray.dev/privacy/"
+                        }
+                    }
+                }));
+
+        Assert.Contains("locked resources do not already match", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(3, handler.RequestUris.Count);
+        Assert.All(handler.Methods, method => Assert.Equal(HttpMethod.Get, method));
     }
 
     [Fact]

--- a/PowerForge.Tests/PowerForgeCliAppleReleaseTests.cs
+++ b/PowerForge.Tests/PowerForgeCliAppleReleaseTests.cs
@@ -8,6 +8,48 @@ public sealed class PowerForgeCliAppleReleaseTests
     private const string ApprovedSourceCommit = "0123456789abcdef0123456789abcdef01234567";
 
     [Fact]
+    public void AppleRelease_ShipCliMapsRouteIntentAndDefaultsToRemoteScreenshots()
+    {
+        var request = BuildReleaseRequest(
+            [
+                "--apple-action", "Ship",
+                "--apple-version", "1.8",
+                "--apple-source-commit", ApprovedSourceCommit,
+                "--apple-testflight-target", "CasaRay iOS,CasaRay Mac",
+                "--apple-app-store-target", "CasaRay iOS"
+            ],
+            "/tmp/powerforge.release.json",
+            planOnly: true,
+            validateOnly: false,
+            packagesOnly: false,
+            moduleOnly: false,
+            toolsOnly: false);
+
+        Assert.Equal(PowerForgeAppleReleaseAction.Ship, request.AppleAction);
+        Assert.Equal("1.8", request.AppleMarketingVersion);
+        Assert.Equal(ApprovedSourceCommit, request.AppleSourceCommit);
+        Assert.True(request.RequireImmutableAppleSourceSnapshot);
+        Assert.Equal(["CasaRay iOS", "CasaRay Mac"], request.AppleShipTestFlightTargets);
+        Assert.Equal(["CasaRay iOS"], request.AppleShipAppStoreTargets);
+        Assert.True(request.AppleShipReuseRemoteScreenshots);
+    }
+
+    [Fact]
+    public void AppleRelease_ShipCliRequiresExplicitSwitchForScreenshotSynchronization()
+    {
+        var request = BuildReleaseRequest(
+            ["--apple-action", "Ship", "--apple-app-store-target", "CasaRay iOS", "--apple-sync-screenshots"],
+            "/tmp/powerforge.release.json",
+            planOnly: true,
+            validateOnly: false,
+            packagesOnly: false,
+            moduleOnly: false,
+            toolsOnly: false);
+
+        Assert.False(request.AppleShipReuseRemoteScreenshots);
+    }
+
+    [Fact]
     public async Task AppleRelease_JsonRedactionPreservesPropertyNames()
     {
         var repoRoot = FindRepositoryRoot();
@@ -517,6 +559,26 @@ public sealed class PowerForgeCliAppleReleaseTests
               }
             }
             """);
+
+    private static PowerForgeReleaseRequest BuildReleaseRequest(
+        string[] arguments,
+        string configPath,
+        bool planOnly,
+        bool validateOnly,
+        bool packagesOnly,
+        bool moduleOnly,
+        bool toolsOnly)
+    {
+        var cliAssembly = System.Reflection.Assembly.LoadFrom(GetCliPath(FindRepositoryRoot()));
+        var program = cliAssembly.GetType("Program", throwOnError: true)!;
+        var method = program.GetMethod(
+            "BuildReleaseRequestFromArgs",
+            System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)
+            ?? throw new MissingMethodException(program.FullName, "BuildReleaseRequestFromArgs");
+        return (PowerForgeReleaseRequest)method.Invoke(
+            null,
+            [arguments, configPath, planOnly, validateOnly, packagesOnly, moduleOnly, toolsOnly, null])!;
+    }
 
     private static async Task<(int ExitCode, string StdOut, string StdErr)> RunCliAsync(
         string workingDirectory,

--- a/PowerForge.Tests/PowerForgeReleaseRequestMapperTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseRequestMapperTests.cs
@@ -92,6 +92,9 @@ public sealed class PowerForgeReleaseRequestMapperTests
                 AppleMarketingVersion = "1.6",
                 AppleSourceCommit = "0123456789abcdef0123456789abcdef01234567",
                 AppleExpectedPlanSha256 = "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+                AppleShipTestFlightTargets = ["CasaRay iOS", "CasaRay Mac"],
+                AppleShipAppStoreTargets = ["CasaRay iOS"],
+                AppleShipReuseRemoteScreenshots = false,
                 AppleActionConfirmed = true,
                 AppleAdoptExistingBuild = true,
                 AppleResume = false,
@@ -106,6 +109,9 @@ public sealed class PowerForgeReleaseRequestMapperTests
         Assert.Equal("0123456789abcdef0123456789abcdef01234567", request.AppleSourceCommit);
         Assert.True(request.RequireImmutableAppleSourceSnapshot);
         Assert.Equal("abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd", request.AppleExpectedPlanSha256);
+        Assert.Equal(["CasaRay iOS", "CasaRay Mac"], request.AppleShipTestFlightTargets);
+        Assert.Equal(["CasaRay iOS"], request.AppleShipAppStoreTargets);
+        Assert.False(request.AppleShipReuseRemoteScreenshots);
         Assert.True(request.AppleActionConfirmed);
         Assert.True(request.AppleAdoptExistingBuild);
         Assert.False(request.AppleResume);

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleShip.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleShip.cs
@@ -1,0 +1,696 @@
+namespace PowerForge.Tests;
+
+public sealed partial class PowerForgeReleaseServiceTests
+{
+    private const string AppleShipPlanSourceCommit = "0123456789abcdef0123456789abcdef01234567";
+
+    [Fact]
+    public void Execute_AppleShipPlan_RequiresExactSourceCommit()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.6.0", "14");
+            WriteXcodeGenVersionSource(root, "1.6.0", "14");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+            EnableInternalAppleShipTargets(spec);
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                CreateAppleAutomationService(
+                        request => CreateReleaseState(request, "VALID"),
+                        getHighestAppleBuildNumber: (_, _, _) => 13)
+                    .Execute(spec, new PowerForgeReleaseRequest
+                    {
+                        ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                        PlanOnly = true,
+                        AppleAction = PowerForgeAppleReleaseAction.Ship,
+                        AppleMarketingVersion = "1.6.0",
+                        AppleShipTestFlightTargets = ["CasaRay iOS"]
+                    }));
+
+            Assert.Contains("requires --apple-source-commit", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Theory]
+    [InlineData(AppleTestFlightPolicy.Automatic)]
+    [InlineData(AppleTestFlightPolicy.External)]
+    public void Execute_AppleShipPlan_RejectsNonInternalTestFlightPolicy(AppleTestFlightPolicy policy)
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.6.0", "14");
+            WriteXcodeGenVersionSource(root, "1.6.0", "14");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+            spec.AppleApps.Apps.Single().TestFlightPolicy = policy;
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                CreateAppleAutomationService(
+                        request => CreateReleaseState(request, "VALID"),
+                        getHighestAppleBuildNumber: (_, _, _) => 13)
+                    .Execute(spec, new PowerForgeReleaseRequest
+                    {
+                        ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                        PlanOnly = true,
+                        AppleAction = PowerForgeAppleReleaseAction.Ship,
+                        AppleMarketingVersion = "1.6.0",
+                        AppleSourceCommit = AppleShipPlanSourceCommit,
+                        AppleShipTestFlightTargets = ["CasaRay iOS"]
+                    }));
+
+            Assert.Contains("TestFlightPolicy=Internal", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public void Execute_AppleShipReleasePlan_SupportsInternalTestFlightRouteMatrix(bool includeIos, bool includeMac)
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.6.0", "14");
+            WriteXcodeGenVersionSource(root, "1.6.0", "14");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+            spec.AppleApps.Apps =
+            [
+                spec.AppleApps.Apps.Single(),
+                new AppleAppConfiguration
+                {
+                    Name = "CasaRay Mac",
+                    BundleId = "com.evotecit.casaray",
+                    Platform = ApplePlatform.macOS,
+                    ArchiveVariant = AppleArchiveVariant.MacCatalyst,
+                    ProjectPath = "CasaRay.xcodeproj",
+                    Scheme = "CasaRayMac",
+                    AppStoreConnectAppId = "6778025328"
+                }
+            ];
+            EnableInternalAppleShipTargets(spec);
+            var targets = new List<string>();
+            if (includeIos) targets.Add("CasaRay iOS");
+            if (includeMac) targets.Add("CasaRay Mac");
+
+            var result = CreateAppleAutomationService(
+                    request => CreateReleaseState(request, processingState: null),
+                    getHighestAppleBuildNumber: (_, _, _) => 13)
+                .Execute(spec, new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true,
+                    AppleAction = PowerForgeAppleReleaseAction.Ship,
+                    AppleMarketingVersion = "1.6.0",
+                    AppleSourceCommit = AppleShipPlanSourceCommit,
+                    AppleShipTestFlightTargets = targets.ToArray()
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(PowerForgeAppleShipPhase.Release, result.AppleReceipt!.ShipPhase);
+            Assert.False(result.AppleAppPlan!.PrepareDistribution);
+            Assert.False(result.AppleAppPlan.SubmitForReview);
+            Assert.False(result.AppleAppPlan.SyncScreenshots);
+            Assert.Equal(includeIos, Assert.Single(result.AppleReceipt.Targets, target => target.Platform == ApplePlatform.iOS).ShipToTestFlight);
+            Assert.Equal(includeMac, Assert.Single(result.AppleReceipt.Targets, target => target.Platform == ApplePlatform.macOS).ShipToTestFlight);
+            Assert.All(result.AppleReceipt.Targets, target => Assert.False(target.ShipToAppStoreReview));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleShipPlan_StopsAtVersionCheckpointAndBindsIntent()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.5.0", "13");
+            WriteXcodeGenVersionSource(root, "1.5.0", "13");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+            EnableInternalAppleShipTargets(spec);
+            var stateQueries = 0;
+            var service = CreateAppleAutomationService(
+                request =>
+                {
+                    stateQueries++;
+                    return CreateReleaseState(request, "VALID");
+                },
+                getHighestAppleBuildNumber: (_, _, _) => 13);
+
+            var result = service.Execute(spec, new PowerForgeReleaseRequest
+            {
+                ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                PlanOnly = true,
+                AppleAction = PowerForgeAppleReleaseAction.Ship,
+                AppleMarketingVersion = "1.6.0",
+                AppleSourceCommit = AppleShipPlanSourceCommit,
+                AppleShipTestFlightTargets = ["CasaRay iOS"]
+            });
+            var appStorePlan = service.Execute(spec, new PowerForgeReleaseRequest
+            {
+                ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                PlanOnly = true,
+                AppleAction = PowerForgeAppleReleaseAction.Ship,
+                AppleMarketingVersion = "1.6.0",
+                AppleSourceCommit = AppleShipPlanSourceCommit,
+                AppleShipAppStoreTargets = ["CasaRay iOS"]
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(PowerForgeAppleShipPhase.VersionCheckpoint, result.AppleReceipt!.ShipPhase);
+            Assert.Equal(0, stateQueries);
+            Assert.Matches("^[0-9A-F]{64}$", result.AppleReceipt.PlanSha256!);
+            Assert.NotEqual(result.AppleReceipt.PlanSha256, appStorePlan.AppleReceipt!.PlanSha256);
+            var target = Assert.Single(result.AppleReceipt.Targets);
+            Assert.True(target.ShipToTestFlight);
+            Assert.False(target.ShipToAppStoreReview);
+            Assert.Null(target.BuildId);
+            Assert.Contains(result.AppleReceipt.NextActions, action =>
+                action.Contains("review and merge", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleShipVersionCheckpoint_UpdatesSourceOnlyAfterExactConfirmation()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.5.0", "13");
+            WriteXcodeGenVersionSource(root, "1.5.0", "13");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+            EnableInternalAppleShipTargets(spec);
+            var sourceCommit = CommitAppleShipSource(root);
+            var archiveCalls = 0;
+            var uploadCalls = 0;
+            var service = CreateAppleAutomationService(
+                request => CreateReleaseState(request, "VALID"),
+                archiveAppleApp: request =>
+                {
+                    archiveCalls++;
+                    return CreateSuccessfulArchive(request);
+                },
+                uploadAppleApp: request =>
+                {
+                    uploadCalls++;
+                    return CreateSuccessfulUpload(request);
+                },
+                generateAppleProject: _ => true,
+                getHighestAppleBuildNumber: (_, _, _) => 13);
+            var request = new PowerForgeReleaseRequest
+            {
+                ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                PlanOnly = true,
+                AppleAction = PowerForgeAppleReleaseAction.Ship,
+                AppleMarketingVersion = "1.6.0",
+                AppleSourceCommit = sourceCommit,
+                AppleShipTestFlightTargets = ["CasaRay iOS"]
+            };
+            var planned = service.Execute(spec, request);
+
+            var execution = service.Execute(spec, new PowerForgeReleaseRequest
+            {
+                ConfigPath = request.ConfigPath,
+                AppleAction = PowerForgeAppleReleaseAction.Ship,
+                AppleMarketingVersion = "1.6.0",
+                AppleSourceCommit = sourceCommit,
+                AppleShipTestFlightTargets = ["CasaRay iOS"],
+                AppleExpectedPlanSha256 = planned.AppleReceipt!.PlanSha256,
+                AppleActionConfirmed = true
+            });
+
+            Assert.True(execution.Success, execution.ErrorMessage);
+            Assert.Equal(0, archiveCalls);
+            Assert.Equal(0, uploadCalls);
+            var source = new AppleReleaseVersionSourceService().Read(Path.Combine(root, "project.yml"));
+            Assert.Equal("1.6.0", source.MarketingVersion);
+            Assert.Equal("14", source.BuildNumber);
+            Assert.Equal(PowerForgeAppleShipPhase.VersionCheckpoint, execution.AppleReceipt!.ShipPhase);
+            Assert.All(execution.AppleReceipt.Targets, target =>
+            {
+                Assert.False(target.ArchiveCreated);
+                Assert.False(target.UploadPerformed);
+            });
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleShipVersionCheckpoint_RejectsCheckoutThatMovedAfterApproval()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.5.0", "13");
+            WriteXcodeGenVersionSource(root, "1.5.0", "13");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+            EnableInternalAppleShipTargets(spec);
+            var approvedSourceCommit = CommitAppleShipSource(root);
+            var service = CreateAppleAutomationService(
+                request => CreateReleaseState(request, "VALID"),
+                generateAppleProject: _ => true,
+                getHighestAppleBuildNumber: (_, _, _) => 13);
+            var request = new PowerForgeReleaseRequest
+            {
+                ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                PlanOnly = true,
+                AppleAction = PowerForgeAppleReleaseAction.Ship,
+                AppleMarketingVersion = "1.6.0",
+                AppleSourceCommit = approvedSourceCommit,
+                AppleShipTestFlightTargets = ["CasaRay iOS"]
+            };
+            var planned = service.Execute(spec, request);
+
+            RunSnapshotGit(root, "commit", "--quiet", "--allow-empty", "-m", "move checkout after approval");
+
+            var execution = service.Execute(spec, new PowerForgeReleaseRequest
+            {
+                ConfigPath = request.ConfigPath,
+                AppleAction = PowerForgeAppleReleaseAction.Ship,
+                AppleMarketingVersion = "1.6.0",
+                AppleSourceCommit = approvedSourceCommit,
+                AppleShipTestFlightTargets = ["CasaRay iOS"],
+                AppleExpectedPlanSha256 = planned.AppleReceipt!.PlanSha256,
+                AppleActionConfirmed = true
+            });
+
+            Assert.False(execution.Success);
+            Assert.Contains("instead of the approved commit", execution.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+            var source = new AppleReleaseVersionSourceService().Read(Path.Combine(root, "project.yml"));
+            Assert.Equal("1.5.0", source.MarketingVersion);
+            Assert.Equal("13", source.BuildNumber);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleShipReleasePlan_SupportsIosStoreAndMacBetaWithoutMacStorePreparation()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.6.0", "14");
+            WriteXcodeGenVersionSource(root, "1.6.0", "14");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+            spec.AppleApps.Apps =
+            [
+                spec.AppleApps.Apps.Single(),
+                new AppleAppConfiguration
+                {
+                    Name = "CasaRay Mac",
+                    BundleId = "com.evotecit.casaray",
+                    Platform = ApplePlatform.macOS,
+                    ArchiveVariant = AppleArchiveVariant.MacCatalyst,
+                    ProjectPath = "CasaRay.xcodeproj",
+                    Scheme = "CasaRay",
+                    AppStoreConnectAppId = "6778025328"
+                }
+            ];
+            EnableInternalAppleShipTargets(spec);
+            var readinessPlatforms = new List<ApplePlatform>();
+            var service = CreateAppleAutomationService(
+                request => CreateReleaseState(request, "VALID"),
+                getHighestAppleBuildNumber: (_, _, _) => 13,
+                checkAppleReleaseReadiness: (_, request) =>
+                {
+                    readinessPlatforms.Add(request.Platform);
+                    return CreateReadyReleaseReadiness(request);
+                });
+
+            var result = service.Execute(spec, new PowerForgeReleaseRequest
+            {
+                ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                PlanOnly = true,
+                AppleAction = PowerForgeAppleReleaseAction.Ship,
+                AppleMarketingVersion = "1.6.0",
+                AppleSourceCommit = AppleShipPlanSourceCommit,
+                AppleShipTestFlightTargets = ["CasaRay Mac"],
+                AppleShipAppStoreTargets = ["CasaRay iOS"]
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(PowerForgeAppleShipPhase.Release, result.AppleReceipt!.ShipPhase);
+            Assert.False(result.AppleAppPlan!.SyncScreenshots);
+            Assert.Empty(result.AppleAppPlan.TestFlightBetaGroupIds);
+            Assert.Empty(result.AppleAppPlan.TestFlightBetaGroupNames);
+            Assert.Empty(result.AppleAppPlan.TestFlightTesterEmails);
+            Assert.Equal([ApplePlatform.iOS], readinessPlatforms);
+            var ios = Assert.Single(result.AppleReceipt.Targets, target => target.Platform == ApplePlatform.iOS);
+            Assert.True(ios.ShipToAppStoreReview);
+            Assert.False(ios.ShipToTestFlight);
+            Assert.True(ios.ReadinessChecked);
+            var mac = Assert.Single(result.AppleReceipt.Targets, target => target.Platform == ApplePlatform.macOS);
+            Assert.True(mac.ShipToTestFlight);
+            Assert.False(mac.ShipToAppStoreReview);
+            Assert.False(mac.ReadinessChecked);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleShipRelease_RunsStoreStepsOnlyForExplicitAppStoreTargets()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.6.0", "14");
+            WriteXcodeGenVersionSource(root, "1.6.0", "14");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+            spec.AppleApps.Automation.MinimumFreeSpaceGB = 0;
+            spec.AppleApps.Automation.CleanupBeforeArchive = false;
+            spec.AppleApps.Automation.CleanupAfterProcessing = false;
+            spec.AppleApps.Automation.WaitForProcessing = false;
+            spec.AppleApps.Apps =
+            [
+                spec.AppleApps.Apps.Single(),
+                new AppleAppConfiguration
+                {
+                    Name = "CasaRay Mac",
+                    BundleId = "com.evotecit.casaray",
+                    Platform = ApplePlatform.macOS,
+                    ArchiveVariant = AppleArchiveVariant.MacCatalyst,
+                    ProjectPath = "CasaRay.xcodeproj",
+                    Scheme = "CasaRayMac",
+                    AppStoreConnectAppId = "6778025328"
+                }
+            ];
+            EnableInternalAppleShipTargets(spec);
+            var sourceCommit = CommitAppleShipSource(root);
+            var archived = new List<string>();
+            var uploaded = new List<string>();
+            var prepared = new List<ApplePlatform>();
+            var submitted = new List<ApplePlatform>();
+            var uploadCompleted = false;
+            var service = CreateAppleAutomationService(
+                request => CreateReleaseState(request, uploadCompleted ? "VALID" : null),
+                archiveAppleApp: request =>
+                {
+                    archived.Add(request.Scheme!);
+                    return CreateSuccessfulArchive(request);
+                },
+                uploadAppleApp: request =>
+                {
+                    uploaded.Add(request.BundleId! + ":" + request.ArchivePath);
+                    if (uploaded.Count == 2)
+                        uploadCompleted = true;
+                    return CreateSuccessfulUpload(request);
+                },
+                prepareAppleDistribution: request =>
+                {
+                    prepared.Add(request.Platform);
+                    return CreateSuccessfulPreparation(request);
+                },
+                generateAppleProject: _ => true,
+                getHighestAppleBuildNumber: (_, _, _) => 13,
+                submitAppleReview: request =>
+                {
+                    submitted.Add(request.Platform);
+                    return new AppStoreConnectReviewSubmissionResult
+                    {
+                        AppId = request.AppId,
+                        VersionString = request.VersionString,
+                        BuildNumber = request.BuildNumber,
+                        Platform = request.Platform
+                    };
+                },
+                checkAppleReleaseReadiness: (_, request) => CreateReadyReleaseReadiness(request));
+            var request = new PowerForgeReleaseRequest
+            {
+                ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                PlanOnly = true,
+                AppleAction = PowerForgeAppleReleaseAction.Ship,
+                AppleMarketingVersion = "1.6.0",
+                AppleSourceCommit = sourceCommit,
+                AppleShipTestFlightTargets = ["CasaRay Mac"],
+                AppleShipAppStoreTargets = ["CasaRay iOS"]
+            };
+            var planned = service.Execute(spec, request);
+
+            var execution = service.Execute(spec, new PowerForgeReleaseRequest
+            {
+                ConfigPath = request.ConfigPath,
+                AppleAction = PowerForgeAppleReleaseAction.Ship,
+                AppleMarketingVersion = "1.6.0",
+                AppleSourceCommit = sourceCommit,
+                AppleShipTestFlightTargets = ["CasaRay Mac"],
+                AppleShipAppStoreTargets = ["CasaRay iOS"],
+                AppleExpectedPlanSha256 = planned.AppleReceipt!.PlanSha256,
+                AppleActionConfirmed = true
+            });
+
+            Assert.True(execution.Success, execution.ErrorMessage);
+            Assert.Equal(2, archived.Count);
+            Assert.Equal(2, uploaded.Count);
+            Assert.Equal([ApplePlatform.iOS], prepared);
+            Assert.Equal([ApplePlatform.iOS], submitted);
+            var mac = Assert.Single(execution.AppleReceipt!.Targets, target => target.Platform == ApplePlatform.macOS);
+            Assert.Null(mac.AppReviewSubmissionId);
+            Assert.True(mac.UploadPerformed);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleShipRelease_ResumesItsAttestedUploadWithOriginalIntentHash()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.6.0", "14");
+            WriteXcodeGenVersionSource(root, "1.6.0", "14");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+            spec.AppleApps.Automation.MinimumFreeSpaceGB = 0;
+            spec.AppleApps.Automation.CleanupBeforeArchive = false;
+            spec.AppleApps.Automation.CleanupAfterProcessing = false;
+            spec.AppleApps.Automation.WaitForProcessing = false;
+            EnableInternalAppleShipTargets(spec);
+            var sourceCommit = CommitAppleShipSource(root);
+            var uploaded = false;
+            var planRequest = new PowerForgeReleaseRequest
+            {
+                ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                PlanOnly = true,
+                AppleAction = PowerForgeAppleReleaseAction.Ship,
+                AppleMarketingVersion = "1.6.0",
+                AppleSourceCommit = sourceCommit,
+                AppleShipAppStoreTargets = ["CasaRay iOS"]
+            };
+            var initialService = CreateAppleAutomationService(
+                request => CreateReleaseState(request, uploaded ? "VALID" : null),
+                archiveAppleApp: CreateSuccessfulArchive,
+                uploadAppleApp: request =>
+                {
+                    uploaded = true;
+                    var result = CreateSuccessfulUpload(request);
+                    result.BuildUploadId = "ship-upload-14";
+                    return result;
+                },
+                prepareAppleDistribution: _ => throw new InvalidOperationException("simulated interruption after upload"),
+                generateAppleProject: _ => true,
+                getHighestAppleBuildNumber: (_, _, _) => uploaded ? 14 : 13,
+                checkAppleReleaseReadiness: (_, request) => CreateReadyReleaseReadiness(request));
+            var planned = initialService.Execute(spec, planRequest);
+
+            var interrupted = initialService.Execute(spec, new PowerForgeReleaseRequest
+            {
+                ConfigPath = planRequest.ConfigPath,
+                AppleAction = PowerForgeAppleReleaseAction.Ship,
+                AppleMarketingVersion = "1.6.0",
+                AppleSourceCommit = sourceCommit,
+                AppleShipAppStoreTargets = ["CasaRay iOS"],
+                AppleExpectedPlanSha256 = planned.AppleReceipt!.PlanSha256,
+                AppleActionConfirmed = true,
+                AppleWaitForProcessing = false
+            });
+
+            Assert.False(interrupted.Success);
+            Assert.Contains("simulated interruption", interrupted.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(
+                new AppleReleaseReceiptStore().ReadAll(interrupted.AppleAppPlan!),
+                receipt => receipt.OperationPhase == "UploadAttested" &&
+                           string.Equals(receipt.PlanSha256, planned.AppleReceipt.PlanSha256, StringComparison.OrdinalIgnoreCase));
+
+            var archiveCalls = 0;
+            var uploadCalls = 0;
+            var prepareCalls = 0;
+            var submitCalls = 0;
+            var resumedService = CreateAppleAutomationService(
+                request => CreateReleaseState(request, "VALID"),
+                archiveAppleApp: request =>
+                {
+                    archiveCalls++;
+                    return CreateSuccessfulArchive(request);
+                },
+                uploadAppleApp: request =>
+                {
+                    uploadCalls++;
+                    return CreateSuccessfulUpload(request);
+                },
+                prepareAppleDistribution: request =>
+                {
+                    prepareCalls++;
+                    return CreateSuccessfulPreparation(request);
+                },
+                generateAppleProject: _ => true,
+                getHighestAppleBuildNumber: (_, _, _) => 14,
+                getAppleBuildUpload: (_, id) => new AppStoreConnectBuildUploadInfo
+                {
+                    Id = id,
+                    State = "COMPLETE",
+                    MarketingVersion = "1.6.0",
+                    BuildNumber = "14",
+                    Platform = "IOS"
+                },
+                submitAppleReview: request =>
+                {
+                    submitCalls++;
+                    return new AppStoreConnectReviewSubmissionResult
+                    {
+                        AppId = request.AppId,
+                        VersionString = request.VersionString,
+                        BuildNumber = request.BuildNumber,
+                        Platform = request.Platform
+                    };
+                },
+                checkAppleReleaseReadiness: (_, request) => CreateReadyReleaseReadiness(request));
+            planRequest.AppleExpectedPlanSha256 = planned.AppleReceipt.PlanSha256;
+            var resumedPlan = resumedService.Execute(spec, planRequest);
+
+            Assert.Equal(planned.AppleReceipt.PlanSha256, resumedPlan.AppleReceipt!.PlanSha256);
+            var resumed = resumedService.Execute(spec, new PowerForgeReleaseRequest
+            {
+                ConfigPath = planRequest.ConfigPath,
+                AppleAction = PowerForgeAppleReleaseAction.Ship,
+                AppleMarketingVersion = "1.6.0",
+                AppleSourceCommit = sourceCommit,
+                AppleShipAppStoreTargets = ["CasaRay iOS"],
+                AppleExpectedPlanSha256 = planned.AppleReceipt.PlanSha256,
+                AppleActionConfirmed = true,
+                AppleWaitForProcessing = false
+            });
+
+            Assert.True(resumed.Success, resumed.ErrorMessage);
+            Assert.Equal(0, archiveCalls);
+            Assert.Equal(0, uploadCalls);
+            Assert.Equal(1, prepareCalls);
+            Assert.Equal(1, submitCalls);
+            Assert.True(Assert.Single(resumed.AppleApps).ResumedExistingBuild);
+            Assert.False(Assert.Single(resumed.AppleApps).AdoptedExistingBuild);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleShipPlan_RejectsUnknownRouteTarget()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.5.0", "13");
+            WriteXcodeGenVersionSource(root, "1.5.0", "13");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+            EnableInternalAppleShipTargets(spec);
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                CreateAppleAutomationService(
+                        request => CreateReleaseState(request, "VALID"),
+                        getHighestAppleBuildNumber: (_, _, _) => 13)
+                    .Execute(spec, new PowerForgeReleaseRequest
+                    {
+                        ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                        PlanOnly = true,
+                        AppleAction = PowerForgeAppleReleaseAction.Ship,
+                        AppleMarketingVersion = "1.6.0",
+                        AppleSourceCommit = AppleShipPlanSourceCommit,
+                        AppleShipTestFlightTargets = ["Missing target"]
+                    }));
+
+            Assert.Contains("Unknown Apple Ship internal TestFlight target", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    private static void EnableInternalAppleShipTargets(PowerForgeReleaseSpec spec)
+    {
+        foreach (var app in spec.AppleApps!.Apps.Where(static app =>
+                     app.DistributionRoute is AppleDistributionRoute.AppStore or AppleDistributionRoute.TestFlightOnly))
+        {
+            app.TestFlightPolicy = AppleTestFlightPolicy.Internal;
+        }
+    }
+
+    private static string CommitAppleShipSource(string root)
+    {
+        File.WriteAllText(Path.Combine(root, ".gitignore"), "build/\n");
+        RunSnapshotGit(root, "init", "--quiet");
+        RunSnapshotGit(root, "config", "user.name", "PowerForge Tests");
+        RunSnapshotGit(root, "config", "user.email", "powerforge-tests@example.invalid");
+        RunSnapshotGit(root, "add", ".");
+        RunSnapshotGit(root, "commit", "--quiet", "-m", "exact Apple Ship source");
+        return RunSnapshotGit(root, "rev-parse", "HEAD").Trim();
+    }
+}

--- a/PowerForge/Models/AppStoreConnectAppInfoMetadataModels.cs
+++ b/PowerForge/Models/AppStoreConnectAppInfoMetadataModels.cs
@@ -96,7 +96,7 @@ public sealed class AppStoreConnectAppInfoMetadataSyncRequest
 /// </summary>
 public sealed class AppStoreConnectAppInfoMetadataSyncResult
 {
-    /// <summary>Matched editable App Information resource.</summary>
+    /// <summary>Matched editable resource, or one locked resource retained after convergence was proven.</summary>
     public AppStoreConnectAppInformationInfo AppInfo { get; set; } = new();
 
     /// <summary>Localization before the metadata update.</summary>

--- a/PowerForge/Models/PowerForgeAppleReleaseAutomation.cs
+++ b/PowerForge/Models/PowerForgeAppleReleaseAutomation.cs
@@ -51,7 +51,20 @@ public enum PowerForgeAppleReleaseAction
     Cleanup,
 
     /// <summary>Create signed archives and complete local export validation without uploading or notarizing them.</summary>
-    Rehearse
+    Rehearse,
+
+    /// <summary>Execute one reviewed, resumable TestFlight and App Store Review shipping intent.</summary>
+    Ship
+}
+
+/// <summary>Current durable phase of one Apple Ship intent.</summary>
+public enum PowerForgeAppleShipPhase
+{
+    /// <summary>The checked-in Apple version source must be updated, reviewed, and merged before shipping resumes.</summary>
+    VersionCheckpoint,
+
+    /// <summary>The exact merged source can be archived, uploaded, prepared, and submitted according to the target routes.</summary>
+    Release
 }
 
 /// <summary>
@@ -160,7 +173,10 @@ internal sealed class PowerForgeAppleReleaseReceipt
 
     public DateTimeOffset CheckedAt { get; set; } = DateTimeOffset.UtcNow;
 
-    /// <summary>SHA-256 binding the stable action, source, target, and observed Apple state represented by a plan.</summary>
+    /// <summary>
+    /// SHA-256 binding the approved action. Ship binds a durable exact-source intent that remains stable
+    /// while its own attested remote operations progress; other actions also bind observed Apple state.
+    /// </summary>
     public string? PlanSha256 { get; set; }
 
     /// <summary>Canonical SHA-256 of effective mutation flags and every local payload consumed by this plan.</summary>
@@ -189,6 +205,9 @@ internal sealed class PowerForgeAppleReleaseReceipt
 
     /// <summary>True when the operator explicitly authorized recovery after independently verifying the remote Apple operation.</summary>
     public bool AdoptExistingBuild { get; set; }
+
+    /// <summary>Current phase when Action is Ship.</summary>
+    public PowerForgeAppleShipPhase? ShipPhase { get; set; }
 
     public PowerForgeAppleVersionReceipt? Versioning { get; set; }
 
@@ -273,6 +292,12 @@ internal sealed class PowerForgeAppleReleaseTargetReceipt
     public string[] Capabilities { get; set; } = Array.Empty<string>();
 
     public AppleTestFlightPolicy TestFlightPolicy { get; set; }
+
+    /// <summary>True when this target is included in the Ship internal-TestFlight intent.</summary>
+    public bool ShipToTestFlight { get; set; }
+
+    /// <summary>True when this target is included in the Ship App Store Review intent.</summary>
+    public bool ShipToAppStoreReview { get; set; }
 
     public string? AppId { get; set; }
 

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -243,6 +243,15 @@ internal sealed class PowerForgeReleaseRequest
 
     public string? AppleExpectedPlanSha256 { get; set; }
 
+    /// <summary>Stable target names or schemes that should receive the build through internal TestFlight.</summary>
+    public string[] AppleShipTestFlightTargets { get; set; } = Array.Empty<string>();
+
+    /// <summary>Stable target names or schemes that should be submitted to App Store Review.</summary>
+    public string[] AppleShipAppStoreTargets { get; set; } = Array.Empty<string>();
+
+    /// <summary>Reuse already-delivered remote screenshots instead of publishing local screenshot bytes.</summary>
+    public bool AppleShipReuseRemoteScreenshots { get; set; } = true;
+
     /// <summary>Checkpoint-only archive hashes keyed by stable Apple target name.</summary>
     internal Dictionary<string, string> AppleExpectedArchiveSha256ByTarget { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
@@ -554,7 +563,21 @@ internal sealed class PowerForgeAppleReleasePlan
 
     public bool RequireImmutableSourceSnapshot { get; set; }
 
+    /// <summary>Reviewed Ship intent hash supplied for execution or recovery.</summary>
+    internal string? ApprovedPlanSha256 { get; set; }
+
+    /// <summary>Version identity bound by the reviewed Ship intent.</summary>
+    internal PowerForgeAppleVersionReceipt? ApprovedVersioning { get; set; }
+
     public bool AdoptExistingBuild { get; set; }
+
+    public PowerForgeAppleShipPhase? ShipPhase { get; set; }
+
+    public string[] ShipTestFlightTargets { get; set; } = Array.Empty<string>();
+
+    public string[] ShipAppStoreTargets { get; set; } = Array.Empty<string>();
+
+    public bool ShipReuseRemoteScreenshots { get; set; } = true;
 
     public bool Archive { get; set; }
 
@@ -673,6 +696,10 @@ internal sealed class PowerForgeAppleAppReleaseTargetPlan
     public string[] Capabilities { get; set; } = Array.Empty<string>();
 
     public AppleTestFlightPolicy TestFlightPolicy { get; set; } = AppleTestFlightPolicy.Automatic;
+
+    public bool ShipToTestFlight { get; set; }
+
+    public bool ShipToAppStoreReview { get; set; }
 
     public string[] RequiredEmbeddedBundleIds { get; set; } = Array.Empty<string>();
 

--- a/PowerForge/Services/AppStoreConnectAppInfoMetadataSyncService.cs
+++ b/PowerForge/Services/AppStoreConnectAppInfoMetadataSyncService.cs
@@ -27,7 +27,8 @@ public sealed class AppStoreConnectAppInfoMetadataSyncService
     }
 
     /// <summary>
-    /// Applies localized metadata to the editable App Information localization for an app.
+    /// Applies localized metadata to the editable App Information localization for an app,
+    /// or proves that every locked resource already matches without issuing a mutation.
     /// </summary>
     public async Task<AppStoreConnectAppInfoMetadataSyncResult> SyncAsync(
         AppStoreConnectAppInfoMetadataSyncRequest request,
@@ -41,33 +42,36 @@ public sealed class AppStoreConnectAppInfoMetadataSyncService
         if (string.IsNullOrWhiteSpace(spec.Locale))
             throw new ArgumentException("Spec.Locale is required.", nameof(request));
 
-        var appInfo = await ResolveAppInfoAsync(spec, cancellationToken).ConfigureAwait(false);
-        var localization = (await _client.GetAppInfoLocalizationsAsync(
-            appInfo.Id,
-            spec.Locale,
-            limit: 10,
-            cancellationToken).ConfigureAwait(false)).FirstOrDefault()
-            ?? throw new InvalidOperationException($"App Information localization '{spec.Locale}' was not found for resource '{appInfo.Id}'.");
+        var appInfos = await _client.GetAppInfosAsync(spec.AppId, limit: 50, cancellationToken).ConfigureAwait(false);
+        var appInfo = ResolveAppInfo(spec, appInfos);
+        var localizations = await LoadAppInfoLocalizationsAsync(spec, appInfos, cancellationToken).ConfigureAwait(false);
+        AssertLockedAppInfoConverged(spec, appInfos, localizations);
+        if (appInfo is null)
+            return CreateConvergedResult(appInfos, localizations);
 
-        var updated = await _client.UpdateAppInfoLocalizationAsync(
-            localization.Id,
-            spec.Metadata,
-            cancellationToken).ConfigureAwait(false);
+        var localization = localizations[appInfo.Id];
+
+        var updatedFields = GetChangedFields(localization, spec.Metadata);
+        var updated = updatedFields.Length == 0
+            ? localization
+            : await _client.UpdateAppInfoLocalizationAsync(
+                localization.Id,
+                spec.Metadata,
+                cancellationToken).ConfigureAwait(false);
 
         return new AppStoreConnectAppInfoMetadataSyncResult
         {
             AppInfo = appInfo,
             Before = localization,
             After = updated,
-            UpdatedFields = AppStoreConnectClient.GetSuppliedAppInfoLocalizationFields(spec.Metadata)
+            UpdatedFields = updatedFields
         };
     }
 
-    private async Task<AppStoreConnectAppInformationInfo> ResolveAppInfoAsync(
+    private static AppStoreConnectAppInformationInfo? ResolveAppInfo(
         AppStoreConnectAppInfoMetadataSpec spec,
-        CancellationToken cancellationToken)
+        AppStoreConnectAppInformationInfo[] appInfos)
     {
-        var appInfos = await _client.GetAppInfosAsync(spec.AppId, limit: 50, cancellationToken).ConfigureAwait(false);
         if (!string.IsNullOrWhiteSpace(spec.AppInfoId))
         {
             var requestedAppInfoId = spec.AppInfoId!.Trim();
@@ -81,11 +85,94 @@ public sealed class AppStoreConnectAppInfoMetadataSyncService
         if (appInfos.Length == 1 && string.IsNullOrWhiteSpace(GetState(appInfos[0])))
             return appInfos[0];
 
+        return null;
+    }
+
+    private async Task<Dictionary<string, AppStoreConnectAppInfoLocalizationInfo>> LoadAppInfoLocalizationsAsync(
+        AppStoreConnectAppInfoMetadataSpec spec,
+        AppStoreConnectAppInformationInfo[] appInfos,
+        CancellationToken cancellationToken)
+    {
+        var localizations = new Dictionary<string, AppStoreConnectAppInfoLocalizationInfo>(StringComparer.OrdinalIgnoreCase);
+        foreach (var appInfo in appInfos)
+        {
+            var localization = (await _client.GetAppInfoLocalizationsAsync(
+                    appInfo.Id,
+                    spec.Locale,
+                    limit: 10,
+                    cancellationToken)
+                .ConfigureAwait(false))
+                .FirstOrDefault();
+            if (localization is null)
+            {
+                throw new InvalidOperationException(
+                    $"App Information localization '{spec.Locale}' was not found for resource '{appInfo.Id}'.");
+            }
+            localizations.Add(appInfo.Id, localization);
+        }
+        return localizations;
+    }
+
+    private static void AssertLockedAppInfoConverged(
+        AppStoreConnectAppInfoMetadataSpec spec,
+        AppStoreConnectAppInformationInfo[] appInfos,
+        IReadOnlyDictionary<string, AppStoreConnectAppInfoLocalizationInfo> localizations)
+    {
+        if (appInfos.Length == 0)
+            throw CreateNoEditableAppInfoException(spec.AppId, appInfos);
+
+        var mismatched = appInfos
+            .Where(appInfo => !IsEditable(appInfo))
+            .Where(appInfo => GetChangedFields(localizations[appInfo.Id], spec.Metadata).Length > 0)
+            .ToArray();
+        if (mismatched.Length > 0)
+            throw CreateNoEditableAppInfoException(spec.AppId, appInfos);
+    }
+
+    private static AppStoreConnectAppInfoMetadataSyncResult CreateConvergedResult(
+        AppStoreConnectAppInformationInfo[] appInfos,
+        IReadOnlyDictionary<string, AppStoreConnectAppInfoLocalizationInfo> localizations)
+    {
+        var retained = appInfos[0];
+        var localization = localizations[retained.Id];
+        return new AppStoreConnectAppInfoMetadataSyncResult
+        {
+            AppInfo = retained,
+            Before = localization,
+            After = localization,
+            UpdatedFields = Array.Empty<string>()
+        };
+    }
+
+    private static InvalidOperationException CreateNoEditableAppInfoException(
+        string appId,
+        AppStoreConnectAppInformationInfo[] appInfos)
+    {
+
         var states = appInfos.Length == 0
             ? "none"
             : string.Join(", ", appInfos.Select(info => GetState(info) ?? "unknown"));
-        throw new InvalidOperationException(
-            $"No editable App Information resource was found for app '{spec.AppId}'. Current states: {states}. Create a new App Store version or provide AppInfoId explicitly.");
+        return new InvalidOperationException(
+            $"App Information metadata cannot converge for app '{appId}' because one or more locked resources do not already match the requested metadata. Current states: {states}. Align the locked resources before applying shared App Information changes.");
+    }
+
+    private static string[] GetChangedFields(
+        AppStoreConnectAppInfoLocalizationInfo current,
+        AppStoreConnectAppInfoLocalizationUpdate desired)
+    {
+        var changed = new List<string>();
+        AddChanged(changed, "name", desired.Name, current.Name);
+        AddChanged(changed, "subtitle", desired.Subtitle, current.Subtitle);
+        AddChanged(changed, "privacyPolicyUrl", desired.PrivacyPolicyUrl, current.PrivacyPolicyUrl);
+        AddChanged(changed, "privacyChoicesUrl", desired.PrivacyChoicesUrl, current.PrivacyChoicesUrl);
+        AddChanged(changed, "privacyPolicyText", desired.PrivacyPolicyText, current.PrivacyPolicyText);
+        return changed.ToArray();
+    }
+
+    private static void AddChanged(List<string> changed, string field, string? desired, string? current)
+    {
+        if (desired is not null && !string.Equals(desired, current, StringComparison.Ordinal))
+            changed.Add(field);
     }
 
     private static bool IsEditable(AppStoreConnectAppInformationInfo appInfo)

--- a/PowerForge/Services/AppleReleaseSourceSnapshot.cs
+++ b/PowerForge/Services/AppleReleaseSourceSnapshot.cs
@@ -39,6 +39,14 @@ internal sealed class AppleReleaseSourceSnapshot : IDisposable
 
     internal string RootPath { get; }
 
+    internal static void ValidateCurrentSourceIfRequired(PowerForgeAppleReleasePlan plan)
+    {
+        if (!plan.RequireImmutableSourceSnapshot || string.IsNullOrWhiteSpace(plan.SourceCommit))
+            return;
+
+        ValidateCurrentSource(plan);
+    }
+
     internal static AppleReleaseSourceSnapshot? CreateIfRequired(PowerForgeAppleReleasePlan plan)
     {
         if (!plan.RequireImmutableSourceSnapshot || string.IsNullOrWhiteSpace(plan.SourceCommit))

--- a/PowerForge/Services/PowerForgeReleaseService.AppleAutomation.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleAutomation.cs
@@ -115,6 +115,21 @@ internal sealed partial class PowerForgeReleaseService
                     (options.TestFlightBetaGroupIds?.Length ?? 0) > 0 ||
                     (options.TestFlightBetaGroupNames?.Length ?? 0) > 0;
                 break;
+            case PowerForgeAppleReleaseAction.Ship:
+                options.Archive = true;
+                options.Upload = true;
+                options.PrepareDistribution = true;
+                options.SelectBuildForDistribution = true;
+                options.SyncMetadata = HasConfiguredPath(options.MetadataConfigPath, options.MetadataConfigPaths);
+                options.SyncAppInfo = HasConfiguredPath(options.AppInfoConfigPath, options.AppInfoConfigPaths);
+                options.SyncScreenshots = !request.AppleShipReuseRemoteScreenshots;
+                options.CheckReleaseReadiness = true;
+                options.CheckGovernance = hasGovernanceConfig;
+                options.DistributeTestFlight =
+                    (options.TestFlightBetaGroupIds?.Length ?? 0) > 0 ||
+                    (options.TestFlightBetaGroupNames?.Length ?? 0) > 0;
+                options.SubmitForReview = true;
+                break;
             case PowerForgeAppleReleaseAction.SubmitTestFlightReview:
                 options.SubmitTestFlightBetaReview = true;
                 break;
@@ -139,6 +154,7 @@ internal sealed partial class PowerForgeReleaseService
              (options.SyncScreenshots && options.ReplaceScreenshots))) ||
            action == PowerForgeAppleReleaseAction.SubmitTestFlightReview ||
            action == PowerForgeAppleReleaseAction.Advance ||
+           action == PowerForgeAppleReleaseAction.Ship ||
            action == PowerForgeAppleReleaseAction.Version ||
            action == PowerForgeAppleReleaseAction.SubmitAppReview ||
            action == PowerForgeAppleReleaseAction.Release ||
@@ -151,7 +167,8 @@ internal sealed partial class PowerForgeReleaseService
     private static bool IsUploadAction(PowerForgeAppleReleaseAction action)
         => action == PowerForgeAppleReleaseAction.Upload ||
            action == PowerForgeAppleReleaseAction.UploadExisting ||
-           action == PowerForgeAppleReleaseAction.Advance;
+           action == PowerForgeAppleReleaseAction.Advance ||
+           action == PowerForgeAppleReleaseAction.Ship;
 
     private static bool IsUploadExecution(PowerForgeAppleReleasePlan plan)
         => IsUploadAction(plan.Action) ||
@@ -190,6 +207,7 @@ internal sealed partial class PowerForgeReleaseService
             PowerForgeAppleReleaseAction.Status or
             PowerForgeAppleReleaseAction.Doctor => UsesAppStoreConnect(app),
             PowerForgeAppleReleaseAction.TestFlight => UsesTestFlight(app),
+            PowerForgeAppleReleaseAction.Ship => IsAppleShipTarget(app),
             PowerForgeAppleReleaseAction.SubmitTestFlightReview => UsesExternalTestFlight(app),
             PowerForgeAppleReleaseAction.Prepare or
             PowerForgeAppleReleaseAction.Screenshots or
@@ -208,6 +226,7 @@ internal sealed partial class PowerForgeReleaseService
             PowerForgeAppleReleaseAction.Screenshots or
             PowerForgeAppleReleaseAction.TestFlight or
             PowerForgeAppleReleaseAction.Advance or
+            PowerForgeAppleReleaseAction.Ship or
             PowerForgeAppleReleaseAction.SubmitTestFlightReview or
             PowerForgeAppleReleaseAction.SubmitAppReview or
             PowerForgeAppleReleaseAction.Release;
@@ -215,6 +234,7 @@ internal sealed partial class PowerForgeReleaseService
     private static bool RequiresAppleReleaseIdentity(PowerForgeAppleReleasePlan plan)
         => plan.Action == PowerForgeAppleReleaseAction.Status ||
            plan.Action == PowerForgeAppleReleaseAction.Doctor ||
+           plan.Action == PowerForgeAppleReleaseAction.Ship ||
            IsUploadExecution(plan) ||
            plan.PrepareDistribution ||
            plan.SyncScreenshots ||
@@ -418,9 +438,12 @@ internal sealed partial class PowerForgeReleaseService
         var remoteAction = plan.Action != PowerForgeAppleReleaseAction.Archive &&
                            plan.Action != PowerForgeAppleReleaseAction.Rehearse &&
                            plan.Action != PowerForgeAppleReleaseAction.Version &&
-                           plan.Action != PowerForgeAppleReleaseAction.Cleanup;
+                           plan.Action != PowerForgeAppleReleaseAction.Cleanup &&
+                           plan.ShipPhase != PowerForgeAppleShipPhase.VersionCheckpoint;
         var refreshSuccessfulMutation = HasAppleReleaseStateMutation(plan);
-        foreach (var app in plan.Apps.Where(UsesAppStoreConnect))
+        foreach (var app in plan.Apps.Where(app =>
+                     UsesAppStoreConnect(app) &&
+                     ShouldExecuteAppleTarget(plan.Action, app)))
         {
             if (!resultByName.TryGetValue(app.Name, out var result))
                 continue;
@@ -588,6 +611,8 @@ internal sealed partial class PowerForgeReleaseService
                 ParentTarget = app.ParentTarget,
                 Capabilities = app.Capabilities,
                 TestFlightPolicy = app.TestFlightPolicy,
+                ShipToTestFlight = app.ShipToTestFlight,
+                ShipToAppStoreReview = app.ShipToAppStoreReview,
                 AppId = app.AppStoreConnectAppId,
                 AppIdDiscovered = app.AppStoreConnectAppIdDiscovered,
                 Version = state?.VersionString ?? values.MarketingVersion,
@@ -670,7 +695,9 @@ internal sealed partial class PowerForgeReleaseService
             AttemptId = attemptId,
             Action = plan.Action,
             SourceCommit = plan.SourceCommit,
+            PlanSha256 = plan.ApprovedPlanSha256,
             AdoptExistingBuild = plan.AdoptExistingBuild,
+            ShipPhase = plan.ShipPhase,
             PlanOnly = false,
             OperationPhase = "Completed",
             CheckedAt = DateTimeOffset.UtcNow,
@@ -683,7 +710,7 @@ internal sealed partial class PowerForgeReleaseService
                     ? null
                     : string.Join(" ", doctorErrors.Select(static diagnostic => diagnostic.Summary)),
             ReceiptPath = FrameworkCompatibility.GetRelativePath(plan.ProjectRoot, plan.ReceiptPath).Replace('\\', '/'),
-            Versioning = versioning,
+            Versioning = versioning ?? plan.ApprovedVersioning,
             Targets = targets,
             Cleanup = cleanup,
             Diagnostics = targets.SelectMany(static target => target.Diagnostics).ToArray(),

--- a/PowerForge/Services/PowerForgeReleaseService.AppleDurability.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleDurability.cs
@@ -16,8 +16,10 @@ internal sealed partial class PowerForgeReleaseService
         _appleReceiptStore.WriteAttempt(plan, new PowerForgeAppleReleaseReceipt
         {
             Action = plan.Action,
+            ShipPhase = plan.ShipPhase,
             SourceCommit = plan.SourceCommit,
-            PlanSha256 = expectedPlanSha256,
+            PlanSha256 = plan.ApprovedPlanSha256 ?? expectedPlanSha256,
+            Versioning = plan.ApprovedVersioning,
             OperationPhase = "Started",
             Success = false,
             ErrorMessage = "Apple release operation started; inspect later receipts and remote state before retrying.",
@@ -46,7 +48,10 @@ internal sealed partial class PowerForgeReleaseService
         {
             AttemptId = attemptId,
             Action = plan.Action,
+            ShipPhase = plan.ShipPhase,
             SourceCommit = plan.SourceCommit,
+            PlanSha256 = plan.ApprovedPlanSha256,
+            Versioning = plan.ApprovedVersioning,
             OperationPhase = "UploadAttested",
             Success = true,
             Targets = new[] { target }
@@ -75,7 +80,10 @@ internal sealed partial class PowerForgeReleaseService
         {
             AttemptId = attemptId,
             Action = plan.Action,
+            ShipPhase = plan.ShipPhase,
             SourceCommit = plan.SourceCommit,
+            PlanSha256 = plan.ApprovedPlanSha256,
+            Versioning = plan.ApprovedVersioning,
             OperationPhase = "UploadAmbiguous",
             Success = false,
             ErrorMessage = target.ErrorMessage,
@@ -109,6 +117,7 @@ internal sealed partial class PowerForgeReleaseService
         _appleReceiptStore.WriteAttempt(plan, new PowerForgeAppleReleaseReceipt
         {
             Action = plan.Action,
+            ShipPhase = plan.ShipPhase,
             SourceCommit = plan.SourceCommit,
             OperationPhase = "NotarizationAttested",
             Success = result.Notarization.Succeeded,
@@ -140,6 +149,7 @@ internal sealed partial class PowerForgeReleaseService
         _appleReceiptStore.WriteAttempt(plan, new PowerForgeAppleReleaseReceipt
         {
             Action = plan.Action,
+            ShipPhase = plan.ShipPhase,
             SourceCommit = plan.SourceCommit,
             OperationPhase = "NotarizationAccepted",
             Success = false,
@@ -169,6 +179,7 @@ internal sealed partial class PowerForgeReleaseService
         _appleReceiptStore.WriteAttempt(plan, new PowerForgeAppleReleaseReceipt
         {
             Action = plan.Action,
+            ShipPhase = plan.ShipPhase,
             SourceCommit = plan.SourceCommit,
             OperationPhase = "NotarizationAmbiguous",
             Success = false,
@@ -200,6 +211,7 @@ internal sealed partial class PowerForgeReleaseService
         _appleReceiptStore.WriteAttempt(plan, new PowerForgeAppleReleaseReceipt
         {
             Action = plan.Action,
+            ShipPhase = plan.ShipPhase,
             SourceCommit = plan.SourceCommit,
             OperationPhase = "NotarizationStapled",
             Success = false,
@@ -227,6 +239,8 @@ internal sealed partial class PowerForgeReleaseService
             ParentTarget = app.ParentTarget,
             Capabilities = app.Capabilities,
             TestFlightPolicy = app.TestFlightPolicy,
+            ShipToTestFlight = app.ShipToTestFlight,
+            ShipToAppStoreReview = app.ShipToAppStoreReview,
             AppId = app.AppStoreConnectAppId,
             Version = app.MarketingVersion,
             Build = app.BuildNumber

--- a/PowerForge/Services/PowerForgeReleaseService.ApplePlanHash.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.ApplePlanHash.cs
@@ -1,0 +1,73 @@
+namespace PowerForge;
+
+internal sealed partial class PowerForgeReleaseService
+{
+    private static string ComputeApplePlanSha256(PowerForgeAppleReleaseReceipt receipt)
+    {
+        var targets = receipt.Action == PowerForgeAppleReleaseAction.Ship
+            ? receipt.Targets.Select(CreateAppleShipIntentHashTarget).ToArray()
+            : receipt.Targets.Cast<object>().ToArray();
+        var versioning = receipt.Action == PowerForgeAppleReleaseAction.Ship && receipt.Versioning is not null
+            ? CreateAppleShipIntentHashVersion(receipt.Versioning)
+            : receipt.Versioning;
+        var canonical = new
+        {
+            receipt.SchemaVersion,
+            receipt.Action,
+            receipt.SourceCommit,
+            receipt.PlanOnly,
+            receipt.AdoptExistingBuild,
+            receipt.ShipPhase,
+            receipt.MutationInputsSha256,
+            MutationInputFiles = receipt.MutationInputFiles
+                .OrderBy(static value => value.Key, StringComparer.Ordinal)
+                .ToArray(),
+            receipt.Success,
+            receipt.ErrorMessage,
+            Versioning = versioning,
+            Targets = targets,
+            receipt.Cleanup,
+            receipt.Diagnostics,
+            receipt.NextActions
+        };
+        return ComputeStableSha256(canonical);
+    }
+
+    private static object CreateAppleShipIntentHashVersion(PowerForgeAppleVersionReceipt versioning)
+        => new
+        {
+            versioning.SourcePath,
+            versioning.RequestedMarketingVersion,
+            versioning.MarketingVersionPattern,
+            versioning.MarketingVersion,
+            versioning.BuildNumber,
+            versioning.PreviousMarketingVersion,
+            versioning.PreviousBuildNumber,
+            versioning.ReusedUnreleasedMarketingVersion,
+            versioning.Changed
+        };
+
+    private static object CreateAppleShipIntentHashTarget(PowerForgeAppleReleaseTargetReceipt target)
+        => new
+        {
+            target.Name,
+            target.BundleId,
+            target.Platform,
+            target.Configuration,
+            target.ProjectPath,
+            target.IsWorkspace,
+            target.Scheme,
+            target.ArchiveVariant,
+            target.Destination,
+            target.DistributionRoute,
+            target.ProductRole,
+            target.ParentTarget,
+            Capabilities = target.Capabilities.OrderBy(static value => value, StringComparer.Ordinal).ToArray(),
+            target.TestFlightPolicy,
+            target.ShipToTestFlight,
+            target.ShipToAppStoreReview,
+            target.AppId,
+            target.Version,
+            target.Build
+        };
+}

--- a/PowerForge/Services/PowerForgeReleaseService.AppleResume.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleResume.cs
@@ -80,7 +80,7 @@ internal sealed partial class PowerForgeReleaseService
                         "uniquely matching build to become visible, then deliberately adopt it with --apple-adopt-existing-build " +
                         "--confirm-apple-action.");
                 }
-                EnsureExplicitAppleRecoveryAdoption(plan, app, "an attested upload that is not yet visible as a build");
+                EnsureExplicitAppleRecoveryAdoption(plan, app, "an attested upload that is not yet visible as a build", attestation);
                 if (plan.Automation.WaitForProcessing)
                     state = WaitForAppleBuild(plan, app, state, attestation.Target.BuildUploadId);
                 else
@@ -106,7 +106,7 @@ internal sealed partial class PowerForgeReleaseService
                 state);
         }
 
-        if (!plan.AdoptExistingBuild)
+        if (!plan.AdoptExistingBuild && !IsApprovedAppleShipResume(plan, attestation))
         {
             var evidence = attestation is null
                 ? "no immutable local upload receipt can independently authorize it"
@@ -145,9 +145,10 @@ internal sealed partial class PowerForgeReleaseService
     private static void EnsureExplicitAppleRecoveryAdoption(
         PowerForgeAppleReleasePlan plan,
         PowerForgeAppleAppReleaseTargetPlan app,
-        string recoveredOperation)
+        string recoveredOperation,
+        AppleUploadAttestation? attestation = null)
     {
-        if (plan.AdoptExistingBuild)
+        if (plan.AdoptExistingBuild || IsApprovedAppleShipResume(plan, attestation))
             return;
 
         throw new InvalidOperationException(
@@ -155,6 +156,19 @@ internal sealed partial class PowerForgeReleaseService
             "Verify the remote operation and exact source/archive evidence, then rerun with --apple-adopt-existing-build " +
             "--confirm-apple-action, or disable resume and start a new version/build.");
     }
+
+    private static bool IsApprovedAppleShipResume(
+        PowerForgeAppleReleasePlan plan,
+        AppleUploadAttestation? attestation)
+        => plan.Action == PowerForgeAppleReleaseAction.Ship &&
+           plan.ShipPhase == PowerForgeAppleShipPhase.Release &&
+           !string.IsNullOrWhiteSpace(plan.ApprovedPlanSha256) &&
+           attestation?.Receipt.Action == PowerForgeAppleReleaseAction.Ship &&
+           attestation.Receipt.ShipPhase == PowerForgeAppleShipPhase.Release &&
+           string.Equals(
+               attestation.Receipt.PlanSha256,
+               plan.ApprovedPlanSha256,
+               StringComparison.OrdinalIgnoreCase);
 
     private void EnsureAppleBuildUploadIsNotTerminal(
         PowerForgeAppleReleasePlan plan,

--- a/PowerForge/Services/PowerForgeReleaseService.AppleShip.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleShip.cs
@@ -1,0 +1,171 @@
+namespace PowerForge;
+
+internal sealed partial class PowerForgeReleaseService
+{
+    private static void BindAppleShipRoutes(
+        PowerForgeReleaseRequest request,
+        PowerForgeAppleReleasePlan plan)
+    {
+        if (request.AppleAction != PowerForgeAppleReleaseAction.Ship)
+        {
+            if (request.AppleShipTestFlightTargets.Length > 0 ||
+                request.AppleShipAppStoreTargets.Length > 0 ||
+                !request.AppleShipReuseRemoteScreenshots)
+            {
+                throw new InvalidOperationException(
+                    "Apple Ship target and screenshot options require Apple action 'Ship'.");
+            }
+            return;
+        }
+
+        if (request.Targets.Length > 0)
+        {
+            throw new InvalidOperationException(
+                "Apple action 'Ship' uses --apple-testflight-target and --apple-app-store-target; do not combine it with --target.");
+        }
+
+        var testFlight = ResolveAppleShipTargets(
+            plan.Apps,
+            request.AppleShipTestFlightTargets,
+            "internal TestFlight");
+        var appStore = ResolveAppleShipTargets(
+            plan.Apps,
+            request.AppleShipAppStoreTargets,
+            "App Store Review");
+        if (testFlight.Length == 0 && appStore.Length == 0)
+        {
+            throw new InvalidOperationException(
+                "Apple action 'Ship' requires at least one --apple-testflight-target or --apple-app-store-target.");
+        }
+
+        foreach (var app in testFlight)
+        {
+            if (!UsesTestFlight(app) || app.TestFlightPolicy != AppleTestFlightPolicy.Internal)
+            {
+                throw new InvalidOperationException(
+                    $"Apple Ship internal TestFlight target '{app.Name}' must use AppStore or TestFlightOnly distribution with TestFlightPolicy=Internal.");
+            }
+            app.ShipToTestFlight = true;
+        }
+
+        foreach (var app in appStore)
+        {
+            if (app.DistributionRoute != AppleDistributionRoute.AppStore)
+            {
+                throw new InvalidOperationException(
+                    $"Apple Ship App Store Review target '{app.Name}' must use DistributionRoute=AppStore.");
+            }
+            app.ShipToAppStoreReview = true;
+        }
+
+        if (!request.AppleShipReuseRemoteScreenshots && appStore.Length == 0)
+        {
+            throw new InvalidOperationException(
+                "Apple Ship screenshot synchronization requires at least one App Store Review target.");
+        }
+
+        if (appStore.Length == 0)
+        {
+            plan.PrepareDistribution = false;
+            plan.SelectBuildForDistribution = false;
+            plan.SyncMetadata = false;
+            plan.SyncAppInfo = false;
+            plan.SyncScreenshots = false;
+            plan.CheckGovernance = false;
+            plan.CheckReleaseReadiness = false;
+            plan.SubmitForReview = false;
+        }
+        if (testFlight.Length == 0)
+            plan.DistributeTestFlight = false;
+
+        plan.ShipTestFlightTargets = testFlight
+            .Select(static app => app.Name)
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+        plan.ShipAppStoreTargets = appStore
+            .Select(static app => app.Name)
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+        plan.ShipReuseRemoteScreenshots = request.AppleShipReuseRemoteScreenshots;
+    }
+
+    private static PowerForgeAppleAppReleaseTargetPlan[] ResolveAppleShipTargets(
+        PowerForgeAppleAppReleaseTargetPlan[] apps,
+        IEnumerable<string>? selectors,
+        string route)
+    {
+        var resolved = new List<PowerForgeAppleAppReleaseTargetPlan>();
+        foreach (var selector in NormalizeStrings(selectors?.ToArray()))
+        {
+            var matches = apps
+                .Where(IsIndependentReleaseTarget)
+                .Where(app =>
+                    app.Name.Equals(selector, StringComparison.OrdinalIgnoreCase) ||
+                    app.Scheme.Equals(selector, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            if (matches.Length == 0)
+                throw new InvalidOperationException($"Unknown Apple Ship {route} target '{selector}'.");
+            if (matches.Length > 1)
+            {
+                throw new InvalidOperationException(
+                    $"Apple Ship {route} target '{selector}' is ambiguous. Use a unique configured target name.");
+            }
+            if (!resolved.Contains(matches[0]))
+                resolved.Add(matches[0]);
+        }
+        return resolved.ToArray();
+    }
+
+    private static bool IsAppleShipTarget(PowerForgeAppleAppReleaseTargetPlan app)
+        => app.ShipToTestFlight || app.ShipToAppStoreReview;
+
+    private static bool ShouldRunAppleShipAppStoreStep(
+        PowerForgeAppleReleasePlan plan,
+        PowerForgeAppleAppReleaseTargetPlan app)
+        => plan.Action != PowerForgeAppleReleaseAction.Ship || app.ShipToAppStoreReview;
+
+    private static bool ShouldRunAppleShipTestFlightDistribution(
+        PowerForgeAppleReleasePlan plan,
+        PowerForgeAppleAppReleaseTargetPlan app)
+        => plan.Action != PowerForgeAppleReleaseAction.Ship || app.ShipToTestFlight;
+
+    private PowerForgeAppleVersionReceipt? ResolveApprovedAppleShipVersion(
+        PowerForgeAppleReleasePlan plan,
+        PowerForgeAppleVersionReceipt current,
+        string requested)
+    {
+        if (plan.Action != PowerForgeAppleReleaseAction.Ship ||
+            string.IsNullOrWhiteSpace(plan.ApprovedPlanSha256))
+        {
+            return null;
+        }
+
+        var approved = _appleReceiptStore.ReadAll(plan)
+            .FirstOrDefault(receipt =>
+                receipt.Action == PowerForgeAppleReleaseAction.Ship &&
+                receipt.ShipPhase == PowerForgeAppleShipPhase.Release &&
+                string.Equals(receipt.PlanSha256, plan.ApprovedPlanSha256, StringComparison.OrdinalIgnoreCase) &&
+                AppleSourceCommitEvidenceMatches(receipt.SourceCommit, plan.SourceCommit) &&
+                receipt.Versioning is not null &&
+                string.Equals(receipt.Versioning.MarketingVersion, current.MarketingVersion, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(receipt.Versioning.BuildNumber, current.BuildNumber, StringComparison.OrdinalIgnoreCase));
+        if (approved?.Versioning is null)
+            return null;
+
+        var versioning = approved.Versioning;
+        return new PowerForgeAppleVersionReceipt
+        {
+            SourcePath = versioning.SourcePath,
+            RequestedMarketingVersion = requested,
+            MarketingVersionPattern = versioning.MarketingVersionPattern,
+            MarketingVersion = versioning.MarketingVersion,
+            BuildNumber = versioning.BuildNumber,
+            PreviousMarketingVersion = versioning.PreviousMarketingVersion,
+            PreviousBuildNumber = versioning.PreviousBuildNumber,
+            HighestRemoteBuildNumber = versioning.HighestRemoteBuildNumber,
+            HighestRemoteMarketingVersion = versioning.HighestRemoteMarketingVersion,
+            ReusedUnreleasedMarketingVersion = versioning.ReusedUnreleasedMarketingVersion,
+            Changed = false
+        };
+    }
+}

--- a/PowerForge/Services/PowerForgeReleaseService.AppleVersioning.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleVersioning.cs
@@ -15,6 +15,12 @@ internal sealed partial class PowerForgeReleaseService
             throw new InvalidOperationException(
                 "Destructive App Store screenshot replacement requires the SHA-256 from a reviewed exact Apple plan.");
         }
+        if (plan.Action == PowerForgeAppleReleaseAction.Ship &&
+            string.IsNullOrWhiteSpace(expectedPlanSha256))
+        {
+            throw new InvalidOperationException(
+                "Apple Ship execution requires --apple-expected-plan-sha256 from the reviewed exact Ship plan.");
+        }
         if (string.IsNullOrWhiteSpace(expectedPlanSha256) &&
             plan.Action != PowerForgeAppleReleaseAction.Version)
         {
@@ -41,6 +47,8 @@ internal sealed partial class PowerForgeReleaseService
                 "Apple state or release inputs changed after plan approval. Review a new exact plan before allowing mutation.");
         }
 
+        plan.ApprovedPlanSha256 = current.PlanSha256;
+        plan.ApprovedVersioning = current.Versioning;
         CaptureApprovedMutationInputContents(plan);
         return current;
     }
@@ -69,7 +77,8 @@ internal sealed partial class PowerForgeReleaseService
             if (!string.IsNullOrWhiteSpace(plan.GovernanceConfigPath)) paths.Add(plan.GovernanceConfigPath!);
             paths.AddRange(plan.GovernanceConfigPaths);
         }
-        if (plan.Action == PowerForgeAppleReleaseAction.Version && !string.IsNullOrWhiteSpace(plan.VersionSourcePath))
+        if ((plan.Action == PowerForgeAppleReleaseAction.Version || plan.Action == PowerForgeAppleReleaseAction.Ship) &&
+            !string.IsNullOrWhiteSpace(plan.VersionSourcePath))
             paths.Add(plan.VersionSourcePath!);
 
         var pathComparer = Path.DirectorySeparatorChar == '\\'
@@ -118,8 +127,15 @@ internal sealed partial class PowerForgeReleaseService
             }
         }
         PowerForgeAppleVersionReceipt? versioning = null;
-        if (plan.Action == PowerForgeAppleReleaseAction.Version)
+        if (plan.Action == PowerForgeAppleReleaseAction.Version ||
+            plan.Action == PowerForgeAppleReleaseAction.Ship)
             versioning = PlanAppleVersion(plan, whatIf: true);
+        if (plan.Action == PowerForgeAppleReleaseAction.Ship)
+        {
+            plan.ShipPhase = versioning?.Changed == true
+                ? PowerForgeAppleShipPhase.VersionCheckpoint
+                : PowerForgeAppleShipPhase.Release;
+        }
 
         var screenshotSpecs = ((plan.SyncScreenshots && plan.ReplaceScreenshots) ||
                                plan.CheckReleaseReadiness ||
@@ -139,11 +155,17 @@ internal sealed partial class PowerForgeReleaseService
             Success = true,
             ReceiptPath = FrameworkCompatibility.GetRelativePath(plan.ProjectRoot, plan.PlanReceiptPath).Replace('\\', '/'),
             AdoptExistingBuild = plan.AdoptExistingBuild,
+            ShipPhase = plan.ShipPhase,
             MutationInputsSha256 = mutationInputs.Sha256,
             MutationInputFiles = mutationInputs.Files,
             Versioning = versioning,
             Targets = targets,
-            NextActions = new[] { $"Run Apple action '{plan.Action}' without --plan after reviewing this plan receipt." }
+            NextActions = plan.ShipPhase == PowerForgeAppleShipPhase.VersionCheckpoint
+                ? new[]
+                {
+                    "Confirm this Ship plan to update the checked-in Apple version source, then review and merge that source change before rerunning the same Ship intent."
+                }
+                : new[] { $"Run Apple action '{plan.Action}' without --plan after reviewing this plan receipt." }
         };
         receipt.PlanSha256 = ComputeApplePlanSha256(receipt);
 
@@ -174,6 +196,8 @@ internal sealed partial class PowerForgeReleaseService
             ParentTarget = app.ParentTarget,
             Capabilities = app.Capabilities,
             TestFlightPolicy = app.TestFlightPolicy,
+            ShipToTestFlight = app.ShipToTestFlight,
+            ShipToAppStoreReview = app.ShipToAppStoreReview,
             AppId = app.AppStoreConnectAppId,
             AppIdDiscovered = app.AppStoreConnectAppIdDiscovered,
             Version = versioning?.MarketingVersion ?? app.MarketingVersion,
@@ -187,7 +211,8 @@ internal sealed partial class PowerForgeReleaseService
                 : null,
             SkippedSteps = new[] { "plan-only" }
         };
-        if (!RequiresObservedApplePlanState(plan, app))
+        if (plan.ShipPhase == PowerForgeAppleShipPhase.VersionCheckpoint ||
+            !RequiresObservedApplePlanState(plan, app))
         {
             return target;
         }
@@ -221,8 +246,12 @@ internal sealed partial class PowerForgeReleaseService
         }
 
         var bindScreenshotInventory = plan.SyncScreenshots && plan.ReplaceScreenshots;
-        var checkReadiness = plan.CheckReleaseReadiness ||
-                             (plan.SubmitForReview && !plan.SkipReviewReadinessCheck);
+        var checkReadiness = (plan.CheckReleaseReadiness ||
+                              (plan.SubmitForReview && !plan.SkipReviewReadinessCheck)) &&
+                             ShouldRunAppleShipAppStoreStep(plan, app) &&
+                             (plan.Action != PowerForgeAppleReleaseAction.Ship ||
+                              target.BuildSelected == true &&
+                              string.Equals(target.BuildProcessingState, "VALID", StringComparison.OrdinalIgnoreCase));
         if (bindScreenshotInventory || checkReadiness)
         {
             var values = ResolveAppleDistributionValues(app, versionUpdate: null);
@@ -293,7 +322,8 @@ internal sealed partial class PowerForgeReleaseService
             PowerForgeAppleReleaseAction.Release or
             PowerForgeAppleReleaseAction.Prepare or
             PowerForgeAppleReleaseAction.TestFlight or
-            PowerForgeAppleReleaseAction.Advance)
+            PowerForgeAppleReleaseAction.Advance or
+            PowerForgeAppleReleaseAction.Ship)
         {
             return true;
         }
@@ -307,7 +337,11 @@ internal sealed partial class PowerForgeReleaseService
     }
 
     private static bool RequiresSelectedApplePlanBuild(PowerForgeAppleReleasePlan plan)
-        => plan.Action is PowerForgeAppleReleaseAction.SubmitTestFlightReview or
+    {
+        if (plan.Action == PowerForgeAppleReleaseAction.Ship)
+            return false;
+
+        return plan.Action is PowerForgeAppleReleaseAction.SubmitTestFlightReview or
                PowerForgeAppleReleaseAction.SubmitAppReview or
                PowerForgeAppleReleaseAction.TestFlight or
                PowerForgeAppleReleaseAction.Release ||
@@ -316,29 +350,6 @@ internal sealed partial class PowerForgeReleaseService
            plan.SubmitTestFlightBetaReview ||
            plan.SubmitForReview ||
            plan.ReleaseApprovedVersion;
-
-    private static string ComputeApplePlanSha256(PowerForgeAppleReleaseReceipt receipt)
-    {
-        var canonical = new
-        {
-            receipt.SchemaVersion,
-            receipt.Action,
-            receipt.SourceCommit,
-            receipt.PlanOnly,
-            receipt.AdoptExistingBuild,
-            receipt.MutationInputsSha256,
-            MutationInputFiles = receipt.MutationInputFiles
-                .OrderBy(static value => value.Key, StringComparer.Ordinal)
-                .ToArray(),
-            receipt.Success,
-            receipt.ErrorMessage,
-            receipt.Versioning,
-            receipt.Targets,
-            receipt.Cleanup,
-            receipt.Diagnostics,
-            receipt.NextActions
-        };
-        return ComputeStableSha256(canonical);
     }
 
     private (Dictionary<string, string> Files, string Sha256) CreateAppleMutationInputEvidence(
@@ -371,7 +382,8 @@ internal sealed partial class PowerForgeReleaseService
                 configuredInputs.Add(plan.GovernanceConfigPath!);
             configuredInputs.AddRange(plan.GovernanceConfigPaths);
         }
-        if (plan.Action == PowerForgeAppleReleaseAction.Version && !string.IsNullOrWhiteSpace(plan.VersionSourcePath))
+        if ((plan.Action == PowerForgeAppleReleaseAction.Version || plan.Action == PowerForgeAppleReleaseAction.Ship) &&
+            !string.IsNullOrWhiteSpace(plan.VersionSourcePath))
             configuredInputs.Add(plan.VersionSourcePath!);
         var effectiveInputs = configuredInputs
             .Distinct(Path.DirectorySeparatorChar == '\\'
@@ -433,6 +445,10 @@ internal sealed partial class PowerForgeReleaseService
             plan.UploadSymbols,
             plan.GenerateAppStoreInformation,
             plan.SigningStyle,
+            plan.ShipPhase,
+            plan.ShipReuseRemoteScreenshots,
+            ShipTestFlightTargets = plan.ShipTestFlightTargets.OrderBy(static value => value, StringComparer.Ordinal).ToArray(),
+            ShipAppStoreTargets = plan.ShipAppStoreTargets.OrderBy(static value => value, StringComparer.Ordinal).ToArray(),
             XcodeTargets = plan.Apps
                 .OrderBy(static app => app.Name, StringComparer.Ordinal)
                 .Select(app => new
@@ -446,6 +462,8 @@ internal sealed partial class PowerForgeReleaseService
                     app.RegenerateProject,
                     app.XcodeGenExecutable,
                     app.ProjectGenerationTimeoutSeconds,
+                    app.ShipToTestFlight,
+                    app.ShipToAppStoreReview,
                     ArchivePath = FrameworkCompatibility.GetRelativePath(plan.ProjectRoot, app.ArchivePath).Replace('\\', '/'),
                     ExportPath = FrameworkCompatibility.GetRelativePath(plan.ProjectRoot, app.ExportPath).Replace('\\', '/'),
                     RequiredEmbeddedBundleIds = app.RequiredEmbeddedBundleIds.OrderBy(static value => value, StringComparer.Ordinal).ToArray(),
@@ -582,7 +600,7 @@ internal sealed partial class PowerForgeReleaseService
         PowerForgeAppleVersionReceipt approved)
     {
         if (string.IsNullOrWhiteSpace(plan.VersionSourcePath))
-            throw new InvalidOperationException("Apple version source path is required for Version.");
+            throw new InvalidOperationException($"Apple version source path is required for {plan.Action}.");
         var source = new AppleReleaseVersionSourceService();
         var approvedContent = ReadApprovedMutationInputText(plan, plan.VersionSourcePath!);
         var versioning = source.Update(
@@ -640,9 +658,9 @@ internal sealed partial class PowerForgeReleaseService
     private PowerForgeAppleVersionReceipt PlanAppleVersion(PowerForgeAppleReleasePlan plan, bool whatIf)
     {
         if (string.IsNullOrWhiteSpace(plan.VersionSourcePath))
-            throw new InvalidOperationException("Apple version source path is required for Version.");
+            throw new InvalidOperationException($"Apple version source path is required for {plan.Action}.");
         if (string.IsNullOrWhiteSpace(plan.RequestedMarketingVersion))
-            throw new InvalidOperationException("Requested Apple marketing version is required for Version.");
+            throw new InvalidOperationException($"Requested Apple marketing version is required for {plan.Action}.");
 
         var source = new AppleReleaseVersionSourceService();
         var approvedContent = ReadApprovedMutationInputText(plan, plan.VersionSourcePath!);
@@ -652,6 +670,9 @@ internal sealed partial class PowerForgeReleaseService
 
         var storeApps = plan.Apps.Where(UsesAppStoreConnect).ToArray();
         var requested = plan.RequestedMarketingVersion!.Trim();
+        var resumed = ResolveApprovedAppleShipVersion(plan, current, requested);
+        if (resumed is not null)
+            return resumed;
         var isPattern = requested.IndexOf("X", StringComparison.OrdinalIgnoreCase) >= 0;
         var highestRemote = 0L;
         AppleReleaseMarketingVersionResolution? resolution = null;

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -827,10 +827,21 @@ internal sealed partial class PowerForgeReleaseService
                     receiptJournalReady = true;
                     if (applePlan.Action == PowerForgeAppleReleaseAction.Version)
                     {
+                        AppleReleaseSourceSnapshot.ValidateCurrentSourceIfRequired(applePlan);
                         appleVersioning = SelectAppleVersion(
                             applePlan,
                             approvedPlan?.Versioning ?? throw new InvalidOperationException(
                                 "Apple Version execution requires one approved remote version observation."));
+                        appleResults = RunAppleVersion(applePlan);
+                    }
+                    else if (applePlan.Action == PowerForgeAppleReleaseAction.Ship &&
+                             approvedPlan?.ShipPhase == PowerForgeAppleShipPhase.VersionCheckpoint)
+                    {
+                        AppleReleaseSourceSnapshot.ValidateCurrentSourceIfRequired(applePlan);
+                        appleVersioning = SelectAppleVersion(
+                            applePlan,
+                            approvedPlan.Versioning ?? throw new InvalidOperationException(
+                                "Apple Ship version checkpoint requires one approved version plan."));
                         appleResults = RunAppleVersion(applePlan);
                     }
                     else if (request.CheckpointAppleApps)
@@ -1097,6 +1108,9 @@ internal sealed partial class PowerForgeReleaseService
                         StringComparer.OrdinalIgnoreCase),
                     AppleActionConfirmed = request.AppleActionConfirmed,
                     AppleAdoptExistingBuild = request.AppleAdoptExistingBuild,
+                    AppleShipTestFlightTargets = request.AppleShipTestFlightTargets.ToArray(),
+                    AppleShipAppStoreTargets = request.AppleShipAppStoreTargets.ToArray(),
+                    AppleShipReuseRemoteScreenshots = request.AppleShipReuseRemoteScreenshots,
                     AppleResume = request.AppleResume,
                     AppleWaitForProcessing = request.AppleWaitForProcessing,
                     AppleProcessingTimeoutSeconds = request.AppleProcessingTimeoutSeconds,
@@ -1653,10 +1667,12 @@ internal sealed partial class PowerForgeReleaseService
         var configuredApps = (options.Apps ?? Array.Empty<AppleAppConfiguration>())
             .Where(app => app.Enabled)
             .ToArray();
-        if (request.AppleAction == PowerForgeAppleReleaseAction.Version && selectedTargets.Length > 0)
+        if ((request.AppleAction == PowerForgeAppleReleaseAction.Version ||
+             request.AppleAction == PowerForgeAppleReleaseAction.Ship) &&
+            selectedTargets.Length > 0)
         {
             throw new InvalidOperationException(
-                "Apple action 'Version' cannot be restricted with --target because the checked-in version source and build identity are shared across every configured Apple platform.");
+                $"Apple action '{request.AppleAction}' cannot be restricted with --target because the checked-in version source and build identity are shared across every configured Apple platform.");
         }
         if (selectedTargets.Length > 0)
         {
@@ -1778,15 +1794,16 @@ internal sealed partial class PowerForgeReleaseService
                                     options.ReleaseApprovedVersion;
         var appStoreConnectApps = apps.Where(UsesAppStoreConnect).ToArray();
         var requiresAppStoreConnect = appStoreConnectAction && appStoreConnectApps.Length > 0;
-        if (request.AppleAction == PowerForgeAppleReleaseAction.Version)
+        if (request.AppleAction == PowerForgeAppleReleaseAction.Version ||
+            request.AppleAction == PowerForgeAppleReleaseAction.Ship)
         {
             if (string.IsNullOrWhiteSpace(requestedMarketingVersion))
             {
                 throw new InvalidOperationException(
-                    "Apple action 'Version' requires --apple-version or AppleApps.Automation.MarketingVersionPattern.");
+                    $"Apple action '{request.AppleAction}' requires --apple-version or AppleApps.Automation.MarketingVersionPattern.");
             }
             if (versionSourcePath is null)
-                throw new InvalidOperationException("Apple action 'Version' requires AppleApps.Automation.VersionSourcePath.");
+                throw new InvalidOperationException($"Apple action '{request.AppleAction}' requires AppleApps.Automation.VersionSourcePath.");
             if (!File.Exists(versionSourcePath))
                 throw new FileNotFoundException($"Apple version source was not found: {versionSourcePath}", versionSourcePath);
         }
@@ -1806,6 +1823,11 @@ internal sealed partial class PowerForgeReleaseService
         if (appleSourceCommit.Length > 0 && !GitObjectId.IsFull(appleSourceCommit))
         {
             throw new InvalidOperationException("Apple source commit must be a full SHA-1 or SHA-256 Git commit object id.");
+        }
+        if (request.AppleAction == PowerForgeAppleReleaseAction.Ship && appleSourceCommit.Length == 0)
+        {
+            throw new InvalidOperationException(
+                "Apple action 'Ship' requires --apple-source-commit so the complete intent is bound to reviewed source.");
         }
         if (request.AppleAdoptExistingBuild &&
             !IsUploadAction(request.AppleAction) &&
@@ -1904,11 +1926,16 @@ internal sealed partial class PowerForgeReleaseService
             VersionSourcePath = versionSourcePath,
             RequestedMarketingVersion = requestedMarketingVersion,
             SourceCommit = appleSourceCommit.Length == 0 ? null : appleSourceCommit,
-            RequireImmutableSourceSnapshot = request.RequireImmutableAppleSourceSnapshot,
-            ExactSourceConfigPath = request.RequireImmutableAppleSourceSnapshot && File.Exists(request.ConfigPath)
+            RequireImmutableSourceSnapshot = request.RequireImmutableAppleSourceSnapshot ||
+                                             request.AppleAction == PowerForgeAppleReleaseAction.Ship,
+            ApprovedPlanSha256 = request.AppleExpectedPlanSha256?.Trim(),
+            ExactSourceConfigPath = (request.RequireImmutableAppleSourceSnapshot ||
+                                     request.AppleAction == PowerForgeAppleReleaseAction.Ship) &&
+                                    File.Exists(request.ConfigPath)
                 ? request.ConfigPath
                 : null,
-            ExactSourceConfigSha256 = request.RequireImmutableAppleSourceSnapshot &&
+            ExactSourceConfigSha256 = (request.RequireImmutableAppleSourceSnapshot ||
+                                       request.AppleAction == PowerForgeAppleReleaseAction.Ship) &&
                                       !string.IsNullOrWhiteSpace(request.ConfigPath) &&
                                       !string.IsNullOrWhiteSpace(request.LoadedConfigurationSha256)
                 ? request.LoadedConfigurationSha256
@@ -1959,6 +1986,7 @@ internal sealed partial class PowerForgeReleaseService
             AppStoreConnectApiIssuerId = appStoreConnectApiIssuerId,
             Apps = apps
         };
+        BindAppleShipRoutes(request, plan);
         var validateReusableArchives =
             (!request.PlanOnly && !request.ValidateOnly) || request.CheckpointAppleApps;
         if (validateReusableArchives &&
@@ -2149,7 +2177,10 @@ internal sealed partial class PowerForgeReleaseService
         var appInfoSpecsByAppId = plan.SyncAppInfo
             ? IndexAppInfoSpecsByAppId(
                 appInfoSpecs,
-                plan.Apps.Where(static app => app.DistributionRoute == AppleDistributionRoute.AppStore).ToArray())
+                plan.Apps
+                    .Where(app => app.DistributionRoute == AppleDistributionRoute.AppStore &&
+                                  ShouldRunAppleShipAppStoreStep(plan, app))
+                    .ToArray())
             : new Dictionary<string, AppStoreConnectAppInfoMetadataSpec[]>(StringComparer.OrdinalIgnoreCase);
         var pendingAppInfoAppIds = new HashSet<string>(appInfoSpecsByAppId.Keys, StringComparer.OrdinalIgnoreCase);
         var governanceSpecsByAppId = plan.CheckGovernance
@@ -2209,6 +2240,7 @@ internal sealed partial class PowerForgeReleaseService
                 }
 
                 var matchingScreenshotSpec = app.DistributionRoute == AppleDistributionRoute.AppStore &&
+                                             ShouldRunAppleShipAppStoreStep(plan, app) &&
                                              (plan.SyncScreenshots ||
                                               plan.CheckReleaseReadiness ||
                                               (plan.SubmitForReview && !plan.SkipReviewReadinessCheck))
@@ -2232,6 +2264,7 @@ internal sealed partial class PowerForgeReleaseService
                     ValidateAppleScreenshotPreflight(matchingScreenshotSpec.Value, plan.SourceCommit);
 
                 var matchingMetadataSpec = plan.SyncMetadata &&
+                                           ShouldRunAppleShipAppStoreStep(plan, app) &&
                                            app.DistributionRoute == AppleDistributionRoute.AppStore
                     ? ResolveMatchingMetadataSpec(
                         metadataSpecs,
@@ -2243,7 +2276,9 @@ internal sealed partial class PowerForgeReleaseService
                 if (matchingMetadataSpec is not null)
                     ValidateAppleMetadataPreflight(matchingMetadataSpec.Value);
 
-                if (plan.CheckGovernance && UsesAppStoreConnect(app))
+                if (plan.CheckGovernance &&
+                    UsesAppStoreConnect(app) &&
+                    ShouldRunAppleShipAppStoreStep(plan, app))
                 {
                     if (!governanceSpecsByAppId.TryGetValue(app.AppStoreConnectAppId!, out var governanceSpec))
                         throw new InvalidOperationException($"No governance config matches Apple app '{app.Name}' (AppStoreConnectAppId '{app.AppStoreConnectAppId}').");
@@ -2524,11 +2559,13 @@ internal sealed partial class PowerForgeReleaseService
             }
 
             var appInfoMetadataSpecs = app.DistributionRoute == AppleDistributionRoute.AppStore &&
+                                       ShouldRunAppleShipAppStoreStep(plan, app) &&
                                        plan.SyncAppInfo &&
                                        pendingAppInfoAppIds.Remove(app.AppStoreConnectAppId!)
                 ? appInfoSpecsByAppId[app.AppStoreConnectAppId!]
                 : Array.Empty<AppStoreConnectAppInfoMetadataSpec>();
             if (app.DistributionRoute == AppleDistributionRoute.AppStore &&
+                ShouldRunAppleShipAppStoreStep(plan, app) &&
                 (plan.PrepareDistribution || plan.SyncScreenshots || plan.SyncMetadata || appInfoMetadataSpecs.Length > 0 || plan.CheckReleaseReadiness) &&
                 result.Success)
             {
@@ -2582,7 +2619,10 @@ internal sealed partial class PowerForgeReleaseService
                     ValidateAppleAppInfoMutationResults(appInfoMetadataSpecs, result.Distribution.AppInfoMetadataResults);
             }
 
-            if (plan.DistributeTestFlight && result.Success && UsesTestFlight(app))
+            if (plan.DistributeTestFlight &&
+                result.Success &&
+                UsesTestFlight(app) &&
+                ShouldRunAppleShipTestFlightDistribution(plan, app))
             {
                 var testFlightValues = valuesByApp[app];
                 result.TestFlight = _distributeTestFlight(new AppStoreConnectTestFlightDistributionRequest
@@ -2619,6 +2659,7 @@ internal sealed partial class PowerForgeReleaseService
 
             if (plan.SubmitForReview &&
                 result.Success &&
+                ShouldRunAppleShipAppStoreStep(plan, app) &&
                 app.DistributionRoute == AppleDistributionRoute.AppStore)
             {
                 var reviewValues = valuesByApp[app];
@@ -5163,6 +5204,11 @@ internal sealed partial class PowerForgeReleaseService
             plan = plan is null ? null : new
             {
                 plan.ProjectRoot,
+                Action = plan.Action.ToString(),
+                ShipPhase = plan.ShipPhase?.ToString(),
+                plan.ShipTestFlightTargets,
+                plan.ShipAppStoreTargets,
+                plan.ShipReuseRemoteScreenshots,
                 plan.Configuration,
                 plan.Archive,
                 plan.Upload,
@@ -5220,6 +5266,8 @@ internal sealed partial class PowerForgeReleaseService
                     app.ExportPath,
                     app.TeamId,
                     app.Upload,
+                    app.ShipToTestFlight,
+                    app.ShipToAppStoreReview,
                     app.VersionUpdateRequested,
                     app.MarketingVersion,
                     app.BuildNumber,


### PR DESCRIPTION
## What changed

Adds one `Ship` action for declaring where each Apple target should go: internal TestFlight, App Store review, or both. The resulting plan binds the exact source and route intent, defaults to reusing complete remote screenshots, and executes or resumes the necessary archive, upload, preparation, and submission steps from one approved plan hash.

A required version change is an explicit checkpoint: Ship updates the configured version source, then stops so that change can be reviewed and merged. Rerunning the same intent from the merged commit continues the release without duplicating already-attested uploads.

The route controls prevent unintended store versions. This supports iOS-only, Mac-only, both platforms in internal TestFlight, and iOS App Store review with Mac internal TestFlight. Ship accepts only internal TestFlight policy and does not invent groups or testers. Locked App Information is treated as converged only when every relevant locked resource already matches.

## Public surfaces

- PowerForge release engine and receipts
- `powerforge release --apple-action Ship`
- `Invoke-PowerForgeRelease -AppleAction Ship`
- Apple release documentation and progress summaries

## Verification

- 512 PowerForge release-service contracts
- focused CLI, PowerShell mapper, route, resume, exact-source, and App Information contracts
- warning-as-error builds for PowerForge net472, PowerForge CLI net10, and PSPublishModule net8
- read-only CasaRay route plan for iOS App Store + internal TestFlight and Mac internal TestFlight; no Apple mutation

No package or public release is published by this PR.