### PR TITLE
Isolate nested PowerForge package resolution

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,9 @@
+<Project>
+  <!--
+    PowerForge is checked out beneath consumer repositories by reusable Actions.
+    Keep this source tree independent from a caller-owned central package file.
+  -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>

--- a/PowerForge.Tests/GitHubWebsiteDeployGuardrailTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteDeployGuardrailTests.cs
@@ -1,10 +1,23 @@
 using System.Diagnostics;
 using System.Text.Json;
+using System.Xml.Linq;
 
 namespace PowerForge.Tests;
 
 public sealed class GitHubWebsiteDeployGuardrailTests
 {
+    [Fact]
+    public void Repository_ShouldIsolateNestedActionBuildsFromCallerCentralPackageManagement()
+    {
+        var document = XDocument.Load(GetRepoPath("Directory.Packages.props"));
+        var setting = document
+            .Descendants("ManagePackageVersionsCentrally")
+            .SingleOrDefault();
+
+        Assert.NotNull(setting);
+        Assert.Equal("false", setting.Value.Trim(), ignoreCase: true);
+    }
+
     [Fact]
     public void ReusableWorkflow_ShouldInvokeSharedGuardrailWithoutEmbeddedPolicyBrain()
     {


### PR DESCRIPTION
## Summary

- make the PowerForge repository an explicit central-package-management boundary
- prevent reusable Actions from inheriting a consumer repository's Directory.Packages.props
- protect the nested source-checkout build contract with a focused test

This fixes the managed Cloudflare policy job failing before its API call when PowerForge is checked out under a consumer that enables NuGet Central Package Management.

## Validation

- focused website deployment guardrail tests pass (7/7)
- the Web CLI builds successfully when the exact PowerForge source is nested under the GraphEssentialsX repository on Windows
- the same nested checkout builds successfully under WSL/Linux