### PR TITLE
Pace live agent readiness requests

### DIFF
--- a/PowerForge.Tests/WebAgentReadinessRequestPacingTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessRequestPacingTests.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using PowerForge.Web;
+
+namespace PowerForge.Tests;
+
+public partial class WebAgentReadinessTests
+{
+    [Fact]
+    public async Task RequestPacingHandler_SpacesRequestStarts()
+    {
+        var recorder = new RequestStartRecorder();
+        using var client = new HttpClient(new WebAgentReadiness.RequestPacingHandler(
+            recorder,
+            TimeSpan.FromMilliseconds(100)));
+
+        _ = await client.GetAsync("https://example.test/first");
+        _ = await client.GetAsync("https://example.test/second");
+
+        Assert.Equal(2, recorder.StartedAt.Count);
+        Assert.True(
+            recorder.StartedAt[1] - recorder.StartedAt[0] >= TimeSpan.FromMilliseconds(75),
+            $"Requests started only {(recorder.StartedAt[1] - recorder.StartedAt[0]).TotalMilliseconds:F0} ms apart.");
+    }
+
+    private sealed class RequestStartRecorder : HttpMessageHandler
+    {
+        internal List<DateTimeOffset> StartedAt { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            StartedAt.Add(DateTimeOffset.UtcNow);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+}

--- a/PowerForge.Tests/WebAgentReadinessUserAgentTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessUserAgentTests.cs
@@ -29,6 +29,7 @@ public partial class WebAgentReadinessTests
         });
 
         Assert.NotEmpty(handler.UserAgents);
+        Assert.Equal(2, handler.RequestUris.Count(uri => uri.AbsolutePath == "/" && string.IsNullOrEmpty(uri.Query)));
         Assert.All(handler.UserAgents, userAgent =>
             Assert.Equal(
                 "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 " +
@@ -39,12 +40,14 @@ public partial class WebAgentReadinessTests
     private sealed class UserAgentScanHandler : HttpMessageHandler
     {
         internal List<string> UserAgents { get; } = [];
+        internal List<Uri> RequestUris { get; } = [];
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
             UserAgents.Add(request.Headers.UserAgent.ToString());
+            RequestUris.Add(request.RequestUri!);
             var path = request.RequestUri!.AbsolutePath;
             var content = path switch
             {

--- a/PowerForge.Web/Services/WebAgentReadiness.RequestPacing.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.RequestPacing.cs
@@ -1,0 +1,45 @@
+namespace PowerForge.Web;
+
+public static partial class WebAgentReadiness
+{
+    internal sealed class RequestPacingHandler : DelegatingHandler
+    {
+        private readonly TimeSpan _minimumInterval;
+        private readonly SemaphoreSlim _gate = new(1, 1);
+        private DateTimeOffset _lastRequestStarted;
+
+        internal RequestPacingHandler(HttpMessageHandler innerHandler, TimeSpan minimumInterval)
+            : base(innerHandler)
+        {
+            _minimumInterval = minimumInterval;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                var remaining = _minimumInterval - (DateTimeOffset.UtcNow - _lastRequestStarted);
+                if (remaining > TimeSpan.Zero)
+                    await Task.Delay(remaining, cancellationToken).ConfigureAwait(false);
+
+                _lastRequestStarted = DateTimeOffset.UtcNow;
+            }
+            finally
+            {
+                _gate.Release();
+            }
+
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _gate.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -337,9 +337,12 @@ public static partial class WebAgentReadiness
             };
         }
 
-        using var http = options.HttpMessageHandler is null
-            ? new HttpClient()
-            : new HttpClient(options.HttpMessageHandler, disposeHandler: false);
+        var transport = options.HttpMessageHandler;
+        using var http = transport is null
+            ? new HttpClient(new RequestPacingHandler(
+                new HttpClientHandler(),
+                TimeSpan.FromMilliseconds(Math.Max(0, options.RequestIntervalMs))))
+            : new HttpClient(transport, disposeHandler: false);
         http.Timeout = TimeSpan.FromMilliseconds(options.TimeoutMs <= 0 ? 15000 : options.TimeoutMs);
         // Treat the remote scan as a normal web-client availability check. Crawler-style
         // identities can be challenged by edge bot protection before the discovery
@@ -348,11 +351,10 @@ public static partial class WebAgentReadiness
             "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 " +
             "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36");
 
-        var root = await TrySendAsync(http, HttpMethod.Get, baseUrl, null, cancellationToken).ConfigureAwait(false);
+        var rootText = await TryGetTextAsync(http, baseUrl, null, cancellationToken).ConfigureAwait(false);
+        var root = new HttpResponseResult(rootText.Success, rootText.Message, rootText.Response);
         var linkHeader = root.Response?.Headers.TryGetValues("Link", out var links) == true ? string.Join(", ", links) : string.Empty;
         AddRemoteSecurityHeaderChecks(checks, root.Response, baseUrl, spec);
-
-        var rootText = await TryGetTextAsync(http, baseUrl, null, cancellationToken).ConfigureAwait(false);
         if (rootText.Success)
         {
             AddHtmlSemanticsChecks(checks, rootText.Text, baseUrl);
@@ -2932,6 +2934,8 @@ public sealed class WebAgentReadinessScanOptions
     public string BaseUrl { get; set; } = string.Empty;
     /// <summary>HTTP timeout in milliseconds.</summary>
     public int TimeoutMs { get; set; } = 15000;
+    /// <summary>Minimum interval between live-site requests in milliseconds.</summary>
+    public int RequestIntervalMs { get; set; } = 1000;
     /// <summary>Optional site policy used to decide which live headers are required.</summary>
     public AgentReadinessSpec? AgentReadiness { get; set; }
     /// <summary>Optional test or host-provided HTTP transport.</summary>


### PR DESCRIPTION
## Summary
- pace live agent-readiness requests so post-deploy validation does not present a bot-like burst to edge protection
- reuse the homepage response for HTML and header checks, avoiding one redundant request
- keep validation strict: challenged or failed responses still fail the readiness contract

## Why
Cloudflare Bot Fight Mode challenged the DomainDetective GitHub-hosted post-deploy scan after several rapid requests, even with a browser user agent. Cloudflare policy verification and the live resources themselves remained healthy. This changes the shared scanner behavior instead of weakening Cloudflare or adding a bypass.

## Validation
- 65 focused WebAgentReadiness tests pass on Windows, including repeated pacing checks
- focused WebAgentReadiness scope passes under WSL/Linux
- live paced scan reached `sitemap.xml` successfully and continued through discovery resources
- `git diff --check` passes

## Operational note
The decisive proof remains the DomainDetective post-deploy workflow from a GitHub-hosted runner after this owner change is merged and the consumer is exactly repinned.