### PR TITLE
Validate website workflows before deployment

### DIFF
--- a/.github/workflows/BuildModule.yml
+++ b/.github/workflows/BuildModule.yml
@@ -67,6 +67,60 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  WorkflowLint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Validate website workflows
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          readonly actionlint_version='1.7.12'
+          readonly actionlint_archive="actionlint_${actionlint_version}_linux_amd64.tar.gz"
+          readonly actionlint_sha256='8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8'
+          readonly actionlint_url="https://github.com/rhysd/actionlint/releases/download/v${actionlint_version}/${actionlint_archive}"
+          readonly lint_root="${RUNNER_TEMP}/powerforge-actionlint"
+
+          rm --recursive --force "$lint_root"
+          mkdir --parents "$lint_root/.github/workflows"
+          curl --fail --location --silent --show-error "$actionlint_url" --output "$lint_root/$actionlint_archive"
+          printf '%s  %s\n' "$actionlint_sha256" "$lint_root/$actionlint_archive" | sha256sum --check --strict
+          tar --extract --gzip --file "$lint_root/$actionlint_archive" --directory "$lint_root" actionlint
+
+          readonly -a website_workflows=(
+            '.github/workflows/powerforge-website-ci.yml'
+            '.github/workflows/powerforge-website-deploy.yml'
+            '.github/workflows/powerforge-website-maintenance.yml'
+            '.github/workflows/powerforge-website-run.yml'
+          )
+
+          # GitHub added job.workflow_* identity fields after actionlint's current schema.
+          # Lint copies with only those five documented fields normalized to another string field.
+          readonly workflow_identity_expression='\$\{\{[[:space:]]*job\.workflow_(repository|sha|ref|file_path)[[:space:]]*\}\}'
+          readonly replacement_expression='$'"{{ job.status }}"
+          readonly expected_workflow_identity_count=5
+          workflow_identity_count="$({ grep --no-filename --only-matching --extended-regexp "$workflow_identity_expression" "${website_workflows[@]}" || true; } | wc --lines | tr --delete '[:space:]')"
+          if [[ "$workflow_identity_count" != "$expected_workflow_identity_count" ]]; then
+            printf 'Expected %s documented job.workflow_* expressions, found %s.\n' "$expected_workflow_identity_count" "$workflow_identity_count" >&2
+            exit 1
+          fi
+
+          lint_workflows=()
+          for workflow in "${website_workflows[@]}"; do
+            lint_workflow="$lint_root/$workflow"
+            cp "$workflow" "$lint_workflow"
+            sed --regexp-extended --in-place "s#$workflow_identity_expression#$replacement_expression#g" "$lint_workflow"
+            lint_workflows+=("$lint_workflow")
+          done
+
+          "$lint_root/actionlint" -oneline "${lint_workflows[@]}"
+
   DependencyAudit:
     # Prefer private/self-hosted runners for private repos to reduce hosted spend.
     runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]') }}

--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -193,7 +193,6 @@ jobs:
       DOTNET_BUNDLE_EXTRACT_BASE_DIR: ${{ github.workspace }}/.cache/powerforge-runner/dotnet-bundle
       BUN_INSTALL_CACHE_DIR: ${{ github.workspace }}/.cache/powerforge-runner/bun-install-cache
       NPM_CONFIG_CACHE: ${{ github.workspace }}/.cache/powerforge-runner/npm-cache
-      POWERFORGE_DEPLOYMENT_MANIFEST: ${{ runner.temp }}/powerforge-deployment-manifest/manifest.json
       POWERFORGE_DEPLOYMENT_BASE_URL: ${{ inputs.deployment_base_url }}
     steps:
       - name: Validate credential mode
@@ -342,6 +341,7 @@ jobs:
           POWERFORGE_REPOSITORY_TOKEN: ${{ inputs.credential_mode != 'none' && secrets.repository_read_token || '' }}
           CLOUDFLARE_API_TOKEN: ${{ inputs.credential_mode != 'none' && secrets.cloudflare_api_token || '' }}
           CLOUDFLARE_ZONE_ID: ${{ inputs.credential_mode != 'none' && secrets.cloudflare_zone_id || '' }}
+          POWERFORGE_DEPLOYMENT_MANIFEST: ${{ runner.temp }}/powerforge-deployment-manifest/manifest.json
           POWERFORGE_RUNNER_RESULT_PATH: ${{ runner.temp }}/powerforge-website-runner-result.json
         run: |
           $runnerRestoreConfig = Join-Path $env:GITHUB_WORKSPACE '.powerforge-runner/.github/nuget.public.config'

--- a/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
@@ -293,7 +293,14 @@ public sealed class GitHubWebsiteRunWorkflowTests
         Assert.Contains("source_ref: ${{ needs.build.outputs.source_sha }}", deployWorkflow, StringComparison.Ordinal);
         Assert.Contains("deployment_manifest_artifact_name: ${{ needs.build.outputs.deployment_manifest_artifact_name }}", deployWorkflow, StringComparison.Ordinal);
         Assert.Contains("deployment_base_url: ${{ inputs.deployment_target == 'linux' && inputs.deployment_url || '' }}", deployWorkflow, StringComparison.Ordinal);
-        Assert.Contains("POWERFORGE_DEPLOYMENT_MANIFEST: ${{ runner.temp }}/powerforge-deployment-manifest/manifest.json", runWorkflow, StringComparison.Ordinal);
+        var manifestEnvironmentLines = runWorkflow
+            .Split('\n')
+            .Where(static line => line.Contains("POWERFORGE_DEPLOYMENT_MANIFEST:", StringComparison.Ordinal))
+            .ToArray();
+        Assert.Equal(2, manifestEnvironmentLines.Length);
+        Assert.All(manifestEnvironmentLines, static line =>
+            Assert.StartsWith("          POWERFORGE_DEPLOYMENT_MANIFEST: ${{ runner.temp }}/powerforge-deployment-manifest/manifest.json", line, StringComparison.Ordinal));
+        Assert.DoesNotContain("\n      POWERFORGE_DEPLOYMENT_MANIFEST:", runWorkflow, StringComparison.Ordinal);
         Assert.Contains("POWERFORGE_DEPLOYMENT_BASE_URL: ${{ inputs.deployment_base_url }}", runWorkflow, StringComparison.Ordinal);
         Assert.Contains("name: ${{ inputs.deployment_manifest_artifact_name }}", runWorkflow, StringComparison.Ordinal);
         Assert.Contains("--artifact $env:POWERFORGE_SITE_ARTIFACT --out $env:POWERFORGE_DEPLOYMENT_MANIFEST", runWorkflow, StringComparison.Ordinal);


### PR DESCRIPTION
## What changed

- scopes `POWERFORGE_DEPLOYMENT_MANIFEST` to the runner step that executes the website pipeline, so reusable workflows no longer reference `runner.temp` from an unsupported job-level context
- adds a checksum-pinned Actionlint gate for the four shared website workflows on every PowerForge pull request
- normalizes only GitHub's documented `job.workflow_*` identity fields in temporary lint copies until Actionlint models them, without suppressing other diagnostics
- strengthens the manifest handoff contract test so runner-temporary paths cannot return to job scope

## Why it matters

GitHub rejected the merged reusable workflow before any job started. This makes the invalid context locally reproducible and turns the same defect class into a PR failure instead of a post-merge deployment failure.

## Validation

- focused PowerForge workflow and deployment verifier tests: 24 passed
- Actionlint 1.7.12 on the build workflow and all website workflows: passed on Windows
- exact checksum-pinned Linux download and lint path: passed under WSL
- negative mutation using unbraced `if: inputs.workflow_sha`: rejected by Actionlint
- independent local review: no P0-P2 findings; the lint-exception P3 was remediated and directly regression-tested