### PR TITLE
fix(web): separate package telemetry aliases from routes

### DIFF
--- a/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
@@ -406,7 +406,7 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
     }
 
     [Fact]
-    public void SyncProjectCatalogTelemetryFromStats_MergesPowerShellGalleryDownloads_WhenStatsIncludeGallery()
+    public void SyncProjectCatalogTelemetryFromStats_AggregatesExplicitPowerShellGalleryAliasModules()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-ecosystem-catalog-telemetry-direct-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
@@ -426,12 +426,12 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                   "summary": {
                     "repositoryCount": 1,
                     "nuGetPackageCount": 0,
-                    "powerShellGalleryModuleCount": 1,
+                    "powerShellGalleryModuleCount": 2,
                     "gitHubStars": 42,
                     "gitHubForks": 5,
                     "nuGetDownloads": 0,
-                    "powerShellGalleryDownloads": 123456,
-                    "totalDownloads": 123456
+                    "powerShellGalleryDownloads": 124456,
+                    "totalDownloads": 124456
                   },
                   "gitHub": {
                     "organization": "EvotecIT",
@@ -453,14 +453,21 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                   },
                   "powerShellGallery": {
                     "owner": "Przemyslaw.Klys",
-                    "moduleCount": 1,
-                    "totalDownloads": 123456,
+                    "moduleCount": 2,
+                    "totalDownloads": 124456,
                     "modules": [
                       {
                         "id": "SecurityPolicy",
                         "version": "0.0.13",
                         "downloadCount": 123456,
                         "galleryUrl": "https://www.powershellgallery.com/packages/SecurityPolicy",
+                        "projectUrl": "https://github.com/EvotecIT/SecurityPolicy"
+                      },
+                      {
+                        "id": "SecurityPolicyLegacy",
+                        "version": "2.0.0",
+                        "downloadCount": 1000,
+                        "galleryUrl": "https://www.powershellgallery.com/packages/SecurityPolicyLegacy",
                         "projectUrl": "https://github.com/EvotecIT/SecurityPolicy"
                       }
                     ]
@@ -498,7 +505,7 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                       "slug": "securitypolicyx",
                       "name": "SecurityPolicyX",
                       "githubRepo": "EvotecIT/SecurityPolicyX",
-                      "aliases": ["/projects/securitypolicy/index.html?ref=legacy"],
+                      "aliases": ["/projects/securitypolicy/index.html?ref=legacy", "SecurityPolicyLegacy"],
                       "links": {
                         "powerShellGallery": "https://www.powershellgallery.com/packages/SecurityPolicy"
                       },
@@ -533,10 +540,10 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
             using var catalog = JsonDocument.Parse(File.ReadAllText(catalogPath));
             var project = catalog.RootElement.GetProperty("projects")[0];
             Assert.Equal(42, project.GetProperty("metrics").GetProperty("github").GetProperty("stars").GetInt32());
-            Assert.Equal(123456L, project.GetProperty("metrics").GetProperty("powerShellGallery").GetProperty("totalDownloads").GetInt64());
+            Assert.Equal(124456L, project.GetProperty("metrics").GetProperty("powerShellGallery").GetProperty("totalDownloads").GetInt64());
             Assert.Equal(2, project.GetProperty("metrics").GetProperty("nuget").GetProperty("packageCount").GetInt32());
             Assert.Equal(300L, project.GetProperty("metrics").GetProperty("nuget").GetProperty("totalDownloads").GetInt64());
-            Assert.Equal(123756L, project.GetProperty("metrics").GetProperty("downloads").GetProperty("total").GetInt64());
+            Assert.Equal(124756L, project.GetProperty("metrics").GetProperty("downloads").GetProperty("total").GetInt64());
             Assert.True(File.Exists(publishedCatalogPath));
         }
         finally

--- a/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerEcosystemStatsTests.cs
@@ -426,12 +426,12 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                   "summary": {
                     "repositoryCount": 1,
                     "nuGetPackageCount": 0,
-                    "powerShellGalleryModuleCount": 2,
+                    "powerShellGalleryModuleCount": 3,
                     "gitHubStars": 42,
                     "gitHubForks": 5,
                     "nuGetDownloads": 0,
-                    "powerShellGalleryDownloads": 124456,
-                    "totalDownloads": 124456
+                    "powerShellGalleryDownloads": 10124456,
+                    "totalDownloads": 10124456
                   },
                   "gitHub": {
                     "organization": "EvotecIT",
@@ -453,8 +453,8 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                   },
                   "powerShellGallery": {
                     "owner": "Przemyslaw.Klys",
-                    "moduleCount": 2,
-                    "totalDownloads": 124456,
+                    "moduleCount": 3,
+                    "totalDownloads": 10124456,
                     "modules": [
                       {
                         "id": "SecurityPolicy",
@@ -469,6 +469,13 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                         "downloadCount": 1000,
                         "galleryUrl": "https://www.powershellgallery.com/packages/SecurityPolicyLegacy",
                         "projectUrl": "https://github.com/EvotecIT/SecurityPolicy"
+                      },
+                      {
+                        "id": "UnrelatedModule",
+                        "version": "9.0.0",
+                        "downloadCount": 10000000,
+                        "galleryUrl": "https://www.powershellgallery.com/packages/UnrelatedModule",
+                        "projectUrl": "https://github.com/EvotecIT/UnrelatedModule"
                       }
                     ]
                   },
@@ -505,7 +512,11 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                       "slug": "securitypolicyx",
                       "name": "SecurityPolicyX",
                       "githubRepo": "EvotecIT/SecurityPolicyX",
-                      "aliases": ["/projects/securitypolicy/index.html?ref=legacy", "SecurityPolicyLegacy"],
+                      "aliases": ["/projects/securitypolicy/index.html?ref=legacy", "/projects/unrelatedmodule/"],
+                      "packageAliases": {
+                        "nuget": ["SecurityPolicy"],
+                        "powerShellGallery": ["SecurityPolicy", "SecurityPolicyLegacy"]
+                      },
                       "links": {
                         "powerShellGallery": "https://www.powershellgallery.com/packages/SecurityPolicy"
                       },
@@ -731,28 +742,47 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                       "githubRepo": "EvotecIT/CurrentRepo"
                     },
                     {
+                      "slug": "route-alias-only",
+                      "name": "Current.Core",
+                      "githubRepo": "EvotecIT/RouteAliasOnly",
+                      "aliases": ["/projects/target-package/"]
+                    },
+                    {
                       "slug": "renamed",
                       "name": "Renamed Product",
                       "githubRepo": "EvotecIT/RenamedRepo",
-                      "aliases": ["/projects/sharedrepo/"]
+                      "aliases": ["/projects/sharedrepo/"],
+                      "packageAliases": {
+                        "nuget": ["SharedRepo"]
+                      }
                     },
                     {
                       "slug": "renamed-separators",
                       "name": "Renamed Separator Product",
                       "githubRepo": "EvotecIT/RenamedSeparatorRepo",
-                      "aliases": ["/projects/foo-bar/"]
+                      "aliases": ["/projects/foo-bar/"],
+                      "packageAliases": {
+                        "nuget": ["Foo-Bar"]
+                      }
                     },
                     {
                       "slug": "renamed-slashless",
                       "name": "Renamed Slashless Product",
                       "githubRepo": "EvotecIT/RenamedSlashlessRepo",
-                      "aliases": ["slashless.html"]
+                      "aliases": ["slashless.html"],
+                      "packageAliases": {
+                        "nuget": ["Slashless"]
+                      }
                     },
                     {
                       "slug": "renamed-exact-variants",
                       "name": "Renamed Exact Variant Product",
                       "githubRepo": "EvotecIT/RenamedExactVariantRepo",
-                      "aliases": ["/projects/target-package/", "/projects/target-module/"]
+                      "aliases": ["/projects/target-package/", "/projects/target-module/"],
+                      "packageAliases": {
+                        "nuget": ["Target.Package"],
+                        "powerShellGallery": ["Target.Module"]
+                      }
                     },
                     {
                       "slug": "renamed-literal-priority",
@@ -764,7 +794,10 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
                       "slug": "renamed-percent-encoded",
                       "name": "Renamed Percent Encoded Product",
                       "githubRepo": "EvotecIT/RenamedPercentEncodedRepo",
-                      "aliases": ["/projects/security%20policy/"]
+                      "aliases": ["/projects/security%20policy/"],
+                      "packageAliases": {
+                        "nuget": ["Security Policy"]
+                      }
                     },
                     {
                       "slug": "renamed-compact-ambiguous",
@@ -782,7 +815,7 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
 
             var args = new object?[] { statsPath, catalogPath, publishedCatalogPath, null };
             var merged = Assert.IsType<int>(syncMethod!.Invoke(null, args));
-            Assert.Equal(7, merged);
+            Assert.Equal(8, merged);
             Assert.Null(args[3]);
 
             using var catalog = JsonDocument.Parse(File.ReadAllText(catalogPath));
@@ -796,6 +829,11 @@ public sealed class WebPipelineRunnerEcosystemStatsTests
             Assert.Equal(1, current.GetProperty("packageCount").GetInt32());
             Assert.Equal(400L, current.GetProperty("totalDownloads").GetInt64());
             Assert.Equal(30, projectsBySlug["legacyrepo"].GetProperty("metrics").GetProperty("github").GetProperty("stars").GetInt32());
+
+            var routeAliasOnly = projectsBySlug["route-alias-only"].GetProperty("metrics").GetProperty("nuget");
+            Assert.Equal("Current.Core", routeAliasOnly.GetProperty("id").GetString());
+            Assert.Equal(1, routeAliasOnly.GetProperty("packageCount").GetInt32());
+            Assert.Equal(400L, routeAliasOnly.GetProperty("totalDownloads").GetInt64());
 
             var renamedMetrics = projectsBySlug["renamed"].GetProperty("metrics");
             var renamed = renamedMetrics.GetProperty("nuget");

--- a/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
@@ -522,9 +522,9 @@ public class WebPipelineRunnerProjectCatalogTests
             var curationPath = Path.Combine(root, "data", "projects", "curation.csv");
             File.WriteAllText(curationPath,
                 """
-                "slug","aliases","apiDocs.quickStartTypes","apiDocs.relatedContentManifest"
-                "beta","[""/projects/beta-legacy/?ids=one,two"",""/projects/beta-classic/?mode=a;b#details""]","Invoke-Beta","./data/projects/beta-api-guides.json"
-                "gamma","[malformed","",""
+                "slug","aliases","packageAliases.nuget","packageAliases.powerShellGallery","apiDocs.quickStartTypes","apiDocs.relatedContentManifest"
+                "beta","[""/projects/beta-legacy/?ids=one,two"",""/projects/beta-classic/?mode=a;b#details""]","[""Beta.Core"",""Beta.Extensions""]","[""Beta"",""BetaLegacy""]","Invoke-Beta","./data/projects/beta-api-guides.json"
+                "gamma","[malformed","","","",""
                 """);
 
             var pipelinePath = Path.Combine(root, "pipeline.json");
@@ -563,6 +563,9 @@ public class WebPipelineRunnerProjectCatalogTests
             Assert.Contains("\"relatedContentManifest\": \"./data/projects/beta-api-guides.json\"", catalogText, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"/projects/beta-legacy/?ids=one,two\"", catalogText, StringComparison.Ordinal);
             Assert.Contains("\"/projects/beta-classic/?mode=a;b#details\"", catalogText, StringComparison.Ordinal);
+            Assert.Contains("\"packageAliases\":", catalogText, StringComparison.Ordinal);
+            Assert.Contains("\"Beta.Extensions\"", catalogText, StringComparison.Ordinal);
+            Assert.Contains("\"BetaLegacy\"", catalogText, StringComparison.Ordinal);
             Assert.Contains("\"/projects/gamma-legacy/\"", catalogText, StringComparison.Ordinal);
             Assert.DoesNotContain("\"aliases\": []", catalogText, StringComparison.Ordinal);
         }

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -490,6 +490,8 @@ internal static partial class WebPipelineRunner
         var modeIndex = FindCsvColumnIndex(header, "mode", "projectMode", "project_mode");
         var externalUrlIndex = FindCsvColumnIndex(header, "externalUrl", "external_url", "external-url", "url");
         var aliasesIndex = FindCsvColumnIndex(header, "aliases", "alias");
+        var nuGetPackageAliasesIndex = FindCsvColumnIndex(header, "packageAliases.nuget", "package-aliases.nuget");
+        var powerShellGalleryPackageAliasesIndex = FindCsvColumnIndex(header, "packageAliases.powerShellGallery", "package-aliases.powerShellGallery");
 
         var linkColumns = BuildCsvPrefixedColumnMap(header, "links.");
         foreach (var pair in BuildCsvPrefixedColumnMap(header, "link."))
@@ -518,6 +520,8 @@ internal static partial class WebPipelineRunner
             modeIndex >= 0 ||
             externalUrlIndex >= 0 ||
             aliasesIndex >= 0 ||
+            nuGetPackageAliasesIndex >= 0 ||
+            powerShellGalleryPackageAliasesIndex >= 0 ||
             linkColumns.Count > 0 ||
             surfaceColumns.Count > 0 ||
             apiDocsColumns.Count > 0;
@@ -563,6 +567,22 @@ internal static partial class WebPipelineRunner
                 TryParseCurationAliases(parts[aliasesIndex], out var aliases))
             {
                 project.Aliases = aliases;
+                updates++;
+            }
+            if (nuGetPackageAliasesIndex >= 0 && nuGetPackageAliasesIndex < parts.Length &&
+                !string.IsNullOrWhiteSpace(parts[nuGetPackageAliasesIndex]) &&
+                TryParseCurationAliases(parts[nuGetPackageAliasesIndex], out var nuGetPackageAliases))
+            {
+                project.PackageAliases ??= new ProjectCatalogPackageAliases();
+                project.PackageAliases.NuGet = nuGetPackageAliases;
+                updates++;
+            }
+            if (powerShellGalleryPackageAliasesIndex >= 0 && powerShellGalleryPackageAliasesIndex < parts.Length &&
+                !string.IsNullOrWhiteSpace(parts[powerShellGalleryPackageAliasesIndex]) &&
+                TryParseCurationAliases(parts[powerShellGalleryPackageAliasesIndex], out var powerShellGalleryPackageAliases))
+            {
+                project.PackageAliases ??= new ProjectCatalogPackageAliases();
+                project.PackageAliases.PowerShellGallery = powerShellGalleryPackageAliases;
                 updates++;
             }
 
@@ -2250,6 +2270,10 @@ internal static partial class WebPipelineRunner
         foreach (var project in projects)
         {
             var candidates = BuildProjectIdentifierCandidates(project);
+            var nuGetCandidates = BuildProjectIdentifierCandidates(project, includeProjectAliases: false);
+            var nuGetPackageAliasCandidates = BuildPackageAliasIdentifierCandidates(project.PackageAliases?.NuGet);
+            var powerShellGalleryCandidates = BuildProjectIdentifierCandidates(project, includeProjectAliases: false);
+            var powerShellGalleryPackageAliasCandidates = BuildPackageAliasIdentifierCandidates(project.PackageAliases?.PowerShellGallery);
 
             WebEcosystemGitHubRepository? github = null;
             if (!string.IsNullOrWhiteSpace(project.GitHubRepo) && githubByFullName.TryGetValue(project.GitHubRepo, out var byFullName))
@@ -2270,7 +2294,7 @@ internal static partial class WebPipelineRunner
             }
 
             WebEcosystemNuGetPackage? nuget = null;
-            foreach (var candidate in candidates)
+            foreach (var candidate in nuGetCandidates)
             {
                 if (nugetById.TryGetValue(candidate, out var package))
                 {
@@ -2281,7 +2305,19 @@ internal static partial class WebPipelineRunner
 
             if (nuget is null)
             {
-                foreach (var candidate in candidates)
+                foreach (var candidate in nuGetPackageAliasCandidates)
+                {
+                    if (nugetById.TryGetValue(candidate, out var package))
+                    {
+                        nuget = package;
+                        break;
+                    }
+                }
+            }
+
+            if (nuget is null)
+            {
+                foreach (var candidate in nuGetCandidates)
                 {
                     var compact = CompactToken(candidate);
                     if (!string.IsNullOrWhiteSpace(compact) &&
@@ -2306,8 +2342,14 @@ internal static partial class WebPipelineRunner
                         nugetPackages.Add(package);
                 }
             }
-            foreach (var candidate in BuildProjectAliasIdentifierCandidates(project, includeSeparatorVariants: false))
+            foreach (var candidate in nuGetPackageAliasCandidates)
             {
+                if (nugetById.TryGetValue(candidate, out var aliasPackage) &&
+                    !nugetPackages.Any(existing => string.Equals(existing.Id, aliasPackage.Id, StringComparison.OrdinalIgnoreCase)))
+                {
+                    nugetPackages.Add(aliasPackage);
+                }
+
                 if (ambiguousNuGetGitHubProjectNames.Contains(candidate) ||
                     !nugetByGitHubProjectName.TryGetValue(candidate, out var aliasProjectPackages))
                     continue;
@@ -2328,7 +2370,7 @@ internal static partial class WebPipelineRunner
             }
 
             WebEcosystemPowerShellGalleryModule? module = null;
-            foreach (var candidate in candidates)
+            foreach (var candidate in powerShellGalleryCandidates)
             {
                 if (psgalleryById.TryGetValue(candidate, out var found))
                 {
@@ -2339,7 +2381,19 @@ internal static partial class WebPipelineRunner
 
             if (module is null)
             {
-                foreach (var candidate in candidates)
+                foreach (var candidate in powerShellGalleryPackageAliasCandidates)
+                {
+                    if (psgalleryById.TryGetValue(candidate, out var found))
+                    {
+                        module = found;
+                        break;
+                    }
+                }
+            }
+
+            if (module is null)
+            {
+                foreach (var candidate in powerShellGalleryCandidates)
                 {
                     var compact = CompactToken(candidate);
                     if (!string.IsNullOrWhiteSpace(compact) &&
@@ -2355,7 +2409,7 @@ internal static partial class WebPipelineRunner
             var powerShellGalleryModules = new List<WebEcosystemPowerShellGalleryModule>();
             if (module is not null)
                 powerShellGalleryModules.Add(module);
-            foreach (var candidate in BuildProjectAliasIdentifierCandidates(project, includeSeparatorVariants: false))
+            foreach (var candidate in powerShellGalleryPackageAliasCandidates)
             {
                 if (!psgalleryById.TryGetValue(candidate, out var aliasModule))
                     continue;
@@ -2650,7 +2704,9 @@ internal static partial class WebPipelineRunner
         return sb.ToString();
     }
 
-    private static string[] BuildProjectIdentifierCandidates(ProjectCatalogEntry project)
+    private static string[] BuildProjectIdentifierCandidates(
+        ProjectCatalogEntry project,
+        bool includeProjectAliases = true)
     {
         var literalCandidates = new List<string?>
         {
@@ -2659,9 +2715,15 @@ internal static partial class WebPipelineRunner
             project.GitHubRepo,
             ExtractRepositoryName(project.GitHubRepo)
         };
-        literalCandidates.AddRange(BuildProjectAliasIdentifierCandidates(project, includeSeparatorVariants: false));
+        if (includeProjectAliases)
+            literalCandidates.AddRange(BuildProjectAliasIdentifierCandidates(project, includeSeparatorVariants: false));
         return BuildIdentifierCandidateSequence(literalCandidates, includeSeparatorVariants: true);
     }
+
+    private static string[] BuildPackageAliasIdentifierCandidates(IEnumerable<string?>? aliases) =>
+        aliases is null
+            ? Array.Empty<string>()
+            : BuildIdentifierCandidateSequence(aliases, includeSeparatorVariants: false);
 
     private static string[] BuildProjectAliasIdentifierCandidates(
         ProjectCatalogEntry project,
@@ -2978,6 +3040,13 @@ internal static partial class WebPipelineRunner
             Version = NormalizeOptionalString(project.Version),
             ManifestCommit = NormalizeOptionalString(project.ManifestCommit),
             Aliases = NormalizeStringArray(project.Aliases),
+            PackageAliases = project.PackageAliases is null
+                ? null
+                : new
+                {
+                    NuGet = NormalizeStringArray(project.PackageAliases.NuGet),
+                    PowerShellGallery = NormalizeStringArray(project.PackageAliases.PowerShellGallery)
+                },
             Brand = project.Brand,
             Product = project.Product,
             Links = NormalizeStringDictionary(project.Links),
@@ -3352,6 +3421,10 @@ internal static partial class WebPipelineRunner
         [JsonPropertyName("aliases")]
         public string[]? Aliases { get; set; }
 
+        [JsonPropertyName("packageAliases")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public ProjectCatalogPackageAliases? PackageAliases { get; set; }
+
         [JsonPropertyName("links")]
         public Dictionary<string, string?>? Links { get; set; }
 
@@ -3374,6 +3447,17 @@ internal static partial class WebPipelineRunner
 
         [JsonExtensionData]
         public Dictionary<string, JsonElement>? ExtensionData { get; set; }
+    }
+
+    private sealed class ProjectCatalogPackageAliases
+    {
+        [JsonPropertyName("nuget")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string[]? NuGet { get; set; }
+
+        [JsonPropertyName("powerShellGallery")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string[]? PowerShellGallery { get; set; }
     }
 
     private sealed class ProjectCatalogMetrics

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -2352,6 +2352,18 @@ internal static partial class WebPipelineRunner
                 }
             }
 
+            var powerShellGalleryModules = new List<WebEcosystemPowerShellGalleryModule>();
+            if (module is not null)
+                powerShellGalleryModules.Add(module);
+            foreach (var candidate in BuildProjectAliasIdentifierCandidates(project, includeSeparatorVariants: false))
+            {
+                if (!psgalleryById.TryGetValue(candidate, out var aliasModule))
+                    continue;
+
+                if (!powerShellGalleryModules.Any(existing => string.Equals(existing.Id, aliasModule.Id, StringComparison.OrdinalIgnoreCase)))
+                    powerShellGalleryModules.Add(aliasModule);
+            }
+
             var hasAnyMetrics = github is not null || nuget is not null || module is not null;
             if (!hasAnyMetrics)
                 continue;
@@ -2392,7 +2404,9 @@ internal static partial class WebPipelineRunner
                 {
                     Id = module.Id,
                     Version = module.Version,
-                    TotalDownloads = module.DownloadCount,
+                    TotalDownloads = powerShellGalleryModules.Count > 1
+                        ? powerShellGalleryModules.Sum(static galleryModule => Math.Max(0, galleryModule.DownloadCount))
+                        : module.DownloadCount,
                     GalleryUrl = module.GalleryUrl,
                     ProjectUrl = module.ProjectUrl
                 };


### PR DESCRIPTION
## Summary

- add explicit `packageAliases.nuget` and `packageAliases.powerShellGallery` curation fields
- aggregate historical package/module download totals only from feed-specific aliases
- keep route and search aliases separate from package ownership
- preserve the primary package identity, version, and URL while deduplicating aggregate totals

## Why

Renamed or consolidated projects can retain several historical package identities. Redirect URLs and search terms do not prove package ownership, so telemetry aggregation now requires an explicit feed-specific declaration and fails closed for ordinary route aliases.

## Validation

- 27 targeted project-catalog, product, and ecosystem tests passed on net10
- route-only aliases were proven unable to add unrelated Gallery or NuGet totals
- EventViewerX consumer generation aggregated PSEventViewer, PSWinReporting, and PSWinReportingV2 to 1,213,499 Gallery downloads and 1,222,948 total downloads
- targeted read-only confirmation found no actionable P0-P3 findings