### PR TITLE
Correct Cloudflare policy permissions and diagnostics

### DIFF
--- a/.github/actions/powerforge-cloudflare-site-policy/Invoke-PowerForgeCloudflareSitePolicy.ps1
+++ b/.github/actions/powerforge-cloudflare-site-policy/Invoke-PowerForgeCloudflareSitePolicy.ps1
@@ -4,14 +4,6 @@ param()
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 
-function Assert-LastExitCode {
-    param([Parameter(Mandatory)][string] $Operation)
-
-    if ($LASTEXITCODE -ne 0) {
-        throw "$Operation failed with exit code $LASTEXITCODE."
-    }
-}
-
 if ($env:RUNNER_OS -ne 'Linux') {
     throw 'PowerForge Cloudflare site policy requires a Linux runner.'
 }
@@ -65,9 +57,15 @@ if ($env:POWERFORGE_CLOUDFLARE_DRY_RUN -eq 'true') {
 }
 $arguments += @('--output', 'json')
 
-$jsonOutput = @(dotnet @arguments)
-Assert-LastExitCode -Operation 'Applying Cloudflare site policy'
+$jsonOutput = [object[]] @(dotnet @arguments)
+$cliExitCode = $LASTEXITCODE
 $jsonText = $jsonOutput -join [Environment]::NewLine
+if ($cliExitCode -ne 0) {
+    if (-not [string]::IsNullOrWhiteSpace($jsonText)) {
+        Write-Host $jsonText
+    }
+    throw "Applying Cloudflare site policy failed with exit code $cliExitCode."
+}
 try {
     $result = $jsonText | ConvertFrom-Json
     if ($result.success -ne $true -or $null -eq $result.result.changesRequired) {

--- a/.github/actions/powerforge-cloudflare-site-policy/action.yml
+++ b/.github/actions/powerforge-cloudflare-site-policy/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: Cloudflare zone identifier from the caller job's protected environment.
     required: true
   api-token:
-    description: Protected token with zone-scoped Cache Rules Write and Transform Rules Write; add Cache Settings Write when SmartTieredCache is configured.
+    description: Protected token with zone-scoped Cache Settings Write and Zone Transform Rules Write; add Zone Settings Read and Write when SmartTieredCache is configured.
     required: true
   hostname:
     description: Optional hostname override; normally derived from the site specification BaseUrl.

--- a/Docs/PowerForge.Web.Cloudflare.md
+++ b/Docs/PowerForge.Web.Cloudflare.md
@@ -33,7 +33,8 @@ powerforge-web cloudflare site-policy apply \
 ```
 
 The token needs write access to Cache Rules and Transform Rules for the target
-zone. Add Cache Settings Write when `Cloudflare.SmartTieredCache` is configured,
+zone. Add Zone Settings Read and Zone Settings Write when
+`Cloudflare.SmartTieredCache` is configured,
 and add Cache Purge when the same token runs the post-deploy purge step. Keep the
 token in a protected environment or secret and pass only its environment-variable
 name to the CLI.
@@ -180,7 +181,8 @@ secrets:
 Never reuse the site-policy token as `deployment_cloudflare_api_token`: that
 credential is deliberately copied into the protected remote promotion staging
 area so the host can purge on finalize or rollback. The policy token needs Cache
-Rules Write and Transform Rules Write, Cache Settings Write when Smart Tiered
+Rules Write and Transform Rules Write, Zone Settings Read and Zone Settings
+Write when Smart Tiered
 Cache is enabled, and Cache Purge for the post-policy hostname invalidation. The
 deployment token needs only Cache Purge (and Zone Read when no zone id is passed).
 

--- a/PowerForge.Tests/CloudflareResponseHeaderPolicyTests.cs
+++ b/PowerForge.Tests/CloudflareResponseHeaderPolicyTests.cs
@@ -490,10 +490,10 @@ public sealed class CloudflareResponseHeaderPolicyTests
         var script = ReadRepoFile(".github", "actions", "powerforge-cloudflare-site-policy", "Invoke-PowerForgeCloudflareSitePolicy.ps1");
 
         Assert.Contains("Reject pull request site-policy changes", action, StringComparison.Ordinal);
-        Assert.Contains("Cache Rules Write", action, StringComparison.Ordinal);
-        Assert.Contains("Transform Rules Write", action, StringComparison.Ordinal);
         Assert.Contains("Cache Settings Write", action, StringComparison.Ordinal);
-        Assert.DoesNotContain("Zone Settings Write", action, StringComparison.Ordinal);
+        Assert.Contains("Zone Transform Rules Write", action, StringComparison.Ordinal);
+        Assert.Contains("Zone Settings Read and Write", action, StringComparison.Ordinal);
+        Assert.DoesNotContain("add Cache Settings Write when SmartTieredCache", action, StringComparison.Ordinal);
         Assert.Contains("Invoke-PowerForgeCloudflareSitePolicy.ps1", action, StringComparison.Ordinal);
         Assert.Contains("--token-env', 'POWERFORGE_CLOUDFLARE_API_TOKEN'", script, StringComparison.Ordinal);
         Assert.DoesNotContain("--token', $env:POWERFORGE_CLOUDFLARE_API_TOKEN", script, StringComparison.Ordinal);

--- a/PowerForge.Tests/CloudflareResponseHeaderPolicyTests.cs
+++ b/PowerForge.Tests/CloudflareResponseHeaderPolicyTests.cs
@@ -497,6 +497,8 @@ public sealed class CloudflareResponseHeaderPolicyTests
         Assert.Contains("Invoke-PowerForgeCloudflareSitePolicy.ps1", action, StringComparison.Ordinal);
         Assert.Contains("--token-env', 'POWERFORGE_CLOUDFLARE_API_TOKEN'", script, StringComparison.Ordinal);
         Assert.DoesNotContain("--token', $env:POWERFORGE_CLOUDFLARE_API_TOKEN", script, StringComparison.Ordinal);
+        Assert.Contains("$cliExitCode = $LASTEXITCODE", script, StringComparison.Ordinal);
+        Assert.Contains("Write-Host $jsonText", script, StringComparison.Ordinal);
         Assert.Contains("'site-policy'", script, StringComparison.Ordinal);
         Assert.True(script.Split('\n').Length < 100, "The action entrypoint should remain a bounded adapter over the CLI.");
     }


### PR DESCRIPTION
## Summary

- correct the composite action guidance to use Cloudflare's current permission names
- require Zone Settings Read and Zone Settings Write when Smart Tiered Cache is managed
- remove the stale claim that Cache Settings Write authorizes Smart Tiered Cache
- preserve the CLI's structured Cloudflare error output when policy reconciliation fails

## Why

Cloudflare Rulesets use Cache Settings Write and Zone Transform Rules Write, while Smart Tiered Cache uses the separate Zone Settings permission group. The stale guidance produced authenticated but unauthorized CI policy runs. The action also discarded the CLI response before throwing, obscuring the exact rejected operation.

## Validation

- Cloudflare response-header/action contract tests: 29/29 passed
- PowerShell entrypoint parse passed; adapter remains 79 lines
- YAML/documentation and diff checks passed
- organization CI token now has the corrected all-zone read/write permissions