### PR TITLE
Retry returned Authenticode provider failures

### DIFF
--- a/PowerForge.Tests/SigningScriptRetryTests.cs
+++ b/PowerForge.Tests/SigningScriptRetryTests.cs
@@ -157,6 +157,34 @@ public sealed class SigningScriptRetryTests
         });
     }
 
+    [Fact]
+    public void ReturnedUnknownErrorReclearsCloudAttributesAndRetriesBeforeCompatibilityFallback()
+    {
+        if (Path.DirectorySeparatorChar != '\\')
+            return;
+
+        const int pinnedAttribute = 0x00080000;
+        var evidence = RunSigningProviderFailureHarness(
+            includePrecheckFailure: false,
+            includeNonCompatibilitySigningFailure: false,
+            signingSucceeds: true,
+            signingTargetAttributes: FileAttributes.Archive | (FileAttributes)pinnedAttribute,
+            resultFailuresBeforeSuccess: 2);
+
+        Assert.Equal(12, evidence.Summary.SignedNew);
+        Assert.Equal(0, evidence.Summary.Failed);
+        Assert.Equal(0, evidence.Summary.UnknownError);
+        Assert.Equal(14, evidence.SigningCallCount);
+        Assert.All(evidence.SigningTargetAttributes, attributes =>
+        {
+            Assert.Equal(0, attributes & pinnedAttribute);
+            Assert.NotEqual(0, attributes & (int)FileAttributes.Archive);
+        });
+        Assert.DoesNotContain(evidence.Summary.FailedFiles, failure => failure.Contains(
+            "Windows PowerShell compatibility retry",
+            StringComparison.Ordinal));
+    }
+
     private static (
         ModuleSigningResult Summary,
         int SigningCallCount,
@@ -170,7 +198,8 @@ public sealed class SigningScriptRetryTests
             bool currentUserHasCodeSigningEku = true,
             bool currentUserHasEkuRestriction = true,
             bool signingSucceeds = false,
-            FileAttributes? signingTargetAttributes = null)
+            FileAttributes? signingTargetAttributes = null,
+            int resultFailuresBeforeSuccess = 0)
     {
         var rootPath = Directory.CreateDirectory(Path.Combine(
             Path.GetTempPath(),
@@ -196,6 +225,9 @@ public sealed class SigningScriptRetryTests
             var script = EmbeddedScripts.Load("Scripts/Signing/Sign-Module.ps1");
             var includeB64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("*.ps1"));
             var precheckFailurePath = includePrecheckFailure ? packageFilePaths[0] : string.Empty;
+            var signingTargetAttributeValue = signingTargetAttributes.HasValue
+                ? (int)signingTargetAttributes.Value
+                : 0;
             var harness = $$"""
                 $scriptText = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(script))}}'))
                 $rootPath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{Convert.ToBase64String(Encoding.UTF8.GetBytes(rootPath))}}'))
@@ -209,7 +241,10 @@ public sealed class SigningScriptRetryTests
                 $currentUserHasCodeSigningEku = [Convert]::ToBoolean('{{currentUserHasCodeSigningEku}}')
                 $currentUserHasEkuRestriction = [Convert]::ToBoolean('{{currentUserHasEkuRestriction}}')
                 $signingSucceeds = [Convert]::ToBoolean('{{signingSucceeds}}')
+                $resultFailuresBeforeSuccess = [Convert]::ToInt32('{{resultFailuresBeforeSuccess}}')
+                $signingTargetAttributeValue = [Convert]::ToInt32('{{signingTargetAttributeValue}}')
                 $script:firstSigningCall = $true
+                $script:signingCallNumber = 0
                 function Get-Item {
                   [CmdletBinding()]
                   param([string]$LiteralPath)
@@ -253,6 +288,18 @@ public sealed class SigningScriptRetryTests
                   [IO.File]::AppendAllText(
                     $signingAttributeLogPath,
                     ([int][IO.File]::GetAttributes($FilePath)).ToString() + [Environment]::NewLine)
+                  $script:signingCallNumber++
+                  if ($script:signingCallNumber -le $resultFailuresBeforeSuccess) {
+                    if ($signingTargetAttributeValue -ne 0) {
+                      [IO.File]::SetAttributes(
+                        $FilePath,
+                        [IO.FileAttributes]$signingTargetAttributeValue)
+                    }
+                    return [pscustomobject]@{
+                      Status = 'UnknownError'
+                      StatusMessage = 'Access was denied because of a security violation.'
+                    }
+                  }
                   if ($signingSucceeds) {
                     return [pscustomobject]@{ Status = 'Valid'; StatusMessage = '' }
                   }

--- a/PowerForge/Scripts/Signing/Sign-Module.ps1
+++ b/PowerForge/Scripts/Signing/Sign-Module.ps1
@@ -150,14 +150,21 @@ function Invoke-WithFileRetry {
     [Parameter(Mandatory = $true)] [scriptblock]$ScriptBlock,
     [Parameter(Mandatory = $true)] [string]$FilePath,
     [Parameter(Mandatory = $true)] [string]$Action,
-    [int]$MaxAttempts = 15
+    [int]$MaxAttempts = 15,
+    [scriptblock]$ShouldRetryResult
   )
 
   if ($MaxAttempts -lt 1) { throw 'MaxAttempts must be at least 1.' }
   $delay = 200
   for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
     try {
-      return & $ScriptBlock
+      $result = & $ScriptBlock
+      if ($null -eq $ShouldRetryResult -or -not (& $ShouldRetryResult $result)) {
+        return $result
+      }
+      if ($attempt -ge $MaxAttempts) {
+        return $result
+      }
     } catch {
       if ($attempt -ge $MaxAttempts) {
         $message = $_.Exception.Message
@@ -167,10 +174,10 @@ function Invoke-WithFileRetry {
 
         throw ('{0} failed for ''{1}'' after {2} attempt(s): {3}' -f $Action, $FilePath, $MaxAttempts, $message)
       }
-
-      Start-Sleep -Milliseconds $delay
-      $delay = [Math]::Min($delay * 2, 5000)
     }
+
+    Start-Sleep -Milliseconds $delay
+    $delay = [Math]::Min($delay * 2, 5000)
   }
 }
 
@@ -307,6 +314,10 @@ try {
     [string]::IsNullOrWhiteSpace($PfxPath) -and `
     [string]::IsNullOrWhiteSpace($PfxBase64)
   $signingMaxAttempts = 15
+  $retryUnknownSigningResult = {
+    param([object]$result)
+    return $null -ne $result -and [string]$result.Status -eq 'UnknownError'
+  }
   $canDeferToWindowsPowerShell = $false
   $hasNonCompatibilitySigningFailure = $false
   $deferRemainingSigningTargets = $false
@@ -378,11 +389,13 @@ try {
       }
       try {
         if ($overwrite) {
-          $r = Invoke-WithFileRetry -FilePath $f -Action 'Set-AuthenticodeSignature' -MaxAttempts $signingMaxAttempts -ScriptBlock {
+          $r = Invoke-WithFileRetry -FilePath $f -Action 'Set-AuthenticodeSignature' -MaxAttempts $signingMaxAttempts -ShouldRetryResult $retryUnknownSigningResult -ScriptBlock {
+            Clear-SigningCloudPlacementAttributes -filePath $f
             Set-AuthenticodeSignature -FilePath $f -Certificate $cert -TimestampServer $ts -IncludeChain All -HashAlgorithm SHA256 -Force -ErrorAction Stop
           }
         } else {
-          $r = Invoke-WithFileRetry -FilePath $f -Action 'Set-AuthenticodeSignature' -MaxAttempts $signingMaxAttempts -ScriptBlock {
+          $r = Invoke-WithFileRetry -FilePath $f -Action 'Set-AuthenticodeSignature' -MaxAttempts $signingMaxAttempts -ShouldRetryResult $retryUnknownSigningResult -ScriptBlock {
+            Clear-SigningCloudPlacementAttributes -filePath $f
             Set-AuthenticodeSignature -FilePath $f -Certificate $cert -TimestampServer $ts -IncludeChain All -HashAlgorithm SHA256 -ErrorAction Stop
           }
         }
@@ -474,11 +487,13 @@ try {
       $wasSigned = $preStatus[$f] -ne 'NotSigned'
       try {
         if ($overwrite) {
-          $r = Invoke-WithFileRetry -FilePath $f -Action 'Set-OpenAuthenticodeSignature' -ScriptBlock {
+          $r = Invoke-WithFileRetry -FilePath $f -Action 'Set-OpenAuthenticodeSignature' -ShouldRetryResult $retryUnknownSigningResult -ScriptBlock {
+            Clear-SigningCloudPlacementAttributes -filePath $f
             Set-OpenAuthenticodeSignature -FilePath $f -Certificate $cert -TimeStampServer $ts -IncludeChain WholeChain -HashAlgorithm SHA256 -Force -ErrorAction Stop
           }
         } else {
-          $r = Invoke-WithFileRetry -FilePath $f -Action 'Set-OpenAuthenticodeSignature' -ScriptBlock {
+          $r = Invoke-WithFileRetry -FilePath $f -Action 'Set-OpenAuthenticodeSignature' -ShouldRetryResult $retryUnknownSigningResult -ScriptBlock {
+            Clear-SigningCloudPlacementAttributes -filePath $f
             Set-OpenAuthenticodeSignature -FilePath $f -Certificate $cert -TimeStampServer $ts -IncludeChain WholeChain -HashAlgorithm SHA256 -ErrorAction Stop
           }
         }


### PR DESCRIPTION
## Summary

`Set-AuthenticodeSignature` can report a transient hardware/provider failure by returning an `UnknownError` result instead of throwing. The existing retry helper handled exceptions only, so these results were treated as final failures and sent immediately to the Windows PowerShell compatibility fallback.

This change:

- retries returned `UnknownError` results in the current signing host
- re-clears Windows cloud-placement attributes immediately before every signing attempt
- preserves the final error result when all attempts are exhausted
- applies the same retry contract to native and OpenAuthenticode signing
- adds a regression that reintroduces `Pinned` metadata between two returned provider failures before succeeding

## Validation

- new regression fails on merged `main` with 10/12 targets signed and passes with 12/12 after the fix
- focused signing and hosted-pipeline contracts: 78 passed
- exact non-publishing `Build/Build-Project.ps1` run with the three affected examples pinned: module 19/19, tools 11/11, packages 6/6
- full solution build: 0 warnings, 0 errors
- Windows PowerShell 5.1 parse validation passed
- independent closure review found no actionable issues