### PR TITLE
fix: support PowerShell 7.0 ALC loader packages

### DIFF
--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -223,6 +223,57 @@ public class ModuleBootstrapperGeneratorTests
     }
 
     [Fact]
+    public void ResolveAssemblyLoadContextTargetFramework_UsesPowerShell70BaselineForNetStandard21()
+    {
+        var framework = ModuleBootstrapperGenerator.ResolveAssemblyLoadContextTargetFramework(new[] { "net472", "netstandard2.1", "net8.0-windows" });
+
+        Assert.Equal("netcoreapp3.1", framework);
+    }
+
+    [Fact]
+    public void ResolveAssemblyLoadContextTargetFramework_IgnoresNetCoreAppBeforeAssemblyDependencyResolver()
+    {
+        var framework = ModuleBootstrapperGenerator.ResolveAssemblyLoadContextTargetFramework(new[] { "netcoreapp2.1", "net8.0" });
+
+        Assert.Equal("net8.0", framework);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Generate_WithNetStandard21_WritesPowerShell70CompatibleAssemblyLoadContextLoader()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-ps70-alc-" + Guid.NewGuid().ToString("N"));
+        var coreRoot = Path.Combine(root, "Lib", "Core");
+        Directory.CreateDirectory(coreRoot);
+        File.WriteAllText(Path.Combine(coreRoot, "DemoModule.dll"), string.Empty);
+
+        try
+        {
+            var exports = new ExportSet(Array.Empty<string>(), new[] { "Get-Demo" }, Array.Empty<string>());
+            ModuleBootstrapperGenerator.Generate(
+                root,
+                "DemoModule",
+                exports,
+                new[] { "DemoModule.dll" },
+                handleRuntimes: false,
+                useAssemblyLoadContext: true,
+                targetFrameworks: new[] { "net8.0", "netstandard2.1", "net472" });
+
+            var loaderPath = Path.Combine(coreRoot, "DemoModule.ModuleLoadContext.dll");
+            Assert.True(File.Exists(loaderPath));
+            Assert.Contains(
+                ".NETCoreApp,Version=v3.1",
+                System.Text.Encoding.UTF8.GetString(File.ReadAllBytes(loaderPath)),
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void ResolveAssemblyLoadContextTargetFramework_DefaultsToNet8WhenNoModernFrameworkIsKnown()
     {
         var framework = ModuleBootstrapperGenerator.ResolveAssemblyLoadContextTargetFramework(new[] { "net472", "netstandard2.0" });
@@ -326,7 +377,7 @@ public class ModuleBootstrapperGeneratorTests
         Assert.Contains("TryLoadPackagedNativeLibrary", source);
         Assert.Contains("Path.Combine(_assemblyDirectory, \"runtimes\", rid, \"native\", fileName)", source);
         Assert.Contains("RuntimeInformation.ProcessArchitecture", source);
-        Assert.Contains("RuntimeInformation.RuntimeIdentifier", source);
+        Assert.Contains("GetProperty(\"RuntimeIdentifier\", BindingFlags.Public | BindingFlags.Static)", source);
         Assert.Contains("LoadUnmanagedDllFromPath(path)", source);
         Assert.Contains("BadImageFormatException || ex is DllNotFoundException || ex is FileLoadException", source);
         Assert.Contains("yield return \"win-\" + arch", source);

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -551,7 +551,22 @@ internal static partial class ModuleBootstrapperGenerator
         if (platformIndex >= 0)
             normalized = normalized.Substring(0, platformIndex);
 
-        return TryGetNetTfmVersion(normalized, out _) ? normalized : null;
+        // PowerShell 7.0 runs on .NET Core 3.1. A netstandard2.1 module payload
+        // explicitly promises compatibility with that host, so compile the small
+        // module-scoped loader against the matching runtime baseline as well.
+        if (normalized.Equals("netstandard2.1", StringComparison.OrdinalIgnoreCase))
+            return "netcoreapp3.1";
+
+        if (!TryGetNetTfmVersion(normalized, out var version))
+            return null;
+
+        if (normalized.StartsWith("netcoreapp", StringComparison.OrdinalIgnoreCase) &&
+            version < new Version(3, 0))
+        {
+            return null;
+        }
+
+        return normalized;
     }
 
     private static Version GetNetTfmVersion(string framework)
@@ -560,17 +575,24 @@ internal static partial class ModuleBootstrapperGenerator
     private static bool TryGetNetTfmVersion(string framework, out Version version)
     {
         version = new Version(0, 0);
-        if (string.IsNullOrWhiteSpace(framework) ||
-            !framework.StartsWith("net", StringComparison.OrdinalIgnoreCase) ||
-            framework.StartsWith("netstandard", StringComparison.OrdinalIgnoreCase) ||
-            framework.Length < 5 ||
-            !char.IsDigit(framework[3]))
+        if (string.IsNullOrWhiteSpace(framework))
         {
             return false;
         }
 
-        if (!Version.TryParse(framework.Substring(3), out var parsed))
+        var versionStart = framework.StartsWith("netcoreapp", StringComparison.OrdinalIgnoreCase)
+            ? "netcoreapp".Length
+            : framework.StartsWith("net", StringComparison.OrdinalIgnoreCase) &&
+              !framework.StartsWith("netstandard", StringComparison.OrdinalIgnoreCase)
+                ? "net".Length
+                : -1;
+        if (versionStart < 0 ||
+            framework.Length <= versionStart ||
+            !char.IsDigit(framework[versionStart]) ||
+            !Version.TryParse(framework.Substring(versionStart), out var parsed))
+        {
             return false;
+        }
 
         version = parsed;
         return true;
@@ -1027,7 +1049,9 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
 
     private static IEnumerable<string> GetRuntimeIdentifiers()
     {{
-        var runtimeIdentifier = RuntimeInformation.RuntimeIdentifier ?? string.Empty;
+        var runtimeIdentifier = typeof(RuntimeInformation)
+            .GetProperty(""RuntimeIdentifier"", BindingFlags.Public | BindingFlags.Static)?
+            .GetValue(null) as string ?? string.Empty;
         if (!string.IsNullOrWhiteSpace(runtimeIdentifier))
             yield return runtimeIdentifier;
 


### PR DESCRIPTION
## Summary

- compile generated module-scoped AssemblyLoadContext loaders against .NET Core 3.1 when a module ships a netstandard2.1 payload
- keep runtime identifier probing compatible with PowerShell 7.0 while preserving newer-host behavior
- reject netcoreapp targets older than the AssemblyDependencyResolver contract

## Validation

- 33 focused ModuleBootstrapperGenerator tests pass
- a packed EventViewerX module imports under Windows PowerShell 5.1 and PowerShell 7.0.13
- both hosts return matching direct/parallel real-EVTX results and complete SQLite write/read validation

No packages were published.