### PR TITLE
Use truthful identity for website verification

### DIFF
--- a/PowerForge.Tests/WebAgentReadinessUserAgentTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessUserAgentTests.cs
@@ -6,7 +6,7 @@ namespace PowerForge.Tests;
 public partial class WebAgentReadinessTests
 {
     [Fact]
-    public async Task Scan_UsesSyntheticBrowserUserAgent()
+    public async Task Scan_UsesSharedVerificationUserAgent()
     {
         var handler = new UserAgentScanHandler();
 
@@ -31,10 +31,7 @@ public partial class WebAgentReadinessTests
         Assert.NotEmpty(handler.UserAgents);
         Assert.Equal(2, handler.RequestUris.Count(uri => uri.AbsolutePath == "/" && string.IsNullOrEmpty(uri.Query)));
         Assert.All(handler.UserAgents, userAgent =>
-            Assert.Equal(
-                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 " +
-                "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-                userAgent));
+            Assert.Equal(WebVerificationIdentity.UserAgent, userAgent));
     }
 
     private sealed class UserAgentScanHandler : HttpMessageHandler

--- a/PowerForge.Web.Cli/CloudflareCacheVerifier.cs
+++ b/PowerForge.Web.Cli/CloudflareCacheVerifier.cs
@@ -62,7 +62,7 @@ internal static class CloudflareCacheVerifier
         {
             Timeout = TimeSpan.FromMilliseconds(timeoutMs)
         };
-        http.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "powerforge-web-cloudflare-verify");
+        http.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", WebVerificationIdentity.UserAgent);
 
         var entries = new List<CloudflareVerifyEntry>(normalizedUrls.Length);
         foreach (var url in normalizedUrls)

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -344,12 +344,10 @@ public static partial class WebAgentReadiness
                 TimeSpan.FromMilliseconds(Math.Max(0, options.RequestIntervalMs))))
             : new HttpClient(transport, disposeHandler: false);
         http.Timeout = TimeSpan.FromMilliseconds(options.TimeoutMs <= 0 ? 15000 : options.TimeoutMs);
-        // Treat the remote scan as a normal web-client availability check. Crawler-style
-        // identities can be challenged by edge bot protection before the discovery
-        // documents themselves are evaluated.
-        http.DefaultRequestHeaders.UserAgent.ParseAdd(
-            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 " +
-            "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36");
+        // Use the same truthful verifier identity as the immediately preceding cache
+        // checks. Pretending HttpClient has a browser TLS/JavaScript fingerprint can
+        // trigger managed bot challenges before discovery documents are evaluated.
+        http.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", WebVerificationIdentity.UserAgent);
 
         var rootText = await TryGetTextAsync(http, baseUrl, null, cancellationToken).ConfigureAwait(false);
         var root = new HttpResponseResult(rootText.Success, rootText.Message, rootText.Response);

--- a/PowerForge.Web/Services/WebVerificationIdentity.cs
+++ b/PowerForge.Web/Services/WebVerificationIdentity.cs
@@ -1,0 +1,6 @@
+namespace PowerForge.Web;
+
+internal static class WebVerificationIdentity
+{
+    internal const string UserAgent = "powerforge-web-cloudflare-verify";
+}


### PR DESCRIPTION
## Summary
- share one truthful HTTP identity between Cloudflare cache verification and agent-readiness checks
- stop presenting `HttpClient` as Chromium, which Cloudflare Bot Fight Mode correctly challenged when its TLS and JavaScript behavior did not match a browser
- keep the existing request pacing and strict readiness validation unchanged

## Why
The final DomainDetective GitHub deployment passed guardrails, build, Pages deployment, and managed Cloudflare policy, but Bot Fight Mode challenged the synthetic Chromium request for `sitemap.xml`. In the same deployment and from the same runner, all 14 cache-verification requests succeeded with the established `powerforge-web-cloudflare-verify` identity. Sharing that identity fixes drift without weakening bot protection or adding a bypass.

## Validation
- Windows focused website readiness and Cloudflare pipeline tests: 86/86
- WSL/Linux focused website readiness and Cloudflare pipeline tests: 86/86
- PowerForge.Tests release build: clean
- PowerShell diff check: clean

The decisive acceptance check remains the downstream DomainDetective GitHub-runner deployment behind Cloudflare Bot Fight Mode.