### PR TITLE
Fix multi-runtime MSBuild restore arguments

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -872,7 +872,7 @@ public sealed partial class DotNetPublishPipelineRunnerHardeningTests
             "net10.0-windows");
 
         Assert.Equal(new[] { "win-arm64", "win-x64" }, runtimes);
-        Assert.Equal("win-arm64;win-x64", DotNetPublishPipelineRunner.BuildMsBuildListPropertyValue(runtimes));
+        Assert.Equal("\"win-arm64;win-x64\"", DotNetPublishPipelineRunner.BuildMsBuildListPropertyValue(runtimes));
     }
 
     [Fact]
@@ -956,7 +956,7 @@ public sealed partial class DotNetPublishPipelineRunnerHardeningTests
             "win-arm64",
             "net10.0-windows");
 
-        Assert.Contains("/p:RuntimeIdentifiers=win-arm64;win-x64", args);
+        Assert.Contains("/p:RuntimeIdentifiers=\"win-arm64;win-x64\"", args);
         Assert.Contains("/p:PublishReadyToRun=true", args);
         Assert.DoesNotContain("/p:TargetFramework=net10.0-windows", args);
     }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -179,9 +179,9 @@ public sealed partial class DotNetPublishPipelineRunner
     }
 
     internal static string BuildMsBuildListPropertyValue(IEnumerable<string> values)
-        => string.Join(";", (values ?? Array.Empty<string>())
+        => $"\"{string.Join(";", (values ?? Array.Empty<string>())
             .Where(value => !string.IsNullOrWhiteSpace(value))
-            .Select(value => value.Trim()));
+            .Select(value => value.Trim()))}\"";
 
     private static bool IsPortableStyle(DotNetPublishStyle style)
     {


### PR DESCRIPTION
## Summary

PowerForge now quotes multi-runtime `RuntimeIdentifiers` values when invoking MSBuild. This keeps semicolon-separated runtime lists inside one property value instead of letting MSBuild interpret the second runtime as another property assignment.

## Why it matters

A declarative CLI release targeting multiple Windows architectures could fail during restore with `MSB1006: Property is not valid`. The corrected shared command path supports one target definition with multiple runtime identifiers and package styles.

## Validation

- `DotNetPublishPipelineRunnerHardeningTests`: 69/69 passed
- EventViewerX consumer proof: built x64 and ARM64, framework-dependent and portable-compatible ZIPs through `Invoke-ProjectRelease`
- Full `PowerForge.Tests`: 8,510 passed; 28 unrelated existing platform/timing failures remained outside this two-file change