### PR TITLE
Use stable user agent for readiness scans

### DIFF
--- a/PowerForge.Tests/WebAgentReadinessUserAgentTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessUserAgentTests.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using PowerForge.Web;
+
+namespace PowerForge.Tests;
+
+public partial class WebAgentReadinessTests
+{
+    [Fact]
+    public async Task Scan_UsesStablePowerForgeUserAgent()
+    {
+        var handler = new UserAgentScanHandler();
+
+        _ = await WebAgentReadiness.ScanAsync(new WebAgentReadinessScanOptions
+        {
+            BaseUrl = "https://example.test",
+            HttpMessageHandler = handler,
+            AgentReadiness = new AgentReadinessSpec
+            {
+                Enabled = true,
+                Robots = false,
+                LinkHeaders = false,
+                SecurityHeaders = new AgentSecurityHeadersSpec { Enabled = false },
+                ContentSignals = new AgentContentSignalsSpec { Enabled = false },
+                ApiCatalog = new AgentApiCatalogSpec { Enabled = false },
+                AgentSkills = new AgentSkillsDiscoverySpec { Enabled = false },
+                AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = false },
+                MarkdownNegotiation = false
+            }
+        });
+
+        Assert.NotEmpty(handler.UserAgents);
+        Assert.All(handler.UserAgents, userAgent => Assert.Equal("PowerForge.Web/1.0", userAgent));
+    }
+
+    private sealed class UserAgentScanHandler : HttpMessageHandler
+    {
+        internal List<string> UserAgents { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            UserAgents.Add(request.Headers.UserAgent.ToString());
+            var path = request.RequestUri!.AbsolutePath;
+            var content = path switch
+            {
+                "/" => "<!doctype html><html><body><main><h1>Example</h1></main></body></html>",
+                "/sitemap.xml" => "<urlset><url><loc>https://example.test/</loc></url></urlset>",
+                _ => "not found"
+            };
+            var response = new HttpResponseMessage(
+                path is "/" or "/sitemap.xml" ? HttpStatusCode.OK : HttpStatusCode.NotFound)
+            {
+                Content = new StringContent(content)
+            };
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -341,7 +341,7 @@ public static partial class WebAgentReadiness
             ? new HttpClient()
             : new HttpClient(options.HttpMessageHandler, disposeHandler: false);
         http.Timeout = TimeSpan.FromMilliseconds(options.TimeoutMs <= 0 ? 15000 : options.TimeoutMs);
-        http.DefaultRequestHeaders.UserAgent.ParseAdd("PowerForge.Web.AgentReady/1.0");
+        http.DefaultRequestHeaders.UserAgent.ParseAdd("PowerForge.Web/1.0");
 
         var root = await TrySendAsync(http, HttpMethod.Get, baseUrl, null, cancellationToken).ConfigureAwait(false);
         var linkHeader = root.Response?.Headers.TryGetValues("Link", out var links) == true ? string.Join(", ", links) : string.Empty;


### PR DESCRIPTION
## Summary

- use the established `PowerForge.Web/1.0` product user agent for remote agent-readiness scans
- avoid Cloudflare Bot Fight Mode classifying the task-specific `PowerForge.Web.AgentReady/1.0` token as an automated challenge target
- add a focused contract proving every readiness request uses the stable product identity

## Why

DomainDetective deployed and cached correctly, but four post-deploy attempts received HTTP 403 only for the readiness `sitemap.xml` request. Cloudflare security-event evidence identified each failure as a Bot Fight Mode managed challenge for the old task-specific user agent, while requests from the established PowerForge user agent were allowed.

## Validation

- focused WebAgentReadiness tests pass 64/64
- production Cloudflare evidence correlates the old user agent with the managed challenges
- no cache, security-header, HSTS, or site-policy configuration changes