### PR TITLE
Support managed Cloudflare policy on protected Linux deployments

### DIFF
--- a/.github/actions/powerforge-cloudflare-site-policy/action.yml
+++ b/.github/actions/powerforge-cloudflare-site-policy/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: Checkout the caller commit before reading site-config. Set false only when the caller already checked out the exact source.
     required: false
     default: "true"
+  purge-after-policy:
+    description: Purge the canonical site hostname after applying the policy. Use after a successful non-Pages deployment so objects cached under the previous rules cannot survive.
+    required: false
+    default: "false"
   manage-incremental-purge:
     description: Restore, apply, and save the private deployment-manifest baseline. Intended for the reusable deployment workflow after it uploads the current manifest.
     required: false
@@ -96,6 +100,7 @@ runs:
       shell: pwsh
       env:
         POWERFORGE_MANAGE_INCREMENTAL_PURGE: ${{ inputs.manage-incremental-purge }}
+        POWERFORGE_PURGE_AFTER_POLICY: ${{ inputs.purge-after-policy }}
         POWERFORGE_CLOUDFLARE_CLI_PROJECT: ${{ github.action_path }}/../../../PowerForge.Web.Cli/PowerForge.Web.Cli.csproj
         POWERFORGE_DEPLOYMENT_ID: ${{ inputs.deployment-id }}
         POWERFORGE_DEPLOYMENT_JOB_ID: ${{ inputs.deployment-job-id }}
@@ -116,6 +121,12 @@ runs:
 
         if ($env:POWERFORGE_MANAGE_INCREMENTAL_PURGE -notin @('true', 'false')) {
           throw 'manage-incremental-purge must be true or false.'
+        }
+        if ($env:POWERFORGE_PURGE_AFTER_POLICY -notin @('true', 'false')) {
+          throw 'purge-after-policy must be true or false.'
+        }
+        if ($env:POWERFORGE_MANAGE_INCREMENTAL_PURGE -eq 'true' -and $env:POWERFORGE_PURGE_AFTER_POLICY -eq 'true') {
+          throw 'purge-after-policy cannot be combined with manage-incremental-purge.'
         }
         $jsonOutput = @(dotnet run --no-build --no-restore --configuration Release --framework net10.0 --project $env:POWERFORGE_CLOUDFLARE_CLI_PROJECT -- cloudflare inspect --site-config $siteConfig --output json)
         if ($LASTEXITCODE -ne 0) {
@@ -212,6 +223,37 @@ runs:
         POWERFORGE_CLOUDFLARE_SITE_CONFIG: ${{ inputs.site-config }}
         POWERFORGE_CLOUDFLARE_ZONE_ID: ${{ inputs.zone-id }}
       run: '& "$env:GITHUB_ACTION_PATH/Invoke-PowerForgeCloudflareSitePolicy.ps1"'
+
+    - name: Purge hostname after policy application
+      if: ${{ inputs.purge-after-policy == 'true' && steps.incremental.outputs.enabled != 'true' }}
+      shell: pwsh
+      env:
+        POWERFORGE_CLOUDFLARE_API_TOKEN: ${{ inputs.api-token }}
+        POWERFORGE_CLOUDFLARE_CLI_PROJECT: ${{ github.action_path }}/../../../PowerForge.Web.Cli/PowerForge.Web.Cli.csproj
+        POWERFORGE_CLOUDFLARE_DRY_RUN: ${{ inputs.dry-run }}
+        POWERFORGE_CLOUDFLARE_HOSTNAME: ${{ inputs.hostname }}
+        POWERFORGE_CLOUDFLARE_SITE_CONFIG: ${{ inputs.site-config }}
+        POWERFORGE_CLOUDFLARE_ZONE_ID: ${{ inputs.zone-id }}
+      run: |
+        $arguments = @(
+          'run', '--no-build', '--no-restore', '--configuration', 'Release', '--framework', 'net10.0',
+          '--project', $env:POWERFORGE_CLOUDFLARE_CLI_PROJECT, '--',
+          'cloudflare', 'purge',
+          '--zone-id', $env:POWERFORGE_CLOUDFLARE_ZONE_ID,
+          '--token-env', 'POWERFORGE_CLOUDFLARE_API_TOKEN',
+          '--site-config', $env:POWERFORGE_CLOUDFLARE_SITE_CONFIG,
+          '--purge-mode', 'hostname'
+        )
+        if (-not [string]::IsNullOrWhiteSpace($env:POWERFORGE_CLOUDFLARE_HOSTNAME)) {
+          $arguments += @('--hostname', $env:POWERFORGE_CLOUDFLARE_HOSTNAME)
+        }
+        if ($env:POWERFORGE_CLOUDFLARE_DRY_RUN -eq 'true') {
+          $arguments += '--dry-run'
+        }
+        dotnet @arguments
+        if ($LASTEXITCODE -ne 0) {
+          throw "Purging the Cloudflare hostname after policy application failed with exit code $LASTEXITCODE."
+        }
 
     - name: Purge changed Cloudflare URLs
       if: ${{ steps.incremental.outputs.enabled == 'true' && steps.baseline_order.outputs.stale != 'true' }}

--- a/.github/nuget.public.config
+++ b/.github/nuget.public.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -157,6 +157,9 @@ on:
         required: false
       deployment_cloudflare_api_token:
         required: false
+      deployment_cloudflare_policy_api_token:
+        description: Optional protected Cloudflare site-policy token. Unlike the narrow deploy-time purge token, this credential never reaches the Linux host.
+        required: false
       deployment_host:
         description: Optional masked deployment host from the caller's protected environment.
         required: false
@@ -365,7 +368,7 @@ jobs:
           fetch-depth: 1
 
       - name: Apply managed Cloudflare cache policy
-        if: ${{ inputs.deployment_cloudflare_zone != '' }}
+        if: ${{ inputs.deployment_cloudflare_zone != '' && !inputs.manage_cloudflare_site_policy }}
         uses: ./.powerforge-deployment/.github/actions/powerforge-cloudflare-cache-policy
         with:
           site-config: ${{ format('{0}/site.json', inputs.website_root) }}
@@ -396,6 +399,16 @@ jobs:
           engine-sha: ${{ needs.build.outputs.engine_sha }}
           engine-asset: ${{ needs.build.outputs.engine_asset }}
           engine-asset-sha256: ${{ needs.build.outputs.engine_asset_sha256 }}
+
+      - name: Apply managed Cloudflare site policy
+        if: ${{ inputs.deployment_cloudflare_zone != '' && inputs.manage_cloudflare_site_policy }}
+        uses: ./.powerforge-deployment/.github/actions/powerforge-cloudflare-site-policy
+        with:
+          site-config: ${{ format('{0}/site.json', inputs.website_root) }}
+          zone-id: ${{ vars.CLOUDFLARE_ZONE_ID || secrets.cloudflare_zone_id }}
+          api-token: ${{ secrets.deployment_cloudflare_policy_api_token }}
+          checkout-caller: "false"
+          purge-after-policy: "true"
 
   post-deploy:
     if: ${{ always() && inputs.post_deploy_pipeline_config != '' && ((inputs.deployment_target == 'github-pages' && needs.deploy.result == 'success' && (!inputs.manage_cloudflare_site_policy || needs.cloudflare-site-policy.result == 'success')) || (inputs.deployment_target == 'linux' && needs.deploy-linux.result == 'success')) }}

--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -316,6 +316,11 @@ jobs:
           CLOUDFLARE_ZONE_ID: ${{ inputs.credential_mode != 'none' && secrets.cloudflare_zone_id || '' }}
           POWERFORGE_RUNNER_RESULT_PATH: ${{ runner.temp }}/powerforge-website-runner-result.json
         run: |
+          $runnerRestoreConfig = Join-Path $env:GITHUB_WORKSPACE '.powerforge-runner/.github/nuget.public.config'
+          if (-not (Test-Path -LiteralPath $runnerRestoreConfig -PathType Leaf)) {
+            throw "PowerForge runner NuGet configuration not found: $runnerRestoreConfig"
+          }
+
           $runnerArgs = @(
             'website-runner',
             '--website-root', '${{ inputs.website_root }}',
@@ -336,7 +341,7 @@ jobs:
             $runnerArgs += '--maintenance-note'
           }
 
-          dotnet run --framework net10.0 -p:RestoreLockedMode=false --project ./.powerforge-runner/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj -- $runnerArgs
+          dotnet run --framework net10.0 -p:RestoreLockedMode=false "-p:RestoreConfigFile=$runnerRestoreConfig" --project ./.powerforge-runner/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj -- $runnerArgs
 
       - name: Resolve actual PowerForge engine provenance
         id: engine_provenance

--- a/Docs/PowerForge.Web.Cloudflare.md
+++ b/Docs/PowerForge.Web.Cloudflare.md
@@ -147,8 +147,11 @@ inputs:
     api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 ```
 
-Pin `POWERFORGE_COMMIT` to an exact commit. The reusable GitHub Pages deployment
-workflow can apply the same action after a successful deployment:
+Pin `POWERFORGE_COMMIT` to an exact commit. The reusable website deployment
+workflow can apply the same action. GitHub Pages applies it after a successful
+Pages deployment so incremental purge can correlate the exact deployment record.
+
+For GitHub Pages, pass the policy credential directly to the reusable policy job:
 
 ```yaml
 with:
@@ -157,6 +160,29 @@ secrets:
   cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
   cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 ```
+
+Linux deployment has two distinct credential boundaries. The narrow purge-only
+token is staged ephemerally for promotion and rollback. The broader policy token
+stays on the protected Actions runner, is used only after promotion succeeds, and
+performs a final hostname purge after policy reconciliation:
+
+```yaml
+with:
+  deployment_target: linux
+  deployment_cloudflare_zone: example.com
+  manage_cloudflare_site_policy: true
+secrets:
+  deployment_cloudflare_api_token: ${{ secrets.CLOUDFLARE_CACHE_PURGE_TOKEN }}
+  deployment_cloudflare_policy_api_token: ${{ secrets.CLOUDFLARE_SITE_POLICY_TOKEN }}
+  cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+```
+
+Never reuse the site-policy token as `deployment_cloudflare_api_token`: that
+credential is deliberately copied into the protected remote promotion staging
+area so the host can purge on finalize or rollback. The policy token needs Cache
+Rules Write and Transform Rules Write, Cache Settings Write when Smart Tiered
+Cache is enabled, and Cache Purge for the post-policy hostname invalidation. The
+deployment token needs only Cache Purge (and Zone Read when no zone id is passed).
 
 The existing `powerforge-cloudflare-cache-policy` action remains cache-only for
 backward compatibility.

--- a/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
@@ -8,6 +8,7 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         var workflow = ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml");
         var normalizedWorkflow = workflow.Replace("\r\n", "\n", StringComparison.Ordinal);
 
+        Assert.NotNull(new YamlDotNet.Serialization.DeserializerBuilder().Build().Deserialize<object>(workflow));
         Assert.Contains("default: \"github-pages\"", workflow, StringComparison.Ordinal);
         Assert.Contains("deployment_target == 'linux'", workflow, StringComparison.Ordinal);
         Assert.Contains("deployment_site", workflow, StringComparison.Ordinal);
@@ -98,24 +99,45 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.Contains("^/tmp/powerforge-([0-9]+)-([0-9]+)-", script, StringComparison.Ordinal);
         Assert.Contains("BASH_REMATCH[3]", script, StringComparison.Ordinal);
         string workflow = ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml");
+        string linuxJob = workflow[
+            workflow.IndexOf("  deploy-linux:", StringComparison.Ordinal)..
+            workflow.IndexOf("  post-deploy:", StringComparison.Ordinal)];
+        string linuxSitePolicyStep = linuxJob[
+            linuxJob.IndexOf("      - name: Apply managed Cloudflare site policy", StringComparison.Ordinal)..];
         Assert.Contains("deployment_cloudflare_zone", workflow, StringComparison.Ordinal);
         Assert.Contains("deployment_cloudflare_api_token", workflow, StringComparison.Ordinal);
+        Assert.Contains("deployment_cloudflare_policy_api_token", workflow, StringComparison.Ordinal);
         Assert.Contains("deployment-cloudflare-api-token: ${{ secrets.deployment_cloudflare_api_token }}", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("deployment-cloudflare-api-token: ${{ secrets.cloudflare_api_token }}", workflow, StringComparison.Ordinal);
         Assert.Contains("cloudflare-zone-id: ${{ vars.CLOUDFLARE_ZONE_ID || secrets.cloudflare_zone_id }}", workflow, StringComparison.Ordinal);
         Assert.Contains("zone-id: ${{ vars.CLOUDFLARE_ZONE_ID || secrets.cloudflare_zone_id }}", workflow, StringComparison.Ordinal);
         Assert.Contains("deployment-public-url: ${{ inputs.deployment_url }}", workflow, StringComparison.Ordinal);
         Assert.Contains("deployment-smoke-paths: ${{ inputs.deployment_smoke_paths }}", workflow, StringComparison.Ordinal);
-        Assert.Contains("uses: ./.powerforge-deployment/.github/actions/powerforge-cloudflare-cache-policy", workflow, StringComparison.Ordinal);
-        Assert.Contains("checkout-caller: \"false\"", workflow, StringComparison.Ordinal);
-        Assert.Contains("if: ${{ inputs.deployment_cloudflare_zone != '' }}", workflow, StringComparison.Ordinal);
+        Assert.Contains("uses: ./.powerforge-deployment/.github/actions/powerforge-cloudflare-site-policy", linuxJob, StringComparison.Ordinal);
+        Assert.Contains("uses: ./.powerforge-deployment/.github/actions/powerforge-cloudflare-cache-policy", linuxJob, StringComparison.Ordinal);
+        Assert.Equal(2, linuxJob.Split("checkout-caller: \"false\"", StringSplitOptions.None).Length - 1);
+        Assert.Contains("if: ${{ inputs.deployment_cloudflare_zone != '' && inputs.manage_cloudflare_site_policy }}", linuxJob, StringComparison.Ordinal);
+        Assert.Contains("if: ${{ inputs.deployment_cloudflare_zone != '' && !inputs.manage_cloudflare_site_policy }}", linuxJob, StringComparison.Ordinal);
+        Assert.Contains("api-token: ${{ secrets.deployment_cloudflare_policy_api_token }}", linuxJob, StringComparison.Ordinal);
+        Assert.Contains("purge-after-policy: \"true\"", linuxJob, StringComparison.Ordinal);
+        Assert.DoesNotContain("secrets.deployment_cloudflare_api_token", linuxSitePolicyStep, StringComparison.Ordinal);
         Assert.DoesNotContain("\n  cache-policy:\n", workflow.Replace("\r\n", "\n", StringComparison.Ordinal), StringComparison.Ordinal);
         Assert.True(
-            workflow.IndexOf("powerforge-cloudflare-cache-policy", StringComparison.Ordinal) < workflow.IndexOf("powerforge-linux-site-deploy", StringComparison.Ordinal),
-            "The optional cache policy and deployment must share one protected job and approval boundary.");
+            linuxJob.IndexOf("powerforge-linux-site-deploy", StringComparison.Ordinal) < linuxJob.IndexOf("powerforge-cloudflare-site-policy", StringComparison.Ordinal),
+            "The optional full site policy must run only after a successful protected deployment so rollback cannot leave new policy over old content.");
+        Assert.True(
+            linuxJob.IndexOf("powerforge-cloudflare-cache-policy", StringComparison.Ordinal) < linuxJob.IndexOf("powerforge-linux-site-deploy", StringComparison.Ordinal),
+            "The compatibility cache policy and deployment must share one protected job and approval boundary.");
         Assert.Contains("name: ${{ inputs.deployment_environment }}", workflow, StringComparison.Ordinal);
         string deployAction = ReadRepoFile(".github", "actions", "powerforge-linux-site-deploy", "Invoke-PowerForgeLinuxSiteDeploy.ps1");
         Assert.Contains("per_page=5", deployAction, StringComparison.Ordinal);
+        string sitePolicyAction = ReadRepoFile(".github", "actions", "powerforge-cloudflare-site-policy", "action.yml");
+        Assert.NotNull(new YamlDotNet.Serialization.DeserializerBuilder().Build().Deserialize<object>(sitePolicyAction));
+        Assert.Contains("purge-after-policy:", sitePolicyAction, StringComparison.Ordinal);
+        Assert.Contains("--purge-mode', 'hostname'", sitePolicyAction, StringComparison.Ordinal);
+        Assert.Contains("$arguments += @('--hostname', $env:POWERFORGE_CLOUDFLARE_HOSTNAME)", sitePolicyAction, StringComparison.Ordinal);
+        Assert.Contains("POWERFORGE_CLOUDFLARE_DRY_RUN", sitePolicyAction, StringComparison.Ordinal);
+        Assert.Contains("purge-after-policy cannot be combined with manage-incremental-purge", sitePolicyAction, StringComparison.Ordinal);
         string environmentExample = ReadRepoFile("Deployment", "Linux", "powerforge-site.env.example");
         Assert.Contains("deployment_cloudflare_api_token", environmentExample, StringComparison.Ordinal);
         Assert.DoesNotContain("workflow's cloudflare_api_token secret", environmentExample, StringComparison.Ordinal);

--- a/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
@@ -100,6 +100,23 @@ public sealed class GitHubWebsiteRunWorkflowTests
     }
 
     [Fact]
+    public void WebsiteRunWorkflow_ShouldRestoreRunnerWithItsOwnNuGetConfiguration()
+    {
+        var repoRoot = FindRepoRoot();
+        var workflowPath = Path.Combine(repoRoot, ".github", "workflows", "powerforge-website-run.yml");
+        var workflowYaml = File.ReadAllText(workflowPath);
+
+        Assert.Contains("Join-Path $env:GITHUB_WORKSPACE '.powerforge-runner/.github/nuget.public.config'", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("-p:RestoreConfigFile=$runnerRestoreConfig", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("PowerForge runner NuGet configuration not found", workflowYaml, StringComparison.Ordinal);
+
+        var restoreConfigPath = Path.Combine(repoRoot, ".github", "nuget.public.config");
+        var restoreConfig = File.ReadAllText(restoreConfigPath);
+        Assert.Contains("<clear />", restoreConfig, StringComparison.Ordinal);
+        Assert.Contains("https://api.nuget.org/v3/index.json", restoreConfig, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void WebsiteRunWorkflow_ShouldValidateCredentialModeBeforeCheckout()
     {
         var repoRoot = FindRepoRoot();


### PR DESCRIPTION
## What changed

- let Linux website deployments opt into the complete managed Cloudflare site policy instead of the legacy cache-only action
- keep the narrow deploy-time purge credential separate from the broader site-policy credential
- apply the full policy only after a successful promotion, then purge the canonical hostname so objects cached under previous rules cannot survive
- preserve the existing cache-only path for consumers that have not opted in
- isolate the reusable website runner restore from credentialed consumer `NuGet.config` files by using an explicit public NuGet source
- document the GitHub Pages and protected Linux credential boundaries

## Safety and compatibility

- Linux consumers remain cache-only unless `manage_cloudflare_site_policy` is enabled
- the policy credential never enters remote deployment staging
- hostname overrides are used consistently for both policy application and the post-policy purge
- untrusted website CI remains credential-free while the shared runner restores only from nuget.org
- HSTS remains controlled solely by each consumer's `site.json`

## Validation

- focused Linux deployment, guardrail, Cloudflare continuity, and reusable website workflow tests pass
- a cold restore from the explicit public NuGet configuration succeeds from inside a credentialed private consumer checkout
- changed workflow YAML deserializes successfully in the contract tests
- independent read-only review and one targeted confirmation completed; all actionable findings were corrected