### PR TITLE
Fix package command detection in generated agent prose

### DIFF
--- a/PowerForge.Tests/WebAgentContentSecurityScannerCommandContextTests.cs
+++ b/PowerForge.Tests/WebAgentContentSecurityScannerCommandContextTests.cs
@@ -1,0 +1,69 @@
+using PowerForge.Web;
+
+namespace PowerForge.Tests;
+
+public sealed partial class WebAgentContentSecurityScannerTests
+{
+    [Theory]
+    [InlineData("- IntelligenceX.OpenAI.Auth.AuthBundle — Represents an authentication bundle for OpenAI providers.")]
+    [InlineData("- IntelligenceX.OpenAI.Auth.FileAuthBundleStore — File-based authentication bundle store with optional encryption.")]
+    [InlineData("- public const CopilotCliInstallMethod Npm — Install via npm.")]
+    [InlineData("Represents an authentication bundle for OpenAI providers.")]
+    [InlineData("- public Boolean IsExpired(Nullable<DateTimeOffset> now = null) — Returns whether the bundle is expired.")]
+    [InlineData("- public static String Serialize(AuthBundle bundle) — Serializes an auth bundle to JSON text.")]
+    [InlineData("- public static AuthBundle Deserialize(String json) — Deserializes an auth bundle from JSON text.")]
+    [InlineData("- public static String ResolveAuthPath() — Resolves the default auth bundle path.")]
+    public void Scan_IgnoresPackageManagerWordsInGeneratedApiProse(string prose)
+    {
+        using var scanner = new WebAgentContentSecurityScanner();
+        var root = CreateArtifact("llms-full.txt", prose);
+
+        try
+        {
+            var result = scanner.Scan(new WebAgentContentSecurityOptions
+            {
+                SiteRoot = root,
+                Files = ["llms-full.txt"],
+                VerifyPackages = false
+            });
+
+            Assert.True(result.Success, string.Join(" | ", result.Findings.Select(static finding => finding.Message)));
+            Assert.Equal(0, result.PackageReferenceCount);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Theory]
+    [InlineData("npm ci-test")]
+    [InlineData("- npm ci-test")]
+    [InlineData("> npm ci-test")]
+    [InlineData("Run npm ci-test")]
+    [InlineData("Use `npm ci-test` for validation.")]
+    [InlineData("```shell\nnpm ci-test\n```")]
+    public void Scan_StillRejectsCommandShapedUnsupportedPackageOperations(string command)
+    {
+        using var scanner = new WebAgentContentSecurityScanner();
+        var root = CreateArtifact("llms.txt", command);
+
+        try
+        {
+            var result = scanner.Scan(new WebAgentContentSecurityOptions
+            {
+                SiteRoot = root,
+                Files = ["llms.txt"],
+                VerifyPackages = false
+            });
+
+            Assert.False(result.Success);
+            Assert.Contains(result.Findings, static finding =>
+                finding.Code == "PFAGENT.PACKAGE.UNVERIFIABLE_OPERAND");
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+}

--- a/PowerForge.Web/Services/WebAgentContentSecurityScanner.CommandContext.cs
+++ b/PowerForge.Web/Services/WebAgentContentSecurityScanner.CommandContext.cs
@@ -1,0 +1,98 @@
+namespace PowerForge.Web;
+
+public sealed partial class WebAgentContentSecurityScanner
+{
+    private static readonly string[] PackageCommandIntroducers =
+    [
+        "run", "execute", "invoke", "try", "use", "using", "then", "and then", "with"
+    ];
+
+    private static bool IsPackageCommandInvocationContext(string content, int commandIndex)
+    {
+        if (commandIndex < 0 || commandIndex > content.Length)
+            return false;
+
+        var lineStart = commandIndex;
+        while (lineStart > 0 && content[lineStart - 1] is not ('\r' or '\n'))
+            lineStart--;
+
+        var prefix = content[lineStart..commandIndex];
+        if (prefix.EndsWith('`'))
+            return true;
+
+        var candidate = prefix.Trim();
+        while (candidate.StartsWith('>'))
+            candidate = candidate[1..].TrimStart();
+
+        if (candidate.Length == 0 || candidate is "$" or "#" or "PS>" or "-" or "*" or "+")
+            return true;
+
+        if (candidate.Length >= 2 && candidate[0] is '-' or '*' or '+' && char.IsWhiteSpace(candidate[1]))
+            return candidate[2..].Trim().Length == 0;
+
+        var markerEnd = 0;
+        while (markerEnd < candidate.Length && char.IsDigit(candidate[markerEnd]))
+            markerEnd++;
+        if (markerEnd > 0 && markerEnd + 1 < candidate.Length &&
+            candidate[markerEnd] is '.' or ')' && char.IsWhiteSpace(candidate[markerEnd + 1]))
+            return candidate[(markerEnd + 2)..].Trim().Length == 0;
+
+        foreach (var introducer in PackageCommandIntroducers)
+        {
+            if (candidate.Equals(introducer, StringComparison.OrdinalIgnoreCase) ||
+                candidate.EndsWith(" " + introducer, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return candidate.EndsWith('$') || candidate.EndsWith("PS>", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool HasShellCommandSeparatorPrefix(string content, int commandIndex)
+    {
+        var lineStart = commandIndex;
+        while (lineStart > 0 && content[lineStart - 1] is not ('\r' or '\n'))
+            lineStart--;
+
+        var prefix = content[lineStart..commandIndex].TrimEnd();
+        if (prefix.LastIndexOf("$(", StringComparison.Ordinal) > prefix.LastIndexOf(')'))
+            return true;
+        return prefix.EndsWith(';') ||
+               prefix.EndsWith('|') ||
+               prefix.EndsWith("&&", StringComparison.Ordinal) ||
+               prefix.EndsWith("||", StringComparison.Ordinal);
+    }
+
+    private static string TrimMarkdownInlineCodeCommand(
+        string content,
+        int commandIndex,
+        string matchedCommand)
+    {
+        var openingStart = commandIndex;
+        while (openingStart > 0 && content[openingStart - 1] == '`')
+            openingStart--;
+
+        var delimiterLength = commandIndex - openingStart;
+        if (delimiterLength == 0)
+            return matchedCommand;
+
+        var lineEnd = content.IndexOfAny(['\r', '\n'], commandIndex);
+        if (lineEnd < 0)
+            lineEnd = content.Length;
+
+        for (var index = commandIndex; index < lineEnd; index++)
+        {
+            if (content[index] != '`')
+                continue;
+
+            var runLength = 1;
+            while (index + runLength < lineEnd && content[index + runLength] == '`')
+                runLength++;
+            if (runLength == delimiterLength)
+                return content.Substring(commandIndex, index - commandIndex);
+
+            index += runLength - 1;
+        }
+
+        return matchedCommand;
+    }
+}

--- a/PowerForge.Web/Services/WebAgentContentSecurityScanner.Commands.cs
+++ b/PowerForge.Web/Services/WebAgentContentSecurityScanner.Commands.cs
@@ -41,6 +41,19 @@ public sealed partial class WebAgentContentSecurityScanner
         ScanDynamicExecutableInvocations(content, path, lineOffset, countLogicalLines, findings);
         foreach (Match match in CommandSegmentRegex.Matches(content))
         {
+            if (!IsPackageCommandInvocationContext(content, match.Index) &&
+                !IsUntrustedExecutableReference(content, match.Index) &&
+                !HasCommandScopedEnvironmentPrefix(content, match.Index) &&
+                !HasExecutionContextWrapperPrefix(content, match.Index) &&
+                !HasDataAppendingWrapperPrefix(content, match.Index) &&
+                !HasRemoteExecutionWrapperPrefix(content, match.Index) &&
+                flowState?.WorkingDirectoryChanged != true &&
+                !(workingDirectoryChange.Success && workingDirectoryChange.Index < match.Index) &&
+                flowState?.RemoteExecutionContextChanged != true &&
+                !(remoteExecutionContextChange.Success && remoteExecutionContextChange.Index < match.Index) &&
+                !HasShellCommandSeparatorPrefix(content, match.Index))
+                continue;
+
             var matchedCommand = TrimMarkdownInlineCodeCommand(
                 content,
                 match.Index,
@@ -197,40 +210,6 @@ public sealed partial class WebAgentContentSecurityScanner
         return references;
     }
 
-    private static string TrimMarkdownInlineCodeCommand(
-        string content,
-        int commandIndex,
-        string matchedCommand)
-    {
-        var openingStart = commandIndex;
-        while (openingStart > 0 && content[openingStart - 1] == '`')
-            openingStart--;
-
-        var delimiterLength = commandIndex - openingStart;
-        if (delimiterLength == 0)
-            return matchedCommand;
-
-        var lineEnd = content.IndexOfAny(['\r', '\n'], commandIndex);
-        if (lineEnd < 0)
-            lineEnd = content.Length;
-
-        for (var index = commandIndex; index < lineEnd; index++)
-        {
-            if (content[index] != '`')
-                continue;
-
-            var runLength = 1;
-            while (index + runLength < lineEnd && content[index + runLength] == '`')
-                runLength++;
-            if (runLength == delimiterLength)
-                return content.Substring(commandIndex, index - commandIndex);
-
-            index += runLength - 1;
-        }
-
-        return matchedCommand;
-    }
-
     private static bool HasShellExpansionInOptionValue(string[] tokens)
     {
         for (var index = 1; index < tokens.Length; index++)
@@ -261,6 +240,9 @@ public sealed partial class WebAgentContentSecurityScanner
     {
         foreach (Match match in ObfuscatedExecutableRegex.Matches(content))
         {
+            if (!IsPackageCommandInvocationContext(content, match.Index))
+                continue;
+
             var escaped = match.Groups["command"].Value;
             var normalized = NormalizeExecutable(escaped.Replace("\\", string.Empty, StringComparison.Ordinal)
                 .Replace("`", string.Empty, StringComparison.Ordinal)


### PR DESCRIPTION
## Summary

- distinguish executable package-manager commands from generated API prose that merely mentions words such as undle or 
pm
- retain detection for shell-shaped commands, unsafe executable references, execution wrappers, remote/data-appending contexts, working-directory flows, and shell separators
- cover the exact IntelligenceX generated-content false positives plus command-shaped unsupported operations

## Validation

- PowerForge scanner tests: 844/844 passed
- IntelligenceX website pipeline with this PowerForge source: all 18 stages passed
- IntelligenceX agent readiness: 39 checks, 0 failures
- changed files remain below the 800-line repository limit
- git diff --check passed