### PR TITLE
Fix signed packed module manifest authorization

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackedSigningEvidence.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackedSigningEvidence.cs
@@ -43,12 +43,14 @@ public sealed partial class ModulePipelineRunner
             }
 
             string projectManifestPath = Path.Combine(plan.ProjectRoot, plan.ModuleName + ".psd1");
-            string? authorizedManifestSha256 = state.AuthorizedProjectManifestSha256;
-            if (string.IsNullOrWhiteSpace(authorizedManifestSha256) ||
+            string? authorizedProjectManifestSha256 = state.AuthorizedProjectManifestSha256;
+            string? authorizedStagingManifestSha256 = state.AuthorizedStagingManifestSha256;
+            if (string.IsNullOrWhiteSpace(authorizedProjectManifestSha256) ||
+                string.IsNullOrWhiteSpace(authorizedStagingManifestSha256) ||
                 !File.Exists(projectManifestPath) ||
                 (File.GetAttributes(projectManifestPath) & FileAttributes.ReparsePoint) != 0 ||
-                !string.Equals(ComputeFileSha256(projectManifestPath), authorizedManifestSha256, StringComparison.OrdinalIgnoreCase) ||
-                !string.Equals(ComputeFileSha256(context.ManifestPath), authorizedManifestSha256, StringComparison.OrdinalIgnoreCase))
+                !string.Equals(ComputeFileSha256(projectManifestPath), authorizedProjectManifestSha256, StringComparison.OrdinalIgnoreCase) ||
+                !string.Equals(ComputeFileSha256(context.ManifestPath), authorizedStagingManifestSha256, StringComparison.OrdinalIgnoreCase))
             {
                 throw new InvalidOperationException(
                     "The generated project manifest changed after its pipeline-owned synchronization or does not match the final packed module manifest.");
@@ -164,14 +166,18 @@ public sealed partial class ModulePipelineRunner
             return;
 
         string projectManifestPath = Path.Combine(plan.ProjectRoot, plan.ModuleName + ".psd1");
+        string stagingManifestPath = state.RequireBuildResult().ManifestPath;
         if (!File.Exists(projectManifestPath) ||
-            (File.GetAttributes(projectManifestPath) & FileAttributes.ReparsePoint) != 0)
+            (File.GetAttributes(projectManifestPath) & FileAttributes.ReparsePoint) != 0 ||
+            !File.Exists(stagingManifestPath) ||
+            (File.GetAttributes(stagingManifestPath) & FileAttributes.ReparsePoint) != 0)
         {
             throw new InvalidOperationException(
-                "The pipeline-owned project manifest synchronization did not produce a regular manifest file.");
+                "The pipeline-owned manifest synchronization did not produce regular project and staging manifest files.");
         }
 
         state.AuthorizedProjectManifestSha256 = ComputeFileSha256(projectManifestPath);
+        state.AuthorizedStagingManifestSha256 = ComputeFileSha256(stagingManifestPath);
     }
 
     private static string ComputeFileSha256(string path)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.State.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.State.cs
@@ -53,6 +53,7 @@ public sealed partial class ModulePipelineRunner
         public ModuleInstallerResult? InstallResult { get; set; }
         public string? ProjectManifestSyncMessage { get; set; }
         public string? AuthorizedProjectManifestSha256 { get; set; }
+        public string? AuthorizedStagingManifestSha256 { get; set; }
         public bool PackageWithoutScriptFolders =>
             MergeExecution.MergedModule ||
             (MergeExecution.UsedExistingPsm1 && !MergeExecution.HasScriptSources);

--- a/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.Signing.cs
+++ b/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.Signing.cs
@@ -152,7 +152,19 @@ public sealed partial class ModulePipelineScriptExecutionSeamTests
             var hostedOperations = new FakeHostedOperations
             {
                 AutoSuccessfulSigningResult = true,
-                AutoSuccessfulPublishResult = true
+                AutoSuccessfulPublishResult = true,
+                SigningFilesCompleted = (call, files) =>
+                {
+                    if (call != 1)
+                        return;
+
+                    string stagedManifest = Assert.Single(
+                        files,
+                        path => path.EndsWith(moduleName + ".psd1", StringComparison.OrdinalIgnoreCase));
+                    File.AppendAllText(
+                        stagedManifest,
+                        Environment.NewLine + "# SIG # simulated Authenticode mutation" + Environment.NewLine);
+                }
             };
             var runner = CreateRunner(hostedOperations);
             string outputRoot = Path.Combine(root.FullName, "Artefacts", "Packed");
@@ -720,8 +732,10 @@ public sealed partial class ModulePipelineScriptExecutionSeamTests
         }
     }
 
-    [Fact]
-    public void Run_SignedGitHubPackedArtifactRejectsManifestMutationAfterAuthorizedSync()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Run_SignedGitHubPackedArtifactRejectsManifestMutationAfterAuthorizedSync(bool mutateProjectManifest)
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
@@ -740,8 +754,10 @@ public sealed partial class ModulePipelineScriptExecutionSeamTests
                 ActionStarted = (_, context) =>
                 {
                     string mutation = Environment.NewLine + "# changed after authorized manifest synchronization";
-                    File.AppendAllText(context.ManifestPath!, mutation);
-                    File.AppendAllText(Path.Combine(root.FullName, moduleName + ".psd1"), mutation);
+                    string manifestPath = mutateProjectManifest
+                        ? Path.Combine(root.FullName, moduleName + ".psd1")
+                        : context.ManifestPath!;
+                    File.AppendAllText(manifestPath, mutation);
                 }
             };
             var runner = CreateRunner(hostedOperations);

--- a/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.cs
+++ b/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.cs
@@ -574,6 +574,7 @@ public sealed partial class ModulePipelineScriptExecutionSeamTests
         public bool AutoSuccessfulSigningResult { get; set; }
         public bool AutoSuccessfulPublishResult { get; set; }
         public Action<int>? SigningCallStarted { get; set; }
+        public Action<int, string[]>? SigningFilesCompleted { get; set; }
         public Action<ModulePipelineActionConfiguration, ModulePipelineActionContext>? ActionStarted { get; set; }
         public List<string> SigningRootPaths { get; } = new();
         public List<string> OperationOrder { get; } = new();
@@ -740,6 +741,7 @@ public sealed partial class ModulePipelineScriptExecutionSeamTests
                 .Where(path => !LastExcludePatterns.Any(excluded =>
                     path.IndexOf(excluded, StringComparison.OrdinalIgnoreCase) >= 0))
                 .ToArray();
+            SigningFilesCompleted?.Invoke(SignCalls, verified);
             return new ModuleSigningResult
             {
                 TotalMatched = verified.Length,


### PR DESCRIPTION
Real Authenticode signing changes the staged manifest bytes. The packed-artifact guard incorrectly compared that signed copy with the separately generated unsigned project manifest, so normal release builds failed after signing.

This change:

- records independent authorized hashes for the project and signed staging manifests
- rejects later changes to either manifest before packing
- makes the signing contract test mutate manifest bytes and verifies project-only and staging-only tampering separately

The exact default `Build/Build-Project.ps1` workflow now completes through all module artefacts, executable outputs, and NuGet packages without publishing.