### PR TITLE
Require exact commit provenance in tool manifests

### DIFF
--- a/Build/Install-PowerForgeTool.ps1
+++ b/Build/Install-PowerForgeTool.ps1
@@ -58,6 +58,9 @@ if ($repository -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
     throw 'PowerForge repository must use owner/name.'
 }
 $expectedCommit = [string] (Get-ManifestPropertyValue -Object $manifest -Name 'commit')
+if ($schemaVersion -eq 2 -and [string]::IsNullOrWhiteSpace($expectedCommit)) {
+    throw 'PowerForge tool manifest schema version 2 requires an exact commit.'
+}
 if (-not [string]::IsNullOrWhiteSpace($expectedCommit) -and $expectedCommit -notmatch '^[A-Fa-f0-9]{40}$') {
     throw 'PowerForge tool manifest commit must be an exact 40-character Git SHA.'
 }

--- a/Module/Tests/PublicRelease.Tests.ps1
+++ b/Module/Tests/PublicRelease.Tests.ps1
@@ -26,6 +26,36 @@ Describe 'Standalone PowerForge installer host compatibility' {
         $content | Should -Match '\$PSVersionTable\.PSEdition'
     }
 
+    It 'rejects schema version 2 without exact commit provenance' {
+        $testRoot = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().ToString('N'))
+        try {
+            New-Item -ItemType Directory -Path $testRoot -Force | Out-Null
+            $manifestPath = Join-Path $testRoot 'PowerForge-tool-manifest.json'
+            @'
+{
+  "schemaVersion": 2,
+  "version": "3.0.116",
+  "assets": {
+    "osx-arm64": {
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "executableSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  }
+}
+'@ | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+
+            {
+                & $script:ToolInstallerPath `
+                    -ManifestPath $manifestPath `
+                    -CacheRoot (Join-Path $testRoot 'cache')
+            } | Should -Throw '*schema version 2 requires an exact commit*'
+        } finally {
+            if (Test-Path -LiteralPath $testRoot) {
+                Remove-Item -LiteralPath $testRoot -Recurse -Force
+            }
+        }
+    }
+
     It 'publishes a native standalone CLI asset for every installer host RID' {
         $releaseConfig = Get-Content -Raw -LiteralPath (
             Join-Path $script:RepositoryRoot 'Build\release.json') | ConvertFrom-Json

--- a/PowerForge.Tests/PowerForgeReleaseSchemaTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseSchemaTests.cs
@@ -6,22 +6,28 @@ namespace PowerForge.Tests;
 public sealed class PowerForgeReleaseSchemaTests
 {
     [Theory]
-    [InlineData(1, false, true)]
-    [InlineData(1, true, true)]
-    [InlineData(2, false, false)]
-    [InlineData(2, true, true)]
-    public void Tool_lock_schema_preserves_v1_and_requires_executable_digest_for_v2(
+    [InlineData(1, false, false, true)]
+    [InlineData(1, true, false, true)]
+    [InlineData(2, false, true, false)]
+    [InlineData(2, true, false, false)]
+    [InlineData(2, true, true, true)]
+    public void Tool_lock_schema_preserves_v1_and_requires_executable_digest_and_commit_for_v2(
         int schemaVersion,
         bool includeExecutableDigest,
+        bool includeCommit,
         bool expectedValid)
     {
         var schema = JsonSchema.FromText(File.ReadAllText(GetSchemaPath("powerforge.tool.schema.json")));
         var executableDigest = includeExecutableDigest
             ? ", \"executableSha256\": \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\""
             : string.Empty;
+        var commit = includeCommit
+            ? "\"commit\": \"0123456789abcdef0123456789abcdef01234567\","
+            : string.Empty;
         var document = JsonNode.Parse($$"""
             {
               "schemaVersion": {{schemaVersion}},
+              {{commit}}
               "version": "3.0.110",
               "assets": {
                 "osx-arm64": {

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.StandaloneToolVersion.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.StandaloneToolVersion.cs
@@ -402,6 +402,29 @@ public sealed partial class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void ValidatePowerForgeToolManifestStaging_requires_exact_commit_provenance()
+    {
+        var spec = new PowerForgeReleaseSpec
+        {
+            Outputs = new PowerForgeReleaseOutputsOptions
+            {
+                PowerForgeToolManifestPath = "PowerForge-tool-manifest.json"
+            },
+            GitHub = new PowerForgeReleaseGitHubOptions
+            {
+                Owner = "EvotecIT",
+                Repository = "PSPublishModule"
+            }
+        };
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            PowerForgeReleaseService.ValidatePowerForgeToolManifestStaging(spec));
+
+        Assert.Contains("GitHub.Commitish", error.Message, StringComparison.Ordinal);
+        Assert.Contains("exact 40-character Git SHA", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_DotNetPublishToolOutputExcludedSkipsConsumerToolManifest()
     {
         var root = CreateSandbox();

--- a/PowerForge/Services/PowerForgeReleaseService.ToolManifest.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.ToolManifest.cs
@@ -45,6 +45,12 @@ internal sealed partial class PowerForgeReleaseService
                 "PowerForgeToolManifestPath cannot be combined with Outputs.Staging.ToolsNameTemplate because " +
                 "the installer manifest must name the exact published tool archive.");
         }
+
+        if (NormalizePowerForgeToolManifestCommit(spec.GitHub?.Commitish) is null)
+        {
+            throw new InvalidOperationException(
+                "PowerForgeToolManifestPath requires GitHub.Commitish to be an exact 40-character Git SHA.");
+        }
     }
 
     private static bool IsStandalonePowerForgeToolSelected(PowerForgeReleaseResult result)

--- a/Schemas/powerforge.tool.schema.json
+++ b/Schemas/powerforge.tool.schema.json
@@ -49,6 +49,7 @@
         "required": ["schemaVersion"]
       },
       "then": {
+        "required": ["commit"],
         "properties": {
           "assets": {
             "patternProperties": {


### PR DESCRIPTION
Prevents schema-v2 standalone PowerForge tool manifests from being published or accepted without exact Git commit provenance.

The release engine now requires `GitHub.Commitish` to be an exact 40-character SHA whenever it emits `PowerForgeToolManifestPath`. The schema and public installer enforce the same requirement, so an incomplete v2 manifest fails before download or execution. Schema-v1 manifests remain compatible.

Validation:
- actual published 3.0.116 manifest without `commit` is rejected before artifact access
- focused generation and schema contracts passed
- complete public-release Pester suite passed
- PowerForge `net8.0` and `net472` warning-as-error builds passed
- independent read-only review found no actionable issues
