### PR TITLE
Update EventViewerX example path

### DIFF
--- a/Module/Examples/Example.CmdletAliasDetection.ps1
+++ b/Module/Examples/Example.CmdletAliasDetection.ps1
@@ -2,5 +2,5 @@
 
 #Get-PowerShellAssemblyMetadata -Path "C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.PowerShell\bin\Release\net472\Mailozaurr.PowerShell.dll" | Format-Table
 #Get-PowerShellAssemblyMetadata -Path "C:\Support\GitHub\Mailozaurr\Sources\Mailozaurr.PowerShell\bin\Release\net7.0\Mailozaurr.PowerShell.dll"
-#Get-PowerShellAssemblyMetadata -Path "C:\Support\GitHub\PSEventViewer\Sources\PSEventViewer\bin\Debug\net6.0\PSEventViewer.dll" | Format-Table
-Get-PowerShellAssemblyMetadata -Path "C:\Support\GitHub\PSEventViewer\Sources\PSEventViewer\bin\Debug\net472\PSEventViewer.dll" -Verbose | Format-Table
+#Get-PowerShellAssemblyMetadata -Path "C:\Support\GitHub\EventViewerX\Sources\PSEventViewer\bin\Debug\net8.0-windows\PSEventViewer.dll" | Format-Table
+Get-PowerShellAssemblyMetadata -Path "C:\Support\GitHub\EventViewerX\Sources\PSEventViewer\bin\Debug\net472\PSEventViewer.dll" -Verbose | Format-Table


### PR DESCRIPTION
## Summary

- update the cmdlet metadata example to use the canonical local `EventViewerX` checkout
- update the modern example target from the retired `net6.0` path to `net8.0-windows`

## Validation

- parsed the changed PowerShell example successfully