### PR TITLE
Preserve static cache with targeted deployment purges

### DIFF
--- a/Docs/PowerForge.Web.Cloudflare.md
+++ b/Docs/PowerForge.Web.Cloudflare.md
@@ -248,8 +248,25 @@ Incremental purge targets the canonical URLs emitted by the deployment. It is
 therefore intended for static sites whose query parameters do not select a
 different representation. Cloudflare's default cache key includes the query
 string, and a canonical URL purge does not enumerate arbitrary cached query
-variants. Keep `PurgeMode` set to `hostname` for a site that intentionally
-caches query-dependent responses.
+variants. List every known mutable variant in `Cloudflare.AlwaysPurgePaths` when
+the variants are a small, bounded part of the site's deployment contract:
+
+```json
+{
+  "Cloudflare": {
+    "PurgeMode": "incremental",
+    "AlwaysPurgePaths": [
+      "/apps/converter/",
+      "/apps/converter/?embedded=1"
+    ]
+  }
+}
+```
+
+These site-relative URLs are included in every successful incremental purge,
+deduplicated with changed deployment URLs, and counted against the same 500-URL
+safety limit. Unknown or unbounded query-dependent responses should still keep
+`PurgeMode` set to `hostname`.
 The reusable managed-incremental action derives its hostname and base path from
 the same `site.json` `BaseUrl` used to build the manifest. It rejects the
 action's `hostname` and `base-path` overrides in this mode so purge targets

--- a/PowerForge.Tests/CloudflareIncrementalCachePurgeTests.AlwaysPurge.cs
+++ b/PowerForge.Tests/CloudflareIncrementalCachePurgeTests.AlwaysPurge.cs
@@ -1,0 +1,170 @@
+using System.Net;
+using System.Text.Json.Nodes;
+using PowerForge.Web.Cli;
+
+namespace PowerForge.Tests;
+
+public sealed partial class CloudflareIncrementalCachePurgeTests
+{
+    [Fact]
+    public void IncrementalPurge_ShouldPurgeConfiguredVariantsWhenManifestIsUnchanged()
+    {
+        var root = NewTempDirectory();
+        try
+        {
+            var entries = new[] { Entry("apps/converter/", 'a'), Entry("apps/converter/index.html", 'a') };
+            var previousPath = WriteManifest(root, "previous.json", entries, baseUrl: "https://example.test/project/");
+            var currentPath = WriteManifest(root, "current.json", entries, baseUrl: "https://example.test/project/");
+            var handler = new RecordingHandler(SuccessResponse());
+            using var client = NewClient(handler);
+
+            var result = CloudflareIncrementalCachePurger.Purge(
+                ZoneId,
+                "secret-token",
+                "https://example.test/project/",
+                currentPath,
+                previousPath,
+                dryRun: false,
+                logger: null,
+                client,
+                alwaysPurgePaths:
+                [
+                    "/apps/converter/",
+                    "/apps/converter/?embedded=1"
+                ]);
+
+            Assert.True(result.Success, result.Message);
+            Assert.False(result.UsedFallback);
+            Assert.Equal(2, result.TargetCount);
+            Assert.Equal(1, result.RequestCount);
+            var files = JsonNode.Parse(Assert.Single(handler.Bodies))!["files"]!.AsArray()
+                .Select(node => node!.GetValue<string>())
+                .ToArray();
+            Assert.Equal(
+                [
+                    "https://example.test/project/apps/converter/",
+                    "https://example.test/project/apps/converter/?embedded=1"
+                ],
+                files);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void IncrementalPurge_ShouldDeduplicateChangedAndAlwaysPurgeUrlsBeforeApplyingLimit()
+    {
+        var root = NewTempDirectory();
+        try
+        {
+            var previousPath = WriteManifest(root, "previous.json", [Entry("index.html", 'a')]);
+            var currentPath = WriteManifest(root, "current.json", [Entry("index.html", 'b')]);
+            var handler = new RecordingHandler(SuccessResponse());
+            using var client = NewClient(handler);
+
+            var result = CloudflareIncrementalCachePurger.Purge(
+                ZoneId,
+                "secret-token",
+                "https://example.test/",
+                currentPath,
+                previousPath,
+                dryRun: false,
+                logger: null,
+                client,
+                alwaysPurgePaths: ["/index.html", "/?embedded=1"]);
+
+            Assert.True(result.Success, result.Message);
+            Assert.Equal(2, result.TargetCount);
+            var files = JsonNode.Parse(Assert.Single(handler.Bodies))!["files"]!.AsArray();
+            Assert.Equal(2, files.Count);
+            Assert.Single(files, node => node!.GetValue<string>() == "https://example.test/index.html");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void IncrementalPurge_ShouldUseHostnameFallbackWhenChangedAndAlwaysPurgeTargetsExceedLimit()
+    {
+        var root = NewTempDirectory();
+        try
+        {
+            var previousPath = WriteManifest(root, "previous.json", Array.Empty<CloudflareDeploymentManifestEntry>());
+            var currentPath = WriteManifest(root, "current.json", Enumerable.Range(0, CloudflareIncrementalCachePurger.MaxIncrementalTargets)
+                .Select(index => Entry($"assets/{index}.js", 'a')).ToArray());
+            var handler = new RecordingHandler(SuccessResponse());
+            using var client = NewClient(handler);
+
+            var result = CloudflareIncrementalCachePurger.Purge(
+                ZoneId,
+                "secret-token",
+                "https://example.test/",
+                currentPath,
+                previousPath,
+                dryRun: false,
+                logger: null,
+                client,
+                alwaysPurgePaths: ["/?embedded=1"]);
+
+            Assert.True(result.Success, result.Message);
+            Assert.True(result.UsedFallback);
+            Assert.Equal(CloudflareCachePurgeMode.Hostname, result.ActualMode);
+            Assert.Contains("501 URL targets", result.FallbackReason, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("https://outside.test/app/")]
+    [InlineData("//outside.test/app/")]
+    [InlineData("/app/#fragment")]
+    [InlineData("/../outside/")]
+    [InlineData("/%2e%2e/outside/")]
+    public void ResolveAlwaysPurgeUrl_ShouldRejectUnsafeTargets(string path)
+    {
+        Assert.Throws<InvalidDataException>(() =>
+            CloudflareIncrementalCachePurger.ResolveAlwaysPurgeUrl("https://example.test/project/", path));
+    }
+
+    [Fact]
+    public void RouteProfile_ShouldLoadAndNormalizeAlwaysPurgePaths()
+    {
+        var root = NewTempDirectory();
+        try
+        {
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath,
+                """
+                {
+                  "Name": "Example",
+                  "BaseUrl": "https://example.test/project/",
+                  "Cloudflare": {
+                    "PurgeMode": "incremental",
+                    "AlwaysPurgePaths": [
+                      " /apps/converter/ ",
+                      "/apps/converter/?embedded=1",
+                      "/apps/converter/"
+                    ]
+                  }
+                }
+                """);
+
+            var profile = CloudflareRouteProfileResolver.Load(configPath);
+
+            Assert.Equal(
+                ["/apps/converter/", "/apps/converter/?embedded=1"],
+                profile.Cloudflare!.AlwaysPurgePaths);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/PowerForge.Tests/CloudflareIncrementalCachePurgeTests.cs
+++ b/PowerForge.Tests/CloudflareIncrementalCachePurgeTests.cs
@@ -597,11 +597,11 @@ public sealed partial class CloudflareIncrementalCachePurgeTests
         var action = ReadRepoFile(".github", "actions", "powerforge-cloudflare-site-policy", "action.yml");
 
         Assert.Contains("cloudflare manifest create", runWorkflow, StringComparison.Ordinal);
-        Assert.Contains("powerforge-cloudflare-cache-manifest", runWorkflow, StringComparison.Ordinal);
+        Assert.Contains("powerforge-deployment-manifest-", runWorkflow, StringComparison.Ordinal);
         Assert.Contains("cloudflare_cache_manifest_artifact_name", runWorkflow, StringComparison.Ordinal);
         Assert.Contains("inputs.site_artifact_name != '' || inputs.generate_cloudflare_cache_manifest", runWorkflow, StringComparison.Ordinal);
         foreach (var operatingSystem in new[] { "Linux", "macOS", "Windows" })
-            Assert.Contains($"inputs.generate_cloudflare_cache_manifest) && runner.os == '{operatingSystem}'", runWorkflow, StringComparison.Ordinal);
+            Assert.Contains($"inputs.generate_deployment_manifest) && runner.os == '{operatingSystem}'", runWorkflow, StringComparison.Ordinal);
         Assert.Contains("generate_cloudflare_cache_manifest", deployWorkflow, StringComparison.Ordinal);
         Assert.Contains("manifest-artifact-name: ${{ needs.build.outputs.cloudflare_cache_manifest_artifact_name }}", deployWorkflow, StringComparison.Ordinal);
         Assert.Contains("deployment-run-id: ${{ needs.deploy.outputs.run_id }}", deployWorkflow, StringComparison.Ordinal);
@@ -640,9 +640,9 @@ public sealed partial class CloudflareIncrementalCachePurgeTests
         Assert.Contains("Purge changed Cloudflare URLs", action, StringComparison.Ordinal);
         Assert.True(
             runWorkflow.IndexOf("Archive site artifact", StringComparison.Ordinal) <
-            runWorkflow.IndexOf("Create incremental Cloudflare deployment manifest", StringComparison.Ordinal));
+            runWorkflow.IndexOf("Create exact deployment manifest", StringComparison.Ordinal));
         Assert.True(
-            runWorkflow.IndexOf("Create incremental Cloudflare deployment manifest", StringComparison.Ordinal) <
+            runWorkflow.IndexOf("Create exact deployment manifest", StringComparison.Ordinal) <
             runWorkflow.IndexOf("Upload Pages artifact", StringComparison.Ordinal));
         Assert.True(
             action.IndexOf("Purge changed Cloudflare URLs", StringComparison.Ordinal) <

--- a/PowerForge.Tests/CloudflareStaticCacheProfileTests.cs
+++ b/PowerForge.Tests/CloudflareStaticCacheProfileTests.cs
@@ -140,6 +140,7 @@ public sealed class CloudflareStaticCacheProfileTests
         using var siteSchema = JsonDocument.Parse(ReadRepoFile("Schemas", "powerforge.web.sitespec.schema.json"));
         var cloudflare = siteSchema.RootElement.GetProperty("$defs").GetProperty("CloudflareSitePolicySpec");
         Assert.True(cloudflare.GetProperty("properties").TryGetProperty("Cache", out _));
+        Assert.True(cloudflare.GetProperty("properties").TryGetProperty("AlwaysPurgePaths", out _));
         Assert.Equal(
             ["files", "incremental", "hostname", "everything"],
             cloudflare.GetProperty("properties").GetProperty("PurgeMode").GetProperty("enum")

--- a/PowerForge.Tests/GitHubWebsiteDeployGuardrailTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteDeployGuardrailTests.cs
@@ -46,7 +46,7 @@ public sealed class GitHubWebsiteDeployGuardrailTests
         Assert.Contains("default: '[\"ubuntu-latest\"]'", cloudflareInput, StringComparison.Ordinal);
         Assert.Contains("runs-on: ${{ fromJson(inputs.cloudflare_runner_labels_json) }}", policyJob, StringComparison.Ordinal);
         Assert.Contains("powerforge-cloudflare-site-policy", policyJob, StringComparison.Ordinal);
-        Assert.Contains("needs: [deploy, cloudflare-site-policy, deploy-linux]", workflow, StringComparison.Ordinal);
+        Assert.Contains("needs: [build, deploy, cloudflare-site-policy, deploy-linux]", workflow, StringComparison.Ordinal);
         Assert.Contains("needs.cloudflare-site-policy.result == 'success'", workflow, StringComparison.Ordinal);
     }
 

--- a/PowerForge.Web.Cli/CloudflareIncrementalCachePurger.cs
+++ b/PowerForge.Web.Cli/CloudflareIncrementalCachePurger.cs
@@ -28,7 +28,8 @@ internal static class CloudflareIncrementalCachePurger
         bool dryRun,
         WebConsoleLogger? logger,
         HttpClient? httpClient = null,
-        string? forcedHostnameFallbackReason = null)
+        string? forcedHostnameFallbackReason = null,
+        IEnumerable<string>? alwaysPurgePaths = null)
     {
         CloudflareDeploymentManifest current;
         string normalizedBaseUrl;
@@ -80,39 +81,42 @@ internal static class CloudflareIncrementalCachePurger
             .OrderBy(path => path, StringComparer.Ordinal)
             .ToArray();
 
-        if (changedPaths.Length == 0)
+        string[] urls;
+        try
+        {
+            urls = changedPaths
+                .Select(path => CloudflareDeploymentManifestStore.ResolveUrl(normalizedBaseUrl, path).AbsoluteUri)
+                .Concat((alwaysPurgePaths ?? Array.Empty<string>())
+                    .Select(path => ResolveAlwaysPurgeUrl(normalizedBaseUrl, path)))
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(url => url, StringComparer.Ordinal)
+                .ToArray();
+        }
+        catch (InvalidDataException ex)
+        {
+            return Failure($"Incremental purge contains an unsafe configured URL path: {ex.Message}");
+        }
+
+        if (urls.Length == 0)
         {
             return new CloudflareIncrementalPurgeResult
             {
                 Success = true,
-                Message = "Deployment manifest is unchanged; no Cloudflare purge was required.",
+                Message = "Deployment manifest is unchanged and no always-purge paths are configured; no Cloudflare purge was required.",
                 ActualMode = CloudflareCachePurgeMode.Files
             };
         }
 
-        if (changedPaths.Length > MaxIncrementalTargets)
+        if (urls.Length > MaxIncrementalTargets)
         {
             return PurgeHostnameFallback(
                 zoneId,
                 apiToken,
                 fallbackBaseUrls,
                 dryRun,
-                $"incremental diff contains {changedPaths.Length} URL paths, exceeding the {MaxIncrementalTargets} target safety limit",
+                $"incremental purge contains {urls.Length} URL targets, exceeding the {MaxIncrementalTargets} target safety limit",
                 logger,
                 httpClient);
-        }
-
-        string[] urls;
-        try
-        {
-            urls = changedPaths
-                .Select(path => CloudflareDeploymentManifestStore.ResolveUrl(normalizedBaseUrl, path).AbsoluteUri)
-                .Distinct(StringComparer.Ordinal)
-                .ToArray();
-        }
-        catch (InvalidDataException ex)
-        {
-            return Failure($"Deployment manifest diff contains an unsafe URL path: {ex.Message}");
         }
 
         var ownsHttpClient = httpClient is null;
@@ -141,8 +145,8 @@ internal static class CloudflareIncrementalCachePurger
             {
                 Success = true,
                 Message = dryRun
-                    ? $"Incremental purge dry-run selected {urls.Length} changed URL(s) in {plannedBatchCount} planned batch(es)."
-                    : $"Incrementally purged {urls.Length} changed URL(s) in {requestCount} batch(es).",
+                    ? $"Incremental purge dry-run selected {urls.Length} deployment URL(s) in {plannedBatchCount} planned batch(es)."
+                    : $"Incrementally purged {urls.Length} deployment URL(s) in {requestCount} batch(es).",
                 ActualMode = CloudflareCachePurgeMode.Files,
                 TargetCount = urls.Length,
                 RequestCount = requestCount
@@ -153,6 +157,34 @@ internal static class CloudflareIncrementalCachePurger
             if (ownsHttpClient)
                 httpClient.Dispose();
         }
+    }
+
+    internal static string ResolveAlwaysPurgeUrl(string baseUrl, string path)
+    {
+        var normalizedBaseUrl = CloudflareDeploymentManifestStore.NormalizeBaseUrl(baseUrl);
+        var baseUri = new Uri(normalizedBaseUrl, UriKind.Absolute);
+        var value = (path ?? string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(value) ||
+            value.StartsWith("//", StringComparison.Ordinal) ||
+            value.Contains('\\') ||
+            value.Contains('#') ||
+            value.Any(char.IsControl))
+            throw new InvalidDataException($"Always-purge path '{path}' must be a site-relative URL path without credentials, fragment, or control characters.");
+
+        var relative = value.TrimStart('/');
+        if (Uri.TryCreate(relative, UriKind.Absolute, out _))
+            throw new InvalidDataException($"Always-purge path '{path}' must be a site-relative URL path without credentials, fragment, or control characters.");
+
+        var target = new Uri(baseUri, relative);
+        if (!target.Scheme.Equals(baseUri.Scheme, StringComparison.OrdinalIgnoreCase) ||
+            !target.Host.Equals(baseUri.Host, StringComparison.OrdinalIgnoreCase) ||
+            target.Port != baseUri.Port ||
+            !target.AbsolutePath.StartsWith(baseUri.AbsolutePath, StringComparison.Ordinal) ||
+            !string.IsNullOrEmpty(target.UserInfo) ||
+            !string.IsNullOrEmpty(target.Fragment))
+            throw new InvalidDataException($"Always-purge path '{path}' escapes configured site base '{baseUri}'.");
+
+        return target.AbsoluteUri;
     }
 
     private static bool TryLoadPrevious(

--- a/PowerForge.Web.Cli/CloudflareRouteProfileResolver.cs
+++ b/PowerForge.Web.Cli/CloudflareRouteProfileResolver.cs
@@ -48,6 +48,8 @@ internal static class CloudflareRouteProfileResolver
         var purgePaths = BuildPurgePaths(verifyPaths);
         var agentReadiness = spec.AgentReadiness is null ? null : WebAgentReadiness.ResolveSpec(spec.AgentReadiness);
         ValidateCloudflarePolicy(spec.Cloudflare);
+        foreach (var path in spec.Cloudflare?.AlwaysPurgePaths ?? Array.Empty<string>())
+            CloudflareIncrementalCachePurger.ResolveAlwaysPurgeUrl(baseUrl, path);
 
         return new CloudflareSiteRouteProfile
         {
@@ -72,6 +74,12 @@ internal static class CloudflareRouteProfileResolver
         if (!CloudflareCachePurger.TryParseCanonicalMode(policy.PurgeMode, out var purgeMode))
             throw new InvalidOperationException("Cloudflare.PurgeMode must be files, incremental, hostname, or everything.");
         policy.PurgeMode = CloudflareCachePurger.FormatMode(purgeMode);
+
+        policy.AlwaysPurgePaths = (policy.AlwaysPurgePaths ?? Array.Empty<string>())
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => path.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
 
         if (policy.Cache is null)
             return;

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Cloudflare.Manifest.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Cloudflare.Manifest.cs
@@ -112,7 +112,8 @@ internal static partial class WebCliCommandHandlers
             logger,
             forcedHostnameFallbackReason: forceHostnameFallback
                 ? forceHostnameFallbackReason?.Trim() ?? "the managed site policy was reconciled"
-                : null);
+                : null,
+            alwaysPurgePaths: siteProfile?.Cloudflare?.AlwaysPurgePaths);
 
         if (outputJson)
         {

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.Cloudflare.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.Cloudflare.cs
@@ -108,7 +108,8 @@ internal static partial class WebPipelineRunner
                 currentManifestPath,
                 previousManifestPath,
                 dryRun,
-                logger: null);
+                logger: null,
+                alwaysPurgePaths: siteProfile?.Cloudflare?.AlwaysPurgePaths);
             stepResult.Success = result.Success;
             stepResult.Message = result.Message;
             if (!result.Success)

--- a/PowerForge.Web/Models/CloudflareSitePolicySpec.cs
+++ b/PowerForge.Web/Models/CloudflareSitePolicySpec.cs
@@ -10,6 +10,12 @@ public sealed class CloudflareSitePolicySpec
     public string PurgeMode { get; set; } = "files";
 
     /// <summary>
+    /// Site-relative URL paths that incremental deployments purge on every successful deployment.
+    /// Use this for mutable entry points whose query variants have distinct Cloudflare cache keys.
+    /// </summary>
+    public string[] AlwaysPurgePaths { get; set; } = Array.Empty<string>();
+
+    /// <summary>
     /// When set, PowerForge manages the zone's Smart Tiered Cache setting as part of the recoverable site policy.
     /// Leave null to preserve the operator-managed zone setting.
     /// </summary>

--- a/Schemas/powerforge.web.sitespec.schema.json
+++ b/Schemas/powerforge.web.sitespec.schema.json
@@ -117,6 +117,8 @@
         "cache": { "$ref": "#/$defs/CloudflareCacheSpec" },
         "PurgeMode": { "type": "string", "enum": ["files", "incremental", "hostname", "everything"] },
         "purgeMode": { "type": "string", "enum": ["files", "incremental", "hostname", "everything"] },
+        "AlwaysPurgePaths": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+        "alwaysPurgePaths": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
         "SmartTieredCache": { "type": ["boolean", "null"] },
         "smartTieredCache": { "type": ["boolean", "null"] }
       }


### PR DESCRIPTION
## Summary
- add site-owned `Cloudflare.AlwaysPurgePaths` for mutable route and query variants
- union those URLs with incremental manifest changes while preserving the 500-target hostname fallback and 100-URL batching
- validate that configured targets remain within the site's scheme, host, port, and base path on Windows and Linux
- refresh stale private-manifest workflow assertions to match the current randomized deployment artifacts

## Why
Static sites can retain unchanged assets across deployments without leaving mutable converter entry points or query-keyed HTML stale. Consumers remain declarative: PowerForge owns URL safety, deduplication, limits, and transport.

## Validation
- Cloudflare tests: 216/216 on Windows
- Cloudflare tests: 216/216 on WSL/Linux
- focused incremental/static-profile tests: 68/68
- PowerForge.Web.Cli Release build
- schema parse and diff hygiene
- independent local review: no P0-P3 findings
