### PR TITLE
Report truthful PowerShell compilation coverage

### DIFF
--- a/Docs/PowerForge.PowerShellCompilation.md
+++ b/Docs/PowerForge.PowerShellCompilation.md
@@ -449,11 +449,11 @@ powerforge powershell census `
     --output json
 ```
 
-The current six-product frontier candidate reports 1,263 authored files, 1,353 units, 104 emitted typed methods, 1,249 fallback units, and zero parse errors, or 7.69% typed coverage. The per-product typed/fallback split is PowerInfoBlox 2/56, PSSharedGoods 16/269, PSWriteHTML 5/318, O365Essentials 76/210, ADEssentials 4/266, and PSWriteWord 1/130. This is the actual binary-module graph emitted after export shaping, dependency closure, collision handling, and cmdlet-shape checks, not the larger analyzer-only eligibility count. It measures Hybrid compilation opportunity rather than runtime-free Strict coverage.
+The current six-root example census reports 1,263 authored files and 1,353 whole script/function units with zero parse errors. Its post-emission view separates 1,235 authored functions from 118 top-level script or module-initialization units: 133 functions pass structural analysis, 103 survive graph and artifact shaping as typed CLR methods, and 30 analyzer-eligible functions are routed back to fallback. Post-emission function coverage is therefore 8.34%. The per-root emitted/total function split is PowerInfoBlox 2/57, PSSharedGoods 15/281, PSWriteHTML 5/238, O365Essentials 76/282, ADEssentials 4/247, and PSWriteWord 1/130. These repositories are replaceable regression workloads, not compiler design targets; PowerForge support remains based on generic language, binding, type-system, host, and artifact contracts.
 
-Low initial coverage is not hidden by Hybrid mode. It is written to the manifest, and every fallback has a diagnostic explaining what needs compiler support. Diagnostics are deliberately blocker-masked to avoid cascades, so accepting one outer construct can reveal deeper runtime semantics without increasing coverage. Roadmap priority therefore comes from repeated full-corpus passes and executable differential proof, not raw syntax-occurrence counts.
+Low initial coverage is not hidden by Hybrid mode. It is written to the manifest, and every fallback has a diagnostic explaining what needs compiler support. Diagnostics are deliberately blocker-masked to avoid cascades, so accepting one outer construct can reveal deeper runtime semantics without increasing coverage. Roadmap priority therefore comes from repeated full-corpus passes and executable differential proof, not raw syntax-occurrence counts. Census baselines also carry a portable SHA-256 fingerprint over relative source paths and exact file content, so a changed corpus cannot silently pass merely because its aggregate counts stayed equal.
 
-The machine-readable `frontier` separates four questions that raw occurrence counts mix together:
+The machine-readable `functionFrontier` separates four questions that raw occurrence counts mix together and excludes module-initialization units that cannot become emitted CLR methods. The compatibility `frontier` remains available for callers that need the older whole-unit view:
 
 - `occurrences`: visible diagnostics assigned to the stable feature ID;
 - `affectedUnits`: distinct fallback functions or script bodies reporting it;
@@ -462,21 +462,20 @@ The machine-readable `frontier` separates four questions that raw occurrence cou
 
 `candidateCoveragePercentage` adds only visible sole-blocker units to current typed coverage. It is a counterfactual planning signal, not a promise: accepting an outer AST construct can reveal a deeper blocker that was deliberately masked. `coBlockers` shows which features commonly need to land together. Features are ranked lexically by complete-product candidates, visible sole-blocker units, affected units, occurrences, and stable ID; PowerForge does not invent an effort score.
 
-The current six-product run produces this leading planning frontier:
+The current six-root run produces this leading emitted-function planning frontier:
 
 | Feature ID | Occurrences | Affected units | Visible sole-blocker units | Products | Candidate coverage |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| `command.register-argumentcompleter` | 229 | 82 | 78 | 2 | 13.45% |
-| `parameter.type` | 1,518 | 566 | 57 | 6 | 11.90% |
-| `runtime.scope` | 1,642 | 418 | 36 | 6 | 10.35% |
-| `parameter.metadata` | 1,617 | 357 | 34 | 6 | 10.20% |
-| `parameter.default` | 829 | 357 | 31 | 6 | 9.98% |
-| `function.graph` | 29 | 29 | 29 | 3 | 9.83% |
-| `command.new-htmltab` | 22 | 22 | 22 | 1 | 9.31% |
-| `expression.conversion` | 710 | 243 | 10 | 6 | 8.43% |
-| `syntax.subexpression` | 746 | 197 | 8 | 6 | 8.28% |
+| `parameter.type` | 1,518 | 566 | 57 | 6 | 12.96% |
+| `parameter.metadata` | 1,617 | 357 | 34 | 6 | 11.09% |
+| `parameter.default` | 829 | 357 | 31 | 6 | 10.85% |
+| `function.graph` | 30 | 30 | 30 | 3 | 10.77% |
+| `runtime.scope` | 1,594 | 385 | 29 | 6 | 10.69% |
+| `command.new-htmltab` | 22 | 22 | 22 | 1 | 10.12% |
+| `expression.conversion` | 702 | 237 | 10 | 6 | 9.15% |
+| `syntax.subexpression` | 734 | 191 | 8 | 6 | 8.99% |
 
-This changes feature planning materially. For example, parameter types have far more total impact than `Register-ArgumentCompleter`, but the latter is the only visible blocker for more units in the current Hybrid module graph. That does not mean it should be implemented as a runtime-free Strict intrinsic: the recommendation attached to each feature still distinguishes a safe intrinsic, a PowerShell-backed command region, an authoring change, or behavior that should remain Package/Hybrid-only.
+This changes feature planning materially. `Register-ArgumentCompleter` leads the compatibility whole-unit frontier because it appears in many module-initialization bodies, but it disappears from the emitted-function frontier and must not be treated as 78 potential CLR methods. Likewise, a sample-specific command identifier such as `command.new-htmltab` is evidence for a generic command-boundary shape, not authorization for a product-specific compiler intrinsic. Recommendations must distinguish generic typed IR, a contract-driven PowerShell-backed command region, an authoring change, and behavior that should remain Package/Hybrid-only.
 
 ### Real product rebuild matrix
 

--- a/PowerForge.Cli/Program.Command.PowerShell.cs
+++ b/PowerForge.Cli/Program.Command.PowerShell.cs
@@ -312,11 +312,17 @@ internal static partial class Program
                 return exitCode;
             }
 
-            logger.Info($"PowerShell compilation census: {result.SourceFiles} files, {result.TotalUnits} units, {result.CompilableUnits} typed, {result.RuntimeFallbackUnits} fallback, {result.ParseErrorFiles} parse-error files.");
+            if (result.PostEmissionEvaluated)
+                logger.Info($"PowerShell compilation census: {result.SourceFiles} files, {result.EmittedFunctions}/{result.TotalFunctions} functions emitted ({result.EmittedFunctionCoveragePercentage:0.0}%), {result.DroppedEligibleFunctions} analyzer-eligible function(s) dropped after shaping, {result.ParseErrorFiles} parse-error files.");
+            else
+                logger.Info($"PowerShell compilation census: {result.SourceFiles} files, {result.CompilableUnits}/{result.TotalUnits} units structurally eligible; post-emission shaping was not evaluated, {result.ParseErrorFiles} parse-error files.");
             foreach (var product in result.Products)
             {
-                logger.Info($"{product.Name}: {product.SourceFiles} files, {product.CompilableUnits}/{product.TotalUnits} typed ({product.CompilationCoveragePercentage:0.0}%), {product.AnalysisMilliseconds:0.0} ms.");
-                foreach (var feature in product.FeatureImpacts.Take(5))
+                if (product.Coverage.PostEmissionEvaluated)
+                    logger.Info($"{product.Name}: {product.SourceFiles} files, {product.Coverage.EmittedFunctions}/{product.Coverage.TotalFunctions} functions emitted ({product.Coverage.EmittedFunctionCoveragePercentage:0.0}%), {product.Coverage.TotalScriptUnits} script/init unit(s), {product.AnalysisMilliseconds:0.0} ms.");
+                else
+                    logger.Info($"{product.Name}: {product.SourceFiles} files, {product.CompilableUnits}/{product.TotalUnits} units structurally eligible; post-emission shaping was not evaluated, {product.AnalysisMilliseconds:0.0} ms.");
+                foreach (var feature in product.FunctionImpacts.Take(5))
                     logger.Warn($"  [{feature.FeatureId}] {feature.AffectedUnits} affected, {feature.VisibleSoleBlockerUnits} visible sole-blocker candidate(s), candidate coverage {feature.CandidateCoveragePercentage:0.0}%.");
                 var payload = product.DependencySummary.Where(static summary =>
                     summary.Kind is not PowerShellCompilationDependencyKind.PowerShellSource and not PowerShellCompilationDependencyKind.ModuleManifest).ToArray();
@@ -326,22 +332,24 @@ internal static partial class Program
                 if (resources.IncludedFiles + resources.ExcludedFiles + resources.UnclassifiedFiles > 0)
                     logger.Info($"  Resources: {resources.IncludedFiles} included, {resources.RequiredFiles} required, {resources.InferredFiles} inferred, {resources.ExcludedFiles} excluded, {resources.UnclassifiedFiles} unclassified ({resources.IncludedBytes + resources.ExcludedBytes + resources.UnclassifiedBytes} inventoried byte(s)).");
             }
-            if (result.Frontier.Length > 0)
+            if (result.FunctionFrontier.Length > 0)
             {
-                logger.Info("Observed compiler frontier (current visible blockers; not a guarantee that masked blockers will not appear):");
+                logger.Info("Observed emitted-function frontier (current visible blockers; not a guarantee that masked blockers will not appear):");
                 var rank = 0;
-                foreach (var feature in result.Frontier.Take(10))
+                foreach (var feature in result.FunctionFrontier.Take(10))
                 {
                     logger.Info($"  {++rank}. [{feature.FeatureId}] {feature.Title}: {feature.AffectedUnits} affected, {feature.VisibleSoleBlockerUnits} visible sole-blocker candidate(s), {feature.AffectedProducts} product(s), candidate coverage {feature.CandidateCoveragePercentage:0.0}%.");
                     logger.Info($"     {feature.Recommendation}");
                 }
             }
-            if (result.CoBlockers.Length > 0)
+            if (result.FunctionCoBlockers.Length > 0)
             {
-                logger.Info("Frequent co-blockers:");
-                foreach (var pair in result.CoBlockers.Take(5))
+                logger.Info("Frequent function co-blockers:");
+                foreach (var pair in result.FunctionCoBlockers.Take(5))
                     logger.Info($"  [{pair.FirstFeatureId}] + [{pair.SecondFeatureId}]: {pair.AffectedUnits} unit(s).");
             }
+            foreach (var drift in result.SourceDrifts)
+                logger.Error($"{drift.Product}: census source content differs from the baseline fingerprint.");
             foreach (var regression in result.Regressions)
                 logger.Error($"Census regression in {regression.Product}: {regression.Metric} was {regression.Baseline:0.###}, now {regression.Current:0.###}.");
             return exitCode;

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationCensusRunner.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationCensusRunner.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace PowerForge;
 
@@ -39,13 +41,38 @@ public sealed class PowerShellCompilationCensusRunner
         var regressions = baseline is null
             ? Array.Empty<PowerShellCompilationCensusRegression>()
             : Compare(products, baseline.Products);
+        var sourceDrifts = baseline is null
+            ? Array.Empty<PowerShellCompilationCensusSourceDrift>()
+            : CompareSourceDrifts(products, baseline.Products);
         var frontier = BuildFeatureImpacts(
             analyses.SelectMany(static analysis => analysis.FeatureEvidence),
             products.Sum(static product => product.CompilableUnits),
             products.Sum(static product => product.TotalUnits),
             products);
         var coBlockers = BuildCoBlockers(analyses.SelectMany(static analysis => analysis.FeatureEvidence));
-        return new PowerShellCompilationCensusResult(targetFramework, products, regressions, frontier, coBlockers);
+        var functionFrontier = BuildFeatureImpacts(
+            analyses.SelectMany(static analysis => analysis.FeatureEvidence),
+            products.Sum(static product => product.Coverage.EmittedFunctions),
+            products.Sum(static product => product.Coverage.TotalFunctions),
+            products.Select(static product => new ProductMetrics(
+                product.Path,
+                product.Coverage.TotalFunctions,
+                product.Coverage.EmittedFunctions,
+                product.Coverage.FallbackFunctions,
+                product.ParseErrorFiles)),
+            PowerShellCompilationUnitKind.Function);
+        var functionCoBlockers = BuildCoBlockers(
+            analyses.SelectMany(static analysis => analysis.FeatureEvidence),
+            PowerShellCompilationUnitKind.Function);
+        return new PowerShellCompilationCensusResult(
+            targetFramework,
+            products,
+            regressions,
+            frontier,
+            coBlockers,
+            sourceDrifts,
+            functionFrontier,
+            functionCoBlockers);
     }
 
     private static AnalyzedProduct AnalyzeProduct(string path, string? targetFramework, bool recurse)
@@ -55,6 +82,8 @@ public sealed class PowerShellCompilationCensusRunner
         PowerShellCompilationPlan plan;
         PowerShellCompilationDependency[] dependencies = Array.Empty<PowerShellCompilationDependency>();
         var sourceFiles = 0;
+        var sourceFingerprint = string.Empty;
+        var coverage = new PowerShellCompilationCoverageBreakdown();
         if (recurse)
         {
             var resolved = new PowerShellCompilationInputResolver().Resolve(path);
@@ -96,6 +125,13 @@ public sealed class PowerShellCompilationCensusRunner
             var files = compiledFiles.Concat(runtimeOnlyFiles).ToArray();
             plan = new PowerShellCompilationPlan(PowerShellCompilationMode.Analyze, files, targetFramework);
             sourceFiles = resolved.SourceFiles.Length;
+            sourceFingerprint = ComputeSourceFingerprint(resolved.SourceFiles, path);
+            coverage = BuildCoverageBreakdown(
+                analyzedCompilation.Files,
+                files,
+                runtimeOnlyFiles,
+                emitted.Methods.Length,
+                postEmissionEvaluated: true);
         }
         else
         {
@@ -106,9 +142,16 @@ public sealed class PowerShellCompilationCensusRunner
                 targetFramework: targetFramework,
                 capabilities: PowerShellCompilationCapability.PowerShellStreams |
                               PowerShellCompilationCapability.LocalFunctionCalls |
-                              PowerShellCompilationCapability.BoundParameters |
-                              PowerShellCompilationCapability.PowerShellObjects));
+                                  PowerShellCompilationCapability.BoundParameters |
+                                  PowerShellCompilationCapability.PowerShellObjects));
             sourceFiles = plan.Files.Length;
+            sourceFingerprint = ComputeSourceFingerprint(plan.Files.Select(static file => file.FullPath), path);
+            coverage = BuildCoverageBreakdown(
+                plan.Files,
+                plan.Files,
+                Array.Empty<PowerShellCompilationFilePlan>(),
+                emittedFunctions: 0,
+                postEmissionEvaluated: false);
         }
         stopwatch.Stop();
 
@@ -132,6 +175,15 @@ public sealed class PowerShellCompilationCensusRunner
         {
             new ProductMetrics(path, plan.TotalUnits, plan.CompilableUnits, plan.RuntimeFallbackUnits, plan.ParseErrorFiles)
         };
+        var functionMetrics = new[]
+        {
+            new ProductMetrics(
+                path,
+                coverage.TotalFunctions,
+                coverage.EmittedFunctions,
+                coverage.FallbackFunctions,
+                plan.ParseErrorFiles)
+        };
         var product = new PowerShellCompilationCensusProduct(
             name,
             path,
@@ -144,7 +196,15 @@ public sealed class PowerShellCompilationCensusRunner
             diagnostics,
             BuildFeatureImpacts(featureEvidence, plan.CompilableUnits, plan.TotalUnits, productMetrics),
             PowerShellCompilationDependencyPlanner.Summarize(dependencies),
-            PowerShellCompilationResourceSummary.Create(dependencies));
+            PowerShellCompilationResourceSummary.Create(dependencies),
+            coverage,
+            sourceFingerprint,
+            BuildFeatureImpacts(
+                featureEvidence,
+                coverage.EmittedFunctions,
+                coverage.TotalFunctions,
+                functionMetrics,
+                PowerShellCompilationUnitKind.Function));
         return new AnalyzedProduct(product, featureEvidence);
     }
 
@@ -159,6 +219,7 @@ public sealed class PowerShellCompilationCensusRunner
                     product,
                     file.RelativePath + ":" + unit.StartLine + ":" + unit.Name,
                     isCompilationUnit: true,
+                    unit.Kind,
                     diagnostics);
             }
             if (file.Diagnostics.Length > 0)
@@ -167,6 +228,7 @@ public sealed class PowerShellCompilationCensusRunner
                     product,
                     file.RelativePath,
                     isCompilationUnit: false,
+                    unitKind: null,
                     file.Diagnostics);
             }
         }
@@ -192,9 +254,12 @@ public sealed class PowerShellCompilationCensusRunner
         IEnumerable<FeatureUnitEvidence> evidence,
         int currentCompilableUnits,
         int totalUnits,
-        IEnumerable<ProductMetrics> products)
+        IEnumerable<ProductMetrics> products,
+        PowerShellCompilationUnitKind? unitKind = null)
     {
-        var units = evidence.ToArray();
+        var units = evidence
+            .Where(unit => !unitKind.HasValue || unit.UnitKind == unitKind.Value)
+            .ToArray();
         var metrics = products.ToDictionary(static product => product.Name, StringComparer.OrdinalIgnoreCase);
         return units
             .SelectMany(static unit => unit.FeatureIds)
@@ -238,9 +303,13 @@ public sealed class PowerShellCompilationCensusRunner
             .ToArray();
     }
 
-    private static PowerShellCompilationFeaturePair[] BuildCoBlockers(IEnumerable<FeatureUnitEvidence> evidence)
+    private static PowerShellCompilationFeaturePair[] BuildCoBlockers(
+        IEnumerable<FeatureUnitEvidence> evidence,
+        PowerShellCompilationUnitKind? unitKind = null)
         => evidence
-            .Where(static unit => unit.IsCompilationUnit && unit.FeatureIds.Length > 1)
+            .Where(unit => unit.IsCompilationUnit &&
+                           unit.FeatureIds.Length > 1 &&
+                           (!unitKind.HasValue || unit.UnitKind == unitKind.Value))
             .SelectMany(static unit => EnumeratePairs(unit.FeatureIds).Select(pair => new { unit.Product, unit.UnitId, pair.First, pair.Second }))
             .GroupBy(static item => new { item.First, item.Second })
             .Select(static group => new PowerShellCompilationFeaturePair(
@@ -282,10 +351,112 @@ public sealed class PowerShellCompilationCensusRunner
             AddLowerIsRegression(regressions, actual.Name, "TotalUnits", expected.TotalUnits, actual.TotalUnits);
             AddHigherIsRegression(regressions, actual.Name, "RuntimeFallbackUnits", expected.RuntimeFallbackUnits, actual.RuntimeFallbackUnits);
             AddHigherIsRegression(regressions, actual.Name, "ParseErrorFiles", expected.ParseErrorFiles, actual.ParseErrorFiles);
+            if (expected.Coverage.PostEmissionEvaluated)
+            {
+                AddLowerIsRegression(regressions, actual.Name, "EmittedFunctions", expected.Coverage.EmittedFunctions, actual.Coverage.EmittedFunctions);
+                AddHigherIsRegression(regressions, actual.Name, "FallbackFunctions", expected.Coverage.FallbackFunctions, actual.Coverage.FallbackFunctions);
+                AddHigherIsRegression(regressions, actual.Name, "DroppedEligibleFunctions", expected.Coverage.DroppedEligibleFunctions, actual.Coverage.DroppedEligibleFunctions);
+            }
         }
 
         return regressions.ToArray();
     }
+
+    private static PowerShellCompilationCensusSourceDrift[] CompareSourceDrifts(
+        IReadOnlyList<PowerShellCompilationCensusProduct> current,
+        IReadOnlyList<PowerShellCompilationCensusProduct> baseline)
+    {
+        var drifts = new List<PowerShellCompilationCensusSourceDrift>();
+        var unmatched = current.ToList();
+        foreach (var expected in baseline)
+        {
+            var actual = unmatched.FirstOrDefault(candidate => PathsEqual(candidate.Path, expected.Path))
+                         ?? FindUniquePortableMatch(expected, unmatched);
+            if (actual is null)
+                continue;
+            unmatched.Remove(actual);
+            if (string.IsNullOrWhiteSpace(expected.SourceFingerprint) ||
+                string.IsNullOrWhiteSpace(actual.SourceFingerprint) ||
+                expected.SourceFingerprint.Equals(actual.SourceFingerprint, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            drifts.Add(new PowerShellCompilationCensusSourceDrift(
+                actual.Name,
+                expected.SourceFingerprint,
+                actual.SourceFingerprint));
+        }
+        return drifts.ToArray();
+    }
+
+    private static PowerShellCompilationCoverageBreakdown BuildCoverageBreakdown(
+        IEnumerable<PowerShellCompilationFilePlan> analyzerFiles,
+        IEnumerable<PowerShellCompilationFilePlan> finalFiles,
+        IEnumerable<PowerShellCompilationFilePlan> runtimeOnlyFiles,
+        int emittedFunctions,
+        bool postEmissionEvaluated)
+    {
+        var analyzerUnits = analyzerFiles.SelectMany(static file => file.Units).ToArray();
+        var finalUnits = finalFiles.SelectMany(static file => file.Units).ToArray();
+        var runtimeUnits = runtimeOnlyFiles.SelectMany(static file => file.Units).ToArray();
+        var totalFunctions = finalUnits.Count(static unit => unit.Kind == PowerShellCompilationUnitKind.Function);
+        var analyzerEligibleFunctions = analyzerUnits.Count(static unit =>
+            unit.Kind == PowerShellCompilationUnitKind.Function && unit.IsCompilable);
+        var totalScriptUnits = finalUnits.Count(static unit => unit.Kind == PowerShellCompilationUnitKind.Script);
+        var structurallyEligibleScriptUnits = finalUnits.Count(static unit =>
+            unit.Kind == PowerShellCompilationUnitKind.Script && unit.IsCompilable);
+        return new PowerShellCompilationCoverageBreakdown(
+            postEmissionEvaluated,
+            totalFunctions,
+            analyzerEligibleFunctions,
+            emittedFunctions,
+            postEmissionEvaluated ? Math.Max(0, analyzerEligibleFunctions - emittedFunctions) : 0,
+            postEmissionEvaluated ? Math.Max(0, totalFunctions - emittedFunctions) : totalFunctions,
+            totalScriptUnits,
+            structurallyEligibleScriptUnits,
+            totalScriptUnits,
+            runtimeUnits.Count(static unit => unit.Kind == PowerShellCompilationUnitKind.Function),
+            runtimeUnits.Count(static unit => unit.Kind == PowerShellCompilationUnitKind.Script));
+    }
+
+    private static string ComputeSourceFingerprint(IEnumerable<string> files, string sourceRoot)
+    {
+        var fullRoot = Directory.Exists(sourceRoot)
+            ? Path.GetFullPath(sourceRoot)
+            : Path.GetDirectoryName(Path.GetFullPath(sourceRoot)) ?? Directory.GetCurrentDirectory();
+        var identities = files
+            .Where(File.Exists)
+            .Select(Path.GetFullPath)
+            .Distinct(PowerShellCompilationPathSafety.PathComparer)
+            .Select(file => new
+            {
+                Path = file,
+                RelativePath = FrameworkCompatibility.GetRelativePath(fullRoot, file).Replace('\\', '/')
+            })
+            .OrderBy(static item => item.RelativePath, StringComparer.Ordinal)
+            .ToArray();
+        var canonical = new StringBuilder();
+        using (var fileHasher = SHA256.Create())
+        {
+            foreach (var identity in identities)
+            {
+                byte[] contentHash;
+                using (var stream = File.OpenRead(identity.Path))
+                    contentHash = fileHasher.ComputeHash(stream);
+                canonical.Append(identity.RelativePath)
+                    .Append('\0')
+                    .Append(ToLowerHex(contentHash))
+                    .Append('\n');
+            }
+        }
+
+        using (var aggregateHasher = SHA256.Create())
+            return ToLowerHex(aggregateHasher.ComputeHash(Encoding.UTF8.GetBytes(canonical.ToString())));
+    }
+
+    private static string ToLowerHex(byte[] bytes)
+        => BitConverter.ToString(bytes).Replace("-", string.Empty).ToLowerInvariant();
 
     private static bool PathsEqual(string left, string right)
     {
@@ -424,11 +595,13 @@ public sealed class PowerShellCompilationCensusRunner
             string product,
             string unitId,
             bool isCompilationUnit,
+            PowerShellCompilationUnitKind? unitKind,
             PowerShellCompilationDiagnostic[] diagnostics)
         {
             Product = product;
             UnitId = unitId;
             IsCompilationUnit = isCompilationUnit;
+            UnitKind = unitKind;
             Diagnostics = diagnostics;
             FeatureIds = diagnostics
                 .Select(static diagnostic => diagnostic.FeatureId)
@@ -441,6 +614,7 @@ public sealed class PowerShellCompilationCensusRunner
         internal string Product { get; }
         internal string UnitId { get; }
         internal bool IsCompilationUnit { get; }
+        internal PowerShellCompilationUnitKind? UnitKind { get; }
         internal PowerShellCompilationDiagnostic[] Diagnostics { get; }
         internal string[] FeatureIds { get; }
     }

--- a/PowerForge.Tests/PowerShellCompilationCoverageV2Tests.cs
+++ b/PowerForge.Tests/PowerShellCompilationCoverageV2Tests.cs
@@ -1,0 +1,154 @@
+using PowerForge;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed class PowerShellCompilationCoverageV2Tests
+{
+    [Fact]
+    public void Run_SeparatesEmittedFunctionsFromModuleInitialization()
+    {
+        var root = CreateRoot();
+        var source = Path.Combine(root, "Example.psm1");
+        File.WriteAllText(
+            source,
+            "function Get-One { return 1 }; Register-ArgumentCompleter -CommandName Get-One -ParameterName Name -ScriptBlock { 'one' }");
+        try
+        {
+            var result = new PowerShellCompilationCensusRunner().Run(new[] { source }, "net10.0");
+
+            var product = Assert.Single(result.Products);
+            Assert.True(product.Coverage.PostEmissionEvaluated);
+            Assert.Equal(1, product.Coverage.TotalFunctions);
+            Assert.Equal(1, product.Coverage.AnalyzerEligibleFunctions);
+            Assert.Equal(1, product.Coverage.EmittedFunctions);
+            Assert.Equal(0, product.Coverage.DroppedEligibleFunctions);
+            Assert.Equal(0, product.Coverage.FallbackFunctions);
+            Assert.Equal(1, product.Coverage.TotalScriptUnits);
+            Assert.Equal(1, product.Coverage.StructurallyEligibleScriptUnits);
+            Assert.Equal(1, product.Coverage.FallbackScriptUnits);
+            Assert.Equal(100d, product.Coverage.EmittedFunctionCoveragePercentage);
+            Assert.Equal(1, result.EmittedFunctions);
+            Assert.Equal(1, result.TotalFunctions);
+            Assert.DoesNotContain(
+                result.FunctionFrontier,
+                impact => impact.FeatureId == "command.register-argumentcompleter");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Run_ReportsAnalyzerEligibleFunctionsDroppedByGraphShaping()
+    {
+        var root = CreateRoot();
+        var source = Path.Combine(root, "Recursive.psm1");
+        File.WriteAllText(
+            source,
+            "function Get-Even { param([int] $Value) if ($Value -le 0) { return $true }; return Get-Odd -Value ($Value - 1) }; " +
+            "function Get-Odd { param([int] $Value) if ($Value -le 0) { return $false }; return Get-Even -Value ($Value - 1) }");
+        try
+        {
+            var result = new PowerShellCompilationCensusRunner().Run(new[] { source }, "net10.0");
+            var product = Assert.Single(result.Products);
+
+            Assert.Equal(2, product.Coverage.TotalFunctions);
+            Assert.Equal(2, product.Coverage.AnalyzerEligibleFunctions);
+            Assert.Equal(0, product.Coverage.EmittedFunctions);
+            Assert.Equal(2, product.Coverage.DroppedEligibleFunctions);
+            Assert.Equal(2, product.Coverage.FallbackFunctions);
+            var graph = Assert.Single(result.FunctionFrontier, impact =>
+                impact.FeatureId == PowerShellCompilationFeatureIds.FunctionGraph);
+            Assert.Equal(2, graph.VisibleSoleBlockerUnits);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Run_FailsBaselineWhenSourceContentChangesWithoutMetricChanges()
+    {
+        var root = CreateRoot();
+        var source = Path.Combine(root, "StableShape.psm1");
+        File.WriteAllText(source, "function Get-Value { return 1 }");
+        try
+        {
+            var runner = new PowerShellCompilationCensusRunner();
+            var baseline = runner.Run(new[] { source }, "net10.0");
+            File.WriteAllText(source, "function Get-Value { return 2 }");
+
+            var current = runner.Run(new[] { source }, "net10.0", baseline);
+
+            var drift = Assert.Single(current.SourceDrifts);
+            Assert.Equal("StableShape", drift.Product);
+            Assert.NotEqual(drift.BaselineFingerprint, drift.CurrentFingerprint);
+            Assert.Empty(current.Regressions);
+            Assert.False(current.Passed);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Run_UsesPortableContentFingerprintAcrossCheckoutRoots()
+    {
+        var root = CreateRoot();
+        var first = Path.Combine(root, "First", "Module");
+        var second = Path.Combine(root, "Second", "Module");
+        Directory.CreateDirectory(first);
+        Directory.CreateDirectory(second);
+        File.WriteAllText(Path.Combine(first, "Module.psm1"), "function Get-Value { return 1 }");
+        File.WriteAllText(Path.Combine(second, "Module.psm1"), "function Get-Value { return 1 }");
+        try
+        {
+            var runner = new PowerShellCompilationCensusRunner();
+            var baseline = runner.Run(new[] { first }, "net10.0");
+            var current = runner.Run(new[] { second }, "net10.0", baseline);
+
+            Assert.Equal(baseline.Products[0].SourceFingerprint, current.Products[0].SourceFingerprint);
+            Assert.Empty(current.SourceDrifts);
+            Assert.True(current.Passed);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Run_NoRecurseDoesNotPresentAnalyzerEligibilityAsEmittedCoverage()
+    {
+        var root = CreateRoot();
+        var source = Path.Combine(root, "AnalyzeOnly.ps1");
+        File.WriteAllText(source, "function Get-Value { return 1 }");
+        try
+        {
+            var result = new PowerShellCompilationCensusRunner().Run(
+                new[] { source },
+                "net10.0",
+                recurse: false);
+
+            Assert.False(result.PostEmissionEvaluated);
+            Assert.False(result.Products[0].Coverage.PostEmissionEvaluated);
+            Assert.Equal(1, result.CompilableUnits);
+            Assert.Equal(0, result.EmittedFunctions);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static string CreateRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge Coverage V2 Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+}

--- a/PowerForge/Models/PowerShellCompilation/PowerShellCompilationCensus.cs
+++ b/PowerForge/Models/PowerShellCompilation/PowerShellCompilationCensus.cs
@@ -18,7 +18,10 @@ public sealed class PowerShellCompilationCensusProduct
         PowerShellCompilationCensusBlocker[] blockers,
         PowerShellCompilationFeatureImpact[]? featureImpacts = null,
         PowerShellCompilationDependencySummary[]? dependencySummary = null,
-        PowerShellCompilationResourceSummary? resourceSummary = null)
+        PowerShellCompilationResourceSummary? resourceSummary = null,
+        PowerShellCompilationCoverageBreakdown? coverage = null,
+        string? sourceFingerprint = null,
+        PowerShellCompilationFeatureImpact[]? functionImpacts = null)
     {
         Name = name ?? string.Empty;
         Path = path ?? string.Empty;
@@ -32,6 +35,9 @@ public sealed class PowerShellCompilationCensusProduct
         FeatureImpacts = featureImpacts ?? Array.Empty<PowerShellCompilationFeatureImpact>();
         DependencySummary = dependencySummary ?? Array.Empty<PowerShellCompilationDependencySummary>();
         ResourceSummary = resourceSummary ?? new PowerShellCompilationResourceSummary();
+        Coverage = coverage ?? new PowerShellCompilationCoverageBreakdown();
+        SourceFingerprint = sourceFingerprint ?? string.Empty;
+        FunctionImpacts = functionImpacts ?? Array.Empty<PowerShellCompilationFeatureImpact>();
     }
 
     /// <summary>Stable product name derived from the source root.</summary>
@@ -72,6 +78,15 @@ public sealed class PowerShellCompilationCensusProduct
 
     /// <summary>Included, excluded, required, inferred, and unclassified resource totals.</summary>
     public PowerShellCompilationResourceSummary ResourceSummary { get; }
+
+    /// <summary>Post-emission function coverage separated from script/module initialization.</summary>
+    public PowerShellCompilationCoverageBreakdown Coverage { get; }
+
+    /// <summary>SHA-256 identity of the discovered authored PowerShell source set.</summary>
+    public string SourceFingerprint { get; }
+
+    /// <summary>Missing-feature impact restricted to authored functions and post-emission coverage.</summary>
+    public PowerShellCompilationFeatureImpact[] FunctionImpacts { get; }
 }
 
 /// <summary>One aggregated blocker category in a compilation census.</summary>
@@ -104,13 +119,19 @@ public sealed class PowerShellCompilationCensusResult
         PowerShellCompilationCensusProduct[] products,
         PowerShellCompilationCensusRegression[] regressions,
         PowerShellCompilationFeatureImpact[]? frontier = null,
-        PowerShellCompilationFeaturePair[]? coBlockers = null)
+        PowerShellCompilationFeaturePair[]? coBlockers = null,
+        PowerShellCompilationCensusSourceDrift[]? sourceDrifts = null,
+        PowerShellCompilationFeatureImpact[]? functionFrontier = null,
+        PowerShellCompilationFeaturePair[]? functionCoBlockers = null)
     {
         TargetFramework = string.IsNullOrWhiteSpace(targetFramework) ? null : targetFramework;
         Products = products ?? Array.Empty<PowerShellCompilationCensusProduct>();
         Regressions = regressions ?? Array.Empty<PowerShellCompilationCensusRegression>();
         Frontier = frontier ?? Array.Empty<PowerShellCompilationFeatureImpact>();
         CoBlockers = coBlockers ?? Array.Empty<PowerShellCompilationFeaturePair>();
+        SourceDrifts = sourceDrifts ?? Array.Empty<PowerShellCompilationCensusSourceDrift>();
+        FunctionFrontier = functionFrontier ?? Array.Empty<PowerShellCompilationFeatureImpact>();
+        FunctionCoBlockers = functionCoBlockers ?? Array.Empty<PowerShellCompilationFeaturePair>();
     }
 
     /// <summary>Target framework used for CLR surface analysis.</summary>
@@ -128,8 +149,20 @@ public sealed class PowerShellCompilationCensusResult
     /// <summary>Feature pairs most often observed together in the same fallback unit.</summary>
     public PowerShellCompilationFeaturePair[] CoBlockers { get; }
 
+    /// <summary>Corpus inputs whose content no longer matches the supplied baseline.</summary>
+    public PowerShellCompilationCensusSourceDrift[] SourceDrifts { get; }
+
+    /// <summary>Cross-product feature priorities restricted to functions that could become emitted CLR methods.</summary>
+    public PowerShellCompilationFeatureImpact[] FunctionFrontier { get; }
+
+    /// <summary>Function-only feature pairs most often observed together.</summary>
+    public PowerShellCompilationFeaturePair[] FunctionCoBlockers { get; }
+
     /// <summary>Total authored source files discovered.</summary>
     public int SourceFiles => Sum(static product => product.SourceFiles);
+
+    /// <summary>Whether every product was evaluated through final typed artifact shaping.</summary>
+    public bool PostEmissionEvaluated => Products.Length > 0 && Products.All(static product => product.Coverage.PostEmissionEvaluated);
 
     /// <summary>Total executable units discovered.</summary>
     public int TotalUnits => Sum(static product => product.TotalUnits);
@@ -143,8 +176,20 @@ public sealed class PowerShellCompilationCensusResult
     /// <summary>Total files containing parser errors.</summary>
     public int ParseErrorFiles => Sum(static product => product.ParseErrorFiles);
 
+    /// <summary>Total authored function units discovered.</summary>
+    public int TotalFunctions => Sum(static product => product.Coverage.TotalFunctions);
+
+    /// <summary>Total functions emitted as typed CLR methods after artifact shaping.</summary>
+    public int EmittedFunctions => Sum(static product => product.Coverage.EmittedFunctions);
+
+    /// <summary>Total analyzer-eligible functions lost during graph or artifact shaping.</summary>
+    public int DroppedEligibleFunctions => Sum(static product => product.Coverage.DroppedEligibleFunctions);
+
+    /// <summary>Post-emission typed-function coverage percentage.</summary>
+    public double EmittedFunctionCoveragePercentage => TotalFunctions == 0 ? 0 : EmittedFunctions * 100d / TotalFunctions;
+
     /// <summary>Whether the current result meets or improves the supplied baseline.</summary>
-    public bool Passed => Regressions.Length == 0;
+    public bool Passed => Regressions.Length == 0 && SourceDrifts.Length == 0;
 
     private int Sum(Func<PowerShellCompilationCensusProduct, int> selector)
     {

--- a/PowerForge/Models/PowerShellCompilation/PowerShellCompilationCoverage.cs
+++ b/PowerForge/Models/PowerShellCompilation/PowerShellCompilationCoverage.cs
@@ -1,0 +1,93 @@
+using System;
+
+namespace PowerForge;
+
+/// <summary>
+/// Separates analyzer eligibility from functions that survive post-emission artifact shaping.
+/// </summary>
+public sealed class PowerShellCompilationCoverageBreakdown
+{
+    /// <summary>Creates a coverage breakdown.</summary>
+    public PowerShellCompilationCoverageBreakdown(
+        bool postEmissionEvaluated = false,
+        int totalFunctions = 0,
+        int analyzerEligibleFunctions = 0,
+        int emittedFunctions = 0,
+        int droppedEligibleFunctions = 0,
+        int fallbackFunctions = 0,
+        int totalScriptUnits = 0,
+        int structurallyEligibleScriptUnits = 0,
+        int fallbackScriptUnits = 0,
+        int runtimeOnlyFunctions = 0,
+        int runtimeOnlyScriptUnits = 0)
+    {
+        PostEmissionEvaluated = postEmissionEvaluated;
+        TotalFunctions = totalFunctions;
+        AnalyzerEligibleFunctions = analyzerEligibleFunctions;
+        EmittedFunctions = emittedFunctions;
+        DroppedEligibleFunctions = droppedEligibleFunctions;
+        FallbackFunctions = fallbackFunctions;
+        TotalScriptUnits = totalScriptUnits;
+        StructurallyEligibleScriptUnits = structurallyEligibleScriptUnits;
+        FallbackScriptUnits = fallbackScriptUnits;
+        RuntimeOnlyFunctions = runtimeOnlyFunctions;
+        RuntimeOnlyScriptUnits = runtimeOnlyScriptUnits;
+    }
+
+    /// <summary>Whether artifact-surface emission and shaping were evaluated.</summary>
+    public bool PostEmissionEvaluated { get; }
+
+    /// <summary>Total authored function units discovered.</summary>
+    public int TotalFunctions { get; }
+
+    /// <summary>Functions accepted by the analyzer before graph and artifact shaping.</summary>
+    public int AnalyzerEligibleFunctions { get; }
+
+    /// <summary>Functions that survived graph validation and artifact shaping as CLR methods.</summary>
+    public int EmittedFunctions { get; }
+
+    /// <summary>Analyzer-eligible functions rejected during graph or artifact shaping.</summary>
+    public int DroppedEligibleFunctions { get; }
+
+    /// <summary>Functions that remain on the PowerShell runtime path.</summary>
+    public int FallbackFunctions { get; }
+
+    /// <summary>Top-level script or module-initialization units discovered.</summary>
+    public int TotalScriptUnits { get; }
+
+    /// <summary>Script units structurally accepted by analysis; these are not counted as emitted methods.</summary>
+    public int StructurallyEligibleScriptUnits { get; }
+
+    /// <summary>Script units requiring PowerShell runtime behavior.</summary>
+    public int FallbackScriptUnits { get; }
+
+    /// <summary>Function units loaded through runtime-only manifest hooks.</summary>
+    public int RuntimeOnlyFunctions { get; }
+
+    /// <summary>Script units loaded through runtime-only manifest hooks.</summary>
+    public int RuntimeOnlyScriptUnits { get; }
+
+    /// <summary>Percentage of authored functions emitted as typed CLR methods.</summary>
+    public double EmittedFunctionCoveragePercentage => TotalFunctions == 0 ? 0 : EmittedFunctions * 100d / TotalFunctions;
+}
+
+/// <summary>Reports that a baseline corpus input changed while retaining its portable identity.</summary>
+public sealed class PowerShellCompilationCensusSourceDrift
+{
+    /// <summary>Creates a source-drift result.</summary>
+    public PowerShellCompilationCensusSourceDrift(string product, string baselineFingerprint, string currentFingerprint)
+    {
+        Product = product ?? string.Empty;
+        BaselineFingerprint = baselineFingerprint ?? string.Empty;
+        CurrentFingerprint = currentFingerprint ?? string.Empty;
+    }
+
+    /// <summary>Portable census product name.</summary>
+    public string Product { get; }
+
+    /// <summary>Content fingerprint recorded by the baseline.</summary>
+    public string BaselineFingerprint { get; }
+
+    /// <summary>Content fingerprint observed in the current run.</summary>
+    public string CurrentFingerprint { get; }
+}


### PR DESCRIPTION
## Summary

- reports analyzer-eligible, emitted, and fallback function counts after graph and artifact shaping
- adds portable source fingerprints, baseline comparison, and emitted-function planning frontiers
- keeps external corpora as replaceable scale evidence rather than compiler-specific targets

Coverage now describes CLR methods that were actually emitted, while every Hybrid fallback remains visible and attributable.

## Stack

Builds on #806. Followed by #812.

## Validation

On the complete stack:

- `dotnet build .\PowerForge.PowerShell\PowerForge.PowerShell.csproj -c Release --no-restore` (net472, net8.0, and net10.0; zero warnings/errors)
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~PowerShellCompilation"` (450 passed)