### PR TITLE
Evaluate inherited versions in project build plans

### DIFF
--- a/PowerForge.Tests/DotNetRepositoryReleaseCentralVersionTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseCentralVersionTests.cs
@@ -212,4 +212,52 @@ public sealed class DotNetRepositoryReleaseCentralVersionTests
             try { root.Delete(recursive: true); } catch { /* best effort */ }
         }
     }
+
+    [Fact]
+    public void Execute_WhatIf_EvaluatesImportedVersionWhenProjectDeclaresNoVersion()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "Directory.Build.props"), """
+                <Project>
+                  <PropertyGroup>
+                    <VersionPrefix>1.2.3</VersionPrefix>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.WhatIfCentralVersion"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.WhatIfCentralVersion.csproj");
+            const string projectSource = """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <PackageId>Sample.WhatIfCentralVersion</PackageId>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                </Project>
+                """;
+            File.WriteAllText(projectPath, projectSource);
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Pack = false,
+                Publish = false,
+                UpdateVersions = false,
+                WhatIf = true,
+                SignAssemblies = false,
+                SignPackages = false
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal("1.2.3", result.ResolvedVersionsByProject["Sample.WhatIfCentralVersion"]);
+            Assert.Equal(projectSource, File.ReadAllText(projectPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
 }

--- a/PowerForge.Tests/DotNetRepositoryReleaseCentralVersionTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseCentralVersionTests.cs
@@ -260,4 +260,92 @@ public sealed class DotNetRepositoryReleaseCentralVersionTests
             try { root.Delete(recursive: true); } catch { /* best effort */ }
         }
     }
+
+    [Fact]
+    public void Execute_WhatIf_PrefersEvaluatedPackageVersionOverLiteralProjectVersion()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "Directory.Build.props"), """
+                <Project>
+                  <PropertyGroup>
+                    <PackageVersion>2.3.4</PackageVersion>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.EffectiveVersion"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.EffectiveVersion.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <PackageId>Sample.EffectiveVersion</PackageId>
+                    <VersionPrefix>1.0.0</VersionPrefix>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Pack = false,
+                Publish = false,
+                UpdateVersions = false,
+                WhatIf = true,
+                SignAssemblies = false,
+                SignPackages = false
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal("2.3.4", result.ResolvedVersionsByProject["Sample.EffectiveVersion"]);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Execute_NormalizesReusedPlannedVersion()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.PlannedVersion"));
+            File.WriteAllText(Path.Combine(projectDirectory.FullName, "Sample.PlannedVersion.csproj"), """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <PackageId>Sample.PlannedVersion</PackageId>
+                    <VersionPrefix>1.0.0</VersionPrefix>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Pack = false,
+                Publish = false,
+                UpdateVersions = false,
+                PlannedVersionsByProject = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Sample.PlannedVersion"] = "1.00.0"
+                },
+                SignAssemblies = false,
+                SignPackages = false
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal("1.0.0", result.ResolvedVersionsByProject["Sample.PlannedVersion"]);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
 }

--- a/PowerForge.Tests/DotNetRepositoryReleaseService.VersioningTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseService.VersioningTests.cs
@@ -8,6 +8,40 @@ namespace PowerForge.Tests;
 public sealed class DotNetRepositoryReleaseServiceVersioningTests
 {
     [Fact]
+    public void Execute_DoesNotResolveAlignedFeedsWhenPlanCoversSelection()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            WritePackableProject(root.FullName, "Suite.Core", "Suite.Core");
+            WritePackableProject(root.FullName, "Suite.Rendering", "Suite.Rendering");
+            var logger = new InfoRecordingLogger();
+
+            var result = new DotNetRepositoryReleaseService(logger).Execute(new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                ExpectedVersion = "1.0.X",
+                AlignPackageVersions = true,
+                UpdateVersions = true,
+                Pack = false,
+                PlannedVersionsByProject = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Suite.Core"] = "1.0.1",
+                    ["Suite.Rendering"] = "1.0.1"
+                }
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.All(result.ResolvedVersionsByProject.Values, version => Assert.Equal("1.0.1", version));
+            Assert.DoesNotContain(logger.InfoMessages, message => message.StartsWith("Aligned ", StringComparison.Ordinal));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Execute_AlignsXPatternProjectsAfterHighestCurrentPackageVersion()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -610,5 +644,18 @@ public sealed class DotNetRepositoryReleaseServiceVersioningTests
             "  </PropertyGroup>",
             "</Project>"
         }));
+    }
+
+    private sealed class InfoRecordingLogger : ILogger
+    {
+        public List<string> InfoMessages { get; } = new();
+
+        public bool IsVerbose => false;
+
+        public void Info(string message) => InfoMessages.Add(message);
+        public void Success(string message) { }
+        public void Warn(string message) { }
+        public void Error(string message) { }
+        public void Verbose(string message) { }
     }
 }

--- a/PowerForge.Tests/DotNetRepositoryReleaseVersionBindingTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseVersionBindingTests.cs
@@ -124,6 +124,75 @@ public sealed class DotNetRepositoryReleaseVersionBindingTests
         }
     }
 
+    [Fact]
+    public void Execute_refreshes_inherited_package_versions_after_binding_updates()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-release-binding-" + Guid.NewGuid().ToString("N")));
+        try
+        {
+            var propsPath = Path.Combine(root.FullName, "Directory.Build.props");
+            File.WriteAllText(propsPath, """
+                <Project>
+                  <PropertyGroup>
+                    <VersionPrefix>1.0.0</VersionPrefix>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var primaryDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Example.Primary"));
+            File.WriteAllText(Path.Combine(primaryDirectory.FullName, "Example.Primary.csproj"), """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <VersionPrefix>1.0.0</VersionPrefix>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            var inheritedDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Example.Inherited"));
+            var inheritedPath = Path.Combine(inheritedDirectory.FullName, "Example.Inherited.csproj");
+            var inheritedSource = """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                </Project>
+                """;
+            File.WriteAllText(inheritedPath, inheritedSource);
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                ExpectedVersionsByProject = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Example.Primary"] = "1.1.0"
+                },
+                UpdateVersions = true,
+                Pack = false,
+                VersionBindings = new[]
+                {
+                    new ProjectVersionBinding
+                    {
+                        Path = "Directory.Build.props",
+                        Project = "Example.Primary",
+                        Pattern = @"(?<=<VersionPrefix>)\d+\.\d+\.\d+(?=</VersionPrefix>)"
+                    }
+                }
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal("1.1.0", result.ResolvedVersionsByProject["Example.Primary"]);
+            Assert.Equal("1.1.0", result.ResolvedVersionsByProject["Example.Inherited"]);
+            Assert.Contains("<VersionPrefix>1.1.0</VersionPrefix>", File.ReadAllText(propsPath), StringComparison.Ordinal);
+            Assert.Equal(inheritedSource, File.ReadAllText(inheritedPath));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
     private static DotNetRepositoryReleaseResult Execute(DirectoryInfo root, string pattern)
         => new DotNetRepositoryReleaseService(new NullLogger()).Execute(new DotNetRepositoryReleaseSpec
         {

--- a/PowerForge.Tests/ProjectBuildWorkflowServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildWorkflowServiceTests.cs
@@ -513,6 +513,62 @@ public sealed class ProjectBuildWorkflowServiceTests
         }
     }
 
+    [Fact]
+    public void Execute_reuses_evaluated_package_version_instead_of_literal_project_version()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "Directory.Build.props"), """
+                <Project>
+                  <PropertyGroup>
+                    <PackageVersion>2.3.4</PackageVersion>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.EffectiveVersion"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.EffectiveVersion.csproj");
+            const string projectSource = """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <PackageId>Sample.EffectiveVersion</PackageId>
+                    <VersionPrefix>1.0.0</VersionPrefix>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                </Project>
+                """;
+            File.WriteAllText(projectPath, projectSource);
+
+            var workflow = new ProjectBuildWorkflowService(new NullLogger()).Execute(
+                new ProjectBuildConfiguration(),
+                root.FullName,
+                new ProjectBuildPreparedContext
+                {
+                    RootPath = root.FullName,
+                    Spec = new DotNetRepositoryReleaseSpec
+                    {
+                        RootPath = root.FullName,
+                        Pack = false,
+                        Publish = false,
+                        UpdateVersions = false,
+                        SignAssemblies = false,
+                        SignPackages = false
+                    }
+                },
+                executeBuild: true);
+
+            Assert.True(workflow.Result.Success, workflow.Result.ErrorMessage);
+            Assert.Equal("2.3.4", workflow.Result.Release!.ResolvedVersionsByProject["Sample.EffectiveVersion"]);
+            Assert.Equal(projectSource, File.ReadAllText(projectPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     private static DotNetRepositoryReleaseResult CreateMixedVersionRelease()
         => new()
         {

--- a/PowerForge.Tests/ProjectBuildWorkflowServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildWorkflowServiceTests.cs
@@ -125,9 +125,8 @@ public sealed class ProjectBuildWorkflowServiceTests
                 }
 
                 Assert.False(spec.WhatIf);
-                Assert.Null(spec.ExpectedVersion);
-                Assert.NotNull(spec.ExpectedVersionsByProject);
-                Assert.Equal("1.2.3", spec.ExpectedVersionsByProject!["ProjectA"]);
+                Assert.NotNull(spec.PlannedVersionsByProject);
+                Assert.Equal("1.2.3", spec.PlannedVersionsByProject!["ProjectA"]);
                 return new DotNetRepositoryReleaseResult
                 {
                     Success = true,
@@ -456,6 +455,62 @@ public sealed class ProjectBuildWorkflowServiceTests
             message.Contains("Project build release execution failed after", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(logger.ErrorMessages, message =>
             message.Contains("ProjectA: package provenance mismatch", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_reuses_planned_central_version_without_inserting_project_version()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "Directory.Build.props"), """
+                <Project>
+                  <PropertyGroup>
+                    <VersionPrefix>1.2.3</VersionPrefix>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.CentralVersion"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.CentralVersion.csproj");
+            const string projectSource = """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <PackageId>Sample.CentralVersion</PackageId>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                </Project>
+                """;
+            File.WriteAllText(projectPath, projectSource);
+
+            var workflow = new ProjectBuildWorkflowService(new NullLogger()).Execute(
+                new ProjectBuildConfiguration(),
+                root.FullName,
+                new ProjectBuildPreparedContext
+                {
+                    RootPath = root.FullName,
+                    UpdateVersions = true,
+                    Spec = new DotNetRepositoryReleaseSpec
+                    {
+                        RootPath = root.FullName,
+                        Pack = false,
+                        Publish = false,
+                        UpdateVersions = true,
+                        SignAssemblies = false,
+                        SignPackages = false
+                    }
+                },
+                executeBuild: true);
+
+            Assert.True(workflow.Result.Success, workflow.Result.ErrorMessage);
+            Assert.Equal("1.2.3", workflow.Result.Release!.ResolvedVersionsByProject["Sample.CentralVersion"]);
+            Assert.Equal(projectSource, File.ReadAllText(projectPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
     }
 
     private static DotNetRepositoryReleaseResult CreateMixedVersionRelease()

--- a/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
@@ -9,6 +9,7 @@ public sealed class DotNetRepositoryReleaseSpec
     internal string? ReleaseVersionFloor { get; set; }
     internal string? ReleaseVersionFloorProject { get; set; }
     internal string? ResolvedReleaseVersionFloorProject { get; set; }
+    internal IReadOnlyDictionary<string, string>? PlannedVersionsByProject { get; set; }
 
     /// <summary>Root path of the repository to scan for projects.</summary>
     public string RootPath { get; set; } = string.Empty;

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -220,7 +220,13 @@ public sealed partial class DotNetRepositoryReleaseService
                 string? resolutionWarning;
                 try
                 {
-                    if (alignedVersions.TryGetValue(project.ProjectName, out var alignedVersion))
+                    if (spec.PlannedVersionsByProject is not null &&
+                        spec.PlannedVersionsByProject.TryGetValue(project.ProjectName, out var plannedVersion))
+                    {
+                        resolvedVersion = plannedVersion;
+                        resolutionWarning = null;
+                    }
+                    else if (alignedVersions.TryGetValue(project.ProjectName, out var alignedVersion))
                     {
                         resolvedVersion = alignedVersion;
                         resolutionWarning = null;

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -193,7 +193,11 @@ public sealed partial class DotNetRepositoryReleaseService
             }
 
             PrepareReleaseVersionFloor(packable, expectedGlobal, expectedMap, spec);
-            var alignedVersions = ResolveAlignedPackageVersions(packable, expectedGlobal, expectedMap, spec);
+            var plannedVersionsCoverSelection = spec.PlannedVersionsByProject is not null &&
+                packable.All(project => spec.PlannedVersionsByProject.ContainsKey(project.ProjectName));
+            var alignedVersions = plannedVersionsCoverSelection
+                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                : ResolveAlignedPackageVersions(packable, expectedGlobal, expectedMap, spec);
             var detailedProgress = progress as IProjectBuildProgressReporterV2;
             var versionItems = CreateVersionProgressItems(packable, detailedProgress);
             progress?.PhaseStarted(ProjectBuildProgressPhase.Versioning, packable.Length, "Resolving project versions");
@@ -223,7 +227,11 @@ public sealed partial class DotNetRepositoryReleaseService
                     if (spec.PlannedVersionsByProject is not null &&
                         spec.PlannedVersionsByProject.TryGetValue(project.ProjectName, out var plannedVersion))
                     {
-                        resolvedVersion = plannedVersion;
+                        if (!PackageVersionUtility.TryNormalizeExact(plannedVersion, out resolvedVersion))
+                        {
+                            throw new InvalidOperationException(
+                                $"Planned version '{plannedVersion}' is not a valid exact package version.");
+                        }
                         resolutionWarning = null;
                     }
                     else if (alignedVersions.TryGetValue(project.ProjectName, out var alignedVersion))
@@ -362,9 +370,22 @@ public sealed partial class DotNetRepositoryReleaseService
                     }
 
                     versionBindingService.LogApplied(versionBindingPlan);
+
+                    if (versionBindingPlan.Any(static item => item.HasChanges) &&
+                        !TryRefreshEffectiveVersionsAfterBindings(
+                            packable,
+                            result,
+                            spec,
+                            spec.VersionBindings,
+                            out var refreshError))
+                    {
+                        result.Success = false;
+                        progress?.PhaseFailed(ProjectBuildProgressPhase.Versioning, refreshError);
+                    }
                 }
 
-                progress?.PhaseCompleted(ProjectBuildProgressPhase.Versioning, $"{packable.Length} project version(s) resolved");
+                if (!packable.Any(project => !string.IsNullOrWhiteSpace(project.ErrorMessage)))
+                    progress?.PhaseCompleted(ProjectBuildProgressPhase.Versioning, $"{packable.Length} project version(s) resolved");
             }
             if (spec.Pack)
             {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -61,9 +61,6 @@ public sealed partial class DotNetRepositoryReleaseService
         {
             if (!string.IsNullOrWhiteSpace(declaredVersion))
                 return declaredVersion!;
-
-            warning = "WhatIf cannot resolve a project version without evaluating MSBuild because no version tag was declared.";
-            return string.Empty;
         }
 
         var projectDirectory = Path.GetDirectoryName(project.CsprojPath) ?? spec.RootPath;

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -57,12 +57,6 @@ public sealed partial class DotNetRepositoryReleaseService
                 declaredExactVersion = exact;
         }
 
-        if (spec.WhatIf)
-        {
-            if (!string.IsNullOrWhiteSpace(declaredVersion))
-                return declaredVersion!;
-        }
-
         var projectDirectory = Path.GetDirectoryName(project.CsprojPath) ?? spec.RootPath;
         var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
         var exitCode = RunDotnetMsBuildGetProperty(
@@ -109,7 +103,73 @@ public sealed partial class DotNetRepositoryReleaseService
                     : $"Project version '{declaredVersion}' did not evaluate to a package version.";
         }
 
-        return declaredExactVersion ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(declaredExactVersion))
+            return declaredExactVersion!;
+
+        return spec.WhatIf && !string.IsNullOrWhiteSpace(declaredVersion)
+            ? declaredVersion!
+            : string.Empty;
+    }
+
+    private bool TryRefreshEffectiveVersionsAfterBindings(
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        DotNetRepositoryReleaseResult result,
+        DotNetRepositoryReleaseSpec spec,
+        IReadOnlyList<ProjectVersionBinding>? bindings,
+        out string? error)
+    {
+        error = null;
+        var bindingSources = new HashSet<string>(
+            (bindings ?? Array.Empty<ProjectVersionBinding>())
+                .Where(static binding => binding is not null && !string.IsNullOrWhiteSpace(binding.Project))
+                .Select(static binding => binding.Project.Trim()),
+            StringComparer.OrdinalIgnoreCase);
+        var sourceVersionsBeforeRefresh = result.ResolvedVersionsByProject
+            .Where(pair => bindingSources.Contains(pair.Key))
+            .ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var project in projects)
+        {
+            var effectiveVersion = ResolveCurrentProjectVersion(project, spec, out var warning);
+            if (!string.IsNullOrWhiteSpace(warning))
+                _logger.Warn($"{project.ProjectName}: {warning}");
+            if (string.IsNullOrWhiteSpace(effectiveVersion) ||
+                !PackageVersionUtility.TryNormalizeExact(effectiveVersion, out var normalizedVersion))
+            {
+                project.ErrorMessage = "Unable to re-evaluate the effective package version after applying version bindings.";
+                error = $"{project.ProjectName}: {project.ErrorMessage}";
+                _logger.Warn(error);
+                return false;
+            }
+
+            if (!string.Equals(project.NewVersion, normalizedVersion, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.Info(
+                    $"{project.ProjectName}: effective package version changed from {project.NewVersion} to {normalizedVersion} after version bindings.");
+            }
+
+            result.ResolvedVersionsByProject[project.ProjectName] = normalizedVersion;
+            project.NewVersion = normalizedVersion;
+        }
+
+        foreach (var source in sourceVersionsBeforeRefresh)
+        {
+            if (result.ResolvedVersionsByProject.TryGetValue(source.Key, out var refreshed) &&
+                string.Equals(source.Value, refreshed, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var project = projects.First(item =>
+                string.Equals(item.ProjectName, source.Key, StringComparison.OrdinalIgnoreCase));
+            project.ErrorMessage =
+                $"Version binding source '{source.Key}' changed its effective package version after the binding was applied.";
+            error = project.ErrorMessage;
+            _logger.Warn(error);
+            return false;
+        }
+
+        return true;
     }
 
     private static DotNetPackResult PackProject(

--- a/PowerForge/Services/ProjectBuildWorkflowService.cs
+++ b/PowerForge/Services/ProjectBuildWorkflowService.cs
@@ -79,8 +79,7 @@ internal sealed class ProjectBuildWorkflowService
             preflightErrors.Add(plan.ErrorMessage ?? "Plan/preflight validation failed.");
         else if (plan.ResolvedVersionsByProject.Count > 0)
         {
-            spec.ExpectedVersion = null;
-            spec.ExpectedVersionsByProject = new Dictionary<string, string>(
+            spec.PlannedVersionsByProject = new Dictionary<string, string>(
                 plan.ResolvedVersionsByProject,
                 StringComparer.OrdinalIgnoreCase);
             _logger.Info($"Reusing {plan.ResolvedVersionsByProject.Count} resolved project version(s) from the plan for release execution.");

--- a/PowerForge/Services/ProjectBuildWorkflowService.cs
+++ b/PowerForge/Services/ProjectBuildWorkflowService.cs
@@ -77,12 +77,16 @@ internal sealed class ProjectBuildWorkflowService
         var preflightErrors = new List<string>();
         if (!plan.Success)
             preflightErrors.Add(plan.ErrorMessage ?? "Plan/preflight validation failed.");
+        else if (TryCreateReusablePlanVersions(plan.ResolvedVersionsByProject, out var reusablePlanVersions) &&
+                 (spec.VersionBindings is null || spec.VersionBindings.Count == 0))
+        {
+            spec.PlannedVersionsByProject = reusablePlanVersions;
+            _logger.Info($"Reusing {plan.ResolvedVersionsByProject.Count} resolved project version(s) from the plan for release execution.");
+        }
         else if (plan.ResolvedVersionsByProject.Count > 0)
         {
-            spec.PlannedVersionsByProject = new Dictionary<string, string>(
-                plan.ResolvedVersionsByProject,
-                StringComparer.OrdinalIgnoreCase);
-            _logger.Info($"Reusing {plan.ResolvedVersionsByProject.Count} resolved project version(s) from the plan for release execution.");
+            spec.PlannedVersionsByProject = null;
+            _logger.Info("Release execution will re-evaluate effective project versions because the plan cannot be reused safely.");
         }
 
         if (!executeBuild || preparation.PlanOnly)
@@ -229,6 +233,28 @@ internal sealed class ProjectBuildWorkflowService
             Result = result,
             GitHubPublishSummary = publishSummary
         };
+    }
+
+    private static bool TryCreateReusablePlanVersions(
+        IReadOnlyDictionary<string, string> resolvedVersions,
+        out Dictionary<string, string> reusableVersions)
+    {
+        reusableVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (resolvedVersions.Count == 0)
+            return false;
+
+        foreach (var pair in resolvedVersions)
+        {
+            if (!PackageVersionUtility.TryNormalizeExact(pair.Value, out var normalized))
+            {
+                reusableVersions.Clear();
+                return false;
+            }
+
+            reusableVersions[pair.Key] = normalized;
+        }
+
+        return true;
     }
 
     private static ProjectBuildResult CreateResult(IReadOnlyCollection<string> errors, DotNetRepositoryReleaseResult plan)


### PR DESCRIPTION
## Summary

- evaluate effective MSBuild `PackageVersion` values during read-only project build plans, including centrally inherited and imported overrides
- reuse only normalized exact plan results and keep them separate from explicit project-file rewrite authorization
- skip duplicate aligned-feed resolution when a complete safe plan is available
- re-evaluate effective package versions after version bindings change imported build properties
- preserve project files whose versions remain centrally owned

## Why it matters

Repositories that centralize versions in `Directory.Build.props` can use `Invoke-ProjectBuild` planning and coordinated packaging without adding duplicate version properties to every project. Planning, version bindings, package identity matching, and execution now agree on the effective normalized package version.

## Validation

- focused workflow, central-version, alignment, and binding tests: 31/31
- related `DotNetRepositoryRelease` tests: 129/129
- PowerForge and PowerForge.PowerShell builds: `net472`, `net8.0`, and `net10.0`, zero warnings
- real coordinated MessageX build: 12 local 0.1.0 NuGet packages and 12 release archives, with the source worktree unchanged

No package was published.