### PR TITLE
Reuse package-created GitHub releases in coordinated publishing

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -74,7 +74,10 @@ public sealed partial class ModulePipelineRunner
 
             var operationKey = CreateProjectBuildPublishOperationFingerprint(plan, segment, destination);
             if (ShouldSkipSynchronizedReleaseOperation(state, operationKey))
+            {
+                RestoreSynchronizedGitHubReleaseResults(state, segment, destination, operationKey);
                 continue;
+            }
 
             var useDuplicateTolerantNuGetRetry = destination == PackageBuildPublishDestination.NuGet &&
                 state.IsResumingSynchronizedRelease &&
@@ -92,7 +95,10 @@ public sealed partial class ModulePipelineRunner
                     remotePublishAttempted,
                     coordinatedReleaseCheckpointActive))
             {
-                MarkSynchronizedReleaseOperationCompleted(state, operationKey);
+                MarkSynchronizedReleaseOperationCompleted(
+                    state,
+                    operationKey,
+                    ResolveSynchronizedGitHubReleaseCheckpoints(state, segment, destination, operationKey));
                 continue;
             }
 
@@ -105,7 +111,10 @@ public sealed partial class ModulePipelineRunner
                 useDuplicateTolerantNuGetRetry,
                 remotePublishAttempted,
                 coordinatedReleaseCheckpointActive);
-            MarkSynchronizedReleaseOperationCompleted(state, operationKey);
+            MarkSynchronizedReleaseOperationCompleted(
+                state,
+                operationKey,
+                ResolveSynchronizedGitHubReleaseCheckpoints(state, segment, destination, operationKey));
         }
 
         foreach (var segment in plan.PackageBuilds ?? Array.Empty<ConfigurationPackageBuildSegment>())
@@ -115,7 +124,10 @@ public sealed partial class ModulePipelineRunner
 
             var operationKey = CreatePackageBuildPublishOperationFingerprint(plan, segment, destination);
             if (ShouldSkipSynchronizedReleaseOperation(state, operationKey))
+            {
+                RestoreSynchronizedGitHubReleaseResults(state, segment, destination, operationKey);
                 continue;
+            }
 
             var useDuplicateTolerantNuGetRetry = destination == PackageBuildPublishDestination.NuGet &&
                 state.IsResumingSynchronizedRelease &&
@@ -133,7 +145,10 @@ public sealed partial class ModulePipelineRunner
                     remotePublishAttempted,
                     coordinatedReleaseCheckpointActive))
             {
-                MarkSynchronizedReleaseOperationCompleted(state, operationKey);
+                MarkSynchronizedReleaseOperationCompleted(
+                    state,
+                    operationKey,
+                    ResolveSynchronizedGitHubReleaseCheckpoints(state, segment, destination, operationKey));
                 continue;
             }
 
@@ -146,7 +161,105 @@ public sealed partial class ModulePipelineRunner
                 useDuplicateTolerantNuGetRetry,
                 remotePublishAttempted,
                 coordinatedReleaseCheckpointActive);
-            MarkSynchronizedReleaseOperationCompleted(state, operationKey);
+            MarkSynchronizedReleaseOperationCompleted(
+                state,
+                operationKey,
+                ResolveSynchronizedGitHubReleaseCheckpoints(state, segment, destination, operationKey));
+        }
+    }
+
+    private static SynchronizedGitHubReleaseCheckpoint[] ResolveSynchronizedGitHubReleaseCheckpoints(
+        ModulePipelineRunState state,
+        object segment,
+        PackageBuildPublishDestination destination,
+        string operationKey)
+    {
+        if (destination != PackageBuildPublishDestination.GitHub ||
+            state.SynchronizedReleaseCheckpoint is null)
+        {
+            return Array.Empty<SynchronizedGitHubReleaseCheckpoint>();
+        }
+
+        if (!state.PackageBuildResultsBySegment.TryGetValue(segment, out var result))
+        {
+            throw new InvalidOperationException(
+                "A successful coordinated package GitHub publish did not retain its project build result.");
+        }
+
+        var publishedReleases = result.Result.GitHub.ToArray();
+        if (publishedReleases.Length == 0 ||
+            publishedReleases.Any(static release =>
+                !release.Success ||
+                release.ReleaseId <= 0 ||
+                string.IsNullOrWhiteSpace(release.Owner) ||
+                string.IsNullOrWhiteSpace(release.Repository) ||
+                string.IsNullOrWhiteSpace(release.TagName)))
+        {
+            throw new InvalidOperationException(
+                "A successful coordinated package GitHub publish did not return complete release identities. Preserve the checkpoint and inspect the remote release before retrying.");
+        }
+
+        return publishedReleases
+            .Select(release => new SynchronizedGitHubReleaseCheckpoint
+            {
+                OperationKey = operationKey,
+                ProjectName = release.ProjectName,
+                Owner = release.Owner.Trim(),
+                Repository = release.Repository.Trim(),
+                TagName = release.TagName!.Trim(),
+                ReleaseId = release.ReleaseId
+            })
+            .GroupBy(CreateSynchronizedGitHubReleaseCheckpointIdentity, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.First())
+            .ToArray();
+    }
+
+    private static void RestoreSynchronizedGitHubReleaseResults(
+        ModulePipelineRunState state,
+        object segment,
+        PackageBuildPublishDestination destination,
+        string operationKey)
+    {
+        if (destination != PackageBuildPublishDestination.GitHub)
+            return;
+
+        var releases = state.SynchronizedReleaseCheckpoint?.GitHubReleases
+            .Where(release => string.Equals(release.OperationKey, operationKey, StringComparison.OrdinalIgnoreCase))
+            .ToArray() ?? Array.Empty<SynchronizedGitHubReleaseCheckpoint>();
+        if (releases.Length == 0)
+        {
+            throw new InvalidOperationException(
+                "The completed coordinated package GitHub operation has no exact release identities. Preserve or abandon the incomplete checkpoint before retrying.");
+        }
+
+        if (!state.PackageBuildResultsBySegment.TryGetValue(segment, out var result))
+        {
+            throw new InvalidOperationException(
+                "The resumed coordinated package GitHub operation has no project build result to restore.");
+        }
+
+        foreach (var release in releases)
+        {
+            if (result.Result.GitHub.Any(existing =>
+                    existing.ReleaseId == release.ReleaseId &&
+                    string.Equals(existing.ProjectName, release.ProjectName, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(existing.Owner, release.Owner, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(existing.Repository, release.Repository, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(existing.TagName, release.TagName, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            result.Result.GitHub.Add(new ProjectBuildGitHubResult
+            {
+                ProjectName = release.ProjectName,
+                Owner = release.Owner,
+                Repository = release.Repository,
+                Success = true,
+                TagName = release.TagName,
+                ReleaseId = release.ReleaseId,
+                ReleaseUrl = $"https://github.com/{release.Owner}/{release.Repository}/releases/tag/{release.TagName}"
+            });
         }
     }
 
@@ -648,6 +761,20 @@ public sealed partial class ModulePipelineRunner
 
         if (mode is PackageBuildExecutionMode.PublishNuGet or PackageBuildExecutionMode.PublishGitHub)
         {
+            if (mode == PackageBuildExecutionMode.PublishGitHub)
+            {
+                if (state.PackageBuildResultsBySegment.TryGetValue(segment, out var existing))
+                {
+                    existing.Result.GitHub.AddRange(result.Result.GitHub);
+                    existing.Result.Success = result.Result.Success;
+                    existing.Result.ErrorMessage = result.Result.ErrorMessage;
+                }
+                else
+                {
+                    state.PackageBuildResultsBySegment[segment] = result;
+                }
+            }
+
             state.ReleaseCoordinationResult = null;
             return;
         }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
@@ -426,6 +426,13 @@ public sealed partial class ModulePipelineRunner
         var tag = ModulePublisher.GetGitHubTag(publish, plan.ModuleName, plan.ResolvedVersion, plan.PreRelease);
         var versionText = ModulePathTokenFormatter.FormatVersionWithPreRelease(plan.ResolvedVersion, plan.PreRelease);
         var isPreRelease = !string.IsNullOrWhiteSpace(plan.PreRelease) && !publish.DoNotMarkAsPreRelease;
+        var coordinatedReleaseId = ResolveSynchronizedGitHubReleaseId(state, owner, repo, tag);
+
+        if (coordinatedReleaseId.HasValue)
+        {
+            _logger.Info(
+                $"Reusing package-created GitHub release {coordinatedReleaseId.Value} for coordinated tag '{tag}'.");
+        }
 
         _logger.Info($"Publishing unified GitHub release {owner}/{repo} tag '{tag}' with {release.AssetPaths.Length} asset(s).");
         remotePublishAttempted();
@@ -439,7 +446,9 @@ public sealed partial class ModulePipelineRunner
             GenerateReleaseNotes = publish.GenerateReleaseNotes,
             IsDraft = false,
             IsPreRelease = isPreRelease,
-            ReuseExistingReleaseOnConflict = publish.ReuseExistingRelease,
+            ReuseExistingReleaseOnConflict = publish.ReuseExistingRelease || coordinatedReleaseId.HasValue,
+            RequireExpectedExistingRelease = coordinatedReleaseId.HasValue,
+            ExpectedExistingReleaseId = coordinatedReleaseId,
             ReplaceExistingAssets = publish.ReuseExistingRelease && publish.ReplaceExistingAssets,
             AssetFilePaths = release.AssetPaths,
             Progress = gitHubProgress
@@ -464,6 +473,30 @@ public sealed partial class ModulePipelineRunner
             releaseUrl: releaseUrl,
             succeeded: true,
             errorMessage: null);
+    }
+
+    private static long? ResolveSynchronizedGitHubReleaseId(
+        ModulePipelineRunState state,
+        string owner,
+        string repository,
+        string tag)
+    {
+        var releaseIds = state.SynchronizedReleaseCheckpoint?.GitHubReleases
+            .Where(release =>
+                string.Equals(release.Owner, owner, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(release.Repository, repository, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(release.TagName, tag, StringComparison.OrdinalIgnoreCase))
+            .Select(static release => release.ReleaseId)
+            .Distinct()
+            .ToArray() ?? Array.Empty<long>();
+
+        return releaseIds.Length switch
+        {
+            0 => null,
+            1 => releaseIds[0],
+            _ => throw new InvalidOperationException(
+                $"Coordinated release {owner}/{repository} tag '{tag}' is bound to multiple GitHub release identifiers. Preserve the checkpoint and inspect the incomplete release before retrying.")
+        };
     }
 
     private static bool ShouldPublishUnifiedGitHubRelease(ModulePipelinePlan plan, PublishConfiguration publish)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpoint.Storage.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpoint.Storage.cs
@@ -192,7 +192,8 @@ public sealed partial class ModulePipelineRunner
             previous.PayloadComponents is null || candidate.PayloadComponents is null ||
             previous.PlannedLanes is null || candidate.PlannedLanes is null ||
             previous.AttemptedLanes is null || candidate.AttemptedLanes is null ||
-            previous.Lanes is null || candidate.Lanes is null)
+            previous.Lanes is null || candidate.Lanes is null ||
+            previous.GitHubReleases is null || candidate.GitHubReleases is null)
         {
             return false;
         }
@@ -228,6 +229,9 @@ public sealed partial class ModulePipelineRunner
             !IsSetSubset(previous.AttemptedOperations, candidate.AttemptedOperations) ||
             !IsSetSubset(previous.CompletedOperations, candidate.CompletedOperations) ||
             !IsSetSubset(previous.AttemptedLanes, candidate.AttemptedLanes) ||
+            !IsValidSynchronizedGitHubReleaseCheckpoints(previous) ||
+            !IsValidSynchronizedGitHubReleaseCheckpoints(candidate) ||
+            !IsSynchronizedGitHubReleaseCheckpointSubset(previous.GitHubReleases, candidate.GitHubReleases) ||
             (previous.AuxiliaryRemoteSideEffectsObserved && !candidate.AuxiliaryRemoteSideEffectsObserved))
         {
             return false;
@@ -258,6 +262,33 @@ public sealed partial class ModulePipelineRunner
 
         return true;
     }
+
+    private static bool IsValidSynchronizedGitHubReleaseCheckpoints(SynchronizedReleaseCheckpoint checkpoint)
+        => checkpoint.GitHubReleases.All(release =>
+               release is not null &&
+               release.ReleaseId > 0 &&
+               !string.IsNullOrWhiteSpace(release.Owner) &&
+               !string.IsNullOrWhiteSpace(release.Repository) &&
+               !string.IsNullOrWhiteSpace(release.TagName) &&
+               !string.IsNullOrWhiteSpace(release.OperationKey) &&
+               checkpoint.CompletedOperations.Contains(release.OperationKey, StringComparer.OrdinalIgnoreCase)) &&
+           checkpoint.GitHubReleases
+               .Select(CreateSynchronizedGitHubReleaseCheckpointIdentity)
+               .Distinct(StringComparer.OrdinalIgnoreCase)
+               .Count() == checkpoint.GitHubReleases.Length;
+
+    private static bool IsSynchronizedGitHubReleaseCheckpointSubset(
+        SynchronizedGitHubReleaseCheckpoint[] subset,
+        SynchronizedGitHubReleaseCheckpoint[] superset)
+    {
+        var identities = superset
+            .Select(CreateSynchronizedGitHubReleaseCheckpointIdentity)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return subset.All(release => identities.Contains(CreateSynchronizedGitHubReleaseCheckpointIdentity(release)));
+    }
+
+    private static string CreateSynchronizedGitHubReleaseCheckpointIdentity(SynchronizedGitHubReleaseCheckpoint release)
+        => $"{release.OperationKey}\n{release.ProjectName}\n{release.Owner}\n{release.Repository}\n{release.TagName}\n{release.ReleaseId}";
 
     private static bool CanAdvanceSynchronizedReleaseVersion(string? previous, string? candidate)
     {
@@ -410,7 +441,18 @@ public sealed partial class ModulePipelineRunner
         public string[] PlannedLanes { get; set; } = Array.Empty<string>();
         public string[] AttemptedLanes { get; set; } = Array.Empty<string>();
         public SynchronizedReleaseLaneCheckpoint[] Lanes { get; set; } = Array.Empty<SynchronizedReleaseLaneCheckpoint>();
+        public SynchronizedGitHubReleaseCheckpoint[] GitHubReleases { get; set; } = Array.Empty<SynchronizedGitHubReleaseCheckpoint>();
         public DateTimeOffset CreatedUtc { get; set; }
+    }
+
+    private sealed class SynchronizedGitHubReleaseCheckpoint
+    {
+        public string OperationKey { get; set; } = string.Empty;
+        public string ProjectName { get; set; } = string.Empty;
+        public string Owner { get; set; } = string.Empty;
+        public string Repository { get; set; } = string.Empty;
+        public string TagName { get; set; } = string.Empty;
+        public long ReleaseId { get; set; }
     }
 
     private sealed class SynchronizedReleaseLaneCheckpoint

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpoint.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpoint.cs
@@ -424,13 +424,48 @@ public sealed partial class ModulePipelineRunner
 
     private void MarkSynchronizedReleaseOperationCompleted(
         ModulePipelineRunState state,
-        string operationKey)
+        string operationKey,
+        IReadOnlyCollection<SynchronizedGitHubReleaseCheckpoint>? gitHubReleases = null)
     {
         var checkpoint = state.SynchronizedReleaseCheckpoint;
         if (checkpoint is null)
             return;
 
         EnsureSynchronizedReleaseOperationIsPlanned(checkpoint, operationKey);
+        var releaseStateChanged = false;
+        foreach (var release in gitHubReleases ?? Array.Empty<SynchronizedGitHubReleaseCheckpoint>())
+        {
+            if (release.ReleaseId <= 0 ||
+                string.IsNullOrWhiteSpace(release.Owner) ||
+                string.IsNullOrWhiteSpace(release.Repository) ||
+                string.IsNullOrWhiteSpace(release.TagName) ||
+                !string.Equals(release.OperationKey, operationKey, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    "A coordinated GitHub release identity is incomplete or belongs to a different publish operation.");
+            }
+
+            var identity = CreateSynchronizedGitHubReleaseCheckpointIdentity(release);
+            if (checkpoint.GitHubReleases.Any(existing =>
+                    string.Equals(
+                        CreateSynchronizedGitHubReleaseCheckpointIdentity(existing),
+                        identity,
+                        StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            checkpoint.GitHubReleases = checkpoint.GitHubReleases
+                .Append(release)
+                .OrderBy(static value => value.OperationKey, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(static value => value.Owner, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(static value => value.Repository, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(static value => value.TagName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(static value => value.ReleaseId)
+                .ToArray();
+            releaseStateChanged = true;
+        }
+
         if (!checkpoint.AttemptedOperations.Contains(operationKey, StringComparer.OrdinalIgnoreCase))
         {
             checkpoint.AttemptedOperations = checkpoint.AttemptedOperations
@@ -439,7 +474,11 @@ public sealed partial class ModulePipelineRunner
                 .ToArray();
         }
         if (checkpoint.CompletedOperations.Contains(operationKey, StringComparer.OrdinalIgnoreCase))
+        {
+            if (releaseStateChanged)
+                SaveSynchronizedReleaseCheckpoint(state);
             return;
+        }
 
         checkpoint.CompletedOperations = checkpoint.CompletedOperations
             .Append(operationKey)
@@ -648,6 +687,7 @@ public sealed partial class ModulePipelineRunner
             checkpoint.PlannedLanes.Length == 0 ||
             checkpoint.AttemptedLanes is null ||
             checkpoint.Lanes is null ||
+            checkpoint.GitHubReleases is null ||
             checkpoint.Lanes.Any(static lane =>
                 lane is null ||
                 string.IsNullOrWhiteSpace(lane.Label) ||
@@ -701,6 +741,7 @@ public sealed partial class ModulePipelineRunner
                         storedPlanned.Contains(operation, StringComparer.OrdinalIgnoreCase)) &&
                     checkpoint.CompletedOperations.All(operation =>
                         checkpoint.AttemptedOperations.Contains(operation, StringComparer.OrdinalIgnoreCase)) &&
+                    IsValidSynchronizedGitHubReleaseCheckpoints(checkpoint) &&
                     (hasBoundPayload ||
                      (hasNoBoundPayload && checkpoint.AttemptedOperations.Length == 0)) &&
                     (hasExactVersion ||

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpointReset.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseCheckpointReset.cs
@@ -339,6 +339,7 @@ public sealed partial class ModulePipelineRunner
            checkpoint.PlannedOperations.Distinct(StringComparer.OrdinalIgnoreCase).Count() == checkpoint.PlannedOperations.Length &&
            checkpoint.AttemptedOperations is { Length: 0 } &&
            checkpoint.CompletedOperations is { Length: 0 } &&
+           checkpoint.GitHubReleases is { Length: 0 } &&
            checkpoint.OperationFingerprints is { Length: > 0 } &&
            checkpoint.OperationFingerprints.All(IsSynchronizedReleaseFingerprint) &&
            (hasNoBoundPayload || hasValidBoundPayload) &&

--- a/PowerForge.Tests/GitHubReleasePublisherTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherTests.cs
@@ -49,9 +49,53 @@ public sealed class GitHubReleasePublisherTests
 
             await server.WaitAsync(TimeSpan.FromSeconds(10));
             Assert.True(result.Succeeded);
+            Assert.Equal(42, result.ReleaseId);
             var request = JsonNode.Parse(requestBody!)!.AsObject();
             Assert.Equal(metadata, request["body"]!.GetValue<string>());
             Assert.True(request["generate_release_notes"]!.GetValue<bool>());
+        }
+        finally
+        {
+            listener.Stop();
+            listener.Close();
+        }
+    }
+
+    [Fact]
+    public async Task PublishRelease_RejectsSuccessfulResponseWithoutReleaseId()
+    {
+        var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var server = Task.Run(async () =>
+        {
+            var context = await listener.GetContextAsync();
+            var responseBody = Encoding.UTF8.GetBytes(
+                $$"""{"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""");
+            context.Response.StatusCode = 201;
+            context.Response.ContentType = "application/json";
+            context.Response.ContentLength64 = responseBody.Length;
+            await context.Response.OutputStream.WriteAsync(responseBody);
+            context.Response.Close();
+        });
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new GitHubReleasePublisher(new NullLogger()).PublishRelease(
+                    new GitHubReleasePublishRequest
+                    {
+                        Owner = "EvotecIT",
+                        Repository = "example",
+                        Token = "token",
+                        ApiBaseUrl = apiBaseUrl,
+                        TagName = "v1.2.3"
+                    }));
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Contains("invalid release identifier", exception.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseGitHubBindingTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseGitHubBindingTests.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class ModulePipelineUnifiedReleaseTests
+{
+    [Fact]
+    public void Run_RejectsCompletedPackageGitHubPublishWithoutExactIdentity()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var stagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        try
+        {
+            const string moduleName = "TestModule";
+            const string coordinatedTag = "TestModule-v2.0.11";
+            WriteMinimalModule(root.FullName, moduleName, "2.0.10");
+            WriteSynchronizedProjectBuildConfig(
+                root.FullName,
+                "project.build.json",
+                moduleName,
+                publishNuGet: false,
+                publishGitHub: true);
+
+            var runner = CreateRunner(
+                new FakeHostedOperations(new List<string>()),
+                (request, configuration, configPath) =>
+                {
+                    var result = CreateProjectBuildResult(
+                        root.FullName,
+                        moduleName,
+                        "2.0.11",
+                        Path.Combine(root.FullName, "PackageOutput", "NuGet"),
+                        request,
+                        configPath);
+                    if (request.PublishGitHub == true)
+                    {
+                        result.Result.GitHub.Add(new ProjectBuildGitHubResult
+                        {
+                            ProjectName = moduleName,
+                            Owner = "EvotecIT",
+                            Repository = moduleName,
+                            Success = true,
+                            TagName = coordinatedTag,
+                            ReleaseId = 0
+                        });
+                    }
+
+                    return result;
+                },
+                _ => throw new Xunit.Sdk.XunitException("Unified GitHub publishing must not run without an exact package release identity."));
+
+            var exception = Assert.Throws<InvalidOperationException>(() => runner.Run(
+                CreateCoordinatedGitHubSpec(root.FullName, stagingPath, moduleName, coordinatedTag)));
+
+            Assert.Contains("complete release identities", exception.Message, StringComparison.OrdinalIgnoreCase);
+            var checkpointPath = Assert.Single(Directory.GetFiles(GetCoordinatedReleaseCheckpointRoot(root.FullName), "*.json"));
+            using var checkpoint = JsonDocument.Parse(File.ReadAllText(checkpointPath));
+            Assert.Empty(checkpoint.RootElement.GetProperty("GitHubReleases").EnumerateArray());
+            Assert.DoesNotContain(
+                checkpoint.RootElement.GetProperty("AttemptedOperations").EnumerateArray()
+                    .Select(static item => item.GetString()),
+                operation => checkpoint.RootElement.GetProperty("CompletedOperations").EnumerateArray()
+                    .Select(static item => item.GetString())
+                    .Contains(operation, StringComparer.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+            try { if (Directory.Exists(stagingPath)) Directory.Delete(stagingPath, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Run_ReusesPackageCreatedGitHubReleaseByExactIdAfterResume()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var firstStagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        var secondStagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        try
+        {
+            const string moduleName = "TestModule";
+            const string synchronizedVersion = "2.0.11";
+            const string coordinatedTag = "TestModule-v2.0.11";
+            const long packageReleaseId = 4242;
+            WriteMinimalModule(root.FullName, moduleName, "2.0.10");
+            WriteSynchronizedProjectBuildConfig(
+                root.FullName,
+                "project.build.json",
+                moduleName,
+                publishNuGet: false,
+                publishGitHub: true);
+
+            var packageGitHubPublishCount = 0;
+            var unifiedGitHubRequests = new List<GitHubReleasePublishRequest>();
+
+            ProjectBuildHostExecutionResult ExecutePackageBuild(
+                ProjectBuildHostRequest request,
+                ProjectBuildConfiguration? configuration,
+                string? configPath)
+            {
+                var result = CreateProjectBuildResult(
+                    root.FullName,
+                    moduleName,
+                    synchronizedVersion,
+                    Path.Combine(root.FullName, "PackageOutput", "NuGet"),
+                    request,
+                    configPath);
+                if (request.PublishGitHub == true)
+                {
+                    packageGitHubPublishCount++;
+                    result.Result.GitHub.Add(new ProjectBuildGitHubResult
+                    {
+                        ProjectName = moduleName,
+                        Owner = "EvotecIT",
+                        Repository = moduleName,
+                        Success = true,
+                        TagName = coordinatedTag,
+                        ReleaseId = packageReleaseId,
+                        ReleaseUrl = $"https://github.com/EvotecIT/{moduleName}/releases/tag/{coordinatedTag}"
+                    });
+                }
+
+                return result;
+            }
+
+            GitHubReleasePublishResult PublishUnifiedGitHub(GitHubReleasePublishRequest request)
+            {
+                unifiedGitHubRequests.Add(request);
+                Assert.True(request.ReuseExistingReleaseOnConflict);
+                Assert.True(request.RequireExpectedExistingRelease);
+                Assert.Equal(packageReleaseId, request.ExpectedExistingReleaseId);
+                Assert.False(request.ReplaceExistingAssets);
+
+                if (unifiedGitHubRequests.Count == 1)
+                    throw new InvalidOperationException("Simulated unified GitHub interruption.");
+
+                return new GitHubReleasePublishResult
+                {
+                    Succeeded = true,
+                    ReleaseCreationSucceeded = true,
+                    ReleaseId = packageReleaseId,
+                    AllAssetUploadsSucceeded = true,
+                    HtmlUrl = $"https://github.com/EvotecIT/{moduleName}/releases/tag/{coordinatedTag}"
+                };
+            }
+
+            var firstRunner = CreateRunner(
+                new FakeHostedOperations(new List<string>()),
+                ExecutePackageBuild,
+                PublishUnifiedGitHub);
+            var firstException = Assert.Throws<InvalidOperationException>(() => firstRunner.Run(
+                CreateCoordinatedGitHubSpec(root.FullName, firstStagingPath, moduleName, coordinatedTag)));
+
+            Assert.Contains("interruption", firstException.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(1, packageGitHubPublishCount);
+            var checkpointPath = Assert.Single(Directory.GetFiles(GetCoordinatedReleaseCheckpointRoot(root.FullName), "*.json"));
+            using (var checkpoint = JsonDocument.Parse(File.ReadAllText(checkpointPath)))
+            {
+                var release = Assert.Single(checkpoint.RootElement.GetProperty("GitHubReleases").EnumerateArray());
+                Assert.Equal(packageReleaseId, release.GetProperty("ReleaseId").GetInt64());
+                Assert.Equal("EvotecIT", release.GetProperty("Owner").GetString());
+                Assert.Equal(moduleName, release.GetProperty("Repository").GetString());
+                Assert.Equal(coordinatedTag, release.GetProperty("TagName").GetString());
+                Assert.Contains(
+                    release.GetProperty("OperationKey").GetString(),
+                    checkpoint.RootElement.GetProperty("CompletedOperations").EnumerateArray()
+                        .Select(static item => item.GetString()),
+                    StringComparer.OrdinalIgnoreCase);
+            }
+
+            var secondRunner = CreateRunner(
+                new FakeHostedOperations(new List<string>()),
+                ExecutePackageBuild,
+                PublishUnifiedGitHub);
+            var result = secondRunner.Run(
+                CreateCoordinatedGitHubSpec(root.FullName, secondStagingPath, moduleName, coordinatedTag));
+
+            Assert.Equal(synchronizedVersion, result.Plan.ResolvedVersion);
+            Assert.Equal(1, packageGitHubPublishCount);
+            Assert.Equal(2, unifiedGitHubRequests.Count);
+            Assert.All(unifiedGitHubRequests, request => Assert.Equal(packageReleaseId, request.ExpectedExistingReleaseId));
+            var restoredGitHub = Assert.Single(Assert.Single(result.ProjectBuildResults).Result.GitHub);
+            Assert.Equal(moduleName, restoredGitHub.ProjectName);
+            Assert.Equal("EvotecIT", restoredGitHub.Owner);
+            Assert.Equal(moduleName, restoredGitHub.Repository);
+            Assert.Equal(coordinatedTag, restoredGitHub.TagName);
+            Assert.Equal(packageReleaseId, restoredGitHub.ReleaseId);
+            AssertNoCoordinatedReleaseCheckpoint(root.FullName);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+            try { if (Directory.Exists(firstStagingPath)) Directory.Delete(firstStagingPath, recursive: true); } catch { }
+            try { if (Directory.Exists(secondStagingPath)) Directory.Delete(secondStagingPath, recursive: true); } catch { }
+        }
+    }
+
+    private static ModulePipelineSpec CreateCoordinatedGitHubSpec(
+        string rootPath,
+        string stagingPath,
+        string moduleName,
+        string coordinatedTag)
+        => new()
+        {
+            Build = new ModuleBuildSpec
+            {
+                Name = moduleName,
+                SourcePath = rootPath,
+                Version = "2.0.10",
+                StagingPath = stagingPath
+            },
+            Install = new ModulePipelineInstallOptions { Enabled = false },
+            Segments = new IConfigurationSegment[]
+            {
+                CreateProjectBuildSegment(
+                    moduleName,
+                    enabled: true,
+                    buildBeforeModule: true,
+                    configPath: Path.Combine("Build", "project.build.json")),
+                new ConfigurationArtefactSegment
+                {
+                    ArtefactType = ArtefactType.Packed,
+                    Configuration = new ArtefactConfiguration
+                    {
+                        Enabled = true,
+                        ID = "module",
+                        Path = Path.Combine(rootPath, "Artifacts", "Module")
+                    }
+                },
+                new ConfigurationPublishSegment
+                {
+                    Configuration = new PublishConfiguration
+                    {
+                        Enabled = true,
+                        Destination = PublishDestination.GitHub,
+                        UserName = "EvotecIT",
+                        RepositoryName = moduleName,
+                        ApiKey = "test-token",
+                        OverwriteTagName = coordinatedTag
+                    }
+                },
+                new ConfigurationReleaseSegment
+                {
+                    Configuration = new ReleaseConfiguration
+                    {
+                        VersionSource = ReleaseVersionSource.ProjectBuild,
+                        PrimaryProject = moduleName,
+                        SynchronizeModuleVersion = true,
+                        ResumeIncompleteRelease = true,
+                        PublishOrder = new[] { "GitHub" }
+                    }
+                }
+            }
+        };
+}

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseRetrySafetyTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseRetrySafetyTests.cs
@@ -193,7 +193,7 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
                     var projectName = configPath!.EndsWith("companion.build.json", StringComparison.OrdinalIgnoreCase)
                         ? companionName
                         : moduleName;
-                    return CreateProjectBuildResult(
+                    var result = CreateProjectBuildResult(
                         root.FullName,
                         projectName,
                         "2.0.11",
@@ -201,6 +201,20 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
                         request,
                         configPath,
                         includePackage: true);
+                    if (request.PublishGitHub == true)
+                    {
+                        result.Result.GitHub.Add(new ProjectBuildGitHubResult
+                        {
+                            ProjectName = projectName,
+                            Owner = "EvotecIT",
+                            Repository = moduleName,
+                            Success = true,
+                            TagName = $"{moduleName}-v2.0.11",
+                            ReleaseId = 4242
+                        });
+                    }
+
+                    return result;
                 });
             var spec = CreatePackageOnlyReleaseSpec(
                 root.FullName,

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
@@ -140,6 +140,8 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             Assert.False(gitHubRequest.IsPreRelease);
             Assert.True(gitHubRequest.GenerateReleaseNotes);
             Assert.False(gitHubRequest.ReuseExistingReleaseOnConflict);
+            Assert.False(gitHubRequest.RequireExpectedExistingRelease);
+            Assert.Null(gitHubRequest.ExpectedExistingReleaseId);
             Assert.False(gitHubRequest.ReplaceExistingAssets);
             Assert.NotNull(gitHubRequest.Progress);
             Assert.Equal("1.2.3", result.Plan.ResolvedVersion);

--- a/PowerForge.Tests/ProjectBuildGitHubPublisherTests.cs
+++ b/PowerForge.Tests/ProjectBuildGitHubPublisherTests.cs
@@ -26,6 +26,7 @@ public sealed class ProjectBuildGitHubPublisherTests
                 return new GitHubReleasePublishResult
                 {
                     Succeeded = true,
+                    ReleaseId = 42,
                     HtmlUrl = $"https://example.test/{request.TagName}"
                 };
             },
@@ -78,6 +79,9 @@ public sealed class ProjectBuildGitHubPublisherTests
             Assert.True(summary.Success);
             Assert.True(summary.PerProject);
             Assert.Equal(2, summary.Results.Count);
+            Assert.All(summary.Results, result => Assert.Equal(42, result.ReleaseId));
+            Assert.All(summary.Results, result => Assert.Equal("EvotecIT", result.Owner));
+            Assert.All(summary.Results, result => Assert.Equal("PSPublishModule", result.Repository));
             Assert.Collection(
                 requests.OrderBy(request => request.TagName, StringComparer.OrdinalIgnoreCase),
                 first =>

--- a/PowerForge/Models/GitHubReleasePublishResult.cs
+++ b/PowerForge/Models/GitHubReleasePublishResult.cs
@@ -13,6 +13,9 @@ public sealed class GitHubReleasePublishResult
     /// <summary>True when release creation or reuse succeeded.</summary>
     public bool ReleaseCreationSucceeded { get; set; }
 
+    /// <summary>Numeric GitHub release identifier returned by the API.</summary>
+    public long ReleaseId { get; set; }
+
     /// <summary>True when all asset uploads succeeded; null when no assets were requested.</summary>
     public bool? AllAssetUploadsSucceeded { get; set; }
 

--- a/PowerForge/Models/ProjectBuildGitHubResult.cs
+++ b/PowerForge/Models/ProjectBuildGitHubResult.cs
@@ -8,11 +8,20 @@ public sealed class ProjectBuildGitHubResult
     /// <summary>Project name.</summary>
     public string ProjectName { get; set; } = string.Empty;
 
+    /// <summary>GitHub repository owner.</summary>
+    public string Owner { get; set; } = string.Empty;
+
+    /// <summary>GitHub repository name.</summary>
+    public string Repository { get; set; } = string.Empty;
+
     /// <summary>True when publishing succeeded.</summary>
     public bool Success { get; set; }
 
     /// <summary>Computed tag name.</summary>
     public string? TagName { get; set; }
+
+    /// <summary>Numeric GitHub release identifier returned by the API.</summary>
+    public long ReleaseId { get; set; }
 
     /// <summary>Release URL when publishing succeeded.</summary>
     public string? ReleaseUrl { get; set; }

--- a/PowerForge/Services/GitHubReleasePublisher.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.cs
@@ -106,6 +106,11 @@ public sealed partial class GitHubReleasePublisher
             expectedExistingReleaseId,
             requirePublishedStableRelease,
             cancellationToken);
+        if (release.Id <= 0)
+        {
+            throw new InvalidOperationException(
+                $"GitHub returned an invalid release identifier for tag '{tagName}'.");
+        }
         releaseWatch.Stop();
         _logger.Success($"GitHub release ready in {DotNetRepositoryReleaseService.FormatDuration(releaseWatch.Elapsed)}: {release.HtmlUrl}");
 
@@ -113,6 +118,7 @@ public sealed partial class GitHubReleasePublisher
         {
             Succeeded = true,
             ReleaseCreationSucceeded = true,
+            ReleaseId = release.Id,
             AllAssetUploadsSucceeded = assets.Length == 0 ? null : true,
             HtmlUrl = release.HtmlUrl,
             UploadUrl = release.UploadUrl,

--- a/PowerForge/Services/ProjectBuildGitHubPublisher.cs
+++ b/PowerForge/Services/ProjectBuildGitHubPublisher.cs
@@ -330,8 +330,11 @@ public sealed class ProjectBuildGitHubPublisher
             summary.Results.Add(new ProjectBuildGitHubResult
             {
                 ProjectName = project.ProjectName,
+                Owner = publishResult.Owner,
+                Repository = publishResult.Repository,
                 Success = publishResult.Success,
                 TagName = publishResult.TagName,
+                ReleaseId = publishResult.ReleaseId,
                 ReleaseUrl = publishResult.ReleaseUrl,
                 ErrorMessage = publishResult.ErrorMessage
             });
@@ -353,6 +356,8 @@ public sealed class ProjectBuildGitHubPublisher
         ProjectBuildGitHubResult result,
         IGitHubReleaseProgressReporter? progress)
     {
+        result.Owner = request.Owner;
+        result.Repository = request.Repository;
         try
         {
             var publishResult = _publishRelease(new GitHubReleasePublishRequest
@@ -371,6 +376,7 @@ public sealed class ProjectBuildGitHubPublisher
 
             result.Success = publishResult.Succeeded;
             result.TagName = tag;
+            result.ReleaseId = publishResult.ReleaseId;
             result.ReleaseUrl = publishResult.HtmlUrl;
             result.ErrorMessage = null;
             WriteGitHubPublishNotes(tag, publishResult);


### PR DESCRIPTION
## Summary

- persist the exact owner, repository, tag, and GitHub release ID created by package publishing
- reuse only that verified release when the unified module phase targets the same release, including checkpoint resume
- fail closed when GitHub does not return a usable identity and restore completed package release results after resume

This prevents a coordinated release from failing with an lready_exists response when package assets and unified module assets intentionally share one GitHub tag. Existing opt-in asset replacement behavior is unchanged.

## Release impact

No consumer configuration change is required. Checkpoints created before this identity was recorded cannot safely infer an existing release and must be abandoned or handled as a new release version.

After this merges and a new PSPublishModule/PowerForge package is published, Mailozaurr can use the normal coordinated flow for a fresh 3.0.1 release.