### PR TITLE
Reduce .NET publish provenance evaluation overhead

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
@@ -1478,6 +1478,82 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
     }
 
     [Fact]
+    public void ReadSourceProvenance_EvaluatesEachRestoreDistinctRootBeforeNextRestore()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string projectDirectory = Directory.CreateDirectory(Path.Combine(root, "src", "App")).FullName;
+            string projectPath = Path.Combine(projectDirectory, "App.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net8.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """);
+            File.WriteAllText(
+                Path.Combine(projectDirectory, "Program.cs"),
+                "internal static class Program { private static void Main() { } }");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
+            RunDotNet(root, $"restore \"{projectPath}\" --use-lock-file --nologo");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source\"");
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Configuration = "Release",
+                Targets =
+                [
+                    new DotNetPublishTargetPlan
+                    {
+                        Name = "App",
+                        ProjectPath = projectPath,
+                        Combinations =
+                        [
+                            new DotNetPublishTargetCombination
+                            {
+                                Framework = "net8.0",
+                                Runtime = "win-x64",
+                                Style = DotNetPublishStyle.FrameworkDependent
+                            },
+                            new DotNetPublishTargetCombination
+                            {
+                                Framework = "net8.0",
+                                Runtime = "win-arm64",
+                                Style = DotNetPublishStyle.FrameworkDependent
+                            }
+                        ]
+                    }
+                ]
+            };
+
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(
+                    root,
+                    buildProjectPaths: [projectPath],
+                    buildConfiguration: "Release",
+                    buildPlan: plan);
+
+            Assert.False(provenance.Dirty);
+            Assert.Empty(provenance.DirtyPaths);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                foreach (FileInfo file in new DirectoryInfo(root).EnumerateFiles("*", SearchOption.AllDirectories))
+                    file.Attributes = FileAttributes.Normal;
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void ReadSourceProvenance_TracksSourceItemWithProjectReferenceMetadata()
     {
         string root = Directory.CreateTempSubdirectory().FullName;

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
@@ -303,53 +303,71 @@ public sealed partial class DotNetPublishPipelineRunner
         out HashSet<string> sourceInputs)
     {
         var comparison = IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
-        var pending = new Queue<ProjectEvaluationRequest>(BuildProjectEvaluationRequests(
-            projectPaths,
-            configuration,
-            buildPlan));
+        ProjectEvaluationRequest[] roots = BuildProjectEvaluationRequests(
+                projectPaths,
+                configuration,
+                buildPlan)
+            .ToArray();
         var visited = new HashSet<string>(comparison);
         var directories = new HashSet<string>(comparison);
+        using var verifiedPackageArchives = new VerifiedPackageArchiveCache();
         buildInputs = new HashSet<string>(comparison);
         sourceInputs = new HashSet<string>(comparison);
 
-        while (pending.Count > 0)
+        foreach (ProjectEvaluationRequest root in roots)
         {
-            ProjectEvaluationRequest request = pending.Dequeue();
-            string visitKey = request.BuildVisitKey();
-            if (!visited.Add(visitKey) || !File.Exists(request.ProjectPath))
-                continue;
-
-            string projectDirectory = Path.GetDirectoryName(request.ProjectPath)!;
-            directories.Add(projectDirectory);
-            buildInputs.Add(request.ProjectPath);
-            sourceInputs.Add(request.ProjectPath);
-            if (!TryReadEvaluatedProjectInputs(request, out EvaluatedProjectInputs? evaluation) || evaluation is null)
+            if (!TryRefreshLockedRestoreOutputs(root))
             {
-                projectDirectories = directories.ToArray();
+                projectDirectories = roots
+                    .Select(request => Path.GetDirectoryName(request.ProjectPath)!)
+                    .Distinct(comparison)
+                    .ToArray();
                 return false;
             }
 
-            foreach (string input in evaluation.BuildInputs)
-                buildInputs.Add(input);
-            foreach (string input in evaluation.SourceInputs)
-                sourceInputs.Add(input);
-            if (request.TargetFramework is null)
+            var pending = new Queue<ProjectEvaluationRequest>(new[] { root });
+            while (pending.Count > 0)
             {
-                if (evaluation.TargetFrameworks.Length > 0)
+                ProjectEvaluationRequest request = pending.Dequeue();
+                string visitKey = request.BuildVisitKey();
+                if (!visited.Add(visitKey) || !File.Exists(request.ProjectPath))
+                    continue;
+
+                string projectDirectory = Path.GetDirectoryName(request.ProjectPath)!;
+                directories.Add(projectDirectory);
+                buildInputs.Add(request.ProjectPath);
+                sourceInputs.Add(request.ProjectPath);
+                if (!TryReadEvaluatedProjectInputs(
+                        request,
+                        verifiedPackageArchives,
+                        out EvaluatedProjectInputs? evaluation) || evaluation is null)
                 {
-                    foreach (string targetFramework in evaluation.TargetFrameworks)
-                        pending.Enqueue(request.ForProject(request.ProjectPath, targetFramework));
+                    projectDirectories = directories.ToArray();
+                    return false;
+                }
+
+                foreach (string input in evaluation.BuildInputs)
+                    buildInputs.Add(input);
+                foreach (string input in evaluation.SourceInputs)
+                    sourceInputs.Add(input);
+                if (request.TargetFramework is null)
+                {
+                    if (evaluation.TargetFrameworks.Length > 0)
+                    {
+                        foreach (string targetFramework in evaluation.TargetFrameworks)
+                            pending.Enqueue(request.ForProject(request.ProjectPath, targetFramework));
+                    }
+                    else
+                    {
+                        foreach (EvaluatedProjectReference projectReference in evaluation.ProjectReferences)
+                            pending.Enqueue(request.ForProject(projectReference.ProjectPath, targetFramework: null));
+                    }
                 }
                 else
                 {
                     foreach (EvaluatedProjectReference projectReference in evaluation.ProjectReferences)
-                        pending.Enqueue(request.ForProject(projectReference.ProjectPath, targetFramework: null));
+                        pending.Enqueue(request.ForProject(projectReference.ProjectPath, projectReference.TargetFramework));
                 }
-            }
-            else
-            {
-                foreach (EvaluatedProjectReference projectReference in evaluation.ProjectReferences)
-                    pending.Enqueue(request.ForProject(projectReference.ProjectPath, projectReference.TargetFramework));
             }
         }
 
@@ -453,11 +471,10 @@ public sealed partial class DotNetPublishPipelineRunner
 
     private static bool TryReadEvaluatedProjectInputs(
         ProjectEvaluationRequest request,
+        VerifiedPackageArchiveCache verifiedPackageArchives,
         out EvaluatedProjectInputs? evaluation)
     {
         evaluation = null;
-        if (!TryRefreshLockedRestoreOutputs(request))
-            return false;
         var arguments = new List<string>
         {
             "msbuild",
@@ -484,6 +501,7 @@ public sealed partial class DotNetPublishPipelineRunner
         if (!string.IsNullOrWhiteSpace(request.TargetFramework))
         {
             arguments.Add("-target:ResolveReferences");
+            arguments.Add("-getItem:_MSBuildProjectReferenceExistent");
             arguments.Add("-p:TargetFramework=" + request.TargetFramework);
         }
         foreach (KeyValuePair<string, string> property in request.GlobalProperties.OrderBy(entry => entry.Key, StringComparer.OrdinalIgnoreCase))
@@ -549,8 +567,12 @@ public sealed partial class DotNetPublishPipelineRunner
                 if (targetFrameworks.Count == 0)
                     AddSemicolonSeparatedValues(properties, "TargetFramework", targetFrameworks);
 
-                using VerifiedPackageInputCatalog? verifiedPackages =
-                    VerifiedPackageInputCatalog.TryCreate(request.ProjectPath, properties, packageRoots);
+                VerifiedPackageInputCatalog? verifiedPackages =
+                    VerifiedPackageInputCatalog.TryCreate(
+                        request.ProjectPath,
+                        properties,
+                        packageRoots,
+                        verifiedPackageArchives);
                 string[] trustedBuildInfrastructureRoots =
                     ReadTrustedBuildInfrastructureRoots(properties, Path.GetDirectoryName(request.ProjectPath)!);
                 var importPaths = new HashSet<string>(
@@ -652,7 +674,10 @@ public sealed partial class DotNetPublishPipelineRunner
             }
             else if (rawReferences.Count > 0)
             {
-                if (!TryReadResolvedProjectReferences(request, out EvaluatedProjectReference[] resolvedReferences))
+                if (!root.TryGetProperty("Items", out JsonElement resolvedItems) ||
+                    !TryReadResolvedProjectReferences(
+                        resolvedItems,
+                        out EvaluatedProjectReference[] resolvedReferences))
                     return false;
                 foreach (EvaluatedProjectReference reference in resolvedReferences)
                 {
@@ -797,71 +822,28 @@ public sealed partial class DotNetPublishPipelineRunner
     }
 
     private static bool TryReadResolvedProjectReferences(
-        ProjectEvaluationRequest request,
+        JsonElement items,
         out EvaluatedProjectReference[] references)
     {
         references = Array.Empty<EvaluatedProjectReference>();
-        var arguments = new List<string>
-        {
-            "msbuild",
-            request.ProjectPath,
-            "-nologo",
-            "-verbosity:quiet",
-            "-target:PrepareProjectReferences",
-            "-getItem:_MSBuildProjectReferenceExistent",
-            "-p:Configuration=" + request.Configuration,
-            "-p:TargetFramework=" + request.TargetFramework
-        };
-        foreach (KeyValuePair<string, string> property in request.GlobalProperties.OrderBy(entry => entry.Key, StringComparer.OrdinalIgnoreCase))
-        {
-            if (property.Key.Equals("Configuration", StringComparison.OrdinalIgnoreCase) ||
-                property.Key.Equals("TargetFramework", StringComparison.OrdinalIgnoreCase) ||
-                property.Key.Equals("BuildProjectReferences", StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-            arguments.Add("-p:" + property.Key + "=" + property.Value);
-        }
-        arguments.Add("-p:BuildProjectReferences=false");
-
-        try
-        {
-            var process = RunBuildInputEvaluationProcess(
-                "dotnet",
-                Path.GetDirectoryName(request.ProjectPath)!,
-                arguments,
-                request.EnvironmentVariables,
-                TimeSpan.FromMinutes(2));
-            if (process.ExitCode != 0 || process.TimedOut)
-                return false;
-            int jsonStart = process.StdOut.IndexOf('{');
-            int jsonEnd = process.StdOut.LastIndexOf('}');
-            if (jsonStart < 0 || jsonEnd < jsonStart)
-                return false;
-            using JsonDocument document = JsonDocument.Parse(
-                process.StdOut.Substring(jsonStart, jsonEnd - jsonStart + 1));
-            if (!document.RootElement.TryGetProperty("Items", out JsonElement items) ||
-                !items.TryGetProperty("_MSBuildProjectReferenceExistent", out JsonElement resolvedReferences) ||
-                resolvedReferences.ValueKind != JsonValueKind.Array)
-            {
-                return false;
-            }
-
-            references = resolvedReferences.EnumerateArray()
-                .Select(item => TryReadEvaluatedProjectReference(item, out EvaluatedProjectReference? reference)
-                    ? reference
-                    : null)
-                .Where(static reference => reference is not null)
-                .Cast<EvaluatedProjectReference>()
-                .ToArray();
-            // An empty resolved item list is a valid result for a conditional
-            // ProjectReference that does not participate in this target framework.
-            return true;
-        }
-        catch
+        if (!items.TryGetProperty(
+                "_MSBuildProjectReferenceExistent",
+                out JsonElement resolvedReferences) ||
+            resolvedReferences.ValueKind != JsonValueKind.Array)
         {
             return false;
         }
+
+        references = resolvedReferences.EnumerateArray()
+            .Select(item => TryReadEvaluatedProjectReference(item, out EvaluatedProjectReference? reference)
+                ? reference
+                : null)
+            .Where(static reference => reference is not null)
+            .Cast<EvaluatedProjectReference>()
+            .ToArray();
+        // An empty resolved item list is a valid result for a conditional
+        // ProjectReference that does not participate in this target framework.
+        return true;
     }
 
     private static string? ReadItemText(JsonElement item, string name)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
@@ -881,14 +881,51 @@ public sealed partial class DotNetPublishPipelineRunner
 
         var root = Path.GetFullPath(gitRoot)
             .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        if (string.Equals(root, fullPath, comparison))
+        string? relativePath = GetPathBelowRoot(root, fullPath, comparison);
+        if (relativePath is not null)
+            return relativePath;
+
+#if NET472
+        return null;
+#else
+        string fullProjectRoot = Path.GetFullPath(projectRoot)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        string? projectRelativePath = GetPathBelowRoot(fullProjectRoot, fullPath, comparison);
+        if (projectRelativePath is null)
             return null;
 
-        var rootPrefix = root + Path.DirectorySeparatorChar;
-        if (!fullPath.StartsWith(rootPrefix, comparison))
+        try
+        {
+            FileSystemInfo? resolvedProjectRoot = new DirectoryInfo(fullProjectRoot)
+                .ResolveLinkTarget(returnFinalTarget: true);
+            if (resolvedProjectRoot is null)
+                return null;
+
+            string resolvedPath = Path.GetFullPath(Path.Combine(
+                resolvedProjectRoot.FullName,
+                projectRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+            return GetPathBelowRoot(root, resolvedPath, comparison);
+        }
+        catch
+        {
+            return null;
+        }
+#endif
+    }
+
+    private static string? GetPathBelowRoot(
+        string root,
+        string path,
+        StringComparison comparison)
+    {
+        if (string.Equals(root, path, comparison))
+            return string.Empty;
+
+        string rootPrefix = root + Path.DirectorySeparatorChar;
+        if (!path.StartsWith(rootPrefix, comparison))
             return null;
 
-        return fullPath.Substring(rootPrefix.Length)
+        return path.Substring(rootPrefix.Length)
             .Replace('\\', '/')
             .Trim('/');
     }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
@@ -311,22 +311,21 @@ public sealed partial class DotNetPublishPipelineRunner
         IEnumerable<string>? generatedPaths,
         SourceDirtyScope dirtyScope)
     {
-        var comparison = IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-        string[] generatedExclusions = BuildGeneratedPathExclusions(projectRoot, gitRoot, generatedPaths);
-        string? ignoredOutput = ReadGitRawText(
-            gitRoot,
-            "ls-files --others --ignored --exclude-standard -z");
-        if (ignoredOutput is null)
-            return new[] { "Git ignored-input query failed" };
         if (!dirtyScope.BuildInputsResolved)
             return new[] { "MSBuild input evaluation failed" };
         string[] projectDirectories = dirtyScope.ProjectDirectories;
         HashSet<string> buildInputs = dirtyScope.BuildInputs;
         HashSet<string> sourceInputs = dirtyScope.SourceInputs;
+        var reparsePointCache = new Dictionary<string, bool>(
+            IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
         if (HasGeneratedOutputInputOverlap(projectRoot, generatedPaths, buildInputs))
             return new[] { "a generated output overlaps an evaluated build input" };
         string[] untrustedProjectDirectories = projectDirectories
-            .Where(directory => !IsBuildProjectDirectoryAdmitted(directory, projectRoot, gitRoot))
+            .Where(directory => !IsBuildProjectDirectoryAdmitted(
+                directory,
+                projectRoot,
+                gitRoot,
+                reparsePointCache))
             .OrderBy(path => path, IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
             .ToArray();
         if (untrustedProjectDirectories.Length > 0)
@@ -334,40 +333,115 @@ public sealed partial class DotNetPublishPipelineRunner
             return untrustedProjectDirectories;
         }
         string[] untrustedSourceInputs = sourceInputs
-            .Where(path => !IsBuildSourceInputAdmitted(path, projectRoot, gitRoot))
+            .Where(path => !IsBuildSourceInputAdmitted(
+                path,
+                projectRoot,
+                gitRoot,
+                reparsePointCache))
             .OrderBy(path => path, IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
             .ToArray();
         if (untrustedSourceInputs.Length > 0)
         {
             return untrustedSourceInputs;
         }
+        string[] gitRelativeBuildInputs = buildInputs
+            .Where(File.Exists)
+            .Select(path => ToGitRelativeExclusion(projectRoot, gitRoot, path))
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => path!.Replace('\\', '/').TrimStart('/'))
+            .Distinct(IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
+            .ToArray();
+        string? ignoredOutput = ReadIgnoredGitPaths(gitRoot, gitRelativeBuildInputs);
+        if (ignoredOutput is null)
+            return new[] { "Git ignored-input query failed" };
         string[] ignoredPaths = ignoredOutput.Split(
                 new[] { '\0' },
                 StringSplitOptions.RemoveEmptyEntries)
             .Select(path => path.Replace('\\', '/').TrimStart('/'))
             .ToArray();
-        if (ignoredPaths.Length == 0)
-            return Array.Empty<string>();
-        var gitRelativeBuildInputs = new HashSet<string>(
-            buildInputs
-                .Select(path => ToGitRelativeExclusion(projectRoot, gitRoot, path))
-                .Where(path => !string.IsNullOrWhiteSpace(path))
-                .Select(path => path!.Replace('\\', '/').TrimStart('/')),
-            IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
-        string[] ignoredCandidates = ignoredPaths
-            .Where(path => !IsGeneratedPath(path, generatedExclusions, comparison))
-            .ToArray();
-        return ignoredCandidates
-            .Where(gitRelativeBuildInputs.Contains)
+        return ignoredPaths
             .Distinct(IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
             .OrderBy(path => path, IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
             .ToArray();
     }
 
+    private static string? ReadIgnoredGitPaths(string gitRoot, IReadOnlyCollection<string> paths)
+    {
+        if (paths.Count == 0)
+            return string.Empty;
+
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "git",
+                    WorkingDirectory = gitRoot,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+            process.StartInfo.ArgumentList.Add("check-ignore");
+            process.StartInfo.ArgumentList.Add("-z");
+            process.StartInfo.ArgumentList.Add("--stdin");
+            if (!process.Start())
+                return null;
+
+            Task<string> output = process.StandardOutput.ReadToEndAsync();
+            Task<string> error = process.StandardError.ReadToEndAsync();
+            Task input = process.StandardInput.WriteAsync(string.Join('\0', paths) + '\0');
+            Task inputClosed = input.ContinueWith(
+                _ => process.StandardInput.Close(),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+            if (!process.WaitForExit(5000))
+            {
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch
+                {
+                    // A failed or already-exited Git process still makes the query untrusted.
+                }
+                try
+                {
+                    inputClosed.Wait(1000);
+                }
+                catch
+                {
+                    // The process was terminated before it could consume the full request.
+                }
+                return null;
+            }
+
+            input.GetAwaiter().GetResult();
+            inputClosed.GetAwaiter().GetResult();
+            _ = error.GetAwaiter().GetResult();
+            string ignored = output.GetAwaiter().GetResult();
+            return process.ExitCode switch
+            {
+                0 => ignored,
+                1 => string.Empty,
+                _ => null
+            };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     private static bool IsBuildProjectDirectoryAdmitted(
         string directory,
         string projectRoot,
-        string gitRoot)
+        string gitRoot,
+        Dictionary<string, bool> reparsePointCache)
     {
         string fullDirectory = Path.GetFullPath(directory)
             .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
@@ -379,21 +453,32 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             return false;
         }
-        return !HasReparsePointBelowRoot(fullDirectory, fullGitRoot);
+        return !HasReparsePointBelowRoot(fullDirectory, fullGitRoot, reparsePointCache);
     }
 
     private static bool IsBuildSourceInputAdmitted(
         string path,
         string projectRoot,
-        string gitRoot)
+        string gitRoot,
+        Dictionary<string, bool> reparsePointCache)
     {
         string fullPath = Path.GetFullPath(path);
         if (ToGitRelativeExclusion(projectRoot, gitRoot, fullPath) is null)
             return false;
-        return !HasReparsePointBelowRoot(fullPath, gitRoot);
+        return !HasReparsePointBelowRoot(fullPath, gitRoot, reparsePointCache);
     }
 
     internal static bool HasReparsePointBelowRoot(string path, string root)
+        => HasReparsePointBelowRoot(
+            path,
+            root,
+            new Dictionary<string, bool>(
+                IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal));
+
+    private static bool HasReparsePointBelowRoot(
+        string path,
+        string root,
+        Dictionary<string, bool> cache)
     {
         string current = Path.GetFullPath(path);
         string boundary = Path.GetFullPath(root)
@@ -401,28 +486,49 @@ public sealed partial class DotNetPublishPipelineRunner
         var comparison = IsWindows()
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
+        var traversed = new List<string>();
 
         while (!string.Equals(
                    current.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
                    boundary,
                    comparison))
         {
+            if (cache.TryGetValue(current, out bool cached))
+            {
+                foreach (string traversedPath in traversed)
+                    cache[traversedPath] = cached;
+                return cached;
+            }
+
+            traversed.Add(current);
             try
             {
                 if ((File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
+                {
+                    foreach (string traversedPath in traversed)
+                        cache[traversedPath] = true;
                     return true;
+                }
             }
             catch
             {
+                foreach (string traversedPath in traversed)
+                    cache[traversedPath] = true;
                 return true;
             }
 
             string? parent = Path.GetDirectoryName(current);
             if (string.IsNullOrWhiteSpace(parent) || string.Equals(parent, current, comparison))
+            {
+                foreach (string traversedPath in traversed)
+                    cache[traversedPath] = true;
                 return true;
+            }
             current = parent;
         }
 
+        foreach (string traversedPath in traversed)
+            cache[traversedPath] = false;
         return false;
     }
 
@@ -765,27 +871,11 @@ public sealed partial class DotNetPublishPipelineRunner
         if (string.IsNullOrWhiteSpace(path))
             return null;
 
-        var project = Path.GetFullPath(projectRoot)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         var fullPath = Path.GetFullPath(
             Path.IsPathRooted(path)
                 ? path
                 : Path.Combine(projectRoot, path));
         var comparison = IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-
-        var projectPrefix = project + Path.DirectorySeparatorChar;
-        if (fullPath.StartsWith(projectPrefix, comparison))
-        {
-            var gitProjectPrefix = ReadGitText(projectRoot, "rev-parse --show-prefix");
-            if (gitProjectPrefix is not null)
-            {
-                var relativeToProject = fullPath.Substring(projectPrefix.Length)
-                    .Replace('\\', '/')
-                    .Trim('/');
-                return (gitProjectPrefix.Trim('/', '\\') + "/" + relativeToProject)
-                    .Trim('/');
-            }
-        }
 
         var root = Path.GetFullPath(gitRoot)
             .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
@@ -377,6 +377,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 StartInfo = new ProcessStartInfo
                 {
                     FileName = "git",
+                    Arguments = "check-ignore -z --stdin",
                     WorkingDirectory = gitRoot,
                     RedirectStandardInput = true,
                     RedirectStandardOutput = true,
@@ -385,15 +386,12 @@ public sealed partial class DotNetPublishPipelineRunner
                     CreateNoWindow = true
                 }
             };
-            process.StartInfo.ArgumentList.Add("check-ignore");
-            process.StartInfo.ArgumentList.Add("-z");
-            process.StartInfo.ArgumentList.Add("--stdin");
             if (!process.Start())
                 return null;
 
             Task<string> output = process.StandardOutput.ReadToEndAsync();
             Task<string> error = process.StandardError.ReadToEndAsync();
-            Task input = process.StandardInput.WriteAsync(string.Join('\0', paths) + '\0');
+            Task input = process.StandardInput.WriteAsync(string.Join("\0", paths) + '\0');
             Task inputClosed = input.ContinueWith(
                 _ => process.StandardInput.Close(),
                 CancellationToken.None,
@@ -403,7 +401,11 @@ public sealed partial class DotNetPublishPipelineRunner
             {
                 try
                 {
+#if NET472
+                    process.Kill();
+#else
                     process.Kill(entireProcessTree: true);
+#endif
                 }
                 catch
                 {

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
@@ -624,7 +624,18 @@ public sealed partial class DotNetPublishPipelineRunner
             _archives.Clear();
         }
 
-        private sealed record CacheEntry(string ExpectedContentHash, VerifiedPackageArchive Archive);
+        private sealed class CacheEntry
+        {
+            internal CacheEntry(string expectedContentHash, VerifiedPackageArchive archive)
+            {
+                ExpectedContentHash = expectedContentHash;
+                Archive = archive;
+            }
+
+            internal string ExpectedContentHash { get; }
+
+            internal VerifiedPackageArchive Archive { get; }
+        }
     }
 
     private sealed class VerifiedPackageArchive : IDisposable
@@ -753,6 +764,20 @@ public sealed partial class DotNetPublishPipelineRunner
             _stream.Dispose();
         }
 
-        private sealed record ExtractedFileHash(long Length, long LastWriteTimeUtcTicks, byte[] Hash);
+        private sealed class ExtractedFileHash
+        {
+            internal ExtractedFileHash(long length, long lastWriteTimeUtcTicks, byte[] hash)
+            {
+                Length = length;
+                LastWriteTimeUtcTicks = lastWriteTimeUtcTicks;
+                Hash = hash;
+            }
+
+            internal long Length { get; }
+
+            internal long LastWriteTimeUtcTicks { get; }
+
+            internal byte[] Hash { get; }
+        }
     }
 }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
@@ -418,29 +418,30 @@ public sealed partial class DotNetPublishPipelineRunner
         }
     }
 
-    private sealed class VerifiedPackageInputCatalog : IDisposable
+    private sealed class VerifiedPackageInputCatalog
     {
         private readonly string[] _packageRoots;
         private readonly IReadOnlyDictionary<string, string> _lockedPackageHashes;
-        private readonly Dictionary<string, VerifiedPackageArchive> _archives;
+        private readonly VerifiedPackageArchiveCache _archives;
 
         private VerifiedPackageInputCatalog(
             IEnumerable<string> packageRoots,
-            IReadOnlyDictionary<string, string> lockedPackageHashes)
+            IReadOnlyDictionary<string, string> lockedPackageHashes,
+            VerifiedPackageArchiveCache archives)
         {
             _packageRoots = packageRoots
                 .Select(Path.GetFullPath)
                 .Distinct(IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
                 .ToArray();
             _lockedPackageHashes = lockedPackageHashes;
-            _archives = new Dictionary<string, VerifiedPackageArchive>(
-                IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+            _archives = archives;
         }
 
         internal static VerifiedPackageInputCatalog? TryCreate(
             string projectPath,
             JsonElement properties,
-            IEnumerable<string> packageRoots)
+            IEnumerable<string> packageRoots,
+            VerifiedPackageArchiveCache archives)
         {
             string projectDirectory = Path.GetDirectoryName(projectPath)!;
             string lockFilePath = ReadEvaluatedPath(properties, "NuGetLockFilePath", projectDirectory)
@@ -467,7 +468,7 @@ public sealed partial class DotNetPublishPipelineRunner
             if (allRoots.Count == 0)
                 return null;
 
-            return new VerifiedPackageInputCatalog(allRoots, hashes);
+            return new VerifiedPackageInputCatalog(allRoots, hashes, archives);
         }
 
         internal bool TryVerify(string path, out bool isPackageInput)
@@ -510,21 +511,16 @@ public sealed partial class DotNetPublishPipelineRunner
                 }
 
                 string packageDirectory = Path.Combine(root, packageId, packageVersion);
-                string archiveKey = Path.GetFullPath(packageDirectory);
-                if (!_archives.TryGetValue(archiveKey, out VerifiedPackageArchive? archive))
-                {
-                    string expectedName = packageId + "." + packageVersion + ".nupkg";
-                    string? archivePath = Directory.EnumerateFiles(packageDirectory, "*.nupkg", SearchOption.TopDirectoryOnly)
-                        .FirstOrDefault(candidate => Path.GetFileName(candidate).Equals(
-                            expectedName,
-                            StringComparison.OrdinalIgnoreCase));
-                    if (string.IsNullOrWhiteSpace(archivePath))
-                        return false;
-                    archive = VerifiedPackageArchive.TryOpen(archivePath!, expectedHash);
-                    if (archive is null)
-                        return false;
-                    _archives[archiveKey] = archive;
-                }
+                string expectedName = packageId + "." + packageVersion + ".nupkg";
+                string? archivePath = Directory.EnumerateFiles(packageDirectory, "*.nupkg", SearchOption.TopDirectoryOnly)
+                    .FirstOrDefault(candidate => Path.GetFileName(candidate).Equals(
+                        expectedName,
+                        StringComparison.OrdinalIgnoreCase));
+                if (string.IsNullOrWhiteSpace(archivePath))
+                    return false;
+                VerifiedPackageArchive? archive = _archives.TryGetOrOpen(archivePath!, expectedHash);
+                if (archive is null)
+                    return false;
 
                 string packageRelativePath = string.Join("/", segments.Skip(2));
                 return archive.VerifyExtractedFile(packageRelativePath, path);
@@ -533,13 +529,6 @@ public sealed partial class DotNetPublishPipelineRunner
             {
                 return false;
             }
-        }
-
-        public void Dispose()
-        {
-            foreach (VerifiedPackageArchive archive in _archives.Values)
-                archive.Dispose();
-            _archives.Clear();
         }
 
         private static bool TryReadLockedPackageHashes(
@@ -607,11 +596,44 @@ public sealed partial class DotNetPublishPipelineRunner
         }
     }
 
+    private sealed class VerifiedPackageArchiveCache : IDisposable
+    {
+        private readonly Dictionary<string, CacheEntry> _archives = new(
+            IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+
+        internal VerifiedPackageArchive? TryGetOrOpen(string path, string expectedContentHash)
+        {
+            string fullPath = Path.GetFullPath(path);
+            if (_archives.TryGetValue(fullPath, out CacheEntry? cached))
+            {
+                return string.Equals(cached.ExpectedContentHash, expectedContentHash, StringComparison.Ordinal)
+                    ? cached.Archive
+                    : null;
+            }
+
+            VerifiedPackageArchive? archive = VerifiedPackageArchive.TryOpen(fullPath, expectedContentHash);
+            if (archive is not null)
+                _archives.Add(fullPath, new CacheEntry(expectedContentHash, archive));
+            return archive;
+        }
+
+        public void Dispose()
+        {
+            foreach (CacheEntry cached in _archives.Values)
+                cached.Archive.Dispose();
+            _archives.Clear();
+        }
+
+        private sealed record CacheEntry(string ExpectedContentHash, VerifiedPackageArchive Archive);
+    }
+
     private sealed class VerifiedPackageArchive : IDisposable
     {
         private readonly FileStream _stream;
         private readonly ZipArchive _archive;
         private readonly IReadOnlyDictionary<string, ZipArchiveEntry> _entries;
+        private readonly Dictionary<string, byte[]> _entryHashes;
+        private readonly Dictionary<string, ExtractedFileHash> _extractedFileHashes;
 
         private VerifiedPackageArchive(
             FileStream stream,
@@ -621,6 +643,10 @@ public sealed partial class DotNetPublishPipelineRunner
             _stream = stream;
             _archive = archive;
             _entries = entries;
+            _entryHashes = new Dictionary<string, byte[]>(
+                IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+            _extractedFileHashes = new Dictionary<string, ExtractedFileHash>(
+                IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
         }
 
         internal static VerifiedPackageArchive? TryOpen(string path, string expectedContentHash)
@@ -675,20 +701,50 @@ public sealed partial class DotNetPublishPipelineRunner
 
         internal bool VerifyExtractedFile(string relativePath, string extractedPath)
         {
-            if (!_entries.TryGetValue(relativePath.Replace('\\', '/').TrimStart('/'), out ZipArchiveEntry? entry))
+            string normalizedRelativePath = relativePath.Replace('\\', '/').TrimStart('/');
+            if (!_entries.TryGetValue(normalizedRelativePath, out ZipArchiveEntry? entry))
                 return false;
 
             var file = new FileInfo(extractedPath);
             if (!file.Exists || file.Length != entry.Length)
                 return false;
 
-            using Stream entryStream = entry.Open();
+            string fullExtractedPath = file.FullName;
+            long lastWriteTimeUtcTicks = file.LastWriteTimeUtc.Ticks;
+            if (_extractedFileHashes.TryGetValue(fullExtractedPath, out ExtractedFileHash? cached) &&
+                cached.Length == file.Length &&
+                cached.LastWriteTimeUtcTicks == lastWriteTimeUtcTicks)
+            {
+                return GetEntryHash(normalizedRelativePath, entry).SequenceEqual(cached.Hash);
+            }
+
             using FileStream fileStream = file.Open(FileMode.Open, FileAccess.Read, FileShare.Read);
-            using SHA256 entryHasher = SHA256.Create();
             using SHA256 fileHasher = SHA256.Create();
-            byte[] expected = entryHasher.ComputeHash(entryStream);
             byte[] actual = fileHasher.ComputeHash(fileStream);
-            return expected.SequenceEqual(actual);
+            byte[] expected = GetEntryHash(normalizedRelativePath, entry);
+            if (expected.SequenceEqual(actual))
+            {
+                _extractedFileHashes[fullExtractedPath] = new ExtractedFileHash(
+                    file.Length,
+                    lastWriteTimeUtcTicks,
+                    actual);
+                return true;
+            }
+
+            _extractedFileHashes.Remove(fullExtractedPath);
+            return false;
+        }
+
+        private byte[] GetEntryHash(string relativePath, ZipArchiveEntry entry)
+        {
+            if (_entryHashes.TryGetValue(relativePath, out byte[]? hash))
+                return hash;
+
+            using Stream entryStream = entry.Open();
+            using SHA256 entryHasher = SHA256.Create();
+            hash = entryHasher.ComputeHash(entryStream);
+            _entryHashes.Add(relativePath, hash);
+            return hash;
         }
 
         public void Dispose()
@@ -696,5 +752,7 @@ public sealed partial class DotNetPublishPipelineRunner
             _archive.Dispose();
             _stream.Dispose();
         }
+
+        private sealed record ExtractedFileHash(long Length, long LastWriteTimeUtcTicks, byte[] Hash);
     }
 }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SourceDirtyState.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SourceDirtyState.cs
@@ -35,7 +35,7 @@ public sealed partial class DotNetPublishPipelineRunner
         foreach (string directory in projectDirectories)
             AddProjectDirectoryScopePath(scope, projectRoot, gitRoot, directory);
         foreach (string path in buildInputs)
-            AddSourceDirtyScopePath(scope, projectRoot, gitRoot, path, directory: Directory.Exists(path));
+            AddSourceDirtyScopePath(scope, projectRoot, gitRoot, path, directory: false);
         return scope;
     }
 


### PR DESCRIPTION
## Summary

- reuse verified package archive and extracted-file evidence across one provenance graph
- avoid redundant MSBuild and repository-wide Git work while preserving fail-closed input classification
- evaluate each restore-distinct runtime graph before the next restore can replace its assets
- preserve provenance state generation when a Linux build uses a symlinked project root
- cover multi-runtime restore ordering with a dedicated regression

## Impact

On the TestimoX publish path that exposed the issue, provenance evaluation dropped from about 17 minutes 39 seconds to about 27 seconds. Publishing and signing behavior is unchanged.

## Validation

- PowerForge DotNetPublish test suite on Linux: 397 passed
- PowerForge, PowerForge.PowerShell, and PSPublishModule net472 Release builds: succeeded with zero warnings and errors
- PowerForge CLI net10.0 Release build: succeeded with zero warnings and errors
- independent local review completed; its multi-runtime finding was fixed and confirmed