### PR TITLE
Use GitHub-generated notes for Home Assistant releases

### DIFF
--- a/.github/actions/homeassistant-release/action.yml
+++ b/.github/actions/homeassistant-release/action.yml
@@ -52,7 +52,7 @@ inputs:
   powerforge-version:
     description: Exact PowerForge.Build tool version used by the action.
     required: false
-    default: "1.0.8"
+    default: "1.0.9"
 
 outputs:
   action:

--- a/.github/workflows/powerforge-homeassistant-release.yml
+++ b/.github/workflows/powerforge-homeassistant-release.yml
@@ -67,7 +67,7 @@ jobs:
           default-branch: ${{ inputs.default_branch }}
           increment: ${{ inputs.increment }}
           github-token: ${{ secrets['github-token'] != '' && secrets['github-token'] || github.token }}
-          powerforge-version: 1.0.8
+          powerforge-version: 1.0.9
 
   build:
     needs: prepare
@@ -101,7 +101,7 @@ jobs:
           repository-root: ${{ github.workspace }}/source
           release-version: ${{ needs.prepare.outputs.version }}
           release-commit: ${{ needs.prepare.outputs.release-commit }}
-          powerforge-version: 1.0.8
+          powerforge-version: 1.0.9
 
       - name: Transfer the single release asset to the publish job
         if: steps.build.outputs.required-asset != ''
@@ -144,4 +144,4 @@ jobs:
           required-asset: ${{ needs.build.outputs.required-asset }}
           asset-path: ${{ needs.build.outputs.required-asset != '' && format('{0}/powerforge-homeassistant-release-asset/{1}', runner.temp, needs.build.outputs.required-asset) || '' }}
           github-token: ${{ secrets['github-token'] != '' && secrets['github-token'] || github.token }}
-          powerforge-version: 1.0.8
+          powerforge-version: 1.0.9

--- a/PowerForge.Tests/HomeAssistantReleaseWorkflowTests.cs
+++ b/PowerForge.Tests/HomeAssistantReleaseWorkflowTests.cs
@@ -16,16 +16,16 @@ public sealed class HomeAssistantReleaseWorkflowTests {
     }
 
     [Fact]
-    public void WorkflowPinsTheReleasedEngineVersionForEveryStage() {
+    public void WorkflowPinsTheGeneratedReleaseNotesEngineVersionForEveryStage() {
         var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
         var workflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "powerforge-homeassistant-release.yml"));
         var action = File.ReadAllText(Path.Combine(root, ".github", "actions", "homeassistant-release", "action.yml"));
         var skill = File.ReadAllText(Path.Combine(root, ".agents", "skills", "powerforge-homeassistant-release", "SKILL.md"));
 
-        Assert.Equal(3, CountOccurrences(workflow, "powerforge-version: 1.0.8"));
+        Assert.Equal(3, CountOccurrences(workflow, "powerforge-version: 1.0.9"));
         Assert.Contains("actions: read", workflow, StringComparison.Ordinal);
         Assert.Contains("`actions: read`", skill, StringComparison.Ordinal);
-        Assert.Contains("default: \"1.0.8\"", action, StringComparison.Ordinal);
+        Assert.Contains("default: \"1.0.9\"", action, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- pin the shared Home Assistant release action and all three workflow stages to PowerForge.Build 1.0.9
- keep the exact-version workflow contract test aligned with the generated-notes-capable engine

## Release effect

Future Home Assistant and HACS releases can show GitHub's native change list, contributor section, and full changelog while retaining hidden PowerForge provenance for safe retries. Receiver repositories must repin the reusable workflow after this change lands.