### PR TITLE
Probe and prioritize module-native runtimes across framework folders

### DIFF
--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -194,7 +194,10 @@ public class ModuleBootstrapperGeneratorTests
             Assert.Contains("$NativeLibraryFolders = @(", bootstrapper);
             Assert.Contains("Get-ChildItem -LiteralPath $LibraryRoot -Directory", bootstrapper);
             Assert.Contains("foreach ($NativeLibraryFolder in $NativeLibraryFolders)", bootstrapper);
-            Assert.Contains("if ($NativePath -and ($PathEntries -notcontains $NativePath))", bootstrapper);
+            Assert.Contains("[array] $NativePaths = foreach", bootstrapper);
+            Assert.Contains("[array] $MissingNativePaths = foreach", bootstrapper);
+            Assert.Contains("$NativePrefix = [string]::Join([IO.Path]::PathSeparator, $MissingNativePaths)", bootstrapper);
+            Assert.Contains("if ($MissingNativePaths.Count -gt 0)", bootstrapper);
             Assert.Contains("$PathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }", bootstrapper);
             Assert.Contains("$Arch = [string][System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture", bootstrapper);
             Assert.Contains("$Arch = [string]$env:PROCESSOR_ARCHITECTURE", bootstrapper);

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -195,10 +195,11 @@ public class ModuleBootstrapperGeneratorTests
             Assert.Contains("Get-ChildItem -LiteralPath $LibraryRoot -Directory", bootstrapper);
             Assert.Contains("foreach ($NativeLibraryFolder in $NativeLibraryFolders)", bootstrapper);
             Assert.Contains("[array] $NativePaths = foreach", bootstrapper);
-            Assert.Contains("[array] $MissingNativePaths = foreach", bootstrapper);
-            Assert.Contains("$NativePrefix = [string]::Join([IO.Path]::PathSeparator, $MissingNativePaths)", bootstrapper);
-            Assert.Contains("if ($MissingNativePaths.Count -gt 0)", bootstrapper);
             Assert.Contains("$PathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }", bootstrapper);
+            Assert.Contains("[array] $RemainingPathEntries = foreach ($PathEntry in $PathEntries)", bootstrapper);
+            Assert.Contains("if ($NativePaths -notcontains $PathEntry)", bootstrapper);
+            Assert.Contains("[array] $OrderedPathEntries = @($NativePaths) + @($RemainingPathEntries)", bootstrapper);
+            Assert.Contains("$env:PATH = [string]::Join([IO.Path]::PathSeparator, $OrderedPathEntries)", bootstrapper);
             Assert.Contains("$Arch = [string][System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture", bootstrapper);
             Assert.Contains("$Arch = [string]$env:PROCESSOR_ARCHITECTURE", bootstrapper);
             Assert.Contains("'AMD64' { 'win-x64' }", bootstrapper);
@@ -968,7 +969,10 @@ public class ModuleBootstrapperGeneratorTests
             Assert.Contains("$PowerForgeDevelopmentLibFolder = [IO.Path]::GetDirectoryName($PowerForgeDevelopmentBinaryPath)", bootstrapper);
             Assert.Contains("Join-Path -Path $PowerForgeDevelopmentLibFolder -ChildPath (\"runtimes\\{0}\\native\" -f $PowerForgeDevelopmentArchFolder)", bootstrapper);
             Assert.Contains("$PowerForgeDevelopmentPathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH))", bootstrapper);
-            Assert.Contains("$env:PATH = \"$PowerForgeDevelopmentNativePath$([IO.Path]::PathSeparator)$env:PATH\"", bootstrapper);
+            Assert.Contains("[array] $PowerForgeDevelopmentRemainingPathEntries = foreach", bootstrapper);
+            Assert.Contains("if ($PowerForgeDevelopmentPathEntry -ne $PowerForgeDevelopmentNativePath)", bootstrapper);
+            Assert.Contains("[array] $PowerForgeDevelopmentOrderedPathEntries = @($PowerForgeDevelopmentNativePath) +", bootstrapper);
+            Assert.Contains("$env:PATH = [string]::Join([IO.Path]::PathSeparator, $PowerForgeDevelopmentOrderedPathEntries)", bootstrapper);
         }
         finally
         {

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -191,8 +191,11 @@ public class ModuleBootstrapperGeneratorTests
             Assert.Contains("ProcessArchitecture", bootstrapper);
             Assert.Contains("IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)", bootstrapper);
             Assert.Contains("Lib\\{0}\\runtimes\\{1}\\native", bootstrapper);
+            Assert.Contains("$NativeLibraryFolders = @(", bootstrapper);
+            Assert.Contains("Get-ChildItem -LiteralPath $LibraryRoot -Directory", bootstrapper);
+            Assert.Contains("foreach ($NativeLibraryFolder in $NativeLibraryFolders)", bootstrapper);
+            Assert.Contains("if ($NativePath -and ($PathEntries -notcontains $NativePath))", bootstrapper);
             Assert.Contains("$PathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }", bootstrapper);
-            Assert.Contains("($PathEntries -notcontains $NativePath)", bootstrapper);
             Assert.Contains("$Arch = [string][System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture", bootstrapper);
             Assert.Contains("$Arch = [string]$env:PROCESSOR_ARCHITECTURE", bootstrapper);
             Assert.Contains("'AMD64' { 'win-x64' }", bootstrapper);

--- a/PowerForge/Scripts/ModuleBootstrapper/DevelopmentRuntimeHandler.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/DevelopmentRuntimeHandler.Template.ps1
@@ -6,12 +6,14 @@ if ($PowerForgeDevelopmentIsWindowsPlatform) {
     if ($PowerForgeDevelopmentLibFolder) {
         $PowerForgeDevelopmentNativePath = Join-Path -Path $PowerForgeDevelopmentLibFolder -ChildPath ("runtimes\{0}\native" -f $PowerForgeDevelopmentArchFolder)
         $PowerForgeDevelopmentPathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }
-        if ((Test-Path -LiteralPath $PowerForgeDevelopmentNativePath) -and ($PowerForgeDevelopmentPathEntries -notcontains $PowerForgeDevelopmentNativePath)) {
-            if ([string]::IsNullOrWhiteSpace($env:PATH)) {
-                $env:PATH = $PowerForgeDevelopmentNativePath
-            } else {
-                $env:PATH = "$PowerForgeDevelopmentNativePath$([IO.Path]::PathSeparator)$env:PATH"
+        if (Test-Path -LiteralPath $PowerForgeDevelopmentNativePath) {
+            [array] $PowerForgeDevelopmentRemainingPathEntries = foreach ($PowerForgeDevelopmentPathEntry in $PowerForgeDevelopmentPathEntries) {
+                if ($PowerForgeDevelopmentPathEntry -ne $PowerForgeDevelopmentNativePath) {
+                    $PowerForgeDevelopmentPathEntry
+                }
             }
+            [array] $PowerForgeDevelopmentOrderedPathEntries = @($PowerForgeDevelopmentNativePath) + @($PowerForgeDevelopmentRemainingPathEntries)
+            $env:PATH = [string]::Join([IO.Path]::PathSeparator, $PowerForgeDevelopmentOrderedPathEntries)
         }
     }
 }

--- a/PowerForge/Scripts/ModuleBootstrapper/RuntimeHandler.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/RuntimeHandler.Template.ps1
@@ -18,21 +18,26 @@ if ($IsWindowsPlatform -and $LibFolder) {
             }
         }
     )
-    $NativePath = $null
-    foreach ($NativeLibraryFolder in $NativeLibraryFolders) {
+    [array] $NativePaths = foreach ($NativeLibraryFolder in $NativeLibraryFolders) {
         $NativeCandidate = Join-Path -Path $PSScriptRoot -ChildPath ("Lib\{0}\runtimes\{1}\native" -f $NativeLibraryFolder, $ArchFolder)
         if (Test-Path -LiteralPath $NativeCandidate) {
-            $NativePath = $NativeCandidate
-            break
+            $NativeCandidate
         }
     }
     $PathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }
-    if ($NativePath -and ($PathEntries -notcontains $NativePath)) {
-        # Prepend the module-native runtime path so the packaged payload wins over unrelated machine-wide copies.
+    [array] $MissingNativePaths = foreach ($NativePath in $NativePaths) {
+        if ($PathEntries -notcontains $NativePath) {
+            $NativePath
+        }
+    }
+    if ($MissingNativePaths.Count -gt 0) {
+        # Prepend every module-native runtime path so split dependency sets remain complete.
+        # The active managed-framework folder stays first and wins on duplicate file names.
+        $NativePrefix = [string]::Join([IO.Path]::PathSeparator, $MissingNativePaths)
         if ([string]::IsNullOrWhiteSpace($env:PATH)) {
-            $env:PATH = $NativePath
+            $env:PATH = $NativePrefix
         } else {
-            $env:PATH = "$NativePath$([IO.Path]::PathSeparator)$env:PATH"
+            $env:PATH = "$NativePrefix$([IO.Path]::PathSeparator)$env:PATH"
         }
     }
 }

--- a/PowerForge/Scripts/ModuleBootstrapper/RuntimeHandler.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/RuntimeHandler.Template.ps1
@@ -4,9 +4,30 @@ $IsWindowsPlatform = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPl
 if ($IsWindowsPlatform -and $LibFolder) {
 {{ArchitectureResolverBlock}}
 
-    $NativePath = Join-Path -Path $PSScriptRoot -ChildPath ("Lib\{0}\runtimes\{1}\native" -f $LibFolder, $ArchFolder)
+    # Prefer the active managed-framework folder, then reuse a compatible native
+    # runtime bundled under another framework folder. Native assets are selected
+    # by process architecture and do not inherit the managed assembly TFM.
+    $LibraryRoot = Join-Path -Path $PSScriptRoot -ChildPath 'Lib'
+    $NativeLibraryFolders = @(
+        $LibFolder
+        if (Test-Path -LiteralPath $LibraryRoot) {
+            foreach ($LibraryDirectory in @(Get-ChildItem -LiteralPath $LibraryRoot -Directory -ErrorAction SilentlyContinue)) {
+                if ($LibraryDirectory.Name -ne $LibFolder) {
+                    $LibraryDirectory.Name
+                }
+            }
+        }
+    )
+    $NativePath = $null
+    foreach ($NativeLibraryFolder in $NativeLibraryFolders) {
+        $NativeCandidate = Join-Path -Path $PSScriptRoot -ChildPath ("Lib\{0}\runtimes\{1}\native" -f $NativeLibraryFolder, $ArchFolder)
+        if (Test-Path -LiteralPath $NativeCandidate) {
+            $NativePath = $NativeCandidate
+            break
+        }
+    }
     $PathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }
-    if ((Test-Path -LiteralPath $NativePath) -and ($PathEntries -notcontains $NativePath)) {
+    if ($NativePath -and ($PathEntries -notcontains $NativePath)) {
         # Prepend the module-native runtime path so the packaged payload wins over unrelated machine-wide copies.
         if ([string]::IsNullOrWhiteSpace($env:PATH)) {
             $env:PATH = $NativePath

--- a/PowerForge/Scripts/ModuleBootstrapper/RuntimeHandler.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/RuntimeHandler.Template.ps1
@@ -25,19 +25,16 @@ if ($IsWindowsPlatform -and $LibFolder) {
         }
     }
     $PathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }
-    [array] $MissingNativePaths = foreach ($NativePath in $NativePaths) {
-        if ($PathEntries -notcontains $NativePath) {
-            $NativePath
+    if ($NativePaths.Count -gt 0) {
+        [array] $RemainingPathEntries = foreach ($PathEntry in $PathEntries) {
+            if ($NativePaths -notcontains $PathEntry) {
+                $PathEntry
+            }
         }
-    }
-    if ($MissingNativePaths.Count -gt 0) {
-        # Prepend every module-native runtime path so split dependency sets remain complete.
-        # The active managed-framework folder stays first and wins on duplicate file names.
-        $NativePrefix = [string]::Join([IO.Path]::PathSeparator, $MissingNativePaths)
-        if ([string]::IsNullOrWhiteSpace($env:PATH)) {
-            $env:PATH = $NativePrefix
-        } else {
-            $env:PATH = "$NativePrefix$([IO.Path]::PathSeparator)$env:PATH"
-        }
+        # Rebuild the module-owned prefix on every import. This keeps the active
+        # managed-framework folder first even when an earlier import already
+        # inserted a fallback folder, while preserving unrelated PATH order.
+        [array] $OrderedPathEntries = @($NativePaths) + @($RemainingPathEntries)
+        $env:PATH = [string]::Join([IO.Path]::PathSeparator, $OrderedPathEntries)
     }
 }


### PR DESCRIPTION
## Summary

- makes generated module bootstrapper native-runtime probing process-architecture aware across all packaged managed-framework folders
- rebuilds the module-owned PATH prefix on every import, with the active managed-framework folder first and every viable fallback retained
- makes development runtime switching deterministic across repeated Debug/Release imports
- allows a Desktop/Default assembly to reuse x86 native dependencies bundled under Core without dropping other split native dependencies

## Why

Multi-target modules can legitimately place runtime assets under more than one `Lib/<framework>/runtimes/<rid>/native` tree. The existing bootstrapper searched only the active managed framework folder. The first revision discovered fallbacks, but a repeated import could leave an already-present fallback ahead of the newly active framework. The generated handlers now remove every module-owned candidate from the existing PATH and rebuild the prefix in the intended order while preserving unrelated entries.

## Validation

- 35/35 focused `ModuleBootstrapperGeneratorTests` pass on the final head
- generated bootstrapper retains selected-framework precedence and every distinct module-local native path
- direct PowerShell 7 execution proves active-to-fallback and Debug-to-Release-to-Debug ordering across repeated imports
- direct Windows PowerShell 5.1 execution proves the combined packaged and development handlers preserve the same ordering
- the consumer scenario was reproduced with a multi-target EventViewerX module containing x86/x64/arm64 SQLite runtimes
