### PR TITLE
Keep direct releases independent of Git commit state

### DIFF
--- a/Build/Install-PowerForgeTool.ps1
+++ b/Build/Install-PowerForgeTool.ps1
@@ -58,9 +58,6 @@ if ($repository -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
     throw 'PowerForge repository must use owner/name.'
 }
 $expectedCommit = [string] (Get-ManifestPropertyValue -Object $manifest -Name 'commit')
-if ($schemaVersion -eq 2 -and [string]::IsNullOrWhiteSpace($expectedCommit)) {
-    throw 'PowerForge tool manifest schema version 2 requires an exact commit.'
-}
 if (-not [string]::IsNullOrWhiteSpace($expectedCommit) -and $expectedCommit -notmatch '^[A-Fa-f0-9]{40}$') {
     throw 'PowerForge tool manifest commit must be an exact 40-character Git SHA.'
 }

--- a/Docs/PSPublishModule.UnifiedModuleProjectRelease.md
+++ b/Docs/PSPublishModule.UnifiedModuleProjectRelease.md
@@ -573,60 +573,18 @@ For PSPublishModule's self-build, the practical sequence is:
 .\Build\Build-Project.ps1 -Publish
 ```
 
-PSPublishModule maintainers should normally use the **PSPublishModule Public Release**
-workflow instead of running the publish command interactively. The workflow is fixed to
-the signing-capable Windows runner and has three explicit operations:
+`Build-Project.ps1` is also the canonical interactive publish entrypoint for this repository.
+It publishes the versions and content in the current working tree; it does not require a clean
+checkout, a committed version bump, or an exact Git commit. Changing the script's default
+`RunMode` from `Build` to `Publish` is equivalent to passing `-Publish` and is supported for the
+maintainer's F5 workflow.
 
-1. `Plan` validates the exact `main` commit, release credentials, signing certificate,
-   coordinated version, and artifact graph without publishing.
-2. `Prepare` runs the Build gate and opens a narrow version pull request containing only
-   the generated module and package version sources. A retry reuses an existing open
-   release pull request only when its remote branch is based on the authorized commit and
-   its complete tracked tree matches the newly prepared result; stale or divergent refs
-   require explicit reconciliation.
-3. `Publish` accepts only a merged version and an exact
-   `publish:<version>:<main-commit>` confirmation, then publishes and verifies NuGet,
-   PowerShell Gallery, and the GitHub release. That release includes the canonical
-   standalone PowerForge installer and a generated runtime/checksum/commit manifest, so
-   exact CLI consumers use the same binaries that passed the coordinated release gate.
-   Its effective configuration replaces every
-   X-pattern with the authorized exact version and disables source-version mutation, so a
-   recovery run cannot advance a partially published release train. If the exact stable
-   GitHub release already exists after a partial asset upload, recovery first binds its
-   release ID and tag commit to the authorized source, revalidates both immediately before
-   every deletion/upload, and replaces same-named assets. The shared release engine requires
-   that exact 40-character commit binding even when recovery is invoked outside this workflow.
-   Rebuilt NuGet packages are replaced
-   locally with the exact bytes already published by the configured NuGet source before the
-   manifest and checksums are regenerated, so timestamped signatures cannot diverge between
-   NuGet and GitHub. Every package release ZIP is also rewritten from the published packages;
-   this restores matching signed library payloads across sibling project ZIPs while preserving
-   ZIP-only dependencies and diagnostics. The module ZIP payloads are likewise rebuilt from
-   the exact module files downloaded through PowerShell Gallery's supported v2/CDN read path,
-   while full-package-only examples and dependencies are preserved. Registry publishing is
-   disabled only when release replacement, exact NuGet-byte
-   recovery, and exact module-payload recovery are all bound to the verified release. Because
-   NuGet does not expose a matching byte-retrieval contract for
-   `.snupkg` files, recovery fails before mutation when symbol-package assets are present.
-   When no GitHub release or tag exists yet, recovery also inspects the exact public package
-   and module versions. Every first-release publish reconstructs its GitHub payloads from the
-   registries after publication, so a late `SkipDuplicate` result cannot leave GitHub with
-   different rebuilt bytes. If an earlier attempt published only part of the registry train,
-   the retry keeps NuGet publication enabled so `SkipDuplicate` can complete missing packages
-   and suppresses module publication only when that exact gallery version already exists.
-   Project release ZIP recovery supports both `lib/<tfm>/...` library packages and
-   `tools/<tfm>/any/...` .NET tool packages.
-   Registry publication is skipped during this verified GitHub-only recovery because the
-   stable partial GitHub release proves the earlier NuGet and PowerShell Gallery lanes already
-   completed. Existing asset names must be a subset of the authorized rebuilt set.
-   Asset IDs are bound both to the verified pre-delete snapshot and the upload response, and
-   the complete final name-to-ID set is reconciled before success. Late same-name collisions,
-   leftover assets, drafts, prereleases, missing tags, mismatched commits, changed release
-   identities, and changed asset identities fail closed.
+The release still signs configured outputs, validates the module, signs NuGet packages, writes
+archive and executable SHA-256 values to the standalone tool manifest, and publishes the unified
+GitHub release last. For this entrypoint, Git commit metadata is optional and is not a publication gate.
 
-Every run uploads a compact JSON receipt. Release plans are written under the ignored
-repository-level `Artefacts` directory so machine-specific absolute paths no longer
-create tracked release churn.
+Release plans are written under the ignored repository-level `Artefacts` directory so
+machine-specific absolute paths do not create tracked release churn.
 
 The Build gate should report the same resolved version for the primary package and module, list the local NuGet
 source added for the module build, and show the combined module/package assets under `Release.StageRoot`.

--- a/Module/Tests/PublicRelease.Tests.ps1
+++ b/Module/Tests/PublicRelease.Tests.ps1
@@ -26,29 +26,37 @@ Describe 'Standalone PowerForge installer host compatibility' {
         $content | Should -Match '\$PSVersionTable\.PSEdition'
     }
 
-    It 'rejects schema version 2 without exact commit provenance' {
+    It 'accepts schema version 2 without commit metadata' {
         $testRoot = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().ToString('N'))
         try {
             New-Item -ItemType Directory -Path $testRoot -Force | Out-Null
+            $isWindowsHost = $PSVersionTable.PSEdition -eq 'Desktop' -or
+                [Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+                    [Runtime.InteropServices.OSPlatform]::Windows)
+            $isMacOSHost = -not $isWindowsHost -and
+                [Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+                    [Runtime.InteropServices.OSPlatform]::OSX)
+            $platform = if ($isWindowsHost) { 'win' } elseif ($isMacOSHost) { 'osx' } else { 'linux' }
+            $architecture = [Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+            $rid = "$platform-$architecture"
             $manifestPath = Join-Path $testRoot 'PowerForge-tool-manifest.json'
-            @'
-{
-  "schemaVersion": 2,
-  "version": "3.0.116",
-  "assets": {
-    "osx-arm64": {
-      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      "executableSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-    }
-  }
-}
-'@ | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+            [ordered]@{
+                schemaVersion = 2
+                version = '3.0.118'
+                assets = [ordered]@{
+                    $rid = [ordered]@{
+                        sha256 = 'invalid'
+                        executableSha256 = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+                    }
+                }
+            } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $manifestPath -Encoding UTF8
 
             {
                 & $script:ToolInstallerPath `
                     -ManifestPath $manifestPath `
-                    -CacheRoot (Join-Path $testRoot 'cache')
-            } | Should -Throw '*schema version 2 requires an exact commit*'
+                    -CacheRoot (Join-Path $testRoot 'cache') `
+                    -ArtifactRoot $testRoot
+            } | Should -Throw "*asset '$rid' requires a 64-character SHA-256 digest*"
         } finally {
             if (Test-Path -LiteralPath $testRoot) {
                 Remove-Item -LiteralPath $testRoot -Recurse -Force

--- a/PowerForge.Tests/PowerForgeReleaseSchemaTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseSchemaTests.cs
@@ -7,11 +7,12 @@ public sealed class PowerForgeReleaseSchemaTests
 {
     [Theory]
     [InlineData(1, false, false, true)]
-    [InlineData(1, true, false, true)]
+    [InlineData(1, true, true, true)]
+    [InlineData(2, false, false, false)]
     [InlineData(2, false, true, false)]
-    [InlineData(2, true, false, false)]
+    [InlineData(2, true, false, true)]
     [InlineData(2, true, true, true)]
-    public void Tool_lock_schema_preserves_v1_and_requires_executable_digest_and_commit_for_v2(
+    public void Tool_lock_schema_requires_executable_digest_and_keeps_commit_optional(
         int schemaVersion,
         bool includeExecutableDigest,
         bool includeCommit,

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.StandaloneToolVersion.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.StandaloneToolVersion.cs
@@ -159,7 +159,7 @@ public sealed partial class PowerForgeReleaseServiceTests
     }
 
     [Fact]
-    public void Execute_WritesConsumerToolManifestAndIncludesInstallerAsset()
+    public void Execute_WritesConsumerToolManifestWithoutCommitGuard()
     {
         var root = CreateSandbox();
         try
@@ -175,12 +175,6 @@ public sealed partial class PowerForgeReleaseServiceTests
                 stream.Write(executableBytes, 0, executableBytes.Length);
             }
             File.WriteAllText(installer, "param()");
-            RunSnapshotGit(root, "init", "--quiet");
-            RunSnapshotGit(root, "config", "user.name", "PowerForge Tests");
-            RunSnapshotGit(root, "config", "user.email", "powerforge-tests@example.invalid");
-            RunSnapshotGit(root, "add", ".");
-            RunSnapshotGit(root, "commit", "--quiet", "-m", "exact source");
-            var commit = RunSnapshotGit(root, "rev-parse", "HEAD").Trim();
             var service = new PowerForgeReleaseService(
                 new NullLogger(),
                 executePackages: (_, _, _) => throw new InvalidOperationException("Packages must not run."),
@@ -243,7 +237,6 @@ public sealed partial class PowerForgeReleaseServiceTests
                     {
                         Owner = "EvotecIT",
                         Repository = "PSPublishModule",
-                        Commitish = commit,
                         TagTemplate = "v{Version}"
                     }
                 },
@@ -262,7 +255,7 @@ public sealed partial class PowerForgeReleaseServiceTests
             Assert.Equal(2, json.GetProperty("schemaVersion").GetInt32());
             Assert.Equal("3.0.110", json.GetProperty("version").GetString());
             Assert.Equal("v3.0.110", json.GetProperty("releaseTag").GetString());
-            Assert.Equal(commit, json.GetProperty("commit").GetString());
+            Assert.False(json.TryGetProperty("commit", out _));
             var asset = json.GetProperty("assets").GetProperty("osx-arm64");
             Assert.Equal(Path.GetFileName(zip), asset.GetProperty("name").GetString());
             Assert.Equal(
@@ -402,7 +395,7 @@ public sealed partial class PowerForgeReleaseServiceTests
     }
 
     [Fact]
-    public void ValidatePowerForgeToolManifestStaging_requires_exact_commit_provenance()
+    public void ValidatePowerForgeToolManifestStaging_allows_optional_commit_provenance()
     {
         var spec = new PowerForgeReleaseSpec
         {
@@ -417,11 +410,7 @@ public sealed partial class PowerForgeReleaseServiceTests
             }
         };
 
-        var error = Assert.Throws<InvalidOperationException>(() =>
-            PowerForgeReleaseService.ValidatePowerForgeToolManifestStaging(spec));
-
-        Assert.Contains("GitHub.Commitish", error.Message, StringComparison.Ordinal);
-        Assert.Contains("exact 40-character Git SHA", error.Message, StringComparison.Ordinal);
+        PowerForgeReleaseService.ValidatePowerForgeToolManifestStaging(spec);
     }
 
     [Fact]

--- a/PowerForge/Services/PowerForgeReleaseService.ToolManifest.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.ToolManifest.cs
@@ -45,12 +45,6 @@ internal sealed partial class PowerForgeReleaseService
                 "PowerForgeToolManifestPath cannot be combined with Outputs.Staging.ToolsNameTemplate because " +
                 "the installer manifest must name the exact published tool archive.");
         }
-
-        if (NormalizePowerForgeToolManifestCommit(spec.GitHub?.Commitish) is null)
-        {
-            throw new InvalidOperationException(
-                "PowerForgeToolManifestPath requires GitHub.Commitish to be an exact 40-character Git SHA.");
-        }
     }
 
     private static bool IsStandalonePowerForgeToolSelected(PowerForgeReleaseResult result)

--- a/README.MD
+++ b/README.MD
@@ -95,8 +95,8 @@ dotnet tool install --global PowerForge.Web.Build
 
 For an exact standalone `powerforge` binary from a GitHub release, download the
 installer and tool manifest from the same `v<version>` release. The installer selects
-the current OS/architecture asset, verifies its SHA-256, checks the embedded version
-and release commit, and reuses the verified cache on later runs:
+the current OS/architecture asset, verifies the archive and executable SHA-256 values,
+checks the embedded version, and reuses the verified cache on later runs:
 
 ```powershell
 $version = '3.0.110'

--- a/Schemas/powerforge.tool.schema.json
+++ b/Schemas/powerforge.tool.schema.json
@@ -49,7 +49,6 @@
         "required": ["schemaVersion"]
       },
       "then": {
-        "required": ["commit"],
         "properties": {
           "assets": {
             "patternProperties": {


### PR DESCRIPTION
## Summary

- keep `Build/Build-Project.ps1` publish runs independent of Git commit state
- make schema-v2 tool-manifest commit metadata optional while retaining archive and executable SHA-256 requirements
- cover commitless manifest generation and installer parsing, and document the working-tree/F5 release flow as canonical

## Why

The 3.0.118 run published PSPublishModule and the PowerForge NuGet packages, then failed before the unified GitHub release because tool-manifest generation required `GitHub.Commitish`. A Git commit is not needed to validate the artifacts that were actually built. This change removes that late publication gate without weakening package signing, artifact hashes, safe paths, or embedded-version checks.

This PR does not publish or repair any release.

## Validation

- direct `Build-Project.ps1 -Plan -Json` release plan
- 588 release-service/schema tests
- 37 focused exact-head release and manifest tests after rebasing onto current `main`
- 19 Pester release tests
- installer parsing in PowerShell 7 and Windows PowerShell 5.1
- independent read-only review plus targeted confirmation of the added installer regression