### PR TITLE
Make Cloudflare site-policy runner configurable

### DIFF
--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -30,6 +30,11 @@ on:
         required: false
         type: string
         default: '["ubuntu-latest"]'
+      cloudflare_runner_labels_json:
+        description: JSON array of runner labels for the protected Cloudflare site-policy job.
+        required: false
+        type: string
+        default: '["ubuntu-latest"]'
       timeout_minutes:
         description: Maximum deployment or post-deployment job duration. GitHub Pages retries once within this budget because deploy-pages limits each attempt to 10 minutes.
         required: false
@@ -303,7 +308,7 @@ jobs:
   cloudflare-site-policy:
     if: ${{ inputs.deployment_target == 'github-pages' && inputs.manage_cloudflare_site_policy }}
     needs: [deploy, build, guardrails]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJson(inputs.cloudflare_runner_labels_json) }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
     environment:
       name: github-pages

--- a/PowerForge.Tests/GitHubWebsiteDeployGuardrailTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteDeployGuardrailTests.cs
@@ -29,16 +29,22 @@ public sealed class GitHubWebsiteDeployGuardrailTests
     }
 
     [Fact]
-    public void ReusableWorkflow_ShouldApplyGitHubPagesCloudflarePolicyOnLinux()
+    public void ReusableWorkflow_ShouldApplyGitHubPagesCloudflarePolicyOnConfiguredRunner()
     {
         var workflow = ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml");
+        var cloudflareInputStart = workflow.IndexOf("      cloudflare_runner_labels_json:", StringComparison.Ordinal);
+        var timeoutInputStart = workflow.IndexOf("      timeout_minutes:", StringComparison.Ordinal);
         var policyStart = workflow.IndexOf("  cloudflare-site-policy:", StringComparison.Ordinal);
         var linuxStart = workflow.IndexOf("  deploy-linux:", StringComparison.Ordinal);
+        Assert.True(cloudflareInputStart >= 0 && timeoutInputStart > cloudflareInputStart);
         Assert.True(policyStart >= 0 && linuxStart > policyStart);
+        var cloudflareInput = workflow[cloudflareInputStart..timeoutInputStart];
         var policyJob = workflow[policyStart..linuxStart];
 
         Assert.Contains("needs: [deploy, build, guardrails]", policyJob, StringComparison.Ordinal);
-        Assert.Contains("runs-on: ubuntu-latest", policyJob, StringComparison.Ordinal);
+        Assert.Contains("type: string", cloudflareInput, StringComparison.Ordinal);
+        Assert.Contains("default: '[\"ubuntu-latest\"]'", cloudflareInput, StringComparison.Ordinal);
+        Assert.Contains("runs-on: ${{ fromJson(inputs.cloudflare_runner_labels_json) }}", policyJob, StringComparison.Ordinal);
         Assert.Contains("powerforge-cloudflare-site-policy", policyJob, StringComparison.Ordinal);
         Assert.Contains("needs: [deploy, cloudflare-site-policy, deploy-linux]", workflow, StringComparison.Ordinal);
         Assert.Contains("needs.cloudflare-site-policy.result == 'success'", workflow, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

- add a dedicated runner-label input for the protected Cloudflare site-policy job
- retain the GitHub-hosted Linux default for public and unspecified callers
- protect the default and job binding with a focused workflow guardrail

Private website consumers can opt into EvotecIT Linux runners after pinning the merged workflow commit.