### PR TITLE
Make Windows service recovery declarative and reversible

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerServicePackageTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerServicePackageTests.cs
@@ -121,7 +121,8 @@ public sealed class DotNetPublishPipelineRunnerServicePackageTests
                 {
                     Enabled = true,
                     ResetPeriodSeconds = 900,
-                    RestartDelaySeconds = 30
+                    RestartDelaySeconds = 30,
+                    RestartDelaySequenceSeconds = [30, 60, 90]
                 }
             };
 
@@ -152,6 +153,15 @@ public sealed class DotNetPublishPipelineRunnerServicePackageTests
             Assert.Contains("Get-CimInstance -ClassName Win32_Service", installContent, StringComparison.Ordinal);
             Assert.Contains("Invoke-CimMethod -InputObject $service -MethodName Change", installContent, StringComparison.Ordinal);
             Assert.DoesNotContain("sc.exe delete", installContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Invoke-ServiceRecoveryCommand", installContent, StringComparison.Ordinal);
+            Assert.Contains("@('failure', $ServiceName, 'reset=', [string]$recoveryResetPeriodSeconds, 'actions=', $recoveryActions)", installContent, StringComparison.Ordinal);
+            Assert.Contains("$recoveryEnabled = $true", installContent, StringComparison.Ordinal);
+            Assert.Contains("$recoveryConfigured = $true", installContent, StringComparison.Ordinal);
+            Assert.Contains("$recoveryResetPeriodSeconds = 900", installContent, StringComparison.Ordinal);
+            Assert.Contains("$recoveryRestartDelayMilliseconds = @(30000, 60000, 90000)", installContent, StringComparison.Ordinal);
+            Assert.Contains("$recoveryApplyToNonCrashFailures = $true", installContent, StringComparison.Ordinal);
+            Assert.Contains("'Skip' { }", installContent, StringComparison.Ordinal);
+            Assert.Contains("'actions=', $recoveryActions", installContent, StringComparison.Ordinal);
             Assert.Contains("--config", installContent, StringComparison.Ordinal);
             Assert.DoesNotContain("{{", installContent, StringComparison.Ordinal);
 
@@ -164,6 +174,50 @@ public sealed class DotNetPublishPipelineRunnerServicePackageTests
             Assert.Contains("\"ServiceName\": \"PowerForge.Svc\"", metadata, StringComparison.Ordinal);
             Assert.Contains("\"InstallScriptPath\":", metadata, StringComparison.Ordinal);
             Assert.Contains("\"Recovery\":", metadata, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    public void TryCreateServicePackage_DistinguishesAbsentRecoveryFromExplicitDisable(
+        bool declareRecovery,
+        bool enabled)
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var outputDir = Directory.CreateDirectory(Path.Combine(root, "out")).FullName;
+            File.WriteAllText(Path.Combine(outputDir, "Svc.exe"), "dummy");
+            var options = new DotNetPublishServicePackageOptions
+            {
+                ServiceName = "PowerForge.Svc",
+                ExecutablePath = "Svc.exe",
+                GenerateInstallScript = true,
+                Recovery = declareRecovery
+                    ? new DotNetPublishServiceRecoveryOptions { Enabled = enabled, OnFailure = DotNetPublishPolicyMode.Skip }
+                    : null
+            };
+
+            var runner = new DotNetPublishPipelineRunner(new NullLogger());
+            var method = typeof(DotNetPublishPipelineRunner).GetMethod("TryCreateServicePackage", BindingFlags.Instance | BindingFlags.NonPublic);
+            var result = method!.Invoke(runner, new object[] { outputDir, "svc", "win-x64", options }) as DotNetPublishServicePackageResult;
+            string installContent = File.ReadAllText(result!.InstallScriptPath!);
+
+            Assert.Contains($"$recoveryConfigured = {(declareRecovery ? "$true" : "$false")}", installContent, StringComparison.Ordinal);
+            Assert.Contains("-Arguments @('failure', $ServiceName, 'reset=', [string]$recoveryResetPeriodSeconds, 'actions=', $recoveryActions)", installContent, StringComparison.Ordinal);
+            Assert.Contains("$recoveryEnabled -and $recoveryApplyToNonCrashFailures", installContent, StringComparison.Ordinal);
+            Assert.Contains("$recoveryActions = if ($recoveryEnabled)", installContent, StringComparison.Ordinal);
+            Assert.Contains("'\"\"'", installContent, StringComparison.Ordinal);
+            if (declareRecovery)
+            {
+                Assert.Contains("$recoveryEnabled = $false", installContent, StringComparison.Ordinal);
+                Assert.Contains("$recoveryFailureMode = 'Skip'", installContent, StringComparison.Ordinal);
+            }
         }
         finally
         {

--- a/PowerForge/Models/DotNetPublish/DotNetPublishTarget.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishTarget.cs
@@ -568,6 +568,12 @@ public sealed class DotNetPublishServiceRecoveryOptions
     public int RestartDelaySeconds { get; set; } = 60;
 
     /// <summary>
+    /// Optional ordered restart delays in seconds. When empty, <see cref="RestartDelaySeconds"/>
+    /// is repeated for three recovery attempts for backward compatibility.
+    /// </summary>
+    public int[] RestartDelaySequenceSeconds { get; set; } = Array.Empty<int>();
+
+    /// <summary>
     /// When true, enables recovery actions for non-crash failures.
     /// </summary>
     public bool ApplyToNonCrashFailures { get; set; } = true;

--- a/PowerForge/Scripts/DotNetPublish/Install-Service.Template.ps1
+++ b/PowerForge/Scripts/DotNetPublish/Install-Service.Template.ps1
@@ -16,6 +16,12 @@ $ErrorActionPreference = 'Stop'
 
 $binaryRelative = '{{ExecutableRelativePath}}'
 $arguments = '{{Arguments}}'
+$recoveryConfigured = {{RecoveryConfigured}}
+$recoveryEnabled = {{RecoveryEnabled}}
+$recoveryResetPeriodSeconds = {{RecoveryResetPeriodSeconds}}
+$recoveryRestartDelayMilliseconds = @({{RecoveryRestartDelayMilliseconds}})
+$recoveryApplyToNonCrashFailures = {{RecoveryApplyToNonCrashFailures}}
+$recoveryFailureMode = '{{RecoveryFailureMode}}'
 
 $packageRoot = Split-Path -Parent $PSCommandPath
 $exePath = Join-Path -Path $packageRoot -ChildPath $binaryRelative
@@ -43,6 +49,30 @@ function Set-CommandLineOption {
     }
 
     return ($CommandLine + ' ' + $Name + ' "' + $escapedValue + '"').Trim()
+}
+
+function Invoke-ServiceRecoveryCommand {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Arguments,
+
+        [Parameter(Mandatory)]
+        [string]$Operation
+    )
+
+    $output = & sc.exe @Arguments 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        return $true
+    }
+
+    $message = "Failed to $Operation for service '$ServiceName' (sc.exe exit $LASTEXITCODE). $($output -join ' ')"
+    switch ($recoveryFailureMode) {
+        'Fail' { throw $message }
+        'Warn' { Write-Warning $message }
+        'Skip' { }
+        default { Write-Warning $message }
+    }
+    return $false
 }
 
 $binaryPathName = '"' + $exePath + '"'
@@ -129,6 +159,24 @@ if ($existing) {
     Set-Service -Name $ServiceName -DisplayName $DisplayName -Description $Description -StartupType Automatic
 } else {
     New-Service @newServiceParams | Out-Null
+}
+
+if ($recoveryConfigured) {
+    $recoveryActions = if ($recoveryEnabled) {
+        ($recoveryRestartDelayMilliseconds | ForEach-Object { "restart/$_" }) -join '/'
+    } else {
+        # Windows PowerShell 5.1 drops empty native arguments. The quoted payload
+        # preserves the required empty value for `sc.exe failure ... actions= ""`.
+        '""'
+    }
+    $recoveryActionsConfigured = Invoke-ServiceRecoveryCommand `
+        -Arguments @('failure', $ServiceName, 'reset=', [string]$recoveryResetPeriodSeconds, 'actions=', $recoveryActions) `
+        -Operation $(if ($recoveryEnabled) { 'configure recovery actions' } else { 'clear recovery actions' })
+    if ($recoveryActionsConfigured) {
+        [void](Invoke-ServiceRecoveryCommand `
+            -Arguments @('failureflag', $ServiceName, $(if ($recoveryEnabled -and $recoveryApplyToNonCrashFailures) { '1' } else { '0' })) `
+            -Operation 'configure the recovery failure flag')
+    }
 }
 
 if ($Start) {

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -1746,6 +1746,7 @@ public sealed partial class DotNetPublishPipelineRunner
             Enabled = recovery.Enabled,
             ResetPeriodSeconds = recovery.ResetPeriodSeconds,
             RestartDelaySeconds = recovery.RestartDelaySeconds,
+            RestartDelaySequenceSeconds = recovery.RestartDelaySequenceSeconds?.ToArray() ?? Array.Empty<int>(),
             ApplyToNonCrashFailures = recovery.ApplyToNonCrashFailures,
             OnFailure = recovery.OnFailure
         };

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PublishLayout.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PublishLayout.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.IO.Compression;
 using System.Text;
 using System.Text.Json;
@@ -361,7 +362,7 @@ public sealed partial class DotNetPublishPipelineRunner
         if (!string.IsNullOrWhiteSpace(installPath))
             File.WriteAllText(
                 installPath!,
-                BuildInstallServiceScript(serviceName, displayName, description, executableRelativePath, arguments),
+                BuildInstallServiceScript(serviceName, displayName, description, executableRelativePath, arguments, service.Recovery),
                 new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
         if (!string.IsNullOrWhiteSpace(uninstallPath))
             File.WriteAllText(
@@ -394,6 +395,7 @@ public sealed partial class DotNetPublishPipelineRunner
                     Enabled = service.Recovery.Enabled,
                     ResetPeriodSeconds = service.Recovery.ResetPeriodSeconds,
                     RestartDelaySeconds = service.Recovery.RestartDelaySeconds,
+                    RestartDelaySequenceSeconds = service.Recovery.RestartDelaySequenceSeconds?.ToArray() ?? Array.Empty<int>(),
                     ApplyToNonCrashFailures = service.Recovery.ApplyToNonCrashFailures,
                     OnFailure = service.Recovery.OnFailure
                 },
@@ -491,21 +493,48 @@ public sealed partial class DotNetPublishPipelineRunner
         string displayName,
         string description,
         string executableRelativePath,
-        string? arguments)
+        string? arguments,
+        DotNetPublishServiceRecoveryOptions? recovery)
     {
+        var recoveryConfigured = recovery is not null;
+        var recoveryEnabled = recovery?.Enabled == true;
+        var recoveryResetPeriodSeconds = recovery is null || recovery.ResetPeriodSeconds <= 0
+            ? 86400
+            : recovery.ResetPeriodSeconds;
+        int[] recoveryRestartDelayMilliseconds = ResolveRecoveryRestartDelaySeconds(recovery)
+            .Select(static delay => checked(delay * 1000))
+            .ToArray();
         var tokens = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             ["ServiceName"] = EscapePowerShellSingleQuoted(serviceName),
             ["DisplayName"] = EscapePowerShellSingleQuoted(displayName),
             ["Description"] = EscapePowerShellSingleQuoted(description),
             ["ExecutableRelativePath"] = EscapePowerShellSingleQuoted(executableRelativePath),
-            ["Arguments"] = EscapePowerShellSingleQuoted(arguments ?? string.Empty)
+            ["Arguments"] = EscapePowerShellSingleQuoted(arguments ?? string.Empty),
+            ["RecoveryConfigured"] = recoveryConfigured ? "$true" : "$false",
+            ["RecoveryEnabled"] = recoveryEnabled ? "$true" : "$false",
+            ["RecoveryResetPeriodSeconds"] = recoveryResetPeriodSeconds.ToString(CultureInfo.InvariantCulture),
+            ["RecoveryRestartDelayMilliseconds"] = string.Join(", ", recoveryRestartDelayMilliseconds.Select(static delay => delay.ToString(CultureInfo.InvariantCulture))),
+            ["RecoveryApplyToNonCrashFailures"] = recovery?.ApplyToNonCrashFailures == false ? "$false" : "$true",
+            ["RecoveryFailureMode"] = (recovery?.OnFailure ?? DotNetPublishPolicyMode.Warn).ToString()
         };
 
         return RenderServiceTemplate(
             "Install-Service.ps1",
             EmbeddedScripts.Load("Scripts/DotNetPublish/Install-Service.Template.ps1"),
             tokens);
+    }
+
+    private static int[] ResolveRecoveryRestartDelaySeconds(DotNetPublishServiceRecoveryOptions? recovery) {
+        int[] configured = recovery?.RestartDelaySequenceSeconds?
+            .Where(static delay => delay > 0)
+            .ToArray() ?? Array.Empty<int>();
+        if (configured.Length > 0) {
+            return configured;
+        }
+
+        int fallback = recovery is null || recovery.RestartDelaySeconds <= 0 ? 60 : recovery.RestartDelaySeconds;
+        return [fallback, fallback, fallback];
     }
 
     private static string BuildUninstallServiceScript(string serviceName)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.ServiceLifecycle.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.ServiceLifecycle.cs
@@ -326,14 +326,15 @@ public sealed partial class DotNetPublishPipelineRunner
         DotNetPublishServiceLifecycleOptions lifecycle)
     {
         var recovery = ResolveRecoveryOptions(package);
-        if (recovery is null || !recovery.Enabled)
+        if (recovery is null)
             return;
 
-        var reset = recovery.ResetPeriodSeconds <= 0 ? 86400 : recovery.ResetPeriodSeconds;
-        var delayMs = (recovery.RestartDelaySeconds <= 0 ? 60 : recovery.RestartDelaySeconds) * 1000;
-        var actions = $"restart/{delayMs}/restart/{delayMs}/restart/{delayMs}";
+        var reset = recovery.Enabled && recovery.ResetPeriodSeconds > 0 ? recovery.ResetPeriodSeconds : 0;
+        var actions = recovery.Enabled
+            ? string.Join("/", ResolveRecoveryRestartDelaySeconds(recovery).Select(static delay => $"restart/{checked(delay * 1000)}"))
+            : string.Empty;
 
-        _logger.Info($"Service lifecycle: configuring recovery for '{serviceName}'");
+        _logger.Info($"Service lifecycle: {(recovery.Enabled ? "configuring" : "clearing")} recovery for '{serviceName}'");
         var failure = RunProcess("sc.exe", workingDir, new[] { "failure", serviceName, "reset=", reset.ToString(), "actions=", actions });
         if (failure.ExitCode != 0)
         {
@@ -343,7 +344,7 @@ public sealed partial class DotNetPublishPipelineRunner
             return;
         }
 
-        var failureFlag = RunProcess("sc.exe", workingDir, new[] { "failureflag", serviceName, recovery.ApplyToNonCrashFailures ? "1" : "0" });
+        var failureFlag = RunProcess("sc.exe", workingDir, new[] { "failureflag", serviceName, recovery.Enabled && recovery.ApplyToNonCrashFailures ? "1" : "0" });
         if (failureFlag.ExitCode != 0)
         {
             HandlePolicy(

--- a/Schemas/powerforge.dotnetpublish.schema.json
+++ b/Schemas/powerforge.dotnetpublish.schema.json
@@ -799,6 +799,11 @@
         "Enabled": { "type": "boolean" },
         "ResetPeriodSeconds": { "type": "integer", "minimum": 1 },
         "RestartDelaySeconds": { "type": "integer", "minimum": 1 },
+        "RestartDelaySequenceSeconds": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 1 },
+          "minItems": 1
+        },
         "ApplyToNonCrashFailures": { "type": "boolean" },
         "OnFailure": { "$ref": "#/$defs/DotNetPublishPolicyMode" }
       }


### PR DESCRIPTION
## Summary

- apply declared recovery policy in generated Windows service installers and direct lifecycle execution
- support ordered restart delays while retaining the existing single-delay setting for compatibility
- distinguish an absent recovery declaration from an explicit disabled policy
- clear stale recovery actions and the non-crash failure flag when recovery is disabled
- honor Fail, Warn, and Skip error policies, including Windows PowerShell 5.1 native argument behavior

## Validation

- focused service-package tests pass: 16 tests
- generated scripts parse on Windows PowerShell 5.1 and PowerShell 7
- a Windows PowerShell 5.1 argument probe confirms the explicit-disable payload reaches the native process as an empty argument