### PR TITLE
Fix project telemetry matching through aliases

### DIFF
--- a/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
@@ -596,8 +596,8 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                   },
                   "nuget": {
                     "owner": "EvotecIT",
-                    "packageCount": 9,
-                    "totalDownloads": 5600,
+                    "packageCount": 12,
+                    "totalDownloads": 10400,
                     "packages": [
                       {
                         "id": "Current.Core",
@@ -659,13 +659,31 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                         "version": "1.0.0",
                         "totalDownloads": 1200,
                         "packageUrl": "https://www.nuget.org/packages/Target.Package"
+                      },
+                      {
+                        "id": "Security Policy",
+                        "version": "1.0.0",
+                        "totalDownloads": 1500,
+                        "packageUrl": "https://www.nuget.org/packages/Security%20Policy"
+                      },
+                      {
+                        "id": "Ambiguous-One",
+                        "version": "1.0.0",
+                        "totalDownloads": 1600,
+                        "packageUrl": "https://www.nuget.org/packages/Ambiguous-One"
+                      },
+                      {
+                        "id": "Ambiguous.One",
+                        "version": "1.0.0",
+                        "totalDownloads": 1700,
+                        "packageUrl": "https://www.nuget.org/packages/Ambiguous.One"
                       }
                     ]
                   },
                   "powerShellGallery": {
                     "owner": "Przemyslaw.Klys",
-                    "moduleCount": 2,
-                    "totalDownloads": 2700,
+                    "moduleCount": 4,
+                    "totalDownloads": 6400,
                     "modules": [
                       {
                         "id": "TargetModule",
@@ -678,6 +696,18 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                         "version": "1.0.0",
                         "downloadCount": 1400,
                         "galleryUrl": "https://www.powershellgallery.com/packages/Target.Module"
+                      },
+                      {
+                        "id": "Ambiguous-One",
+                        "version": "1.0.0",
+                        "downloadCount": 1800,
+                        "galleryUrl": "https://www.powershellgallery.com/packages/Ambiguous-One"
+                      },
+                      {
+                        "id": "Ambiguous.One",
+                        "version": "1.0.0",
+                        "downloadCount": 1900,
+                        "galleryUrl": "https://www.powershellgallery.com/packages/Ambiguous.One"
                       }
                     ]
                   },
@@ -716,6 +746,24 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                       "name": "Renamed Exact Variant Product",
                       "githubRepo": "EvotecIT/RenamedExactVariantRepo",
                       "aliases": ["/projects/target-package/", "/projects/target-module/"]
+                    },
+                    {
+                      "slug": "renamed-literal-priority",
+                      "name": "TargetPackage",
+                      "githubRepo": "EvotecIT/RenamedLiteralPriorityRepo",
+                      "aliases": ["/projects/target-package/"]
+                    },
+                    {
+                      "slug": "renamed-percent-encoded",
+                      "name": "Renamed Percent Encoded Product",
+                      "githubRepo": "EvotecIT/RenamedPercentEncodedRepo",
+                      "aliases": ["/projects/security%20policy/"]
+                    },
+                    {
+                      "slug": "renamed-compact-ambiguous",
+                      "name": "Renamed Compact Ambiguous Product",
+                      "githubRepo": "EvotecIT/RenamedCompactAmbiguousRepo",
+                      "aliases": ["/projects/ambiguous_one/"]
                     }
                   ]
                 }
@@ -727,7 +775,7 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
 
             var args = new object?[] { statsPath, catalogPath, publishedCatalogPath, null };
             var merged = Assert.IsType<int>(syncMethod!.Invoke(null, args));
-            Assert.Equal(5, merged);
+            Assert.Equal(7, merged);
             Assert.Null(args[3]);
 
             using var catalog = JsonDocument.Parse(File.ReadAllText(catalogPath));
@@ -761,6 +809,16 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
             Assert.Equal(1200L, renamedExactVariants.GetProperty("nuget").GetProperty("totalDownloads").GetInt64());
             Assert.Equal("Target.Module", renamedExactVariants.GetProperty("powerShellGallery").GetProperty("id").GetString());
             Assert.Equal(1400L, renamedExactVariants.GetProperty("powerShellGallery").GetProperty("totalDownloads").GetInt64());
+
+            var renamedLiteralPriority = projectsBySlug["renamed-literal-priority"].GetProperty("metrics").GetProperty("nuget");
+            Assert.Equal("TargetPackage", renamedLiteralPriority.GetProperty("id").GetString());
+            Assert.Equal(1100L, renamedLiteralPriority.GetProperty("totalDownloads").GetInt64());
+
+            var renamedPercentEncoded = projectsBySlug["renamed-percent-encoded"].GetProperty("metrics").GetProperty("nuget");
+            Assert.Equal("Security Policy", renamedPercentEncoded.GetProperty("id").GetString());
+            Assert.Equal(1500L, renamedPercentEncoded.GetProperty("totalDownloads").GetInt64());
+
+            Assert.Equal(JsonValueKind.Null, projectsBySlug["renamed-compact-ambiguous"].GetProperty("metrics").ValueKind);
             Assert.True(File.Exists(publishedCatalogPath));
         }
         finally

--- a/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
@@ -561,8 +561,8 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                 {
                   "nuget": {
                     "owner": "EvotecIT",
-                    "packageCount": 7,
-                    "totalDownloads": 3300,
+                    "packageCount": 9,
+                    "totalDownloads": 5600,
                     "packages": [
                       {
                         "id": "Current.Core",
@@ -612,6 +612,37 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                         "totalDownloads": 700,
                         "packageUrl": "https://www.nuget.org/packages/Slashless.Core",
                         "projectUrl": "https://github.com/Owner/Slashless"
+                      },
+                      {
+                        "id": "TargetPackage",
+                        "version": "1.0.0",
+                        "totalDownloads": 1100,
+                        "packageUrl": "https://www.nuget.org/packages/TargetPackage"
+                      },
+                      {
+                        "id": "Target.Package",
+                        "version": "1.0.0",
+                        "totalDownloads": 1200,
+                        "packageUrl": "https://www.nuget.org/packages/Target.Package"
+                      }
+                    ]
+                  },
+                  "powerShellGallery": {
+                    "owner": "Przemyslaw.Klys",
+                    "moduleCount": 2,
+                    "totalDownloads": 2700,
+                    "modules": [
+                      {
+                        "id": "TargetModule",
+                        "version": "1.0.0",
+                        "downloadCount": 1300,
+                        "galleryUrl": "https://www.powershellgallery.com/packages/TargetModule"
+                      },
+                      {
+                        "id": "Target.Module",
+                        "version": "1.0.0",
+                        "downloadCount": 1400,
+                        "galleryUrl": "https://www.powershellgallery.com/packages/Target.Module"
                       }
                     ]
                   },
@@ -644,6 +675,12 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                       "name": "Renamed Slashless Product",
                       "githubRepo": "EvotecIT/RenamedSlashlessRepo",
                       "aliases": ["slashless.html"]
+                    },
+                    {
+                      "slug": "renamed-exact-variants",
+                      "name": "Renamed Exact Variant Product",
+                      "githubRepo": "EvotecIT/RenamedExactVariantRepo",
+                      "aliases": ["/projects/target-package/", "/projects/target-module/"]
                     }
                   ]
                 }
@@ -655,26 +692,37 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
 
             var args = new object?[] { statsPath, catalogPath, publishedCatalogPath, null };
             var merged = Assert.IsType<int>(syncMethod!.Invoke(null, args));
-            Assert.Equal(4, merged);
+            Assert.Equal(5, merged);
             Assert.Null(args[3]);
 
             using var catalog = JsonDocument.Parse(File.ReadAllText(catalogPath));
             var projects = catalog.RootElement.GetProperty("projects");
-            var current = projects[0].GetProperty("metrics").GetProperty("nuget");
+            var projectsBySlug = projects.EnumerateArray()
+                .ToDictionary(
+                    static project => project.GetProperty("slug").GetString()!,
+                    static project => project,
+                    StringComparer.OrdinalIgnoreCase);
+            var current = projectsBySlug["legacyrepo"].GetProperty("metrics").GetProperty("nuget");
             Assert.Equal(1, current.GetProperty("packageCount").GetInt32());
             Assert.Equal(400L, current.GetProperty("totalDownloads").GetInt64());
 
-            var renamed = projects[1].GetProperty("metrics").GetProperty("nuget");
+            var renamed = projectsBySlug["renamed"].GetProperty("metrics").GetProperty("nuget");
             Assert.Equal(1, renamed.GetProperty("packageCount").GetInt32());
             Assert.Equal(100L, renamed.GetProperty("totalDownloads").GetInt64());
 
-            var renamedSeparators = projects[2].GetProperty("metrics").GetProperty("nuget");
+            var renamedSeparators = projectsBySlug["renamed-separators"].GetProperty("metrics").GetProperty("nuget");
             Assert.Equal(1, renamedSeparators.GetProperty("packageCount").GetInt32());
             Assert.Equal(500L, renamedSeparators.GetProperty("totalDownloads").GetInt64());
 
-            var renamedSlashless = projects[3].GetProperty("metrics").GetProperty("nuget");
+            var renamedSlashless = projectsBySlug["renamed-slashless"].GetProperty("metrics").GetProperty("nuget");
             Assert.Equal(1, renamedSlashless.GetProperty("packageCount").GetInt32());
             Assert.Equal(700L, renamedSlashless.GetProperty("totalDownloads").GetInt64());
+
+            var renamedExactVariants = projectsBySlug["renamed-exact-variants"].GetProperty("metrics");
+            Assert.Equal("Target.Package", renamedExactVariants.GetProperty("nuget").GetProperty("id").GetString());
+            Assert.Equal(1200L, renamedExactVariants.GetProperty("nuget").GetProperty("totalDownloads").GetInt64());
+            Assert.Equal("Target.Module", renamedExactVariants.GetProperty("powerShellGallery").GetProperty("id").GetString());
+            Assert.Equal(1400L, renamedExactVariants.GetProperty("powerShellGallery").GetProperty("totalDownloads").GetInt64());
             Assert.True(File.Exists(publishedCatalogPath));
         }
         finally

--- a/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
@@ -482,7 +482,7 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                         "version": "1.0.0",
                         "totalDownloads": 200,
                         "packageUrl": "https://www.nuget.org/packages/SecurityPolicy.Core",
-                        "projectUrl": "https://github.com/EvotecIT/SecurityPolicy"
+                        "projectUrl": "https://github.com/EvotecIT/SecurityPolicy.git"
                       }
                     ]
                   },

--- a/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
@@ -337,7 +337,7 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                       "slug": "securitypolicyx",
                       "name": "SecurityPolicyX",
                       "githubRepo": "EvotecIT/SecurityPolicyX",
-                      "aliases": ["/projects/securitypolicy/"],
+                      "aliases": ["/projects/securitypolicy/?ref=legacy"],
                       "links": {
                         "powerShellGallery": "https://www.powershellgallery.com/packages/SecurityPolicy"
                       },
@@ -465,6 +465,27 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                       }
                     ]
                   },
+                  "nuget": {
+                    "owner": "EvotecIT",
+                    "packageCount": 2,
+                    "totalDownloads": 300,
+                    "packages": [
+                      {
+                        "id": "SecurityPolicy",
+                        "version": "1.0.0",
+                        "totalDownloads": 100,
+                        "packageUrl": "https://www.nuget.org/packages/SecurityPolicy",
+                        "projectUrl": "https://github.com/EvotecIT/SecurityPolicy"
+                      },
+                      {
+                        "id": "SecurityPolicy.Core",
+                        "version": "1.0.0",
+                        "totalDownloads": 200,
+                        "packageUrl": "https://www.nuget.org/packages/SecurityPolicy.Core",
+                        "projectUrl": "https://github.com/EvotecIT/SecurityPolicy"
+                      }
+                    ]
+                  },
                   "warnings": []
                 }
                 """);
@@ -477,7 +498,7 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                       "slug": "securitypolicyx",
                       "name": "SecurityPolicyX",
                       "githubRepo": "EvotecIT/SecurityPolicyX",
-                      "aliases": ["/projects/securitypolicy/"],
+                      "aliases": ["/projects/securitypolicy/?ref=legacy"],
                       "links": {
                         "powerShellGallery": "https://www.powershellgallery.com/packages/SecurityPolicy"
                       },
@@ -513,7 +534,9 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
             var project = catalog.RootElement.GetProperty("projects")[0];
             Assert.Equal(42, project.GetProperty("metrics").GetProperty("github").GetProperty("stars").GetInt32());
             Assert.Equal(123456L, project.GetProperty("metrics").GetProperty("powerShellGallery").GetProperty("totalDownloads").GetInt64());
-            Assert.Equal(123456L, project.GetProperty("metrics").GetProperty("downloads").GetProperty("total").GetInt64());
+            Assert.Equal(2, project.GetProperty("metrics").GetProperty("nuget").GetProperty("packageCount").GetInt32());
+            Assert.Equal(300L, project.GetProperty("metrics").GetProperty("nuget").GetProperty("totalDownloads").GetInt64());
+            Assert.Equal(123756L, project.GetProperty("metrics").GetProperty("downloads").GetProperty("total").GetInt64());
             Assert.True(File.Exists(publishedCatalogPath));
         }
         finally

--- a/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
@@ -334,9 +334,10 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                   "generatedOn": "2026-03-02T00:00:00.0000000Z",
                   "projects": [
                     {
-                      "slug": "securitypolicy",
-                      "name": "SecurityPolicy",
-                      "githubRepo": "EvotecIT/SecurityPolicy",
+                      "slug": "securitypolicyx",
+                      "name": "SecurityPolicyX",
+                      "githubRepo": "EvotecIT/SecurityPolicyX",
+                      "aliases": ["SecurityPolicy"],
                       "links": {
                         "powerShellGallery": "https://www.powershellgallery.com/packages/SecurityPolicy"
                       },
@@ -473,9 +474,10 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                   "generatedOn": "2026-03-02T00:00:00.0000000Z",
                   "projects": [
                     {
-                      "slug": "securitypolicy",
-                      "name": "SecurityPolicy",
-                      "githubRepo": "EvotecIT/SecurityPolicy",
+                      "slug": "securitypolicyx",
+                      "name": "SecurityPolicyX",
+                      "githubRepo": "EvotecIT/SecurityPolicyX",
+                      "aliases": ["SecurityPolicy"],
                       "links": {
                         "powerShellGallery": "https://www.powershellgallery.com/packages/SecurityPolicy"
                       },

--- a/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
@@ -559,6 +559,41 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
             File.WriteAllText(statsPath,
                 """
                 {
+                  "gitHub": {
+                    "organization": "EvotecIT",
+                    "repositoryCount": 3,
+                    "totalStars": 60,
+                    "totalForks": 6,
+                    "repositories": [
+                      {
+                        "name": "CurrentRepo",
+                        "fullName": "EvotecIT/CurrentRepo",
+                        "url": "https://github.com/EvotecIT/CurrentRepo",
+                        "stars": 30,
+                        "forks": 3,
+                        "watchers": 4,
+                        "openIssues": 1
+                      },
+                      {
+                        "name": "SharedRepo",
+                        "fullName": "OwnerA/SharedRepo",
+                        "url": "https://github.com/OwnerA/SharedRepo",
+                        "stars": 10,
+                        "forks": 1,
+                        "watchers": 2,
+                        "openIssues": 1
+                      },
+                      {
+                        "name": "SharedRepo",
+                        "fullName": "OwnerB/SharedRepo",
+                        "url": "https://github.com/OwnerB/SharedRepo",
+                        "stars": 20,
+                        "forks": 2,
+                        "watchers": 3,
+                        "openIssues": 1
+                      }
+                    ]
+                  },
                   "nuget": {
                     "owner": "EvotecIT",
                     "packageCount": 9,
@@ -705,10 +740,13 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
             var current = projectsBySlug["legacyrepo"].GetProperty("metrics").GetProperty("nuget");
             Assert.Equal(1, current.GetProperty("packageCount").GetInt32());
             Assert.Equal(400L, current.GetProperty("totalDownloads").GetInt64());
+            Assert.Equal(30, projectsBySlug["legacyrepo"].GetProperty("metrics").GetProperty("github").GetProperty("stars").GetInt32());
 
-            var renamed = projectsBySlug["renamed"].GetProperty("metrics").GetProperty("nuget");
+            var renamedMetrics = projectsBySlug["renamed"].GetProperty("metrics");
+            var renamed = renamedMetrics.GetProperty("nuget");
             Assert.Equal(1, renamed.GetProperty("packageCount").GetInt32());
             Assert.Equal(100L, renamed.GetProperty("totalDownloads").GetInt64());
+            Assert.Equal(JsonValueKind.Null, renamedMetrics.GetProperty("github").ValueKind);
 
             var renamedSeparators = projectsBySlug["renamed-separators"].GetProperty("metrics").GetProperty("nuget");
             Assert.Equal(1, renamedSeparators.GetProperty("packageCount").GetInt32());

--- a/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
@@ -337,7 +337,7 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                       "slug": "securitypolicyx",
                       "name": "SecurityPolicyX",
                       "githubRepo": "EvotecIT/SecurityPolicyX",
-                      "aliases": ["https://legacy.evotec.example/projects/securitypolicy/?ref=legacy"],
+                      "aliases": ["https://legacy.evotec.example/projects/securitypolicy.html?ref=legacy"],
                       "links": {
                         "powerShellGallery": "https://www.powershellgallery.com/packages/SecurityPolicy"
                       },
@@ -561,8 +561,8 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                 {
                   "nuget": {
                     "owner": "EvotecIT",
-                    "packageCount": 4,
-                    "totalDownloads": 1500,
+                    "packageCount": 6,
+                    "totalDownloads": 2600,
                     "packages": [
                       {
                         "id": "Current.Core",
@@ -591,6 +591,20 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                         "totalDownloads": 200,
                         "packageUrl": "https://www.nuget.org/packages/SharedRepo.Core",
                         "projectUrl": "https://github.com/OwnerB/SharedRepo"
+                      },
+                      {
+                        "id": "FooDash.Core",
+                        "version": "1.0.0",
+                        "totalDownloads": 500,
+                        "packageUrl": "https://www.nuget.org/packages/FooDash.Core",
+                        "projectUrl": "https://github.com/Owner/Foo-Bar"
+                      },
+                      {
+                        "id": "FooDot.Core",
+                        "version": "1.0.0",
+                        "totalDownloads": 600,
+                        "packageUrl": "https://www.nuget.org/packages/FooDot.Core",
+                        "projectUrl": "https://github.com/Owner/Foo.Bar"
                       }
                     ]
                   },
@@ -611,6 +625,12 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                       "name": "Renamed Product",
                       "githubRepo": "EvotecIT/RenamedRepo",
                       "aliases": ["/projects/sharedrepo/"]
+                    },
+                    {
+                      "slug": "renamed-separators",
+                      "name": "Renamed Separator Product",
+                      "githubRepo": "EvotecIT/RenamedSeparatorRepo",
+                      "aliases": ["/projects/foo-bar/"]
                     }
                   ]
                 }
@@ -622,7 +642,7 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
 
             var args = new object?[] { statsPath, catalogPath, publishedCatalogPath, null };
             var merged = Assert.IsType<int>(syncMethod!.Invoke(null, args));
-            Assert.Equal(2, merged);
+            Assert.Equal(3, merged);
             Assert.Null(args[3]);
 
             using var catalog = JsonDocument.Parse(File.ReadAllText(catalogPath));
@@ -634,6 +654,10 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
             var renamed = projects[1].GetProperty("metrics").GetProperty("nuget");
             Assert.Equal(1, renamed.GetProperty("packageCount").GetInt32());
             Assert.Equal(100L, renamed.GetProperty("totalDownloads").GetInt64());
+
+            var renamedSeparators = projects[2].GetProperty("metrics").GetProperty("nuget");
+            Assert.Equal(1, renamedSeparators.GetProperty("packageCount").GetInt32());
+            Assert.Equal(500L, renamedSeparators.GetProperty("totalDownloads").GetInt64());
             Assert.True(File.Exists(publishedCatalogPath));
         }
         finally

--- a/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
@@ -337,7 +337,7 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                       "slug": "securitypolicyx",
                       "name": "SecurityPolicyX",
                       "githubRepo": "EvotecIT/SecurityPolicyX",
-                      "aliases": ["/projects/securitypolicy/?ref=legacy"],
+                      "aliases": ["https://legacy.evotec.example/projects/securitypolicy/?ref=legacy"],
                       "links": {
                         "powerShellGallery": "https://www.powershellgallery.com/packages/SecurityPolicy"
                       },
@@ -537,6 +537,103 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
             Assert.Equal(2, project.GetProperty("metrics").GetProperty("nuget").GetProperty("packageCount").GetInt32());
             Assert.Equal(300L, project.GetProperty("metrics").GetProperty("nuget").GetProperty("totalDownloads").GetInt64());
             Assert.Equal(123756L, project.GetProperty("metrics").GetProperty("downloads").GetProperty("total").GetInt64());
+            Assert.True(File.Exists(publishedCatalogPath));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void SyncProjectCatalogTelemetryFromStats_DoesNotAggregateNuGetRepositoryNameCollisions()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-ecosystem-catalog-repo-collisions-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var statsPath = Path.Combine(root, "stats.json");
+            var catalogPath = Path.Combine(root, "catalog.json");
+            var publishedCatalogPath = Path.Combine(root, "published-catalog.json");
+            File.WriteAllText(statsPath,
+                """
+                {
+                  "nuget": {
+                    "owner": "EvotecIT",
+                    "packageCount": 4,
+                    "totalDownloads": 1500,
+                    "packages": [
+                      {
+                        "id": "Current.Core",
+                        "version": "1.0.0",
+                        "totalDownloads": 400,
+                        "packageUrl": "https://www.nuget.org/packages/Current.Core",
+                        "projectUrl": "https://github.com/EvotecIT/CurrentRepo"
+                      },
+                      {
+                        "id": "Collision.Core",
+                        "version": "1.0.0",
+                        "totalDownloads": 800,
+                        "packageUrl": "https://www.nuget.org/packages/Collision.Core",
+                        "projectUrl": "https://github.com/OtherOwner/LegacyRepo"
+                      },
+                      {
+                        "id": "SharedRepo",
+                        "version": "1.0.0",
+                        "totalDownloads": 100,
+                        "packageUrl": "https://www.nuget.org/packages/SharedRepo",
+                        "projectUrl": "https://github.com/OwnerA/SharedRepo"
+                      },
+                      {
+                        "id": "SharedRepo.Core",
+                        "version": "1.0.0",
+                        "totalDownloads": 200,
+                        "packageUrl": "https://www.nuget.org/packages/SharedRepo.Core",
+                        "projectUrl": "https://github.com/OwnerB/SharedRepo"
+                      }
+                    ]
+                  },
+                  "warnings": []
+                }
+                """);
+            File.WriteAllText(catalogPath,
+                """
+                {
+                  "projects": [
+                    {
+                      "slug": "legacyrepo",
+                      "name": "Current Product",
+                      "githubRepo": "EvotecIT/CurrentRepo"
+                    },
+                    {
+                      "slug": "renamed",
+                      "name": "Renamed Product",
+                      "githubRepo": "EvotecIT/RenamedRepo",
+                      "aliases": ["/projects/sharedrepo/"]
+                    }
+                  ]
+                }
+                """);
+
+            var syncMethod = typeof(WebPipelineRunner)
+                .GetMethod("SyncProjectCatalogTelemetryFromStats", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            Assert.NotNull(syncMethod);
+
+            var args = new object?[] { statsPath, catalogPath, publishedCatalogPath, null };
+            var merged = Assert.IsType<int>(syncMethod!.Invoke(null, args));
+            Assert.Equal(2, merged);
+            Assert.Null(args[3]);
+
+            using var catalog = JsonDocument.Parse(File.ReadAllText(catalogPath));
+            var projects = catalog.RootElement.GetProperty("projects");
+            var current = projects[0].GetProperty("metrics").GetProperty("nuget");
+            Assert.Equal(1, current.GetProperty("packageCount").GetInt32());
+            Assert.Equal(400L, current.GetProperty("totalDownloads").GetInt64());
+
+            var renamed = projects[1].GetProperty("metrics").GetProperty("nuget");
+            Assert.Equal(1, renamed.GetProperty("packageCount").GetInt32());
+            Assert.Equal(100L, renamed.GetProperty("totalDownloads").GetInt64());
             Assert.True(File.Exists(publishedCatalogPath));
         }
         finally

--- a/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
@@ -498,7 +498,7 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                       "slug": "securitypolicyx",
                       "name": "SecurityPolicyX",
                       "githubRepo": "EvotecIT/SecurityPolicyX",
-                      "aliases": ["/projects/securitypolicy/?ref=legacy"],
+                      "aliases": ["/projects/securitypolicy/index.html?ref=legacy"],
                       "links": {
                         "powerShellGallery": "https://www.powershellgallery.com/packages/SecurityPolicy"
                       },

--- a/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
@@ -561,8 +561,8 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                 {
                   "nuget": {
                     "owner": "EvotecIT",
-                    "packageCount": 6,
-                    "totalDownloads": 2600,
+                    "packageCount": 7,
+                    "totalDownloads": 3300,
                     "packages": [
                       {
                         "id": "Current.Core",
@@ -605,6 +605,13 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                         "totalDownloads": 600,
                         "packageUrl": "https://www.nuget.org/packages/FooDot.Core",
                         "projectUrl": "https://github.com/Owner/Foo.Bar"
+                      },
+                      {
+                        "id": "Slashless.Core",
+                        "version": "1.0.0",
+                        "totalDownloads": 700,
+                        "packageUrl": "https://www.nuget.org/packages/Slashless.Core",
+                        "projectUrl": "https://github.com/Owner/Slashless"
                       }
                     ]
                   },
@@ -631,6 +638,12 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                       "name": "Renamed Separator Product",
                       "githubRepo": "EvotecIT/RenamedSeparatorRepo",
                       "aliases": ["/projects/foo-bar/"]
+                    },
+                    {
+                      "slug": "renamed-slashless",
+                      "name": "Renamed Slashless Product",
+                      "githubRepo": "EvotecIT/RenamedSlashlessRepo",
+                      "aliases": ["slashless.html"]
                     }
                   ]
                 }
@@ -642,7 +655,7 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
 
             var args = new object?[] { statsPath, catalogPath, publishedCatalogPath, null };
             var merged = Assert.IsType<int>(syncMethod!.Invoke(null, args));
-            Assert.Equal(3, merged);
+            Assert.Equal(4, merged);
             Assert.Null(args[3]);
 
             using var catalog = JsonDocument.Parse(File.ReadAllText(catalogPath));
@@ -658,6 +671,10 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
             var renamedSeparators = projects[2].GetProperty("metrics").GetProperty("nuget");
             Assert.Equal(1, renamedSeparators.GetProperty("packageCount").GetInt32());
             Assert.Equal(500L, renamedSeparators.GetProperty("totalDownloads").GetInt64());
+
+            var renamedSlashless = projects[3].GetProperty("metrics").GetProperty("nuget");
+            Assert.Equal(1, renamedSlashless.GetProperty("packageCount").GetInt32());
+            Assert.Equal(700L, renamedSlashless.GetProperty("totalDownloads").GetInt64());
             Assert.True(File.Exists(publishedCatalogPath));
         }
         finally

--- a/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
@@ -337,7 +337,7 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                       "slug": "securitypolicyx",
                       "name": "SecurityPolicyX",
                       "githubRepo": "EvotecIT/SecurityPolicyX",
-                      "aliases": ["SecurityPolicy"],
+                      "aliases": ["/projects/securitypolicy/"],
                       "links": {
                         "powerShellGallery": "https://www.powershellgallery.com/packages/SecurityPolicy"
                       },
@@ -477,7 +477,7 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                       "slug": "securitypolicyx",
                       "name": "SecurityPolicyX",
                       "githubRepo": "EvotecIT/SecurityPolicyX",
-                      "aliases": ["SecurityPolicy"],
+                      "aliases": ["/projects/securitypolicy/"],
                       "links": {
                         "powerShellGallery": "https://www.powershellgallery.com/packages/SecurityPolicy"
                       },

--- a/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
@@ -6,6 +6,18 @@ using Xunit;
 public class WebPipelineRunnerProjectCatalogTests
 {
     [Fact]
+    public void SplitCsvLine_ParsesQuotedEmptyCells()
+    {
+        var splitMethod = typeof(WebPipelineRunner)
+            .GetMethod("SplitCsvLine", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(splitMethod);
+
+        var cells = Assert.IsType<string[]>(splitMethod!.Invoke(null, new object?[] { "\"eventviewerx\",\"\",\"PSEventViewer\"" }));
+
+        Assert.Equal(new[] { "eventviewerx", string.Empty, "PSEventViewer" }, cells);
+    }
+
+    [Fact]
     public void RunPipeline_ProjectCatalog_AllowsDedicatedExternalSurfaceWhenExternalUrlCanBackfillLinks()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-project-catalog-surface-warn-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
@@ -510,7 +510,7 @@ public class WebPipelineRunnerProjectCatalogTests
             File.WriteAllText(curationPath,
                 """
                 "slug","aliases","apiDocs.quickStartTypes","apiDocs.relatedContentManifest"
-                "beta","/projects/beta-legacy/;/projects/beta-classic/","Invoke-Beta","./data/projects/beta-api-guides.json"
+                "beta","[""/projects/beta-legacy/?ids=one,two"",""/projects/beta-classic/?mode=a;b#details""]","Invoke-Beta","./data/projects/beta-api-guides.json"
                 """);
 
             var pipelinePath = Path.Combine(root, "pipeline.json");
@@ -547,8 +547,8 @@ public class WebPipelineRunnerProjectCatalogTests
             Assert.Contains("\"relatedContentManifest\": \"./data/projects/alpha-api-guides.json\"", catalogText, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"quickStartTypes\": \"Invoke-Beta\"", catalogText, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"relatedContentManifest\": \"./data/projects/beta-api-guides.json\"", catalogText, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("\"/projects/beta-legacy/\"", catalogText, StringComparison.Ordinal);
-            Assert.Contains("\"/projects/beta-classic/\"", catalogText, StringComparison.Ordinal);
+            Assert.Contains("\"/projects/beta-legacy/?ids=one,two\"", catalogText, StringComparison.Ordinal);
+            Assert.Contains("\"/projects/beta-classic/?mode=a;b#details\"", catalogText, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
@@ -510,7 +510,7 @@ public class WebPipelineRunnerProjectCatalogTests
             File.WriteAllText(curationPath,
                 """
                 "slug","aliases","apiDocs.quickStartTypes","apiDocs.relatedContentManifest"
-                "beta","BetaLegacy;Beta.Classic","Invoke-Beta","./data/projects/beta-api-guides.json"
+                "beta","/projects/beta-legacy/;/projects/beta-classic/","Invoke-Beta","./data/projects/beta-api-guides.json"
                 """);
 
             var pipelinePath = Path.Combine(root, "pipeline.json");
@@ -547,8 +547,8 @@ public class WebPipelineRunnerProjectCatalogTests
             Assert.Contains("\"relatedContentManifest\": \"./data/projects/alpha-api-guides.json\"", catalogText, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"quickStartTypes\": \"Invoke-Beta\"", catalogText, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"relatedContentManifest\": \"./data/projects/beta-api-guides.json\"", catalogText, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("\"BetaLegacy\"", catalogText, StringComparison.Ordinal);
-            Assert.Contains("\"Beta.Classic\"", catalogText, StringComparison.Ordinal);
+            Assert.Contains("\"/projects/beta-legacy/\"", catalogText, StringComparison.Ordinal);
+            Assert.Contains("\"/projects/beta-classic/\"", catalogText, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
@@ -497,8 +497,8 @@ public class WebPipelineRunnerProjectCatalogTests
             var curationPath = Path.Combine(root, "data", "projects", "curation.csv");
             File.WriteAllText(curationPath,
                 """
-                "slug","apiDocs.quickStartTypes","apiDocs.relatedContentManifest"
-                "beta","Invoke-Beta","./data/projects/beta-api-guides.json"
+                "slug","aliases","apiDocs.quickStartTypes","apiDocs.relatedContentManifest"
+                "beta","BetaLegacy;Beta.Classic","Invoke-Beta","./data/projects/beta-api-guides.json"
                 """);
 
             var pipelinePath = Path.Combine(root, "pipeline.json");
@@ -535,6 +535,8 @@ public class WebPipelineRunnerProjectCatalogTests
             Assert.Contains("\"relatedContentManifest\": \"./data/projects/alpha-api-guides.json\"", catalogText, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"quickStartTypes\": \"Invoke-Beta\"", catalogText, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"relatedContentManifest\": \"./data/projects/beta-api-guides.json\"", catalogText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("\"BetaLegacy\"", catalogText, StringComparison.Ordinal);
+            Assert.Contains("\"Beta.Classic\"", catalogText, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
@@ -506,11 +506,25 @@ public class WebPipelineRunnerProjectCatalogTests
                 }
                 """);
 
+            var gammaManifestPath = Path.Combine(root, "projects-sources", "gamma", "WebsiteArtifacts");
+            Directory.CreateDirectory(gammaManifestPath);
+            File.WriteAllText(Path.Combine(gammaManifestPath, "project-manifest.json"),
+                """
+                {
+                  "slug": "gamma",
+                  "name": "Gamma",
+                  "mode": "hub-full",
+                  "description": "Gamma project",
+                  "aliases": ["/projects/gamma-legacy/"]
+                }
+                """);
+
             var curationPath = Path.Combine(root, "data", "projects", "curation.csv");
             File.WriteAllText(curationPath,
                 """
                 "slug","aliases","apiDocs.quickStartTypes","apiDocs.relatedContentManifest"
                 "beta","[""/projects/beta-legacy/?ids=one,two"",""/projects/beta-classic/?mode=a;b#details""]","Invoke-Beta","./data/projects/beta-api-guides.json"
+                "gamma","[malformed","",""
                 """);
 
             var pipelinePath = Path.Combine(root, "pipeline.json");
@@ -549,6 +563,8 @@ public class WebPipelineRunnerProjectCatalogTests
             Assert.Contains("\"relatedContentManifest\": \"./data/projects/beta-api-guides.json\"", catalogText, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"/projects/beta-legacy/?ids=one,two\"", catalogText, StringComparison.Ordinal);
             Assert.Contains("\"/projects/beta-classic/?mode=a;b#details\"", catalogText, StringComparison.Ordinal);
+            Assert.Contains("\"/projects/gamma-legacy/\"", catalogText, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"aliases\": []", catalogText, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -553,7 +553,7 @@ internal static partial class WebPipelineRunner
             }
             if (aliasesIndex >= 0 && aliasesIndex < parts.Length && !string.IsNullOrWhiteSpace(parts[aliasesIndex]))
             {
-                project.Aliases = SplitDelimitedList(parts[aliasesIndex]);
+                project.Aliases = ParseCurationAliases(parts[aliasesIndex]);
                 updates++;
             }
 
@@ -779,6 +779,31 @@ internal static partial class WebPipelineRunner
         }
         values.Add(sb.ToString());
         return values.ToArray();
+    }
+
+    private static string[] ParseCurationAliases(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return Array.Empty<string>();
+
+        var token = value.Trim();
+        if (token.StartsWith("[", StringComparison.Ordinal))
+        {
+            try
+            {
+                return JsonSerializer.Deserialize<string[]>(token)?
+                    .Where(static alias => !string.IsNullOrWhiteSpace(alias))
+                    .Select(static alias => alias.Trim())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray() ?? Array.Empty<string>();
+            }
+            catch (JsonException)
+            {
+                return Array.Empty<string>();
+            }
+        }
+
+        return new[] { token };
     }
 
     private static bool TryParseBoolean(string? value, out bool parsed)
@@ -2109,6 +2134,7 @@ internal static partial class WebPipelineRunner
         var nugetById = new Dictionary<string, WebEcosystemNuGetPackage>(StringComparer.OrdinalIgnoreCase);
         var nugetByCompactId = new Dictionary<string, WebEcosystemNuGetPackage>(StringComparer.OrdinalIgnoreCase);
         var nugetByGitHubProject = new Dictionary<string, List<WebEcosystemNuGetPackage>>(StringComparer.OrdinalIgnoreCase);
+        var nugetByGitHubProjectName = new Dictionary<string, List<WebEcosystemNuGetPackage>>(StringComparer.OrdinalIgnoreCase);
         if (stats.NuGet?.Items is { Count: > 0 })
         {
             foreach (var package in stats.NuGet.Items)
@@ -2130,6 +2156,17 @@ internal static partial class WebPipelineRunner
                     }
 
                     projectPackages.Add(package);
+                    var packageRepoName = ExtractRepositoryName(packageRepo);
+                    if (!string.IsNullOrWhiteSpace(packageRepoName))
+                    {
+                        if (!nugetByGitHubProjectName.TryGetValue(packageRepoName, out var projectNamePackages))
+                        {
+                            projectNamePackages = new List<WebEcosystemNuGetPackage>();
+                            nugetByGitHubProjectName[packageRepoName] = projectNamePackages;
+                        }
+
+                        projectNamePackages.Add(package);
+                    }
                 }
             }
         }
@@ -2195,6 +2232,17 @@ internal static partial class WebPipelineRunner
                 nugetByGitHubProject.TryGetValue(project.GitHubRepo.Trim(), out var projectNuGetPackages))
             {
                 foreach (var package in projectNuGetPackages)
+                {
+                    if (!nugetPackages.Any(existing => string.Equals(existing.Id, package.Id, StringComparison.OrdinalIgnoreCase)))
+                        nugetPackages.Add(package);
+                }
+            }
+            foreach (var candidate in candidates)
+            {
+                if (!nugetByGitHubProjectName.TryGetValue(candidate, out var aliasProjectPackages))
+                    continue;
+
+                foreach (var package in aliasProjectPackages)
                 {
                     if (!nugetPackages.Any(existing => string.Equals(existing.Id, package.Id, StringComparison.OrdinalIgnoreCase)))
                         nugetPackages.Add(package);
@@ -2540,12 +2588,22 @@ internal static partial class WebPipelineRunner
         {
             foreach (var alias in project.Aliases)
             {
-                Add(alias);
-                if (!string.IsNullOrWhiteSpace(alias) && alias.TrimStart().StartsWith("/", StringComparison.Ordinal))
+                if (string.IsNullOrWhiteSpace(alias))
+                    continue;
+
+                var aliasToken = alias.Trim();
+                if (aliasToken.StartsWith("/", StringComparison.Ordinal))
                 {
-                    var segments = alias.Trim().Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+                    var delimiterIndex = aliasToken.IndexOfAny(new[] { '?', '#' });
+                    if (delimiterIndex >= 0)
+                        aliasToken = aliasToken[..delimiterIndex];
+                    var segments = aliasToken.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
                     if (segments.Length > 0)
                         Add(segments[^1]);
+                }
+                else if (!Uri.TryCreate(aliasToken, UriKind.Absolute, out _))
+                {
+                    Add(aliasToken);
                 }
             }
         }

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -551,9 +551,11 @@ internal static partial class WebPipelineRunner
                 project.ExternalUrl = parts[externalUrlIndex].Trim();
                 updates++;
             }
-            if (aliasesIndex >= 0 && aliasesIndex < parts.Length && !string.IsNullOrWhiteSpace(parts[aliasesIndex]))
+            if (aliasesIndex >= 0 && aliasesIndex < parts.Length &&
+                !string.IsNullOrWhiteSpace(parts[aliasesIndex]) &&
+                TryParseCurationAliases(parts[aliasesIndex], out var aliases))
             {
-                project.Aliases = ParseCurationAliases(parts[aliasesIndex]);
+                project.Aliases = aliases;
                 updates++;
             }
 
@@ -781,29 +783,32 @@ internal static partial class WebPipelineRunner
         return values.ToArray();
     }
 
-    private static string[] ParseCurationAliases(string value)
+    private static bool TryParseCurationAliases(string value, out string[] aliases)
     {
+        aliases = Array.Empty<string>();
         if (string.IsNullOrWhiteSpace(value))
-            return Array.Empty<string>();
+            return false;
 
         var token = value.Trim();
         if (token.StartsWith("[", StringComparison.Ordinal))
         {
             try
             {
-                return JsonSerializer.Deserialize<string[]>(token)?
+                aliases = JsonSerializer.Deserialize<string[]>(token)?
                     .Where(static alias => !string.IsNullOrWhiteSpace(alias))
                     .Select(static alias => alias.Trim())
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToArray() ?? Array.Empty<string>();
+                return true;
             }
             catch (JsonException)
             {
-                return Array.Empty<string>();
+                return false;
             }
         }
 
-        return new[] { token };
+        aliases = new[] { token };
+        return true;
     }
 
     private static bool TryParseBoolean(string? value, out bool parsed)
@@ -2135,6 +2140,8 @@ internal static partial class WebPipelineRunner
         var nugetByCompactId = new Dictionary<string, WebEcosystemNuGetPackage>(StringComparer.OrdinalIgnoreCase);
         var nugetByGitHubProject = new Dictionary<string, List<WebEcosystemNuGetPackage>>(StringComparer.OrdinalIgnoreCase);
         var nugetByGitHubProjectName = new Dictionary<string, List<WebEcosystemNuGetPackage>>(StringComparer.OrdinalIgnoreCase);
+        var nugetGitHubProjectByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var ambiguousNuGetGitHubProjectNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (stats.NuGet?.Items is { Count: > 0 })
         {
             foreach (var package in stats.NuGet.Items)
@@ -2159,6 +2166,16 @@ internal static partial class WebPipelineRunner
                     var packageRepoName = ExtractRepositoryName(packageRepo);
                     if (!string.IsNullOrWhiteSpace(packageRepoName))
                     {
+                        if (nugetGitHubProjectByName.TryGetValue(packageRepoName, out var knownPackageRepo) &&
+                            !string.Equals(knownPackageRepo, packageRepo, StringComparison.OrdinalIgnoreCase))
+                        {
+                            ambiguousNuGetGitHubProjectNames.Add(packageRepoName);
+                        }
+                        else
+                        {
+                            nugetGitHubProjectByName[packageRepoName] = packageRepo;
+                        }
+
                         if (!nugetByGitHubProjectName.TryGetValue(packageRepoName, out var projectNamePackages))
                         {
                             projectNamePackages = new List<WebEcosystemNuGetPackage>();
@@ -2237,9 +2254,10 @@ internal static partial class WebPipelineRunner
                         nugetPackages.Add(package);
                 }
             }
-            foreach (var candidate in candidates)
+            foreach (var candidate in BuildProjectAliasIdentifierCandidates(project))
             {
-                if (!nugetByGitHubProjectName.TryGetValue(candidate, out var aliasProjectPackages))
+                if (ambiguousNuGetGitHubProjectNames.Contains(candidate) ||
+                    !nugetByGitHubProjectName.TryGetValue(candidate, out var aliasProjectPackages))
                     continue;
 
                 foreach (var package in aliasProjectPackages)
@@ -2584,6 +2602,32 @@ internal static partial class WebPipelineRunner
         Add(project.Name);
         Add(project.GitHubRepo);
         Add(ExtractRepositoryName(project.GitHubRepo));
+        candidates.UnionWith(BuildProjectAliasIdentifierCandidates(project));
+        return candidates;
+    }
+
+    private static HashSet<string> BuildProjectAliasIdentifierCandidates(ProjectCatalogEntry project)
+    {
+        var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        void Add(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return;
+
+            var token = value.Trim();
+            if (string.IsNullOrWhiteSpace(token))
+                return;
+
+            candidates.Add(token);
+            var dotVariant = token.Replace("-", ".", StringComparison.Ordinal);
+            if (!string.Equals(dotVariant, token, StringComparison.Ordinal))
+                candidates.Add(dotVariant);
+            var dashVariant = token.Replace(".", "-", StringComparison.Ordinal);
+            if (!string.Equals(dashVariant, token, StringComparison.Ordinal))
+                candidates.Add(dashVariant);
+        }
+
         if (project.Aliases is { Length: > 0 })
         {
             foreach (var alias in project.Aliases)
@@ -2592,16 +2636,24 @@ internal static partial class WebPipelineRunner
                     continue;
 
                 var aliasToken = alias.Trim();
-                if (aliasToken.StartsWith("/", StringComparison.Ordinal))
+                if (Uri.TryCreate(aliasToken, UriKind.Absolute, out var absoluteAlias))
+                {
+                    aliasToken = absoluteAlias.AbsolutePath;
+                }
+                else
                 {
                     var delimiterIndex = aliasToken.IndexOfAny(new[] { '?', '#' });
                     if (delimiterIndex >= 0)
                         aliasToken = aliasToken[..delimiterIndex];
+                }
+
+                if (aliasToken.StartsWith("/", StringComparison.Ordinal))
+                {
                     var segments = aliasToken.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
                     if (segments.Length > 0)
                         Add(segments[^1]);
                 }
-                else if (!Uri.TryCreate(aliasToken, UriKind.Absolute, out _))
+                else
                 {
                     Add(aliasToken);
                 }

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -2159,6 +2159,7 @@ internal static partial class WebPipelineRunner
 
         var nugetById = new Dictionary<string, WebEcosystemNuGetPackage>(StringComparer.OrdinalIgnoreCase);
         var nugetByCompactId = new Dictionary<string, WebEcosystemNuGetPackage>(StringComparer.OrdinalIgnoreCase);
+        var ambiguousNuGetCompactIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var nugetByGitHubProject = new Dictionary<string, List<WebEcosystemNuGetPackage>>(StringComparer.OrdinalIgnoreCase);
         var nugetByGitHubProjectName = new Dictionary<string, List<WebEcosystemNuGetPackage>>(StringComparer.OrdinalIgnoreCase);
         var nugetGitHubProjectByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -2171,8 +2172,18 @@ internal static partial class WebPipelineRunner
                     nugetById[package.Id] = package;
 
                 var compact = CompactToken(package.Id);
-                if (!string.IsNullOrWhiteSpace(compact) && !nugetByCompactId.ContainsKey(compact))
-                    nugetByCompactId[compact] = package;
+                if (!string.IsNullOrWhiteSpace(compact))
+                {
+                    if (nugetByCompactId.TryGetValue(compact, out var compactPackage))
+                    {
+                        if (!string.Equals(compactPackage.Id, package.Id, StringComparison.OrdinalIgnoreCase))
+                            ambiguousNuGetCompactIds.Add(compact);
+                    }
+                    else
+                    {
+                        nugetByCompactId[compact] = package;
+                    }
+                }
 
                 if (!string.IsNullOrWhiteSpace(package.ProjectUrl) &&
                     TryExtractGitHubRepo(package.ProjectUrl!, out var packageRepo))
@@ -2211,6 +2222,7 @@ internal static partial class WebPipelineRunner
 
         var psgalleryById = new Dictionary<string, WebEcosystemPowerShellGalleryModule>(StringComparer.OrdinalIgnoreCase);
         var psgalleryByCompactId = new Dictionary<string, WebEcosystemPowerShellGalleryModule>(StringComparer.OrdinalIgnoreCase);
+        var ambiguousPowerShellGalleryCompactIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (stats.PowerShellGallery?.Modules is { Count: > 0 })
         {
             foreach (var module in stats.PowerShellGallery.Modules)
@@ -2219,8 +2231,18 @@ internal static partial class WebPipelineRunner
                     psgalleryById[module.Id] = module;
 
                 var compact = CompactToken(module.Id);
-                if (!string.IsNullOrWhiteSpace(compact) && !psgalleryByCompactId.ContainsKey(compact))
-                    psgalleryByCompactId[compact] = module;
+                if (!string.IsNullOrWhiteSpace(compact))
+                {
+                    if (psgalleryByCompactId.TryGetValue(compact, out var compactModule))
+                    {
+                        if (!string.Equals(compactModule.Id, module.Id, StringComparison.OrdinalIgnoreCase))
+                            ambiguousPowerShellGalleryCompactIds.Add(compact);
+                    }
+                    else
+                    {
+                        psgalleryByCompactId[compact] = module;
+                    }
+                }
             }
         }
 
@@ -2262,7 +2284,9 @@ internal static partial class WebPipelineRunner
                 foreach (var candidate in candidates)
                 {
                     var compact = CompactToken(candidate);
-                    if (!string.IsNullOrWhiteSpace(compact) && nugetByCompactId.TryGetValue(compact, out var package))
+                    if (!string.IsNullOrWhiteSpace(compact) &&
+                        !ambiguousNuGetCompactIds.Contains(compact) &&
+                        nugetByCompactId.TryGetValue(compact, out var package))
                     {
                         nuget = package;
                         break;
@@ -2318,7 +2342,9 @@ internal static partial class WebPipelineRunner
                 foreach (var candidate in candidates)
                 {
                     var compact = CompactToken(candidate);
-                    if (!string.IsNullOrWhiteSpace(compact) && psgalleryByCompactId.TryGetValue(compact, out var found))
+                    if (!string.IsNullOrWhiteSpace(compact) &&
+                        !ambiguousPowerShellGalleryCompactIds.Contains(compact) &&
+                        psgalleryByCompactId.TryGetValue(compact, out var found))
                     {
                         module = found;
                         break;
@@ -2610,62 +2636,24 @@ internal static partial class WebPipelineRunner
         return sb.ToString();
     }
 
-    private static HashSet<string> BuildProjectIdentifierCandidates(ProjectCatalogEntry project)
+    private static string[] BuildProjectIdentifierCandidates(ProjectCatalogEntry project)
     {
-        var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        void Add(string? value)
+        var literalCandidates = new List<string?>
         {
-            if (string.IsNullOrWhiteSpace(value))
-                return;
-
-            var token = value.Trim();
-            if (string.IsNullOrWhiteSpace(token))
-                return;
-
-            candidates.Add(token);
-            var dotVariant = token.Replace("-", ".", StringComparison.Ordinal);
-            if (!string.Equals(dotVariant, token, StringComparison.Ordinal))
-                candidates.Add(dotVariant);
-            var dashVariant = token.Replace(".", "-", StringComparison.Ordinal);
-            if (!string.Equals(dashVariant, token, StringComparison.Ordinal))
-                candidates.Add(dashVariant);
-        }
-
-        Add(project.Slug);
-        Add(project.Name);
-        Add(project.GitHubRepo);
-        Add(ExtractRepositoryName(project.GitHubRepo));
-        candidates.UnionWith(BuildProjectAliasIdentifierCandidates(project, includeSeparatorVariants: true));
-        return candidates;
+            project.Slug,
+            project.Name,
+            project.GitHubRepo,
+            ExtractRepositoryName(project.GitHubRepo)
+        };
+        literalCandidates.AddRange(BuildProjectAliasIdentifierCandidates(project, includeSeparatorVariants: false));
+        return BuildIdentifierCandidateSequence(literalCandidates, includeSeparatorVariants: true);
     }
 
-    private static HashSet<string> BuildProjectAliasIdentifierCandidates(
+    private static string[] BuildProjectAliasIdentifierCandidates(
         ProjectCatalogEntry project,
         bool includeSeparatorVariants)
     {
-        var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        void Add(string? value)
-        {
-            if (string.IsNullOrWhiteSpace(value))
-                return;
-
-            var token = value.Trim();
-            if (string.IsNullOrWhiteSpace(token))
-                return;
-
-            candidates.Add(token);
-            if (!includeSeparatorVariants)
-                return;
-
-            var dotVariant = token.Replace("-", ".", StringComparison.Ordinal);
-            if (!string.Equals(dotVariant, token, StringComparison.Ordinal))
-                candidates.Add(dotVariant);
-            var dashVariant = token.Replace(".", "-", StringComparison.Ordinal);
-            if (!string.Equals(dashVariant, token, StringComparison.Ordinal))
-                candidates.Add(dashVariant);
-        }
+        var literalCandidates = new List<string?>();
 
         if (project.Aliases is { Length: > 0 })
         {
@@ -2695,18 +2683,63 @@ internal static partial class WebPipelineRunner
                     if (segments.Length > 0)
                     {
                         var identitySegment = segments[^1];
+                        identitySegment = DecodeAliasPathSegment(identitySegment);
                         if (segments.Length > 1 && IsLegacyDefaultDocument(identitySegment))
-                            identitySegment = segments[^2];
-                        Add(RemoveLegacyRouteFileSuffix(identitySegment));
+                            identitySegment = DecodeAliasPathSegment(segments[^2]);
+                        literalCandidates.Add(RemoveLegacyRouteFileSuffix(identitySegment));
                     }
                 }
                 else
                 {
-                    Add(RemoveLegacyRouteFileSuffix(aliasToken));
+                    literalCandidates.Add(RemoveLegacyRouteFileSuffix(DecodeAliasPathSegment(aliasToken)));
                 }
             }
         }
-        return candidates;
+        return BuildIdentifierCandidateSequence(literalCandidates, includeSeparatorVariants);
+    }
+
+    private static string[] BuildIdentifierCandidateSequence(
+        IEnumerable<string?> values,
+        bool includeSeparatorVariants)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var literals = new List<string>();
+        foreach (var value in values)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                continue;
+
+            var token = value.Trim();
+            if (!string.IsNullOrWhiteSpace(token) && seen.Add(token))
+                literals.Add(token);
+        }
+
+        if (!includeSeparatorVariants)
+            return literals.ToArray();
+
+        var candidates = new List<string>(literals);
+        foreach (var literal in literals)
+        {
+            var dotVariant = literal.Replace("-", ".", StringComparison.Ordinal);
+            if (!string.Equals(dotVariant, literal, StringComparison.Ordinal) && seen.Add(dotVariant))
+                candidates.Add(dotVariant);
+            var dashVariant = literal.Replace(".", "-", StringComparison.Ordinal);
+            if (!string.Equals(dashVariant, literal, StringComparison.Ordinal) && seen.Add(dashVariant))
+                candidates.Add(dashVariant);
+        }
+        return candidates.ToArray();
+    }
+
+    private static string DecodeAliasPathSegment(string value)
+    {
+        try
+        {
+            return Uri.UnescapeDataString(value);
+        }
+        catch (UriFormatException)
+        {
+            return value;
+        }
     }
 
     private static bool IsLegacyDefaultDocument(string value)

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -2527,6 +2527,11 @@ internal static partial class WebPipelineRunner
         Add(project.Name);
         Add(project.GitHubRepo);
         Add(ExtractRepositoryName(project.GitHubRepo));
+        if (project.Aliases is { Length: > 0 })
+        {
+            foreach (var alias in project.Aliases)
+                Add(alias);
+        }
         return candidates;
     }
 

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -2659,7 +2659,12 @@ internal static partial class WebPipelineRunner
                 {
                     var segments = aliasToken.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
                     if (segments.Length > 0)
-                        Add(RemoveLegacyRouteFileSuffix(segments[^1]));
+                    {
+                        var identitySegment = segments[^1];
+                        if (segments.Length > 1 && IsLegacyDefaultDocument(identitySegment))
+                            identitySegment = segments[^2];
+                        Add(RemoveLegacyRouteFileSuffix(identitySegment));
+                    }
                 }
                 else
                 {
@@ -2668,6 +2673,14 @@ internal static partial class WebPipelineRunner
             }
         }
         return candidates;
+    }
+
+    private static bool IsLegacyDefaultDocument(string value)
+    {
+        return value.Equals("index.html", StringComparison.OrdinalIgnoreCase) ||
+               value.Equals("index.htm", StringComparison.OrdinalIgnoreCase) ||
+               value.Equals("default.html", StringComparison.OrdinalIgnoreCase) ||
+               value.Equals("default.htm", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string RemoveLegacyRouteFileSuffix(string value)

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -2668,7 +2668,7 @@ internal static partial class WebPipelineRunner
                 }
                 else
                 {
-                    Add(aliasToken);
+                    Add(RemoveLegacyRouteFileSuffix(aliasToken));
                 }
             }
         }

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -2254,7 +2254,7 @@ internal static partial class WebPipelineRunner
                         nugetPackages.Add(package);
                 }
             }
-            foreach (var candidate in BuildProjectAliasIdentifierCandidates(project))
+            foreach (var candidate in BuildProjectAliasIdentifierCandidates(project, includeSeparatorVariants: false))
             {
                 if (ambiguousNuGetGitHubProjectNames.Contains(candidate) ||
                     !nugetByGitHubProjectName.TryGetValue(candidate, out var aliasProjectPackages))
@@ -2602,11 +2602,13 @@ internal static partial class WebPipelineRunner
         Add(project.Name);
         Add(project.GitHubRepo);
         Add(ExtractRepositoryName(project.GitHubRepo));
-        candidates.UnionWith(BuildProjectAliasIdentifierCandidates(project));
+        candidates.UnionWith(BuildProjectAliasIdentifierCandidates(project, includeSeparatorVariants: true));
         return candidates;
     }
 
-    private static HashSet<string> BuildProjectAliasIdentifierCandidates(ProjectCatalogEntry project)
+    private static HashSet<string> BuildProjectAliasIdentifierCandidates(
+        ProjectCatalogEntry project,
+        bool includeSeparatorVariants)
     {
         var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -2620,6 +2622,9 @@ internal static partial class WebPipelineRunner
                 return;
 
             candidates.Add(token);
+            if (!includeSeparatorVariants)
+                return;
+
             var dotVariant = token.Replace("-", ".", StringComparison.Ordinal);
             if (!string.Equals(dotVariant, token, StringComparison.Ordinal))
                 candidates.Add(dotVariant);
@@ -2636,22 +2641,25 @@ internal static partial class WebPipelineRunner
                     continue;
 
                 var aliasToken = alias.Trim();
+                var isRouteAlias = false;
                 if (Uri.TryCreate(aliasToken, UriKind.Absolute, out var absoluteAlias))
                 {
                     aliasToken = absoluteAlias.AbsolutePath;
+                    isRouteAlias = true;
                 }
                 else
                 {
                     var delimiterIndex = aliasToken.IndexOfAny(new[] { '?', '#' });
                     if (delimiterIndex >= 0)
                         aliasToken = aliasToken[..delimiterIndex];
+                    isRouteAlias = aliasToken.Contains('/', StringComparison.Ordinal);
                 }
 
-                if (aliasToken.StartsWith("/", StringComparison.Ordinal))
+                if (isRouteAlias)
                 {
                     var segments = aliasToken.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
                     if (segments.Length > 0)
-                        Add(segments[^1]);
+                        Add(RemoveLegacyRouteFileSuffix(segments[^1]));
                 }
                 else
                 {
@@ -2660,6 +2668,15 @@ internal static partial class WebPipelineRunner
             }
         }
         return candidates;
+    }
+
+    private static string RemoveLegacyRouteFileSuffix(string value)
+    {
+        if (value.EndsWith(".html", StringComparison.OrdinalIgnoreCase))
+            return value[..^5];
+        if (value.EndsWith(".htm", StringComparison.OrdinalIgnoreCase))
+            return value[..^4];
+        return value;
     }
 
     private static void AppendProjectFrontMatterExtensions(

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -482,6 +482,7 @@ internal static partial class WebPipelineRunner
         var listedIndex = Array.FindIndex(header, h => h.Equals("listed", StringComparison.OrdinalIgnoreCase));
         var modeIndex = FindCsvColumnIndex(header, "mode", "projectMode", "project_mode");
         var externalUrlIndex = FindCsvColumnIndex(header, "externalUrl", "external_url", "external-url", "url");
+        var aliasesIndex = FindCsvColumnIndex(header, "aliases", "alias");
 
         var linkColumns = BuildCsvPrefixedColumnMap(header, "links.");
         foreach (var pair in BuildCsvPrefixedColumnMap(header, "link."))
@@ -509,6 +510,7 @@ internal static partial class WebPipelineRunner
             listedIndex >= 0 ||
             modeIndex >= 0 ||
             externalUrlIndex >= 0 ||
+            aliasesIndex >= 0 ||
             linkColumns.Count > 0 ||
             surfaceColumns.Count > 0 ||
             apiDocsColumns.Count > 0;
@@ -547,6 +549,11 @@ internal static partial class WebPipelineRunner
             if (externalUrlIndex >= 0 && externalUrlIndex < parts.Length && !string.IsNullOrWhiteSpace(parts[externalUrlIndex]))
             {
                 project.ExternalUrl = parts[externalUrlIndex].Trim();
+                updates++;
+            }
+            if (aliasesIndex >= 0 && aliasesIndex < parts.Length && !string.IsNullOrWhiteSpace(parts[aliasesIndex]))
+            {
+                project.Aliases = SplitDelimitedList(parts[aliasesIndex]);
                 updates++;
             }
 

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -2240,12 +2240,18 @@ internal static partial class WebPipelineRunner
                     nuget = package;
                     break;
                 }
+            }
 
-                var compact = CompactToken(candidate);
-                if (!string.IsNullOrWhiteSpace(compact) && nugetByCompactId.TryGetValue(compact, out package))
+            if (nuget is null)
+            {
+                foreach (var candidate in candidates)
                 {
-                    nuget = package;
-                    break;
+                    var compact = CompactToken(candidate);
+                    if (!string.IsNullOrWhiteSpace(compact) && nugetByCompactId.TryGetValue(compact, out var package))
+                    {
+                        nuget = package;
+                        break;
+                    }
                 }
             }
 
@@ -2290,12 +2296,18 @@ internal static partial class WebPipelineRunner
                     module = found;
                     break;
                 }
+            }
 
-                var compact = CompactToken(candidate);
-                if (!string.IsNullOrWhiteSpace(compact) && psgalleryByCompactId.TryGetValue(compact, out found))
+            if (module is null)
+            {
+                foreach (var candidate in candidates)
                 {
-                    module = found;
-                    break;
+                    var compact = CompactToken(candidate);
+                    if (!string.IsNullOrWhiteSpace(compact) && psgalleryByCompactId.TryGetValue(compact, out var found))
+                    {
+                        module = found;
+                        break;
+                    }
                 }
             }
 

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -457,14 +457,21 @@ internal static partial class WebPipelineRunner
 
         if (!Uri.TryCreate(sourceUrl, UriKind.Absolute, out var uri))
             return false;
-        if (!uri.Host.Contains("github.com", StringComparison.OrdinalIgnoreCase))
+        if (!uri.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase) &&
+            !uri.Host.Equals("www.github.com", StringComparison.OrdinalIgnoreCase))
             return false;
 
         var segments = uri.AbsolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (segments.Length < 2)
             return false;
 
-        repo = $"{segments[0]}/{segments[1]}";
+        var repositoryName = segments[1];
+        if (repositoryName.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            repositoryName = repositoryName[..^4];
+        if (string.IsNullOrWhiteSpace(repositoryName))
+            return false;
+
+        repo = $"{segments[0]}/{repositoryName}";
         return true;
     }
 

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -756,15 +756,17 @@ internal static partial class WebPipelineRunner
         for (var i = 0; i < line.Length; i++)
         {
             var c = line[i];
-            if (c == '"' && (i + 1 >= line.Length || line[i + 1] != '"'))
+            if (c == '"')
             {
-                inQuotes = !inQuotes;
-                continue;
-            }
-            if (c == '"' && i + 1 < line.Length && line[i + 1] == '"')
-            {
-                sb.Append('"');
-                i++;
+                if (inQuotes && i + 1 < line.Length && line[i + 1] == '"')
+                {
+                    sb.Append('"');
+                    i++;
+                }
+                else
+                {
+                    inQuotes = !inQuotes;
+                }
                 continue;
             }
             if (c == ',' && !inQuotes)

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -2539,7 +2539,15 @@ internal static partial class WebPipelineRunner
         if (project.Aliases is { Length: > 0 })
         {
             foreach (var alias in project.Aliases)
+            {
                 Add(alias);
+                if (!string.IsNullOrWhiteSpace(alias) && alias.TrimStart().StartsWith("/", StringComparison.Ordinal))
+                {
+                    var segments = alias.Trim().Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+                    if (segments.Length > 0)
+                        Add(segments[^1]);
+                }
+            }
         }
         return candidates;
     }

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -2128,18 +2128,32 @@ internal static partial class WebPipelineRunner
 
         var githubByFullName = new Dictionary<string, WebEcosystemGitHubRepository>(StringComparer.OrdinalIgnoreCase);
         var githubByRepoName = new Dictionary<string, WebEcosystemGitHubRepository>(StringComparer.OrdinalIgnoreCase);
+        var ambiguousGitHubRepoNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (stats.GitHub?.Repositories is { Count: > 0 })
         {
+            void IndexRepositoryName(string? name, WebEcosystemGitHubRepository repository)
+            {
+                if (string.IsNullOrWhiteSpace(name))
+                    return;
+
+                if (githubByRepoName.TryGetValue(name, out var existing))
+                {
+                    if (!string.Equals(existing.FullName, repository.FullName, StringComparison.OrdinalIgnoreCase))
+                        ambiguousGitHubRepoNames.Add(name);
+                    return;
+                }
+
+                githubByRepoName[name] = repository;
+            }
+
             foreach (var repository in stats.GitHub.Repositories)
             {
                 if (!string.IsNullOrWhiteSpace(repository.FullName) && !githubByFullName.ContainsKey(repository.FullName))
                     githubByFullName[repository.FullName] = repository;
 
                 var shortName = ExtractRepositoryName(repository.FullName);
-                if (!string.IsNullOrWhiteSpace(shortName) && !githubByRepoName.ContainsKey(shortName))
-                    githubByRepoName[shortName] = repository;
-                if (!string.IsNullOrWhiteSpace(repository.Name) && !githubByRepoName.ContainsKey(repository.Name))
-                    githubByRepoName[repository.Name] = repository;
+                IndexRepositoryName(shortName, repository);
+                IndexRepositoryName(repository.Name, repository);
             }
         }
 
@@ -2224,7 +2238,8 @@ internal static partial class WebPipelineRunner
             {
                 foreach (var candidate in candidates)
                 {
-                    if (githubByRepoName.TryGetValue(candidate, out var repository))
+                    if (!ambiguousGitHubRepoNames.Contains(candidate) &&
+                        githubByRepoName.TryGetValue(candidate, out var repository))
                     {
                         github = repository;
                         break;


### PR DESCRIPTION
## Summary

- include explicit catalog route aliases when matching GitHub, NuGet, and PowerShell Gallery telemetry
- normalize absolute, relative, encoded, slashless-file, legacy HTML, index/default-document, and `.git` clone URL identities
- rank literal slug/name/repository/alias identities ahead of synthesized dot/dash variants
- prefer every exact feed match before compact fallback and reject ambiguous compact tokens
- reject ambiguous cross-owner GitHub and NuGet repository basenames
- preserve existing aliases when curation JSON is malformed

## Why

Renamed projects such as EventViewerX can preserve legacy routes and package identities while generated hubs retain install commands and complete totals. Provenance-aware candidate ranking, canonical repository extraction, and fail-closed ambiguity handling prevent encoded-route misses, compact-token collisions, incomplete groups, and another owner's telemetry from attaching to a project.

## Validation

- project catalog, product catalog, and ecosystem stats tests: 27 passed on .NET 10