### PR TITLE
Prevent provenance evaluation from building project references

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
@@ -1391,6 +1391,147 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
     }
 
     [Fact]
+    public void ReadSourceProvenance_DoesNotBuildProjectReferenceOutputsDuringEvaluation()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string appDirectory = Directory.CreateDirectory(Path.Combine(root, "src", "App")).FullName;
+            string libraryDirectory = Directory.CreateDirectory(Path.Combine(root, "src", "Library")).FullName;
+            string generatorDirectory = Directory.CreateDirectory(Path.Combine(root, "src", "Generator")).FullName;
+            string appProject = Path.Combine(appDirectory, "App.csproj");
+            string libraryProject = Path.Combine(libraryDirectory, "Library.csproj");
+            string generatorProject = Path.Combine(generatorDirectory, "Generator.csproj");
+            File.WriteAllText(appProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+                  <ItemGroup>
+                    <ProjectReference Include="../Library/Library.csproj" />
+                    <ProjectReference Include="../Generator/Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+                  </ItemGroup>
+                </Project>
+                """);
+            File.WriteAllText(libraryProject, "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>");
+            File.WriteAllText(generatorProject, "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>netstandard2.0</TargetFramework></PropertyGroup></Project>");
+            File.WriteAllText(Path.Combine(appDirectory, "Program.cs"), "internal static class Program { private static void Main() { } }");
+            File.WriteAllText(Path.Combine(libraryDirectory, "Library.cs"), "public static class Library { }");
+            File.WriteAllText(Path.Combine(generatorDirectory, "Generator.cs"), "public static class Generator { }");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source\"");
+            RunDotNet(root, $"restore \"{appProject}\" --use-lock-file --nologo");
+            RunGit(root, "add src/*/packages.lock.json");
+            RunGit(root, "commit -m \"lock approved dependencies\"");
+            string libraryOutput = Path.Combine(libraryDirectory, "bin", "Release", "net8.0", "Library.dll");
+            string generatorOutput = Path.Combine(generatorDirectory, "bin", "Release", "netstandard2.0", "Generator.dll");
+            Directory.CreateDirectory(Path.GetDirectoryName(libraryOutput)!);
+            Directory.CreateDirectory(Path.GetDirectoryName(generatorOutput)!);
+            File.WriteAllText(libraryOutput, "stale generated library");
+            File.WriteAllText(generatorOutput, "stale generated analyzer");
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Configuration = "Release",
+                Targets =
+                [
+                    new DotNetPublishTargetPlan
+                    {
+                        Name = "App",
+                        ProjectPath = appProject,
+                        Combinations =
+                        [
+                            new DotNetPublishTargetCombination
+                            {
+                                Framework = "net8.0",
+                                Style = DotNetPublishStyle.FrameworkDependent
+                            }
+                        ]
+                    }
+                ]
+            };
+            plan.MsBuildProperties["BuildProjectReferences"] = "true";
+
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(
+                    root,
+                    buildProjectPaths: [appProject],
+                    buildConfiguration: "Release",
+                    buildPlan: plan);
+
+            Assert.False(provenance.Dirty);
+            Assert.Empty(provenance.DirtyPaths);
+            Assert.Equal("stale generated library", File.ReadAllText(libraryOutput));
+            Assert.Equal("stale generated analyzer", File.ReadAllText(generatorOutput));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                foreach (FileInfo file in new DirectoryInfo(root).EnumerateFiles("*", SearchOption.AllDirectories))
+                    file.Attributes = FileAttributes.Normal;
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void ReadSourceProvenance_TracksSourceItemWithProjectReferenceMetadata()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string appDirectory = Directory.CreateDirectory(Path.Combine(root, "src", "App")).FullName;
+            string inputDirectory = Directory.CreateDirectory(Path.Combine(root, "inputs")).FullName;
+            string appProject = Path.Combine(appDirectory, "App.csproj");
+            string releaseInput = Path.Combine(inputDirectory, "release-input.json");
+            File.WriteAllText(appProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+                  <ItemGroup>
+                    <AdditionalFiles Include="../../inputs/release-input.json">
+                      <ReferenceSourceTarget>ProjectReference</ReferenceSourceTarget>
+                      <MSBuildSourceProjectFile>../Input/Input.csproj</MSBuildSourceProjectFile>
+                    </AdditionalFiles>
+                  </ItemGroup>
+                </Project>
+                """);
+            File.WriteAllText(Path.Combine(appDirectory, "Program.cs"), "internal static class Program { private static void Main() { } }");
+            File.WriteAllText(releaseInput, "{\"approved\":true}");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
+            RunDotNet(root, $"restore \"{appProject}\" --use-lock-file --nologo");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source\"");
+            File.WriteAllText(releaseInput, "{\"approved\":false}");
+
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(
+                    root,
+                    buildProjectPaths: [appProject],
+                    buildConfiguration: "Release");
+
+            Assert.True(provenance.Dirty);
+            Assert.Contains(
+                provenance.DirtyPaths,
+                path => path.Replace('\\', '/').EndsWith("inputs/release-input.json", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                foreach (FileInfo file in new DirectoryInfo(root).EnumerateFiles("*", SearchOption.AllDirectories))
+                    file.Attributes = FileAttributes.Normal;
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void ReadSourceProvenance_RejectsDirtyEvaluatedAnalyzerOutsideProjectDirectory()
     {
         string root = Directory.CreateTempSubdirectory().FullName;

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
@@ -530,12 +530,14 @@ public sealed partial class DotNetPublishPipelineRunner
         foreach (KeyValuePair<string, string> property in request.GlobalProperties.OrderBy(entry => entry.Key, StringComparer.OrdinalIgnoreCase))
         {
             if (property.Key.Equals("Configuration", StringComparison.OrdinalIgnoreCase) ||
-                property.Key.Equals("TargetFramework", StringComparison.OrdinalIgnoreCase))
+                property.Key.Equals("TargetFramework", StringComparison.OrdinalIgnoreCase) ||
+                property.Key.Equals("BuildProjectReferences", StringComparison.OrdinalIgnoreCase))
             {
                 continue;
             }
             arguments.Add("-p:" + property.Key + "=" + property.Value);
         }
+        arguments.Add("-p:BuildProjectReferences=false");
 
         try
         {
@@ -659,15 +661,11 @@ public sealed partial class DotNetPublishPipelineRunner
                                 inputs.Add(fullPath);
                                 rawReferences.Add(fullPath);
                             }
-                            else if ((itemName.Equals("ReferencePath", StringComparison.Ordinal) ||
-                                      itemName.Equals("ReferenceCopyLocalPaths", StringComparison.Ordinal)) &&
-                                     string.Equals(
-                                         ReadItemText(item, "ReferenceSourceTarget"),
-                                         "ProjectReference",
-                                         StringComparison.OrdinalIgnoreCase))
+                            else if (IsGeneratedProjectReferenceOutput(itemName, fullPath, item))
                             {
                                 // The referenced project's evaluated sources are queued below; its compiled
-                                // output is generated state and cannot become a release source input.
+                                // output (including analyzer/source-generator outputs) is generated state and
+                                // cannot become a release source input.
                                 continue;
                             }
                             else if (!itemName.Equals("None", StringComparison.Ordinal) || IsOutputRelevantNoneItem(item))
@@ -858,12 +856,14 @@ public sealed partial class DotNetPublishPipelineRunner
         foreach (KeyValuePair<string, string> property in request.GlobalProperties.OrderBy(entry => entry.Key, StringComparer.OrdinalIgnoreCase))
         {
             if (property.Key.Equals("Configuration", StringComparison.OrdinalIgnoreCase) ||
-                property.Key.Equals("TargetFramework", StringComparison.OrdinalIgnoreCase))
+                property.Key.Equals("TargetFramework", StringComparison.OrdinalIgnoreCase) ||
+                property.Key.Equals("BuildProjectReferences", StringComparison.OrdinalIgnoreCase))
             {
                 continue;
             }
             arguments.Add("-p:" + property.Key + "=" + property.Value);
         }
+        arguments.Add("-p:BuildProjectReferences=false");
 
         try
         {
@@ -909,6 +909,30 @@ public sealed partial class DotNetPublishPipelineRunner
         => item.TryGetProperty(name, out JsonElement value) && value.ValueKind == JsonValueKind.String
             ? value.GetString()
             : null;
+
+    private static bool IsGeneratedProjectReferenceOutput(
+        string itemName,
+        string fullPath,
+        JsonElement item)
+    {
+        bool resolvedFromProjectReference = string.Equals(
+            ReadItemText(item, "ReferenceSourceTarget"),
+            "ProjectReference",
+            StringComparison.OrdinalIgnoreCase);
+        if (itemName.Equals("ReferencePath", StringComparison.Ordinal) ||
+            itemName.Equals("ReferenceCopyLocalPaths", StringComparison.Ordinal))
+        {
+            return resolvedFromProjectReference;
+        }
+
+        // An analyzer ProjectReference resolves to its compiled DLL even when project builds are
+        // disabled. MSBuild stamps that direct target output with its source project but does not
+        // guarantee ReferenceSourceTarget metadata. Other output item types can intentionally return
+        // tracked source inputs and must remain in provenance.
+        return itemName.Equals("Analyzer", StringComparison.Ordinal) &&
+               Path.GetExtension(fullPath).Equals(".dll", StringComparison.OrdinalIgnoreCase) &&
+               !string.IsNullOrWhiteSpace(ReadItemText(item, "MSBuildSourceProjectFile"));
+    }
 
     private static void AddSemicolonSeparatedPathValues(
         JsonElement properties,


### PR DESCRIPTION
## Summary
- force release-provenance MSBuild evaluation to keep project-reference builds disabled, even when publish configuration requests otherwise
- exclude only known generated ordinary and analyzer project-reference outputs while retaining legitimate tracked source inputs
- cover ordinary libraries, analyzer/source-generator projects, conflicting MSBuild properties, and source items carrying project-reference metadata

## Why
A private TestimoX preview correctly stopped before signing because PowerForge's provenance inspection built an analyzer project while evaluating the graph. That mutated ignored build output after source planning and made the release look changed. Provenance inspection must be read-only: it may resolve the graph, but it must not build referenced projects or mistake their generated DLLs for approved source.

## Validation
- provenance regression cases: 2/2
- full manifest-provenance contract class: 35/35 on .NET 10
- PowerForge .NET Framework 4.7.2 build: clean with no warnings
- independent local review completed; both material findings were remediated and directly covered

## Release note
TestimoX should remain pinned to the current public PowerForge package until this change is merged and a new three-part PowerForge/PSPublishModule version is published. No consumer workaround is included.