### PR TITLE
Fix Authenticode signing for pinned staging files

### DIFF
--- a/PowerForge.Tests/SigningScriptRetryTests.cs
+++ b/PowerForge.Tests/SigningScriptRetryTests.cs
@@ -132,13 +132,45 @@ public sealed class SigningScriptRetryTests
         Assert.Contains("Cert:\\CurrentUser\\My", lookupPath, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static (ModuleSigningResult Summary, int SigningCallCount, string[] PackageFilePaths, string[] CertificateLookupPaths)
+    [Theory]
+    [InlineData(0x00080000)]
+    [InlineData(0x00100000)]
+    [InlineData(0x00180000)]
+    public void CloudPlacementAttributesAreClearedBeforeSigning(int cloudAttribute)
+    {
+        if (Path.DirectorySeparatorChar != '\\')
+            return;
+
+        FileAttributes stagedAttributes = FileAttributes.Archive | (FileAttributes)cloudAttribute;
+        var evidence = RunSigningProviderFailureHarness(
+            includePrecheckFailure: false,
+            includeNonCompatibilitySigningFailure: false,
+            signingSucceeds: true,
+            signingTargetAttributes: stagedAttributes);
+
+        Assert.Equal(12, evidence.Summary.SignedNew);
+        Assert.Equal(0, evidence.Summary.Failed);
+        Assert.All(evidence.SigningTargetAttributes, attributes =>
+        {
+            Assert.Equal(0, attributes & cloudAttribute);
+            Assert.NotEqual(0, attributes & (int)FileAttributes.Archive);
+        });
+    }
+
+    private static (
+        ModuleSigningResult Summary,
+        int SigningCallCount,
+        string[] PackageFilePaths,
+        string[] CertificateLookupPaths,
+        int[] SigningTargetAttributes)
         RunSigningProviderFailureHarness(
             bool includePrecheckFailure,
             bool includeNonCompatibilitySigningFailure,
             bool currentUserHasPrivateKey = true,
             bool currentUserHasCodeSigningEku = true,
-            bool currentUserHasEkuRestriction = true)
+            bool currentUserHasEkuRestriction = true,
+            bool signingSucceeds = false,
+            FileAttributes? signingTargetAttributes = null)
     {
         var rootPath = Directory.CreateDirectory(Path.Combine(
             Path.GetTempPath(),
@@ -146,6 +178,7 @@ public sealed class SigningScriptRetryTests
             Guid.NewGuid().ToString("N"))).FullName;
         var packageFileListPath = Path.Combine(rootPath, "package-files.txt");
         var callLogPath = Path.Combine(rootPath, "signing-calls.txt");
+        var signingAttributeLogPath = Path.Combine(rootPath, "signing-attributes.txt");
         var certificateLookupLogPath = Path.Combine(rootPath, "certificate-lookups.txt");
         try
         {
@@ -153,7 +186,11 @@ public sealed class SigningScriptRetryTests
                 .Select(index => Path.Combine(rootPath, $"File{index:D2}.ps1"))
                 .ToArray();
             foreach (var path in packageFilePaths)
+            {
                 File.WriteAllText(path, "# test");
+                if (signingTargetAttributes.HasValue)
+                    File.SetAttributes(path, signingTargetAttributes.Value);
+            }
             File.WriteAllLines(packageFileListPath, packageFilePaths);
 
             var script = EmbeddedScripts.Load("Scripts/Signing/Sign-Module.ps1");
@@ -164,12 +201,14 @@ public sealed class SigningScriptRetryTests
                 $rootPath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(rootPath))}}'))
                 $packageFileListPath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(packageFileListPath))}}'))
                 $callLogPath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(callLogPath))}}'))
+                $signingAttributeLogPath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(signingAttributeLogPath))}}'))
                 $certificateLookupLogPath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(certificateLookupLogPath))}}'))
                 $precheckFailurePath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(precheckFailurePath))}}'))
                 $includeNonCompatibilitySigningFailure = [Convert]::ToBoolean('{{includeNonCompatibilitySigningFailure}}')
                 $currentUserHasPrivateKey = [Convert]::ToBoolean('{{currentUserHasPrivateKey}}')
                 $currentUserHasCodeSigningEku = [Convert]::ToBoolean('{{currentUserHasCodeSigningEku}}')
                 $currentUserHasEkuRestriction = [Convert]::ToBoolean('{{currentUserHasEkuRestriction}}')
+                $signingSucceeds = [Convert]::ToBoolean('{{signingSucceeds}}')
                 $script:firstSigningCall = $true
                 function Get-Item {
                   [CmdletBinding()]
@@ -211,6 +250,12 @@ public sealed class SigningScriptRetryTests
                     [switch]$Force
                   )
                   [IO.File]::AppendAllText($callLogPath, 'x')
+                  [IO.File]::AppendAllText(
+                    $signingAttributeLogPath,
+                    ([int][IO.File]::GetAttributes($FilePath)).ToString() + [Environment]::NewLine)
+                  if ($signingSucceeds) {
+                    return [pscustomobject]@{ Status = 'Valid'; StatusMessage = '' }
+                  }
                   if ($includeNonCompatibilitySigningFailure -and $script:firstSigningCall) {
                     $script:firstSigningCall = $false
                     return [pscustomobject]@{ Status = 'HashMismatch'; StatusMessage = 'file is not retryable' }
@@ -245,7 +290,10 @@ public sealed class SigningScriptRetryTests
                 summary!,
                 File.ReadAllText(callLogPath).Length,
                 packageFilePaths,
-                File.ReadAllLines(certificateLookupLogPath));
+                File.ReadAllLines(certificateLookupLogPath),
+                File.Exists(signingAttributeLogPath)
+                    ? File.ReadAllLines(signingAttributeLogPath).Select(int.Parse).ToArray()
+                    : Array.Empty<int>());
         }
         finally
         {

--- a/PowerForge/Scripts/Signing/Sign-Module.ps1
+++ b/PowerForge/Scripts/Signing/Sign-Module.ps1
@@ -42,6 +42,21 @@ function Get-CodeSigningCertificateByThumbprint([string]$thumbprint) {
 
   return $null
 }
+function Clear-SigningCloudPlacementAttributes([string]$filePath) {
+  if ([System.IO.Path]::DirectorySeparatorChar -ne '\') { return }
+
+  # Cloud providers can propagate FILE_ATTRIBUTE_PINNED or FILE_ATTRIBUTE_UNPINNED
+  # into a local staging copy. Authenticode cannot update such a file even when
+  # its content is fully hydrated, so remove only those placement hints.
+  $cloudPlacementMask = 0x00180000
+  $attributes = [int][System.IO.File]::GetAttributes($filePath)
+  $normalizedAttributes = $attributes -band (-bnot $cloudPlacementMask)
+  if ($normalizedAttributes -ne $attributes) {
+    [System.IO.File]::SetAttributes(
+      $filePath,
+      [System.IO.FileAttributes]$normalizedAttributes)
+  }
+}
 function Test-ExcludedPackagePath([string]$relativePath, [string[]]$exclusions) {
   if ([string]::IsNullOrWhiteSpace($relativePath) -or -not $exclusions -or $exclusions.Count -eq 0) {
     return $false
@@ -307,6 +322,7 @@ try {
 
     foreach ($f in $all) {
       try {
+        Clear-SigningCloudPlacementAttributes -filePath $f
         $sig = Invoke-WithFileRetry -FilePath $f -Action 'Get-AuthenticodeSignature' -ScriptBlock {
           Get-AuthenticodeSignature -FilePath $f -ErrorAction Stop
         }
@@ -413,6 +429,7 @@ try {
 
     foreach ($f in $all) {
       try {
+        Clear-SigningCloudPlacementAttributes -filePath $f
         $sig = Invoke-WithFileRetry -FilePath $f -Action 'Get-OpenAuthenticodeSignature' -ScriptBlock {
           Get-OpenAuthenticodeSignature -FilePath $f -ErrorAction Stop
         }


### PR DESCRIPTION
## Summary

Windows cloud providers can copy `Pinned` or `Unpinned` placement metadata into the module staging tree. Authenticode cannot update files carrying those flags and reports a misleading security-violation error even when the file is fully available.

This change:

- removes only the Windows cloud-placement flags from staged signing candidates before signature inspection
- preserves ordinary file attributes and never changes project source files
- applies consistently to the native Windows and OpenAuthenticode signing paths
- adds regression coverage for pinned, unpinned, and combined placement flags

## Validation

- exact non-publishing build with the three previously failing example inputs deliberately marked pinned: module 19/19, tools 11/11, packages 6/6
- real certificate signing of a pinned staging file: signature `Valid`, cloud-placement mask cleared
- focused signing and hosted-pipeline contracts: 76 passed
- targeted post-review signing contracts: 11 passed
- full solution build: 0 warnings, 0 errors