### PR TITLE
Allow local public-release version preparation

### DIFF
--- a/Build/Invoke-PowerForgePublicRelease.ps1
+++ b/Build/Invoke-PowerForgePublicRelease.ps1
@@ -130,7 +130,11 @@ try {
         -ReleaseConfig $releaseConfig `
         -SourceConfigurationPath $ConfigPath `
         -EvidenceDirectory $effectiveConfigDirectory
-    $releaseConfig.GitHub | Add-Member -NotePropertyName Commitish -NotePropertyValue $ExpectedCommit -Force
+    . (Join-Path (Join-Path $PSScriptRoot 'Private') 'Set-PowerForgeAuthorizedReleaseCommitish.ps1')
+    $releaseConfig = Set-PowerForgeAuthorizedReleaseCommitish `
+        -ReleaseConfig $releaseConfig `
+        -Operation $Operation `
+        -ExpectedCommit $ExpectedCommit
     $certificateThumbprint = [string] $releaseConfig.Packages.CertificateThumbprint
     $certificateStore = [string] $releaseConfig.Packages.CertificateStore
     if ([string]::IsNullOrWhiteSpace($certificateThumbprint) -or [string]::IsNullOrWhiteSpace($certificateStore)) {

--- a/Build/Private/Set-PowerForgeAuthorizedReleaseCommitish.ps1
+++ b/Build/Private/Set-PowerForgeAuthorizedReleaseCommitish.ps1
@@ -1,0 +1,31 @@
+function Set-PowerForgeAuthorizedReleaseCommitish {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [psobject] $ReleaseConfig,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Plan', 'Prepare', 'Publish')]
+        [string] $Operation,
+
+        [Parameter(Mandatory)]
+        [ValidatePattern('^[0-9a-fA-F]{40}$')]
+        [string] $ExpectedCommit
+    )
+
+    if ($null -eq $ReleaseConfig.GitHub) {
+        throw 'The release configuration does not declare a GitHub section.'
+    }
+
+    $commitishProperty = $ReleaseConfig.GitHub.PSObject.Properties['Commitish']
+    if ($Operation -eq 'Prepare') {
+        if ($null -ne $commitishProperty) {
+            $ReleaseConfig.GitHub.PSObject.Properties.Remove('Commitish')
+        }
+    } else {
+        $ReleaseConfig.GitHub |
+            Add-Member -NotePropertyName Commitish -NotePropertyValue $ExpectedCommit -Force
+    }
+
+    $ReleaseConfig
+}

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.PublicModuleRelease.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.PublicModuleRelease.cs
@@ -10,6 +10,7 @@ public sealed partial class AppleReleaseWorkflowTests
         var script = Read(root, "Build", "Invoke-PowerForgePublicRelease.ps1");
         var sourceState = Read(root, "Build", "Private", "Get-PowerForgeReleaseSourceState.ps1");
         var evidenceWorkspace = Read(root, "Build", "Private", "New-PowerForgeReleaseEvidenceWorkspace.ps1");
+        var commitishAuthorization = Read(root, "Build", "Private", "Set-PowerForgeAuthorizedReleaseCommitish.ps1");
         var releaseConfig = Read(root, "Build", "release.json");
         var moduleConfig = Read(root, "powerforge.json");
         var releaseSchema = Read(root, "Schemas", "powerforge.release.schema.json");
@@ -65,7 +66,9 @@ public sealed partial class AppleReleaseWorkflowTests
         Assert.Contains("\"PowerForge.ReleaseProvenance.json\"", moduleConfig, StringComparison.Ordinal);
         Assert.Contains("\"PowerForge.ReleaseProvenance.psd1\"", moduleConfig, StringComparison.Ordinal);
         Assert.Contains(". .\\Build\\Private\\Assert-PowerForgeCommittedReleaseVersion.ps1", workflow, StringComparison.Ordinal);
-        Assert.Contains("$releaseConfig.GitHub | Add-Member -NotePropertyName Commitish", script, StringComparison.Ordinal);
+        Assert.Contains("Set-PowerForgeAuthorizedReleaseCommitish", script, StringComparison.Ordinal);
+        Assert.Contains("$Operation -eq 'Prepare'", commitishAuthorization, StringComparison.Ordinal);
+        Assert.Contains("Add-Member -NotePropertyName Commitish", commitishAuthorization, StringComparison.Ordinal);
         Assert.Contains("ExpectedTagCommitSha = gitHub.Commitish", Read(root, "PowerForge", "Services", "PowerForgeReleaseService.cs"), StringComparison.Ordinal);
         Assert.Contains("Status         = 'Failed'", script, StringComparison.Ordinal);
         Assert.Contains("$release.isDraft -eq $true", workflow, StringComparison.Ordinal);
@@ -84,6 +87,36 @@ public sealed partial class AppleReleaseWorkflowTests
         Assert.DoesNotContain("pull_request:", workflow, StringComparison.Ordinal);
         Assert.Contains("\"PlanOutputPath\": \"../Artefacts/ProjectBuild/project.build.plan.json\"", releaseConfig, StringComparison.Ordinal);
         Assert.Contains("\"Commitish\"", releaseSchema, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("powershell", "Plan", "0123456789abcdef0123456789abcdef01234567")]
+    [InlineData("powershell", "Prepare", "<absent>")]
+    [InlineData("powershell", "Publish", "0123456789abcdef0123456789abcdef01234567")]
+    [InlineData("pwsh", "Plan", "0123456789abcdef0123456789abcdef01234567")]
+    [InlineData("pwsh", "Prepare", "<absent>")]
+    [InlineData("pwsh", "Publish", "0123456789abcdef0123456789abcdef01234567")]
+    public void PublicModuleReleaseOmitsCommitishOnlyWhilePreparingVersionChanges(
+        string shell,
+        string operation,
+        string expectedCommitish)
+    {
+        var root = FindRepoRoot();
+        var helper = Path.Combine(
+            root,
+            "Build",
+            "Private",
+            "Set-PowerForgeAuthorizedReleaseCommitish.ps1");
+        const string commit = "0123456789abcdef0123456789abcdef01234567";
+        string command = $". '{helper.Replace("'", "''", StringComparison.Ordinal)}'; " +
+                         "$config = '{\"GitHub\":{\"Commitish\":\"caller-supplied\"}}' | ConvertFrom-Json; " +
+                         $"$config = Set-PowerForgeAuthorizedReleaseCommitish -ReleaseConfig $config -Operation '{operation}' -ExpectedCommit '{commit}'; " +
+                         "$property = $config.GitHub.PSObject.Properties['Commitish']; " +
+                         "if ($null -eq $property) { '<absent>' } else { [string] $property.Value }";
+
+        var result = Run(shell, root, "-NoProfile", "-Command", command).EnsureSuccess();
+
+        Assert.Equal(expectedCommitish, result.StandardOutput.Trim());
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

- keep an exact authorized GitHub commit for release planning and publication
- omit the commitish only during `Prepare`, when the release script intentionally creates reviewable version-file changes
- prevent caller-supplied commitish values from weakening either path

## Why

Local hardware-backed release preparation previously failed after updating version files because the build was still pinned to the pre-change commit. Publication remains bound to an exact clean commit; only the non-publishing preparation step accepts the expected version changes.

## Validation

- 7 focused release-workflow tests passed across Windows PowerShell 5.1 and PowerShell 7
- independent read-only review found no actionable issues
- a real local `3.0.121` preparation completed with the hardware-backed signing certificate and changed exactly the eight expected version files
- no package, tag, GitHub release, or Control release was published

The broader Apple release test class retained 11 unrelated Windows temporary-directory cleanup failures; 87 tests passed.

## Release state

The public version remains `3.0.120`. After this merges, `3.0.121` can be prepared as a separate mechanical version PR, followed by an explicitly confirmed local publication from its exact merged commit.