### PR TITLE
Improve generated parameter descriptions

### DIFF
--- a/PowerForge.PowerShell/Services/DocumentationEngine.cs
+++ b/PowerForge.PowerShell/Services/DocumentationEngine.cs
@@ -156,6 +156,8 @@ public sealed class DocumentationEngine
                 if (_logger.IsVerbose) _logger.Verbose(ex.ToString());
             }
 
+            var authoredHelpPayload = CloneHelpPayload(extracted);
+
             try
             {
                 if (buildDocumentation.GenerateFallbackExamples)
@@ -238,7 +240,8 @@ public sealed class DocumentationEngine
                 markdownFiles: CountMarkdownFiles(docsPath),
                 externalHelpFilePath: externalHelpFile,
                 errorMessage: null,
-                externalHelpFilePaths: externalHelpFiles);
+                externalHelpFilePaths: externalHelpFiles,
+                authoredHelpPayload: authoredHelpPayload);
         }
         catch (Exception ex)
         {
@@ -320,6 +323,21 @@ public sealed class DocumentationEngine
             try { File.Delete(scriptPath); } catch { /* ignore */ }
             try { File.Delete(jsonPath); } catch { /* ignore */ }
         }
+    }
+
+    private static DocumentationExtractionPayload CloneHelpPayload(DocumentationExtractionPayload payload)
+    {
+        using var stream = new MemoryStream();
+        var serializer = new DataContractJsonSerializer(
+            typeof(DocumentationExtractionPayload),
+            new DataContractJsonSerializerSettings
+            {
+                UseSimpleDictionaryFormat = true
+            });
+        serializer.WriteObject(stream, payload);
+        stream.Position = 0;
+        return serializer.ReadObject(stream) as DocumentationExtractionPayload ??
+            new DocumentationExtractionPayload();
     }
 
     private static string AppendRequiredModulesHint(string moduleManifestPath, string? message)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Phases.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Phases.cs
@@ -602,7 +602,8 @@ public sealed partial class ModulePipelineRunner
                     ModuleName = plan.ModuleName,
                     ManifestPath = buildResult.ManifestPath,
                     BuildSpec = plan.BuildSpec,
-                    Settings = plan.ValidationSettings ?? new ModuleValidationSettings()
+                    Settings = plan.ValidationSettings ?? new ModuleValidationSettings(),
+                    AuthoredHelpPayload = state.DocumentationResult?.AuthoredHelpPayload
                 });
 
                 if (state.ValidationReport.Status == CheckStatus.Fail)

--- a/PowerForge.PowerShell/Services/ModuleValidationService.Checks.cs
+++ b/PowerForge.PowerShell/Services/ModuleValidationService.Checks.cs
@@ -37,8 +37,11 @@ public sealed partial class ModuleValidationService
         DocumentationExtractionPayload payload;
         try
         {
-            var engine = new DocumentationEngine(_runner, _logger);
-            payload = engine.ExtractHelpPayload(spec.StagingPath, manifestPath, TimeSpan.FromSeconds(Math.Max(1, settings.TimeoutSeconds)));
+            payload = spec.AuthoredHelpPayload ??
+                new DocumentationEngine(_runner, _logger).ExtractHelpPayload(
+                    spec.StagingPath,
+                    manifestPath,
+                    TimeSpan.FromSeconds(Math.Max(1, settings.TimeoutSeconds)));
         }
         catch (Exception ex)
         {

--- a/PowerForge.PowerShell/Services/ModuleValidationService.Checks.cs
+++ b/PowerForge.PowerShell/Services/ModuleValidationService.Checks.cs
@@ -87,7 +87,7 @@ public sealed partial class ModuleValidationService
                 if (parameter is null || string.IsNullOrWhiteSpace(parameter.Name)) continue;
 
                 totalParameterCount++;
-                if (!string.IsNullOrWhiteSpace(parameter.Description))
+                if (!ParameterDescriptionFallback.IsMissingOrPlaceholder(parameter.Description))
                 {
                     parameterDescriptionCount++;
                 }

--- a/PowerForge.Tests/DocumentationEngineSafetyTests.cs
+++ b/PowerForge.Tests/DocumentationEngineSafetyTests.cs
@@ -167,6 +167,75 @@ public sealed class DocumentationEngineSafetyTests
     }
 
     [Fact]
+    public void Build_RetainsAuthoredHelpSnapshotBeforeRenderingParameterFallbacks()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var stagingRoot = Path.Combine(root.FullName, "Staging");
+            Directory.CreateDirectory(stagingRoot);
+            var manifestPath = Path.Combine(stagingRoot, "TestModule.psd1");
+            File.WriteAllText(manifestPath, "@{ ModuleVersion = '1.0.0'; RootModule = 'TestModule.psm1' }");
+
+            var payload = new DocumentationExtractionPayload
+            {
+                ModuleName = "TestModule",
+                Commands =
+                [
+                    new DocumentationCommandHelp
+                    {
+                        Name = "Get-Test",
+                        Synopsis = "Gets a test item.",
+                        Description = "Gets a test item.",
+                        Parameters =
+                        {
+                            new DocumentationParameterHelp
+                            {
+                                Name = "Name",
+                                Type = "String",
+                                Description = string.Empty
+                            }
+                        }
+                    }
+                ]
+            };
+
+            var result = new DocumentationEngine(new PayloadPowerShellRunner(payload), new NullLogger()).Build(
+                moduleName: "TestModule",
+                stagingPath: stagingRoot,
+                moduleManifestPath: manifestPath,
+                documentation: new DocumentationConfiguration
+                {
+                    Path = "Docs",
+                    PathReadme = Path.Combine("Docs", "Readme.md")
+                },
+                buildDocumentation: new BuildDocumentationConfiguration
+                {
+                    Enable = true,
+                    GenerateExternalHelp = true
+                });
+
+            Assert.True(result.Succeeded, result.ErrorMessage);
+            Assert.NotNull(result.AuthoredHelpPayload);
+            var authoredCommand = Assert.Single(result.AuthoredHelpPayload!.Commands);
+            Assert.Empty(Assert.Single(authoredCommand.Parameters).Description);
+            Assert.Empty(authoredCommand.Examples);
+            Assert.Contains(
+                "Specifies a value for name.",
+                File.ReadAllText(result.ExternalHelpFilePath),
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "Get-Test",
+                File.ReadAllText(Path.Combine(result.DocsPath, "Get-Test.md")),
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Build_DoesNotCleanDocsWhenExtractionFails()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/DocumentationGenerationTests.cs
+++ b/PowerForge.Tests/DocumentationGenerationTests.cs
@@ -185,6 +185,7 @@ EXAMPLES
                             {
                                 Name = "Mode",
                                 Type = "String",
+                                Description = "{{ Fill Mode Description }}",
                                 ParameterSets = new List<string> { "ByMode" },
                                 PossibleValues = new List<string> { "Basic", "basic", "Advanced" }
                             }
@@ -209,6 +210,9 @@ EXAMPLES
             var parameter = doc.Descendants(commandNs + "parameter")
                 .FirstOrDefault(p => string.Equals(p.Element(mamlNs + "name")?.Value, "Mode", StringComparison.Ordinal));
             Assert.NotNull(parameter);
+            Assert.Equal(
+                "Specifies a value for mode.",
+                parameter!.Element(mamlNs + "description")?.Value.Trim());
 
             var possibleValues = parameter!
                 .Element(commandNs + "parameterValueGroup")?
@@ -222,6 +226,10 @@ EXAMPLES
             new MarkdownHelpWriter().WriteCommandHelpFiles(payload, "TestModule", markdownRoot);
             Assert.Contains(
                 "Possible values: Basic, basic, Advanced",
+                File.ReadAllText(Path.Combine(markdownRoot, "Invoke-Thing.md")),
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                "{{ Fill Mode Description }}",
                 File.ReadAllText(Path.Combine(markdownRoot, "Invoke-Thing.md")),
                 StringComparison.Ordinal);
         }

--- a/PowerForge.Tests/MarkdownHelpWriterTests.cs
+++ b/PowerForge.Tests/MarkdownHelpWriterTests.cs
@@ -22,9 +22,14 @@ public class MarkdownHelpWriterTests
             {
                 new() { Name = "InputObject", Type = "Object", Description = "{{ Fill InputObject Description }}" },
                 new() { Name = "AllowImageExpand", Type = "SwitchParameter" },
+                new() { Name = "SwitchMatrix", Type = "SwitchParameter[]" },
+                new() { Name = "Modes", Type = "BinaryDocMode[,]" },
+                new() { Name = "OpenModes", Type = "BinaryDocMode[*]" },
                 new() { Name = "TargetElementIds", Type = "List`1" },
                 new() { Name = "Properties", Type = "Dictionary`2" },
-                new() { Name = "OptionalCount", Type = "Nullable`1" }
+                new() { Name = "OptionalCount", Type = "Nullable`1" },
+                new() { Name = "TemplateExpression", Type = "String", Description = "{{ FulfillmentMode }}" },
+                new() { Name = "FillColorExpression", Type = "String", Description = "{{ FillColor }}" }
             }
         };
 
@@ -32,10 +37,15 @@ public class MarkdownHelpWriterTests
 
         Assert.Contains("Specifies a value for input object.", markdown, StringComparison.Ordinal);
         Assert.Contains("Specifies the allow image expand switch.", markdown, StringComparison.Ordinal);
+        Assert.Contains("Specifies one or more values for switch matrix.", markdown, StringComparison.Ordinal);
+        Assert.Contains("Specifies one or more values for modes.", markdown, StringComparison.Ordinal);
+        Assert.Contains("Specifies one or more values for open modes.", markdown, StringComparison.Ordinal);
         Assert.Contains("Specifies one or more values for target element ids.", markdown, StringComparison.Ordinal);
         Assert.Contains("Specifies one or more values for properties.", markdown, StringComparison.Ordinal);
         Assert.Contains("Specifies a value for optional count.", markdown, StringComparison.Ordinal);
-        Assert.DoesNotContain("{{ Fill", markdown, StringComparison.Ordinal);
+        Assert.Contains("{{ FulfillmentMode }}", markdown, StringComparison.Ordinal);
+        Assert.Contains("{{ FillColor }}", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("{{ Fill InputObject Description }}", markdown, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/PowerForge.Tests/MarkdownHelpWriterTests.cs
+++ b/PowerForge.Tests/MarkdownHelpWriterTests.cs
@@ -29,6 +29,7 @@ public class MarkdownHelpWriterTests
                 new() { Name = "Properties", Type = "Dictionary`2" },
                 new() { Name = "Metadata", Type = "Hashtable" },
                 new() { Name = "QualifiedMetadata", Type = "System.Collections.Hashtable" },
+                new() { Name = "LegacyItems", Type = "System.Collections.ArrayList" },
                 new() { Name = "Enabled", Type = "System.Boolean" },
                 new() { Name = "OptionalCount", Type = "Nullable`1" },
                 new() { Name = "TemplateExpression", Type = "String", Description = "{{ FulfillmentMode }}" },
@@ -47,6 +48,7 @@ public class MarkdownHelpWriterTests
         Assert.Contains("Specifies one or more values for properties.", markdown, StringComparison.Ordinal);
         Assert.Contains("Specifies one or more values for metadata.", markdown, StringComparison.Ordinal);
         Assert.Contains("Specifies one or more values for qualified metadata.", markdown, StringComparison.Ordinal);
+        Assert.Contains("Specifies one or more values for legacy items.", markdown, StringComparison.Ordinal);
         Assert.Contains("Specifies a Boolean value for enabled.", markdown, StringComparison.Ordinal);
         Assert.Contains("Specifies a value for optional count.", markdown, StringComparison.Ordinal);
         Assert.Contains("{{ FulfillmentMode }}", markdown, StringComparison.Ordinal);

--- a/PowerForge.Tests/MarkdownHelpWriterTests.cs
+++ b/PowerForge.Tests/MarkdownHelpWriterTests.cs
@@ -12,6 +12,33 @@ public class MarkdownHelpWriterTests
             exampleIndentClassifier: PowerShellMarkdownExampleIndentClassifier.Instance);
 
     [Fact]
+    public void RenderCommandMarkdown_UsesReadableFallbacksInsteadOfParameterPlaceholders()
+    {
+        var command = new DocumentationCommandHelp
+        {
+            Name = "Send-DemoMessage",
+            Synopsis = "Sends a demo message.",
+            Parameters = new List<DocumentationParameterHelp>
+            {
+                new() { Name = "InputObject", Type = "Object", Description = "{{ Fill InputObject Description }}" },
+                new() { Name = "AllowImageExpand", Type = "SwitchParameter" },
+                new() { Name = "TargetElementIds", Type = "List`1" },
+                new() { Name = "Properties", Type = "Dictionary`2" },
+                new() { Name = "OptionalCount", Type = "Nullable`1" }
+            }
+        };
+
+        var markdown = RenderCommandMarkdown(command);
+
+        Assert.Contains("Specifies a value for input object.", markdown, StringComparison.Ordinal);
+        Assert.Contains("Specifies the allow image expand switch.", markdown, StringComparison.Ordinal);
+        Assert.Contains("Specifies one or more values for target element ids.", markdown, StringComparison.Ordinal);
+        Assert.Contains("Specifies one or more values for properties.", markdown, StringComparison.Ordinal);
+        Assert.Contains("Specifies a value for optional count.", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("{{ Fill", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RenderCommandMarkdown_NormalizesIncidentalExampleIndentation()
     {
         var command = new DocumentationCommandHelp

--- a/PowerForge.Tests/MarkdownHelpWriterTests.cs
+++ b/PowerForge.Tests/MarkdownHelpWriterTests.cs
@@ -27,6 +27,9 @@ public class MarkdownHelpWriterTests
                 new() { Name = "OpenModes", Type = "BinaryDocMode[*]" },
                 new() { Name = "TargetElementIds", Type = "List`1" },
                 new() { Name = "Properties", Type = "Dictionary`2" },
+                new() { Name = "Metadata", Type = "Hashtable" },
+                new() { Name = "QualifiedMetadata", Type = "System.Collections.Hashtable" },
+                new() { Name = "Enabled", Type = "System.Boolean" },
                 new() { Name = "OptionalCount", Type = "Nullable`1" },
                 new() { Name = "TemplateExpression", Type = "String", Description = "{{ FulfillmentMode }}" },
                 new() { Name = "FillColorExpression", Type = "String", Description = "{{ FillColor }}" }
@@ -42,6 +45,9 @@ public class MarkdownHelpWriterTests
         Assert.Contains("Specifies one or more values for open modes.", markdown, StringComparison.Ordinal);
         Assert.Contains("Specifies one or more values for target element ids.", markdown, StringComparison.Ordinal);
         Assert.Contains("Specifies one or more values for properties.", markdown, StringComparison.Ordinal);
+        Assert.Contains("Specifies one or more values for metadata.", markdown, StringComparison.Ordinal);
+        Assert.Contains("Specifies one or more values for qualified metadata.", markdown, StringComparison.Ordinal);
+        Assert.Contains("Specifies a Boolean value for enabled.", markdown, StringComparison.Ordinal);
         Assert.Contains("Specifies a value for optional count.", markdown, StringComparison.Ordinal);
         Assert.Contains("{{ FulfillmentMode }}", markdown, StringComparison.Ordinal);
         Assert.Contains("{{ FillColor }}", markdown, StringComparison.Ordinal);

--- a/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.cs
+++ b/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.cs
@@ -220,6 +220,89 @@ public sealed partial class ModulePipelineScriptExecutionSeamTests
     }
 
     [Fact]
+    public void Run_DocumentationValidationReceivesAuthoredHelpSnapshot()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var authoredPayload = new DocumentationExtractionPayload
+            {
+                ModuleName = moduleName,
+                Commands =
+                {
+                    new DocumentationCommandHelp
+                    {
+                        Name = "Get-Test",
+                        Parameters =
+                        {
+                            new DocumentationParameterHelp { Name = "Name", Description = string.Empty }
+                        }
+                    }
+                }
+            };
+            var hostedOperations = new FakeHostedOperations
+            {
+                NextAuthoredHelpPayload = authoredPayload
+            };
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationDocumentationSegment
+                    {
+                        Configuration = new DocumentationConfiguration
+                        {
+                            Path = "Docs",
+                            PathReadme = "Docs\\Readme.md"
+                        }
+                    },
+                    new ConfigurationBuildDocumentationSegment
+                    {
+                        Configuration = new BuildDocumentationConfiguration
+                        {
+                            Enable = true,
+                            GenerateExternalHelp = false
+                        }
+                    },
+                    new ConfigurationValidationSegment
+                    {
+                        Settings = new ModuleValidationSettings
+                        {
+                            Enable = true
+                        }
+                    }
+                }
+            };
+
+            var plan = runner.Plan(spec);
+            runner.Run(spec, plan);
+
+            Assert.NotNull(hostedOperations.LastValidationSpec);
+            Assert.Same(authoredPayload, hostedOperations.LastValidationSpec!.AuthoredHelpPayload);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Run_DocumentationGateSyncsRefreshedManifestToProjectRoot()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -584,6 +667,8 @@ public sealed partial class ModulePipelineScriptExecutionSeamTests
         public List<string> OperationOrder { get; } = new();
         public string[] LastDocumentationCommands { get; private set; } = Array.Empty<string>();
         public ArtefactBuildResult[] LastPublishedArtefacts { get; private set; } = Array.Empty<ArtefactBuildResult>();
+        public DocumentationExtractionPayload? NextAuthoredHelpPayload { get; set; }
+        public ModuleValidationSpec? LastValidationSpec { get; private set; }
 
         public IReadOnlyList<ModuleDependencyInstallResult> EnsureDependenciesInstalled(
             ModuleDependency[] dependencies,
@@ -637,11 +722,16 @@ public sealed partial class ModulePipelineScriptExecutionSeamTests
                 exitCode: 0,
                 markdownFiles: LastDocumentationCommands.Length,
                 externalHelpFilePath: string.Empty,
-                errorMessage: null);
+                errorMessage: null,
+                externalHelpFilePaths: Array.Empty<string>(),
+                authoredHelpPayload: NextAuthoredHelpPayload);
         }
 
         public ModuleValidationReport ValidateModule(ModuleValidationSpec spec)
-            => throw new InvalidOperationException("Not used in this test.");
+        {
+            LastValidationSpec = spec;
+            return new ModuleValidationReport(Array.Empty<ModuleValidationCheckResult>());
+        }
 
         public void EnsureBinaryDependenciesValid(string moduleRoot, string powerShellEdition, string? modulePath, string? validationTarget)
             => throw new InvalidOperationException("Not used in this test.");

--- a/PowerForge.Tests/ModuleValidationServiceTests.cs
+++ b/PowerForge.Tests/ModuleValidationServiceTests.cs
@@ -171,6 +171,83 @@ public sealed class ModuleValidationServiceTests
     }
 
     [Fact]
+    public void Run_DocumentationValidation_UsesAuthoredSnapshotInsteadOfRenderedFallbacks()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var manifestPath = Path.Combine(root.FullName, "TestModule.psd1");
+            File.WriteAllText(manifestPath, "@{}");
+
+            var authoredPayload = new DocumentationExtractionPayload
+            {
+                Commands =
+                {
+                    new DocumentationCommandHelp
+                    {
+                        Name = "Get-Thing",
+                        Synopsis = "Gets a thing.",
+                        Description = "Gets a thing.",
+                        Parameters =
+                        {
+                            new DocumentationParameterHelp
+                            {
+                                Name = "Name",
+                                Type = "String",
+                                Description = string.Empty
+                            }
+                        }
+                    }
+                }
+            };
+
+            var settings = new ModuleValidationSettings
+            {
+                Enable = true,
+                Structure = new ModuleStructureValidationSettings { Severity = ValidationSeverity.Off },
+                Documentation = new DocumentationValidationSettings
+                {
+                    Severity = ValidationSeverity.Warning,
+                    MinSynopsisPercent = 100,
+                    MinDescriptionPercent = 100,
+                    MinExampleCountPerCommand = 0,
+                    MinParameterDescriptionPercent = 100
+                },
+                ScriptAnalyzer = new ScriptAnalyzerValidationSettings { Severity = ValidationSeverity.Off },
+                FileIntegrity = new FileIntegrityValidationSettings { Severity = ValidationSeverity.Off },
+                Tests = new TestSuiteValidationSettings { Severity = ValidationSeverity.Off },
+                Binary = new BinaryModuleValidationSettings { Severity = ValidationSeverity.Off },
+                Csproj = new CsprojValidationSettings { Severity = ValidationSeverity.Off }
+            };
+
+            var service = new ModuleValidationService(
+                new NullLogger(),
+                new StubPowerShellRunner(new PowerShellRunResult(1, string.Empty, "must not extract rendered help", TestPowerShellExecutable)));
+
+            var report = service.Run(new ModuleValidationSpec
+            {
+                ProjectRoot = root.FullName,
+                StagingPath = root.FullName,
+                ModuleName = "TestModule",
+                ManifestPath = manifestPath,
+                Settings = settings,
+                AuthoredHelpPayload = authoredPayload
+            });
+
+            var check = Assert.Single(report.Checks);
+            Assert.Equal(CheckStatus.Warning, check.Status);
+            Assert.Contains("parameter docs 0/1", check.Summary, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(
+                check.Issues,
+                issue => issue.Contains("parameter 'Name' is missing description", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Run_DocumentationValidation_TruncatesLongMissingItemLists()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ModuleValidationServiceTests.cs
+++ b/PowerForge.Tests/ModuleValidationServiceTests.cs
@@ -33,7 +33,7 @@ public sealed class ModuleValidationServiceTests
                         Parameters =
                         {
                             new DocumentationParameterHelp { Name = "Name", Description = "Thing name." },
-                            new DocumentationParameterHelp { Name = "Mode", Description = string.Empty }
+                            new DocumentationParameterHelp { Name = "Mode", Description = "{{ Fill Mode Description }}" }
                         },
                         Inputs =
                         {

--- a/PowerForge/Models/DocumentationBuildResult.cs
+++ b/PowerForge/Models/DocumentationBuildResult.cs
@@ -41,6 +41,11 @@ public sealed class DocumentationBuildResult
     public string? ErrorMessage { get; }
 
     /// <summary>
+    /// Help metadata captured before presentation fallbacks are rendered.
+    /// </summary>
+    internal DocumentationExtractionPayload? AuthoredHelpPayload { get; }
+
+    /// <summary>
     /// Creates a new result instance.
     /// </summary>
     public DocumentationBuildResult(
@@ -78,6 +83,31 @@ public sealed class DocumentationBuildResult
         string externalHelpFilePath,
         string? errorMessage,
         IReadOnlyList<string>? externalHelpFilePaths)
+        : this(
+            enabled,
+            docsPath,
+            readmePath,
+            succeeded,
+            exitCode,
+            markdownFiles,
+            externalHelpFilePath,
+            errorMessage,
+            externalHelpFilePaths,
+            authoredHelpPayload: null)
+    {
+    }
+
+    internal DocumentationBuildResult(
+        bool enabled,
+        string docsPath,
+        string readmePath,
+        bool succeeded,
+        int exitCode,
+        int markdownFiles,
+        string externalHelpFilePath,
+        string? errorMessage,
+        IReadOnlyList<string>? externalHelpFilePaths,
+        DocumentationExtractionPayload? authoredHelpPayload)
     {
         Enabled = enabled;
         DocsPath = docsPath;
@@ -91,5 +121,6 @@ public sealed class DocumentationBuildResult
                 ? Array.Empty<string>()
                 : new[] { ExternalHelpFilePath });
         ErrorMessage = errorMessage;
+        AuthoredHelpPayload = authoredHelpPayload;
     }
 }

--- a/PowerForge/Models/ModuleValidationSpec.cs
+++ b/PowerForge/Models/ModuleValidationSpec.cs
@@ -22,4 +22,9 @@ public sealed class ModuleValidationSpec
 
     /// <summary>Validation settings.</summary>
     public ModuleValidationSettings Settings { get; set; } = new();
+
+    /// <summary>
+    /// Help metadata captured before generated presentation fallbacks were written.
+    /// </summary>
+    internal DocumentationExtractionPayload? AuthoredHelpPayload { get; set; }
 }

--- a/PowerForge/Services/Documentation/MamlHelpWriter.cs
+++ b/PowerForge/Services/Documentation/MamlHelpWriter.cs
@@ -317,7 +317,7 @@ internal sealed class MamlHelpWriter
 
         writer.WriteElementString("maml", "name", MamlNs, p.Name.Trim());
         writer.WriteStartElement("maml", "description", MamlNs);
-        WriteParas(writer, p.Description);
+        WriteParas(writer, ParameterDescriptionFallback.Resolve(p.Description, p.Name, p.Type));
         writer.WriteEndElement(); // maml:description
 
         if (includeParameterValue)

--- a/PowerForge/Services/Documentation/MarkdownHelpWriter.cs
+++ b/PowerForge/Services/Documentation/MarkdownHelpWriter.cs
@@ -209,7 +209,7 @@ internal sealed class MarkdownHelpWriter
         {
             var name = p.Name.Trim();
             doc.RawLine($"### -{name}");
-            doc.RawLine(string.IsNullOrWhiteSpace(p.Description) ? $"{{{{ Fill {name} Description }}}}" : p.Description.Trim());
+            doc.RawLine(ParameterDescriptionFallback.Resolve(p.Description, name, p.Type));
             doc.BlankLine();
             doc.CodeFence("yaml", string.Join(Environment.NewLine, new[]
             {

--- a/PowerForge/Services/Documentation/ParameterDescriptionFallback.cs
+++ b/PowerForge/Services/Documentation/ParameterDescriptionFallback.cs
@@ -42,9 +42,16 @@ internal static class ParameterDescriptionFallback
             return true;
 
         var value = description!.Trim();
-        return value.StartsWith("{{", StringComparison.Ordinal) &&
-               value.EndsWith("}}", StringComparison.Ordinal) &&
-               value.IndexOf("Fill", StringComparison.OrdinalIgnoreCase) >= 0;
+        if (!value.StartsWith("{{", StringComparison.Ordinal) ||
+            !value.EndsWith("}}", StringComparison.Ordinal))
+            return false;
+
+        var inner = value.Substring(2, value.Length - 4).Trim();
+        const string prefix = "Fill ";
+        const string suffix = " Description";
+        return inner.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
+               inner.EndsWith(suffix, StringComparison.OrdinalIgnoreCase) &&
+               inner.Length > prefix.Length + suffix.Length;
     }
 
     private static string Create(string parameterName, string? parameterType)
@@ -52,22 +59,23 @@ internal static class ParameterDescriptionFallback
         var words = SplitIdentifier(parameterName).ToLowerInvariant();
         var type = parameterType ?? string.Empty;
 
-        if (type.IndexOf("SwitchParameter", StringComparison.OrdinalIgnoreCase) >= 0)
+        if (IsCollectionType(type))
+            return $"Specifies one or more values for {words}.";
+
+        if (type.Equals("SwitchParameter", StringComparison.OrdinalIgnoreCase) ||
+            type.Equals("System.Management.Automation.SwitchParameter", StringComparison.OrdinalIgnoreCase))
             return $"Specifies the {words} switch.";
 
         if (type.Equals("Boolean", StringComparison.OrdinalIgnoreCase) ||
             type.Equals("Bool", StringComparison.OrdinalIgnoreCase))
             return $"Specifies a Boolean value for {words}.";
 
-        if (IsCollectionType(type))
-            return $"Specifies one or more values for {words}.";
-
         return $"Specifies a value for {words}.";
     }
 
     private static bool IsCollectionType(string type)
     {
-        if (type.EndsWith("[]", StringComparison.Ordinal))
+        if (HasArraySuffix(type))
             return true;
 
         var simpleNameIndex = type.LastIndexOf('.');
@@ -75,6 +83,25 @@ internal static class ParameterDescriptionFallback
         var genericMarker = simpleName.IndexOfAny(new[] { '`', '<' });
         var baseName = genericMarker > 0 ? simpleName.Substring(0, genericMarker) : simpleName;
         return CollectionTypeNames.Contains(baseName);
+    }
+
+    private static bool HasArraySuffix(string type)
+    {
+        if (!type.EndsWith("]", StringComparison.Ordinal))
+            return false;
+
+        var openingBracket = type.LastIndexOf('[');
+        if (openingBracket <= 0)
+            return false;
+
+        for (var index = openingBracket + 1; index < type.Length - 1; index++)
+        {
+            var marker = type[index];
+            if (marker != ',' && marker != '*' && !char.IsWhiteSpace(marker))
+                return false;
+        }
+
+        return true;
     }
 
     private static string SplitIdentifier(string value)

--- a/PowerForge/Services/Documentation/ParameterDescriptionFallback.cs
+++ b/PowerForge/Services/Documentation/ParameterDescriptionFallback.cs
@@ -13,6 +13,7 @@ internal static class ParameterDescriptionFallback
     private static readonly HashSet<string> CollectionTypeNames = new(StringComparer.OrdinalIgnoreCase)
     {
         "Array",
+        "ArrayList",
         "Collection",
         "Dictionary",
         "Hashtable",

--- a/PowerForge/Services/Documentation/ParameterDescriptionFallback.cs
+++ b/PowerForge/Services/Documentation/ParameterDescriptionFallback.cs
@@ -15,6 +15,7 @@ internal static class ParameterDescriptionFallback
         "Array",
         "Collection",
         "Dictionary",
+        "Hashtable",
         "HashSet",
         "ICollection",
         "IDictionary",
@@ -67,7 +68,8 @@ internal static class ParameterDescriptionFallback
             return $"Specifies the {words} switch.";
 
         if (type.Equals("Boolean", StringComparison.OrdinalIgnoreCase) ||
-            type.Equals("Bool", StringComparison.OrdinalIgnoreCase))
+            type.Equals("Bool", StringComparison.OrdinalIgnoreCase) ||
+            type.Equals("System.Boolean", StringComparison.OrdinalIgnoreCase))
             return $"Specifies a Boolean value for {words}.";
 
         return $"Specifies a value for {words}.";

--- a/PowerForge/Services/Documentation/ParameterDescriptionFallback.cs
+++ b/PowerForge/Services/Documentation/ParameterDescriptionFallback.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PowerForge;
+
+/// <summary>
+/// Produces conservative generated help when authored parameter documentation is missing.
+/// Validation still evaluates the authored value; writers use this only as a presentation fallback.
+/// </summary>
+internal static class ParameterDescriptionFallback
+{
+    private static readonly HashSet<string> CollectionTypeNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Array",
+        "Collection",
+        "Dictionary",
+        "HashSet",
+        "ICollection",
+        "IDictionary",
+        "IEnumerable",
+        "IList",
+        "IReadOnlyCollection",
+        "IReadOnlyDictionary",
+        "IReadOnlyList",
+        "List",
+        "Queue",
+        "Stack"
+    };
+
+    internal static string Resolve(string? authoredDescription, string parameterName, string? parameterType)
+    {
+        if (!IsMissingOrPlaceholder(authoredDescription))
+            return authoredDescription!.Trim();
+
+        return Create(parameterName, parameterType);
+    }
+
+    internal static bool IsMissingOrPlaceholder(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+            return true;
+
+        var value = description!.Trim();
+        return value.StartsWith("{{", StringComparison.Ordinal) &&
+               value.EndsWith("}}", StringComparison.Ordinal) &&
+               value.IndexOf("Fill", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static string Create(string parameterName, string? parameterType)
+    {
+        var words = SplitIdentifier(parameterName).ToLowerInvariant();
+        var type = parameterType ?? string.Empty;
+
+        if (type.IndexOf("SwitchParameter", StringComparison.OrdinalIgnoreCase) >= 0)
+            return $"Specifies the {words} switch.";
+
+        if (type.Equals("Boolean", StringComparison.OrdinalIgnoreCase) ||
+            type.Equals("Bool", StringComparison.OrdinalIgnoreCase))
+            return $"Specifies a Boolean value for {words}.";
+
+        if (IsCollectionType(type))
+            return $"Specifies one or more values for {words}.";
+
+        return $"Specifies a value for {words}.";
+    }
+
+    private static bool IsCollectionType(string type)
+    {
+        if (type.EndsWith("[]", StringComparison.Ordinal))
+            return true;
+
+        var simpleNameIndex = type.LastIndexOf('.');
+        var simpleName = simpleNameIndex >= 0 ? type.Substring(simpleNameIndex + 1) : type;
+        var genericMarker = simpleName.IndexOfAny(new[] { '`', '<' });
+        var baseName = genericMarker > 0 ? simpleName.Substring(0, genericMarker) : simpleName;
+        return CollectionTypeNames.Contains(baseName);
+    }
+
+    private static string SplitIdentifier(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return "parameter";
+
+        var builder = new StringBuilder(value.Length + 8);
+        for (var index = 0; index < value.Length; index++)
+        {
+            var current = value[index];
+            if (index > 0 && char.IsUpper(current))
+            {
+                var previous = value[index - 1];
+                var nextIsLower = index + 1 < value.Length && char.IsLower(value[index + 1]);
+                if (char.IsLower(previous) || char.IsDigit(previous) || (char.IsUpper(previous) && nextIsLower))
+                    builder.Append(' ');
+            }
+
+            builder.Append(current);
+        }
+
+        return builder.ToString();
+    }
+}


### PR DESCRIPTION
## Summary

PowerForge now produces conservative, readable parameter help when authored descriptions are missing or still contain generated placeholders.

- use the same fallback descriptions in Markdown and MAML help
- preserve authored descriptions and validation coverage separately from generated presentation fallbacks
- distinguish switches, Boolean values, hashtables, ArrayLists, arrays, collections, and scalar values without guessing parameter semantics
- treat only the known generated description placeholder grammar as missing

## Why this matters

Binary PowerShell modules can generate complete command help from compiled metadata without shipping placeholder text. Generated Markdown and `Get-Help` output stay aligned, while documentation coverage gates continue measuring authored help rather than text synthesized during the build.

## Validation

The final candidate passed 163 affected documentation, generation, pipeline, validation, and configuration tests. PowerForge, PowerForge.PowerShell, and PSPublishModule also build for net472 with zero warnings and zero errors.

One unrelated origin/main documentation fixture remains excluded because its PowerShell metadata collector can hang inside `ConvertTo-Json`; this PR does not change that collector path.