### PR TITLE
Scope release cleanliness to artifact inputs

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -1072,6 +1072,18 @@ public sealed partial class ModulePipelineRunner
                 plan.ResolvedVersion,
                 plan.PreRelease,
                 plan.Artefacts);
+            string[] artefactMappingRoots = CollectReleaseArtefactInputRootPaths(
+                plan.ProjectRoot,
+                plan.ModuleName,
+                plan.ResolvedVersion,
+                plan.PreRelease,
+                plan.Artefacts);
+            plan.SourceRootPaths = new[] { plan.BuildSpec.SourcePath }
+                .Concat(artefactMappingRoots)
+                .Distinct(Path.DirectorySeparatorChar == '\\'
+                    ? StringComparer.OrdinalIgnoreCase
+                    : StringComparer.Ordinal)
+                .ToArray();
             plan.SourceInputPaths = CollectReleaseSourceInputPaths(
                 plan.BuildSpec,
                 (spec.SourceInputPaths ?? Array.Empty<string>())
@@ -1087,7 +1099,7 @@ public sealed partial class ModulePipelineRunner
                         ? Array.Empty<string>()
                         : new[] { plan.BuildSpec.CsprojPath! },
                     buildConfiguration: plan.BuildSpec.Configuration,
-                    sourceRootPaths: new[] { plan.BuildSpec.SourcePath });
+                    sourceRootPaths: plan.SourceRootPaths);
             if (string.IsNullOrWhiteSpace(provenance.Revision) || provenance.Dirty is not false)
             {
                 throw new InvalidOperationException(
@@ -1244,6 +1256,24 @@ public sealed partial class ModulePipelineRunner
         return inputs.OrderBy(static path => path, comparer).ToArray();
     }
 
+    private static string[] CollectReleaseArtefactInputRootPaths(
+        string projectRoot,
+        string moduleName,
+        string moduleVersion,
+        string? preRelease,
+        IEnumerable<ConfigurationArtefactSegment>? artefacts)
+    {
+        var comparer = Path.DirectorySeparatorChar == '\\' ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+        return (artefacts ?? Array.Empty<ConfigurationArtefactSegment>())
+            .Where(static artefact => artefact?.Configuration?.Enabled == true)
+            .SelectMany(static artefact => artefact.Configuration.DirectoryOutput ?? Array.Empty<ArtefactCopyMapping>())
+            .Where(static mapping => mapping is not null)
+            .Select(mapping => ResolveArtefactInputPath(mapping.Source, projectRoot, moduleName, moduleVersion, preRelease))
+            .Distinct(comparer)
+            .OrderBy(static path => path, comparer)
+            .ToArray();
+    }
+
     private static string ResolveArtefactInputPath(
         string value,
         string projectRoot,
@@ -1276,7 +1306,12 @@ public sealed partial class ModulePipelineRunner
             .ToArray();
         string[] currentInputs = CollectReleaseSourceInputPaths(
             plan.BuildSpec,
-            plan.SourceInputPaths,
+            plan.SourceInputPaths.Concat(CollectReleaseArtefactInputPaths(
+                plan.ProjectRoot,
+                plan.ModuleName,
+                plan.ResolvedVersion,
+                plan.PreRelease,
+                plan.Artefacts)),
             generatedPaths);
         DotNetPublishPipelineRunner.SourceProvenance current =
             DotNetPublishPipelineRunner.ReadSourceProvenance(
@@ -1288,7 +1323,7 @@ public sealed partial class ModulePipelineRunner
                     ? Array.Empty<string>()
                     : new[] { plan.BuildSpec.CsprojPath! },
                 buildConfiguration: plan.BuildSpec.Configuration,
-                sourceRootPaths: new[] { plan.BuildSpec.SourcePath });
+                sourceRootPaths: plan.SourceRootPaths);
         if (string.IsNullOrWhiteSpace(current.Revision) ||
             !string.Equals(current.Revision, plan.SourceRevision, StringComparison.OrdinalIgnoreCase) ||
             current.Dirty is not false)
@@ -1311,13 +1346,22 @@ public sealed partial class ModulePipelineRunner
                 ? StringComparer.OrdinalIgnoreCase
                 : StringComparer.Ordinal)
             .ToArray();
+        string[] currentArtefactInputs = CollectReleaseArtefactInputPaths(
+            plan.ProjectRoot,
+            plan.ModuleName,
+            plan.ResolvedVersion,
+            plan.PreRelease,
+            plan.Artefacts);
         DotNetPublishPipelineRunner.SourceProvenance current =
             DotNetPublishPipelineRunner.ReadSourceProvenance(
                 plan.ProjectRoot,
                 generatedPaths: generatedPaths,
-                explicitInputPaths: (plan.SourceInputPaths ?? Array.Empty<string>()).Concat(projectPaths),
+                explicitInputPaths: (plan.SourceInputPaths ?? Array.Empty<string>())
+                    .Concat(currentArtefactInputs)
+                    .Concat(projectPaths),
                 buildProjectPaths: projectPaths,
-                buildConfiguration: spec.Configuration);
+                buildConfiguration: spec.Configuration,
+                sourceRootPaths: plan.SourceRootPaths);
         if (string.IsNullOrWhiteSpace(current.Revision) ||
             !string.Equals(current.Revision, plan.SourceRevision, StringComparison.OrdinalIgnoreCase) ||
             current.Dirty is not false)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -1086,11 +1086,13 @@ public sealed partial class ModulePipelineRunner
                     buildProjectPaths: string.IsNullOrWhiteSpace(plan.BuildSpec.CsprojPath)
                         ? Array.Empty<string>()
                         : new[] { plan.BuildSpec.CsprojPath! },
-                    buildConfiguration: plan.BuildSpec.Configuration);
+                    buildConfiguration: plan.BuildSpec.Configuration,
+                    sourceRootPaths: new[] { plan.BuildSpec.SourcePath });
             if (string.IsNullOrWhiteSpace(provenance.Revision) || provenance.Dirty is not false)
             {
                 throw new InvalidOperationException(
-                    "Signed GitHub module releases require a resolved clean Git checkout before packaging.");
+                    "Signed GitHub module releases require a resolved Git revision with clean release inputs before packaging." +
+                    FormatDirtySourcePaths(provenance));
             }
 
             plan.SourceRevision = DotNetPublishReleaseArtifactVerifier.RequireFullGitObjectId(
@@ -1108,6 +1110,11 @@ public sealed partial class ModulePipelineRunner
             Path.Combine(projectRoot, PublishedRegistryProvenanceValidator.ModuleProvenanceFileName),
             Path.Combine(projectRoot, PowerForgeModuleSourceAttestationWriter.FileName)
         };
+
+    private static string FormatDirtySourcePaths(DotNetPublishPipelineRunner.SourceProvenance provenance)
+        => provenance.DirtyPaths.Length == 0
+            ? string.Empty
+            : " Blocking source input(s): " + string.Join(", ", provenance.DirtyPaths) + ".";
 
     private static string[] CollectReleaseSourceInputPaths(
         ModuleBuildSpec build,
@@ -1280,7 +1287,8 @@ public sealed partial class ModulePipelineRunner
                 buildProjectPaths: string.IsNullOrWhiteSpace(plan.BuildSpec.CsprojPath)
                     ? Array.Empty<string>()
                     : new[] { plan.BuildSpec.CsprojPath! },
-                buildConfiguration: plan.BuildSpec.Configuration);
+                buildConfiguration: plan.BuildSpec.Configuration,
+                sourceRootPaths: new[] { plan.BuildSpec.SourcePath });
         if (string.IsNullOrWhiteSpace(current.Revision) ||
             !string.Equals(current.Revision, plan.SourceRevision, StringComparison.OrdinalIgnoreCase) ||
             current.Dirty is not false)

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
@@ -1227,6 +1227,90 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
     }
 
     [Fact]
+    public void ReadSourceProvenance_RejectsDirtyEvaluatedAnalyzerOutsideProjectDirectory()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string projectDirectory = Directory.CreateDirectory(Path.Combine(root, "src", "App")).FullName;
+            string analyzerDirectory = Directory.CreateDirectory(Path.Combine(root, "tools")).FullName;
+            string projectPath = Path.Combine(projectDirectory, "App.csproj");
+            string analyzerPath = Path.Combine(analyzerDirectory, "Rules.dll");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+                  <ItemGroup><Analyzer Include="../../tools/Rules.dll" /></ItemGroup>
+                </Project>
+                """);
+            File.WriteAllBytes(analyzerPath, [0x01, 0x02, 0x03]);
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source\"");
+            File.WriteAllBytes(analyzerPath, [0x04, 0x05, 0x06]);
+
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(
+                    root,
+                    buildProjectPaths: [projectPath],
+                    buildConfiguration: "Release");
+
+            Assert.True(provenance.Dirty);
+            Assert.Contains("tools/Rules.dll", provenance.DirtyPaths, StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                foreach (FileInfo file in new DirectoryInfo(root).EnumerateFiles("*", SearchOption.AllDirectories))
+                    file.Attributes = FileAttributes.Normal;
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void ReadSourceProvenance_RejectsDeletedRepositoryImportThatDisappearsFromEvaluation()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string projectDirectory = Directory.CreateDirectory(Path.Combine(root, "src", "App")).FullName;
+            string projectPath = Path.Combine(projectDirectory, "App.csproj");
+            string repositoryImport = Path.Combine(root, "Directory.Build.props");
+            File.WriteAllText(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>");
+            File.WriteAllText(repositoryImport, "<Project><PropertyGroup><Deterministic>true</Deterministic></PropertyGroup></Project>");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source\"");
+            File.Delete(repositoryImport);
+
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(
+                    root,
+                    buildProjectPaths: [projectPath],
+                    buildConfiguration: "Release");
+
+            Assert.True(provenance.Dirty);
+            Assert.Contains("Directory.Build.props", provenance.DirtyPaths, StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                foreach (FileInfo file in new DirectoryInfo(root).EnumerateFiles("*", SearchOption.AllDirectories))
+                    file.Attributes = FileAttributes.Normal;
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void ReadPortableInventorySourceProvenance_RejectsDirtySameRevision()
     {
         string root = Directory.CreateTempSubdirectory().FullName;

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
@@ -1171,7 +1171,7 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
             RunGit(root, "init");
             RunGit(root, "config user.name \"PowerForge Tests\"");
             RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
-            string projectRoot = root;
+            string projectRoot = Directory.CreateDirectory(Path.Combine(root, "src", "App")).FullName;
             string buildRoot = Directory.CreateDirectory(Path.Combine(root, "Build")).FullName;
             string projectPath = Path.Combine(projectRoot, "Sample.csproj");
             string sourcePath = Path.Combine(projectRoot, "Program.cs");
@@ -1201,10 +1201,20 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
                     buildConfiguration: "Release");
 
             Assert.True(sourceDirty.Dirty);
-            Assert.Contains("Program.cs", sourceDirty.DirtyPaths, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("src/App/Program.cs", sourceDirty.DirtyPaths, StringComparer.OrdinalIgnoreCase);
             Assert.DoesNotContain("Build/Build-Project.ps1", sourceDirty.DirtyPaths, StringComparer.OrdinalIgnoreCase);
 
             File.WriteAllText(sourcePath, "internal static class Program { }");
+            File.Delete(buildScript);
+            DotNetPublishPipelineRunner.SourceProvenance deletedOperator =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(
+                    root,
+                    buildProjectPaths: [projectPath],
+                    buildConfiguration: "Release");
+
+            Assert.False(deletedOperator.Dirty);
+            Assert.Empty(deletedOperator.DirtyPaths);
+
             File.Delete(sourcePath);
             DotNetPublishPipelineRunner.SourceProvenance deletedSource =
                 DotNetPublishPipelineRunner.ReadSourceProvenance(
@@ -1213,7 +1223,8 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
                     buildConfiguration: "Release");
 
             Assert.True(deletedSource.Dirty);
-            Assert.Contains("Program.cs", deletedSource.DirtyPaths, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("src/App/Program.cs", deletedSource.DirtyPaths, StringComparer.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Build/Build-Project.ps1", deletedSource.DirtyPaths, StringComparer.OrdinalIgnoreCase);
         }
         finally
         {
@@ -1298,6 +1309,51 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
 
             Assert.True(provenance.Dirty);
             Assert.Contains("Directory.Build.props", provenance.DirtyPaths, StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                foreach (FileInfo file in new DirectoryInfo(root).EnumerateFiles("*", SearchOption.AllDirectories))
+                    file.Attributes = FileAttributes.Normal;
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void ReadSourceProvenance_RejectsDeletedLinkedSourceOutsideProjectDirectory()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string projectDirectory = Directory.CreateDirectory(Path.Combine(root, "src", "App")).FullName;
+            string sharedDirectory = Directory.CreateDirectory(Path.Combine(root, "shared")).FullName;
+            string projectPath = Path.Combine(projectDirectory, "App.csproj");
+            string linkedSource = Path.Combine(sharedDirectory, "Linked.cs");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+                  <ItemGroup><Compile Include="../../shared/Linked.cs" Link="Linked.cs" /></ItemGroup>
+                </Project>
+                """);
+            File.WriteAllText(linkedSource, "internal static class Linked { }");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source\"");
+            File.Delete(linkedSource);
+
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(
+                    root,
+                    buildProjectPaths: [projectPath],
+                    buildConfiguration: "Release");
+
+            Assert.True(provenance.Dirty);
+            Assert.Contains("shared/Linked.cs", provenance.DirtyPaths, StringComparer.OrdinalIgnoreCase);
         }
         finally
         {

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
@@ -1163,6 +1163,70 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
     }
 
     [Fact]
+    public void ReadSourceProvenance_IgnoresDirtyTrackedOperatorFileOutsideEvaluatedProjectInputs()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string projectRoot = root;
+            string buildRoot = Directory.CreateDirectory(Path.Combine(root, "Build")).FullName;
+            string projectPath = Path.Combine(projectRoot, "Sample.csproj");
+            string sourcePath = Path.Combine(projectRoot, "Program.cs");
+            string buildScript = Path.Combine(buildRoot, "Build-Project.ps1");
+            File.WriteAllText(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>");
+            File.WriteAllText(sourcePath, "internal static class Program { }");
+            File.WriteAllText(buildScript, "param([string] $RunMode = 'Build')");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source\"");
+            File.WriteAllText(buildScript, "param([string] $RunMode = 'Publish')");
+
+            DotNetPublishPipelineRunner.SourceProvenance operatorDirty =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(
+                    root,
+                    buildProjectPaths: [projectPath],
+                    buildConfiguration: "Release");
+
+            Assert.False(operatorDirty.Dirty);
+            Assert.Empty(operatorDirty.DirtyPaths);
+
+            File.AppendAllText(sourcePath, Environment.NewLine + "// dirty source");
+            DotNetPublishPipelineRunner.SourceProvenance sourceDirty =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(
+                    root,
+                    buildProjectPaths: [projectPath],
+                    buildConfiguration: "Release");
+
+            Assert.True(sourceDirty.Dirty);
+            Assert.Contains("Program.cs", sourceDirty.DirtyPaths, StringComparer.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Build/Build-Project.ps1", sourceDirty.DirtyPaths, StringComparer.OrdinalIgnoreCase);
+
+            File.WriteAllText(sourcePath, "internal static class Program { }");
+            File.Delete(sourcePath);
+            DotNetPublishPipelineRunner.SourceProvenance deletedSource =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(
+                    root,
+                    buildProjectPaths: [projectPath],
+                    buildConfiguration: "Release");
+
+            Assert.True(deletedSource.Dirty);
+            Assert.Contains("Program.cs", deletedSource.DirtyPaths, StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                foreach (FileInfo file in new DirectoryInfo(root).EnumerateFiles("*", SearchOption.AllDirectories))
+                    file.Attributes = FileAttributes.Normal;
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void ReadPortableInventorySourceProvenance_RejectsDirtySameRevision()
     {
         string root = Directory.CreateTempSubdirectory().FullName;

--- a/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.Signing.cs
+++ b/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.Signing.cs
@@ -279,7 +279,43 @@ public sealed partial class ModulePipelineScriptExecutionSeamTests
             InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
                 CreateRunner(new FakeHostedOperations()).Plan(spec));
 
-            Assert.Contains("resolved clean Git checkout", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("clean release inputs", exception.Message, StringComparison.OrdinalIgnoreCase);
+            if (makeDirty)
+                Assert.Contains("dirty.txt", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Plan_SignedGitHubPackedArtifactAllowsDirtyTrackedOperatorFileOutsideReleaseInputs()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            string moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module")).FullName;
+            string buildRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Build")).FullName;
+            string buildScript = Path.Combine(buildRoot, "Build-Project.ps1");
+            WriteMinimalModule(moduleRoot, moduleName, "1.0.0");
+            File.WriteAllText(buildScript, "param([string] $RunMode = 'Build')");
+            RunGit(root.FullName, "init", "--quiet");
+            RunGit(root.FullName, "config", "user.email", "powerforge-tests@example.invalid");
+            RunGit(root.FullName, "config", "user.name", "PowerForge Tests");
+            RunGit(root.FullName, "add", ".");
+            RunGit(root.FullName, "commit", "--quiet", "-m", "fixture");
+            File.WriteAllText(buildScript, "param([string] $RunMode = 'Publish')");
+            ModulePipelineSpec spec = CreateSignedPackedSpec(
+                moduleRoot,
+                moduleName,
+                Path.Combine(root.FullName, "Artefacts", "Packed"));
+            EnableGitHubPublish(spec, moduleName);
+
+            ModulePipelinePlan plan = CreateRunner(new FakeHostedOperations()).Plan(spec);
+
+            Assert.False(plan.SourceDirty);
         }
         finally
         {
@@ -311,7 +347,7 @@ public sealed partial class ModulePipelineScriptExecutionSeamTests
             InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
                 CreateRunner(new FakeHostedOperations()).Plan(spec));
 
-            Assert.Contains("resolved clean Git checkout", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("clean release inputs", exception.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {
@@ -363,7 +399,7 @@ public sealed partial class ModulePipelineScriptExecutionSeamTests
             {
                 InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
                     CreateRunner(new FakeHostedOperations()).Plan(spec));
-                Assert.Contains("resolved clean Git checkout", exception.Message, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("clean release inputs", exception.Message, StringComparison.OrdinalIgnoreCase);
             }
             else
             {
@@ -416,7 +452,7 @@ public sealed partial class ModulePipelineScriptExecutionSeamTests
             InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
                 CreateRunner(new FakeHostedOperations()).Plan(spec));
 
-            Assert.Contains("resolved clean Git checkout", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("clean release inputs", exception.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {
@@ -461,7 +497,7 @@ public sealed partial class ModulePipelineScriptExecutionSeamTests
             InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
                 CreateRunner(new FakeHostedOperations()).Plan(spec));
 
-            Assert.Contains("resolved clean Git checkout", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("clean release inputs", exception.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.Signing.cs
+++ b/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.Signing.cs
@@ -588,6 +588,59 @@ public sealed partial class ModulePipelineScriptExecutionSeamTests
     }
 
     [Fact]
+    public void Run_SignedGitHubPackedArtifactRejectsPostPlanFileAddedToMappedDirectory()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+            string mappedDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "ExternalAssets")).FullName;
+            File.WriteAllText(Path.Combine(mappedDirectory, "approved.json"), "{\"approved\":true}");
+            File.WriteAllText(Path.Combine(root.FullName, ".gitignore"), "ExternalAssets/generated.json\nArtefacts/\n");
+            RunGit(root.FullName, "init", "--quiet");
+            RunGit(root.FullName, "config", "user.email", "powerforge-tests@example.invalid");
+            RunGit(root.FullName, "config", "user.name", "PowerForge Tests");
+            RunGit(root.FullName, "add", ".");
+            RunGit(root.FullName, "commit", "--quiet", "-m", "fixture");
+            var hostedOperations = new FakeHostedOperations
+            {
+                AutoSuccessfulSigningResult = true,
+                SigningCallStarted = call =>
+                {
+                    if (call == 1)
+                        File.WriteAllText(Path.Combine(mappedDirectory, "generated.json"), "{\"generated\":true}");
+                }
+            };
+            var runner = CreateRunner(hostedOperations);
+            ModulePipelineSpec spec = CreateSignedPackedSpec(
+                root.FullName,
+                moduleName,
+                Path.Combine(root.FullName, "Artefacts", "Packed"));
+            EnableGitHubPublish(spec, moduleName);
+            ConfigurationArtefactSegment artefact = Assert.IsType<ConfigurationArtefactSegment>(
+                spec.Segments.Single(segment => segment is ConfigurationArtefactSegment));
+            artefact.Configuration.DirectoryOutput =
+            [
+                new ArtefactCopyMapping
+                {
+                    Source = mappedDirectory,
+                    Destination = "ExternalAssets"
+                }
+            ];
+            ModulePipelinePlan plan = runner.Plan(spec);
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => runner.Run(spec, plan));
+
+            Assert.Contains("source changed after planning", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void Run_SignedGitHubModuleRejectsEmbeddedPackageSourceMutationBeforeRemotePublish()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePublicationOrdering.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePublicationOrdering.cs
@@ -898,6 +898,74 @@ public sealed partial class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_post_build_source_guard_allows_dirty_operator_file_outside_configured_module_source()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            string moduleRoot = Directory.CreateDirectory(Path.Combine(root, "Module")).FullName;
+            string buildRoot = Directory.CreateDirectory(Path.Combine(root, "Build")).FullName;
+            string moduleConfigPath = Path.Combine(root, "powerforge.json");
+            string releasePath = Path.Combine(root, "release.json");
+            string operatorScript = Path.Combine(buildRoot, "Build-Project.ps1");
+            File.WriteAllText(Path.Combine(moduleRoot, "TestModule.psm1"), "function Get-Test { 'ok' }");
+            File.WriteAllText(moduleConfigPath, """
+                {
+                  "Build": {
+                    "Name": "TestModule",
+                    "SourcePath": "Module",
+                    "Version": "1.0.0"
+                  }
+                }
+                """);
+            File.WriteAllText(releasePath, "{}");
+            File.WriteAllText(operatorScript, "param([string] $RunMode = 'Build')");
+            RunGitForSourceGuard(root, "init");
+            RunGitForSourceGuard(root, "config user.name \"PowerForge Tests\"");
+            RunGitForSourceGuard(root, "config user.email \"powerforge-tests@example.invalid\"");
+            RunGitForSourceGuard(root, "add .");
+            RunGitForSourceGuard(root, "commit -m \"approved source\"");
+            string revision = RunGitForSourceGuard(root, "rev-parse HEAD").Trim();
+            File.WriteAllText(operatorScript, "param([string] $RunMode = 'Publish')");
+
+            var moduleCalls = new List<ModuleExecutionSnapshot>();
+            var service = CreateReleaseService(
+                root,
+                moduleCalls,
+                new PowerForgeToolReleaseResult { Success = true });
+            var spec = new PowerForgeReleaseSpec
+            {
+                Module = new PowerForgeModuleReleaseOptions
+                {
+                    RepositoryRoot = root,
+                    ConfigPath = moduleConfigPath
+                }
+            };
+
+            PowerForgeReleaseResult result = service.Execute(
+                spec,
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = releasePath,
+                    ModuleOnly = true,
+                    ModuleRunMode = ConfigurationGateMode.Publish,
+                    SourceRepositoryRoot = root,
+                    ExpectedSourceRevision = revision,
+                    SourceInputPaths = [releasePath]
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(2, moduleCalls.Count);
+            Assert.Equal(ConfigurationGateMode.Build, moduleCalls[0].RunMode);
+            Assert.Equal(ConfigurationGateMode.Publish, moduleCalls[1].RunMode);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void BuildModuleFailureMessage_UsesStructuredFailureWithoutRepeatingStandardOutput()
     {
         var message = PowerForgeReleaseService.BuildModuleFailureMessage(

--- a/PowerForge/Models/ModulePipelinePlan.cs
+++ b/PowerForge/Models/ModulePipelinePlan.cs
@@ -13,6 +13,7 @@ public sealed class ModulePipelinePlan
     internal bool GenerateReleaseProvenance { get; set; }
     internal string? SourceRepositoryUrl { get; set; }
     internal string[] SourceInputPaths { get; set; } = Array.Empty<string>();
+    internal string[] SourceRootPaths { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// Module name resolved for the pipeline.

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -57,6 +57,8 @@ internal sealed class PowerForgeReleaseRequest
 
     internal string[] SourceInputPaths { get; set; } = Array.Empty<string>();
 
+    internal string[] SourceRootPaths { get; set; } = Array.Empty<string>();
+
     internal DotNetPublishPlan? DotNetPublishPlan { get; set; }
 
     internal DotNetRepositoryReleaseSpec? PackageBuildSpec { get; set; }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
@@ -117,7 +117,8 @@ public sealed partial class DotNetPublishPipelineRunner
         IEnumerable<string>? trustedExternalInputPaths = null,
         IEnumerable<string>? buildProjectPaths = null,
         string? buildConfiguration = null,
-        DotNetPublishPlan? buildPlan = null)
+        DotNetPublishPlan? buildPlan = null,
+        IEnumerable<string>? sourceRootPaths = null)
     {
         var gitRevision = ReadGitText(projectRoot, "rev-parse HEAD");
         var environmentRevision = Environment.GetEnvironmentVariable("GITHUB_SHA")?.Trim();
@@ -153,6 +154,26 @@ public sealed partial class DotNetPublishPipelineRunner
         IEnumerable<string> allExplicitInputPaths = (explicitInputPaths ?? Array.Empty<string>())
             .Concat(bundleSourceInputs)
             .Concat(commandHookSourceInputs);
+        SourceDirtyScope dirtyScope = BuildSourceDirtyScope(
+            projectRoot,
+            gitRoot!,
+            allExplicitInputPaths,
+            sourceRootPaths,
+            buildProjectPaths,
+            buildConfiguration,
+            buildPlan);
+        string[]? trackedSourceChanges = FindTrackedSourceChanges(
+            projectRoot,
+            gitRoot!,
+            finalTrackedStatus,
+            trackedGeneratedPaths,
+            dirtyScope);
+        string[] untrackedSourceFiles = FindUntrackedSourceFiles(
+            projectRoot,
+            gitRoot!,
+            untrackedOutput,
+            generatedPaths,
+            dirtyScope);
         bool generatedOutputOverlapsInput = HasGeneratedOutputInputOverlap(
             projectRoot,
             generatedPaths,
@@ -161,16 +182,9 @@ public sealed partial class DotNetPublishPipelineRunner
             ? null
             : statusChangedDuringVerification
               || generatedOutputOverlapsInput
-              || HasTrackedSourceChanges(
-                projectRoot,
-                gitRoot!,
-                finalTrackedStatus!,
-                trackedGeneratedPaths)
-              || HasUntrackedSourceFiles(
-                projectRoot,
-                gitRoot!,
-                untrackedOutput,
-                generatedPaths)
+              || trackedSourceChanges is null
+              || trackedSourceChanges.Length > 0
+              || untrackedSourceFiles.Length > 0
               || HasUntrackedOrIgnoredExplicitInputs(
                   projectRoot,
                   gitRoot!,
@@ -179,13 +193,16 @@ public sealed partial class DotNetPublishPipelineRunner
               || HasIgnoredBuildInputs(
                   projectRoot,
                   gitRoot!,
-                  buildProjectPaths,
-                  buildConfiguration,
-                  buildPlan,
-                  generatedPaths);
+                  generatedPaths,
+                  dirtyScope);
         return new SourceProvenance(
             string.IsNullOrWhiteSpace(revision) ? null : revision,
-            dirty);
+            dirty,
+            (trackedSourceChanges ?? Array.Empty<string>())
+                .Concat(untrackedSourceFiles)
+                .Distinct(IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
+                .OrderBy(path => path, IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
+                .ToArray());
     }
 
     private static bool HasGeneratedOutputInputOverlap(
@@ -257,10 +274,8 @@ public sealed partial class DotNetPublishPipelineRunner
     private static bool HasIgnoredBuildInputs(
         string projectRoot,
         string gitRoot,
-        IEnumerable<string>? buildProjectPaths,
-        string? buildConfiguration,
-        DotNetPublishPlan? buildPlan,
-        IEnumerable<string>? generatedPaths)
+        IEnumerable<string>? generatedPaths,
+        SourceDirtyScope dirtyScope)
     {
         var comparison = IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
         string[] generatedExclusions = BuildGeneratedPathExclusions(projectRoot, gitRoot, generatedPaths);
@@ -269,14 +284,11 @@ public sealed partial class DotNetPublishPipelineRunner
             "ls-files --others --ignored --exclude-standard -z");
         if (ignoredOutput is null)
             return true;
-        if (!TryEvaluateDotNetBuildInputs(
-                buildProjectPaths,
-                buildConfiguration,
-                buildPlan,
-                out string[] projectDirectories,
-                out HashSet<string> buildInputs,
-                out HashSet<string> sourceInputs))
+        if (!dirtyScope.BuildInputsResolved)
             return true;
+        string[] projectDirectories = dirtyScope.ProjectDirectories;
+        HashSet<string> buildInputs = dirtyScope.BuildInputs;
+        HashSet<string> sourceInputs = dirtyScope.SourceInputs;
         if (HasGeneratedOutputInputOverlap(projectRoot, generatedPaths, buildInputs))
             return true;
         if (projectDirectories.Any(directory =>
@@ -654,45 +666,6 @@ public sealed partial class DotNetPublishPipelineRunner
             .ToArray();
     }
 
-    private static bool HasUntrackedSourceFiles(
-        string projectRoot,
-        string gitRoot,
-        string untrackedOutput,
-        IEnumerable<string>? generatedPaths)
-    {
-        var comparison = IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-        var exclusions = BuildGeneratedPathExclusions(projectRoot, gitRoot, generatedPaths);
-
-        foreach (var untrackedPath in untrackedOutput.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries))
-        {
-            var normalizedPath = untrackedPath.Replace('\\', '/').TrimStart('/');
-            if (!IsGeneratedPath(normalizedPath, exclusions, comparison))
-                return true;
-        }
-
-        return false;
-    }
-
-    private static bool HasTrackedSourceChanges(
-        string projectRoot,
-        string gitRoot,
-        string trackedOutput,
-        IEnumerable<string>? generatedPaths)
-    {
-        var comparison = IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-        var exclusions = BuildGeneratedPathExclusions(projectRoot, gitRoot, generatedPaths);
-        if (!TryParseTrackedStatusPaths(trackedOutput, out var changedPaths))
-            return true;
-
-        foreach (var path in changedPaths)
-        {
-            if (!IsGeneratedPath(path, exclusions, comparison))
-                return true;
-        }
-
-        return false;
-    }
-
     private static bool TryParseTrackedStatusPaths(string trackedOutput, out string[] paths)
     {
         var parsed = new List<string>();
@@ -826,15 +799,18 @@ public sealed partial class DotNetPublishPipelineRunner
 
     internal sealed class SourceProvenance
     {
-        public SourceProvenance(string? revision, bool? dirty)
+        public SourceProvenance(string? revision, bool? dirty, string[]? dirtyPaths = null)
         {
             Revision = revision;
             Dirty = dirty;
+            DirtyPaths = dirtyPaths ?? Array.Empty<string>();
         }
 
         public string? Revision { get; }
 
         public bool? Dirty { get; }
+
+        public string[] DirtyPaths { get; }
     }
 
     private sealed class MsiVersionStateWrite

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SourceDirtyState.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SourceDirtyState.cs
@@ -182,10 +182,29 @@ public sealed partial class DotNetPublishPipelineRunner
             if (File.Exists(workingTreePath) || Directory.Exists(workingTreePath))
                 return false;
 
-            // A deleted or renamed path cannot be re-evaluated from the current filesystem. Once a
-            // release has a scoped input closure, treat every missing changed path conservatively so
-            // linked sources and repository-level imports cannot disappear from that closure unnoticed.
-            return true;
+            if (ProjectDirectoryPaths.Any(directory =>
+                    directory.Length == 0 ||
+                    string.Equals(path, directory, comparison) ||
+                    path.StartsWith(directory + "/", comparison)))
+            {
+                return true;
+            }
+
+            string fileName = Path.GetFileName(path);
+            if (!IsRepositoryBuildControlFile(fileName))
+                return false;
+            string directoryPath = Path.GetDirectoryName(path)?.Replace('\\', '/').Trim('/') ?? string.Empty;
+            return ProjectDirectoryPaths.Any(projectDirectory =>
+                directoryPath.Length == 0 ||
+                string.Equals(projectDirectory, directoryPath, comparison) ||
+                projectDirectory.StartsWith(directoryPath + "/", comparison));
         }
+
+        private static bool IsRepositoryBuildControlFile(string fileName)
+            => fileName.Equals("Directory.Build.props", StringComparison.OrdinalIgnoreCase) ||
+               fileName.Equals("Directory.Build.targets", StringComparison.OrdinalIgnoreCase) ||
+               fileName.Equals("Directory.Packages.props", StringComparison.OrdinalIgnoreCase) ||
+               fileName.Equals("global.json", StringComparison.OrdinalIgnoreCase) ||
+               fileName.Equals("NuGet.Config", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SourceDirtyState.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SourceDirtyState.cs
@@ -1,0 +1,190 @@
+namespace PowerForge;
+
+public sealed partial class DotNetPublishPipelineRunner
+{
+    /// <summary>
+    /// Resolves the files and directories whose working-tree state can affect a release artifact.
+    /// Dirty paths outside this closure are operator workspace state and do not invalidate source provenance.
+    /// </summary>
+    private static SourceDirtyScope BuildSourceDirtyScope(
+        string projectRoot,
+        string gitRoot,
+        IEnumerable<string>? explicitInputPaths,
+        IEnumerable<string>? sourceRootPaths,
+        IEnumerable<string>? buildProjectPaths,
+        string? buildConfiguration,
+        DotNetPublishPlan? buildPlan)
+    {
+        var scope = new SourceDirtyScope();
+        foreach (string path in explicitInputPaths ?? Array.Empty<string>())
+            AddSourceDirtyScopePath(scope, projectRoot, gitRoot, path, directory: Directory.Exists(path));
+        foreach (string path in sourceRootPaths ?? Array.Empty<string>())
+            AddSourceDirtyScopePath(scope, projectRoot, gitRoot, path, directory: true);
+
+        scope.BuildInputsResolved = TryEvaluateDotNetBuildInputs(
+            buildProjectPaths,
+            buildConfiguration,
+            buildPlan,
+            out string[] projectDirectories,
+            out HashSet<string> buildInputs,
+            out HashSet<string> sourceInputs);
+        scope.ProjectDirectories = projectDirectories;
+        scope.BuildInputs = buildInputs;
+        scope.SourceInputs = sourceInputs;
+
+        foreach (string directory in projectDirectories)
+            AddProjectDirectoryScopePath(scope, projectRoot, gitRoot, directory);
+        foreach (string path in sourceInputs)
+            AddSourceDirtyScopePath(scope, projectRoot, gitRoot, path, directory: Directory.Exists(path));
+        return scope;
+    }
+
+    private static void AddProjectDirectoryScopePath(
+        SourceDirtyScope scope,
+        string projectRoot,
+        string gitRoot,
+        string? path)
+    {
+        if (TryGetGitScopePath(projectRoot, gitRoot, path, out string? relative))
+            scope.ProjectDirectoryPaths.Add(relative!);
+    }
+
+    private static void AddSourceDirtyScopePath(
+        SourceDirtyScope scope,
+        string projectRoot,
+        string gitRoot,
+        string? path,
+        bool directory)
+    {
+        if (!TryGetGitScopePath(projectRoot, gitRoot, path, out string? relative))
+            return;
+
+        if (directory)
+            scope.DirectoryPaths.Add(relative!);
+        else
+            scope.FilePaths.Add(relative!);
+    }
+
+    private static bool TryGetGitScopePath(
+        string projectRoot,
+        string gitRoot,
+        string? path,
+        out string? relative)
+    {
+        relative = null;
+        if (string.IsNullOrWhiteSpace(path))
+            return false;
+
+        string fullPath = Path.GetFullPath(Path.IsPathRooted(path)
+            ? path
+            : Path.Combine(projectRoot, path));
+        string fullGitRoot = Path.GetFullPath(gitRoot)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        StringComparison comparison = IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        if (string.Equals(
+                fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                fullGitRoot,
+                comparison))
+        {
+            relative = string.Empty;
+            return true;
+        }
+
+        relative = ToGitRelativeExclusion(projectRoot, gitRoot, fullPath)?
+            .Replace('\\', '/')
+            .Trim('/');
+        return relative is not null;
+    }
+
+    private static string[]? FindTrackedSourceChanges(
+        string projectRoot,
+        string gitRoot,
+        string? trackedOutput,
+        IEnumerable<string>? generatedPaths,
+        SourceDirtyScope scope)
+    {
+        if (trackedOutput is null || !TryParseTrackedStatusPaths(trackedOutput, out string[] changedPaths))
+            return null;
+        return FilterDirtySourcePaths(projectRoot, gitRoot, changedPaths, generatedPaths, scope);
+    }
+
+    private static string[] FindUntrackedSourceFiles(
+        string projectRoot,
+        string gitRoot,
+        string? untrackedOutput,
+        IEnumerable<string>? generatedPaths,
+        SourceDirtyScope scope)
+    {
+        if (untrackedOutput is null)
+            return Array.Empty<string>();
+        string[] paths = untrackedOutput.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
+        return FilterDirtySourcePaths(projectRoot, gitRoot, paths, generatedPaths, scope);
+    }
+
+    private static string[] FilterDirtySourcePaths(
+        string projectRoot,
+        string gitRoot,
+        IEnumerable<string> paths,
+        IEnumerable<string>? generatedPaths,
+        SourceDirtyScope scope)
+    {
+        StringComparison comparison = IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        string[] exclusions = BuildGeneratedPathExclusions(projectRoot, gitRoot, generatedPaths);
+        return paths
+            .Select(path => path.Replace('\\', '/').TrimStart('/'))
+            .Where(path => !IsGeneratedPath(path, exclusions, comparison))
+            .Where(path => !scope.IsScoped || scope.Contains(path, gitRoot, comparison))
+            .Distinct(IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
+            .OrderBy(path => path, IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private sealed class SourceDirtyScope
+    {
+        internal HashSet<string> FilePaths { get; } = new(
+            IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+
+        internal HashSet<string> DirectoryPaths { get; } = new(
+            IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+
+        internal HashSet<string> ProjectDirectoryPaths { get; } = new(
+            IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+
+        internal bool BuildInputsResolved { get; set; }
+
+        internal string[] ProjectDirectories { get; set; } = Array.Empty<string>();
+
+        internal HashSet<string> BuildInputs { get; set; } = new(
+            IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+
+        internal HashSet<string> SourceInputs { get; set; } = new(
+            IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+
+        internal bool IsScoped => DirectoryPaths.Count > 0 || ProjectDirectoryPaths.Count > 0;
+
+        internal bool Contains(string path, string gitRoot, StringComparison comparison)
+        {
+            if (FilePaths.Contains(path))
+                return true;
+            if (DirectoryPaths.Any(directory =>
+                directory.Length == 0 ||
+                string.Equals(path, directory, comparison) ||
+                path.StartsWith(directory + "/", comparison)))
+            {
+                return true;
+            }
+
+            string workingTreePath = Path.GetFullPath(Path.Combine(gitRoot, path.Replace('/', Path.DirectorySeparatorChar)));
+            if (File.Exists(workingTreePath) || Directory.Exists(workingTreePath))
+                return false;
+            return ProjectDirectoryPaths.Any(directory =>
+                directory.Length == 0 ||
+                string.Equals(path, directory, comparison) ||
+                path.StartsWith(directory + "/", comparison));
+        }
+    }
+}

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SourceDirtyState.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SourceDirtyState.cs
@@ -34,7 +34,7 @@ public sealed partial class DotNetPublishPipelineRunner
 
         foreach (string directory in projectDirectories)
             AddProjectDirectoryScopePath(scope, projectRoot, gitRoot, directory);
-        foreach (string path in sourceInputs)
+        foreach (string path in buildInputs)
             AddSourceDirtyScopePath(scope, projectRoot, gitRoot, path, directory: Directory.Exists(path));
         return scope;
     }
@@ -181,10 +181,11 @@ public sealed partial class DotNetPublishPipelineRunner
             string workingTreePath = Path.GetFullPath(Path.Combine(gitRoot, path.Replace('/', Path.DirectorySeparatorChar)));
             if (File.Exists(workingTreePath) || Directory.Exists(workingTreePath))
                 return false;
-            return ProjectDirectoryPaths.Any(directory =>
-                directory.Length == 0 ||
-                string.Equals(path, directory, comparison) ||
-                path.StartsWith(directory + "/", comparison));
+
+            // A deleted or renamed path cannot be re-evaluated from the current filesystem. Once a
+            // release has a scoped input closure, treat every missing changed path conservatively so
+            // linked sources and repository-level imports cannot disappear from that closure unnoticed.
+            return true;
         }
     }
 }

--- a/PowerForge/Services/PowerForgeReleaseService.SourceStateGuard.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.SourceStateGuard.cs
@@ -54,7 +54,8 @@ internal sealed partial class PowerForgeReleaseService
                     path.EndsWith(".fsproj", StringComparison.OrdinalIgnoreCase) ||
                     path.EndsWith(".vbproj", StringComparison.OrdinalIgnoreCase)),
                 buildConfiguration: request.Configuration,
-                buildPlan: request.DotNetPublishPlan);
+                buildPlan: request.DotNetPublishPlan,
+                sourceRootPaths: request.SourceRootPaths);
         ValidateExpectedSourceSnapshot(source, expectedRevision);
 
         if (request.PackageBuildSpec is not null)
@@ -67,7 +68,8 @@ internal sealed partial class PowerForgeReleaseService
                     generatedPaths: request.GeneratedProvenancePaths,
                     explicitInputPaths: (request.SourceInputPaths ?? Array.Empty<string>()).Concat(packageProjectPaths),
                     buildProjectPaths: packageProjectPaths,
-                    buildConfiguration: request.PackageBuildSpec.Configuration);
+                    buildConfiguration: request.PackageBuildSpec.Configuration,
+                    sourceRootPaths: request.SourceRootPaths);
             ValidateExpectedSourceSnapshot(packageSource, expectedRevision);
         }
 

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -1487,6 +1487,15 @@ internal sealed partial class PowerForgeReleaseService
         var moduleConfig = configPath is null
             ? null
             : new ModulePipelineConfigurationService().Load(configPath);
+        if (moduleConfig is not null)
+        {
+            request.SourceRootPaths = request.SourceRootPaths
+                .Concat(new[] { moduleConfig.ProjectRoot })
+                .Distinct(Path.DirectorySeparatorChar == '\\'
+                    ? StringComparer.OrdinalIgnoreCase
+                    : StringComparer.Ordinal)
+                .ToArray();
+        }
         if (scriptPath is not null && !File.Exists(scriptPath))
             throw new FileNotFoundException($"Module build script was not found: {scriptPath}", scriptPath);
         if (!request.PlanOnly &&


### PR DESCRIPTION
## Summary

- allow dirty build and operator files when they are outside the inputs that can affect release artifacts
- keep module source roots, evaluated .NET build inputs, lifecycle actions, configuration files, and artifact-copy sources inside the clean-source gate
- re-evaluate mapped artifact directories and propagate module source roots through post-build publication checks so late or ignored inputs still block release

## Validation

- release provenance matrix: 57 tests passed
- PowerForge compiled for net472, net8.0, and net10.0 with no warnings or errors
- the real Build-Project plan completed successfully with the tracked RunMode default changed from Build to Publish; no publish operation was performed

The broader test suite currently contains unrelated Apple, web, network, and documentation failures, including a five-minute documentation timeout; no failures occurred in the changed provenance test surface.