### PR TITLE
Preserve typed PowerShell parameter contracts

### DIFF
--- a/Docs/PowerForge.PowerShellCompilation.md
+++ b/Docs/PowerForge.PowerShellCompilation.md
@@ -180,7 +180,7 @@ powerforge powershell build .\Measure-Threshold.ps1 `
     --name Measure-Threshold
 ```
 
-Strict typed executables accept explicitly typed scalar, switch, and one-dimensional array parameters. Their generated CLI preserves required parameters, aliases, `AllowNull`, and the supported `ValidateNotNull`, `ValidateNotNullOrEmpty`, `ValidateSet`, `ValidateRange`, and `ValidatePattern` metadata. It supports exact names, aliases, unambiguous abbreviations, positional values, repeated array options, `--Name value`, `--Name=value`, switches, and `--`. Missing, duplicate, ambiguous, unknown, or validation-failing parameters are rejected before invoking compiled code.
+Strict typed executables accept process-bindable scalar, enum, nullable, URI/version, date/time, GUID, switch, and one-dimensional array parameters. Their generated CLI preserves required parameters, aliases, explicit or source-order positions, `AllowNull`, `AllowEmptyString`, `AllowEmptyCollection`, and the supported `ValidateNotNull`, `ValidateNotNullOrEmpty`, `ValidateSet`, `ValidateRange`, and `ValidatePattern` metadata. It supports exact names, aliases, unambiguous abbreviations, positional values, repeated array options, `--Name value`, `--Name=value`, switches, and `--`. Missing, duplicate, ambiguous, unknown, or validation-failing parameters are rejected before invoking compiled code. PowerShell parameter sets, pipeline binding, host-only types, and discovery-only metadata are rejected on this runtime-independent surface rather than silently ignored.
 
 The generated host accepts positional arguments, `--Name value`, `--Name=value`, switches and aliases such as `--Force`, common switches on advanced scripts, and `--` to stop named-argument parsing. A non-switch named parameter must have a value; use `--Name=-value` when that value begins with `-`. Duplicate aliases and aliases that collide with an authored or automatic parameter name are rejected before host generation, matching PowerShell's metadata boundary. Pipeline objects use PowerShell's normal formatting system before going to stdout; information records also go to stdout, while warnings and errors go to stderr. Nonterminating error records do not by themselves change a successful process exit code; a top-level explicit `exit <code>` becomes the process exit code, and a terminating exception fails the process. `$PSCommandPath` resolves to the running artifact path. `$PSScriptRoot` normally resolves to the durable artifact directory, while a Package build with explicit or complete-module resources intentionally resolves the script body against the private extracted root; parameter-binding path metadata remains artifact-backed. Packaging rejects `exit` inside a function, nested script block, trap, or caught region because exception instrumentation would change PowerShell behavior. It also rejects `using module` and `using assembly` because those directives are resolved before an embedded script can receive file-backed path metadata.
 
@@ -238,7 +238,7 @@ It supports `-WhatIf`, returns `PowerShellCompilationBuildResult`, and uses the 
 
 `Hybrid` compiles complete eligible functions and retains diagnostics for everything else. A hybrid binary module removes compiled function definitions from its generated `.psm1`, imports the typed DLL, and keeps unsupported functions on the script path. Literal `$PSScriptRoot` dot-source dependencies are staged recursively with their relative layout, including dependencies reached from manifest runtime hooks. Dynamic, missing, wildcard, working-directory-relative, source-root-escaping, or symbolic-link/junction paths fail before publication. A hybrid CLR library extracts eligible methods without carrying script fallback because it is intended for direct .NET consumption.
 
-Binary modules can also compile typed control flow around deliberately bounded PowerShell command regions. Direct `Write-Verbose`, `Write-Debug`, and `Write-Warning` calls use the generated `PSCmdlet` stream APIs. Adjacent top-level command pipelines, parameter-only conditional command blocks, explicit discard assignments such as `$null = Invoke-Operation`, and a safe terminal command-result tail are grouped into one PowerShell invocation so binding and dispatch are amortized across the region. Parameters and typed locals created before the region are passed explicitly. Stream and command-region host requirements propagate through eligible local function graphs, so typed callers do not lose a callee's PowerShell host contract. A tail cannot write back to a CLR parameter or local, and a nested script block that captures unresolved module, environment, or automatic state is not eligible. The complete function stays on the Hybrid script path when either boundary cannot be preserved. The module-scoped dispatcher is cleared when the hybrid module is removed. Runtime-free CLR libraries and Strict typed EXEs never enable these PowerShell-backed regions.
+Binary modules can also compile typed control flow around deliberately bounded PowerShell command regions. Direct `Write-Verbose`, `Write-Debug`, and `Write-Warning` calls use the generated `PSCmdlet` stream APIs. Their parameter contract preserves parameter sets, mandatory/position flags, pipeline and property-name binding, remaining arguments, literal help, hidden parameters, empty-value markers, wildcard discovery, and a conservative set of PowerShell-host types. An implicit end body with pipeline-bound parameters is emitted through `EndProcessing`, so it runs once with the final bound value just as the authored advanced function does; explicit `begin`, `process`, and `clean` blocks remain a separate lifecycle feature and stay on fallback. Adjacent top-level command pipelines, parameter-only conditional command blocks, explicit discard assignments such as `$null = Invoke-Operation`, and a safe terminal command-result tail are grouped into one PowerShell invocation so binding and dispatch are amortized across the region. Parameters and typed locals created before the region are passed explicitly. Stream and command-region host requirements propagate through eligible local function graphs, so typed callers do not lose a callee's PowerShell host contract. A tail cannot write back to a CLR parameter or local, and a nested script block that captures unresolved module, environment, or automatic state is not eligible. The complete function stays on the Hybrid script path when either boundary cannot be preserved. The module-scoped dispatcher is cleared when the hybrid module is removed. Runtime-free CLR libraries and Strict typed EXEs never enable these PowerShell-backed regions.
 
 Only unconditional top-level literal dot-sourced files participate in the root module's typed source set. Conditional and function-local dot-sources plus manifest runtime hooks are still discovered and staged, but are counted as runtime fallback rather than being flattened into a different scope. Nested script modules and nested manifests keep their relative layout, manifest closure, and export policy.
 
@@ -250,8 +250,8 @@ Eligibility is whole-function and intentionally conservative. One unsupported co
 
 The current subset supports:
 
-- explicitly typed scalar, `SwitchParameter`, and one-dimensional typed-array parameters;
-- preserved function and parameter aliases plus `Parameter(Mandatory)`, `AllowNull`, `ValidateNotNull`, `ValidateNotNullOrEmpty`, `ValidateSet`, `ValidateRange`, and `ValidatePattern` metadata;
+- capability-classified CLR, PowerShell-host, process-bindable, `SwitchParameter`, nullable, enum, and one-dimensional typed-array parameters;
+- preserved function and parameter aliases plus parameter-set, position, pipeline, remaining-argument, literal-help, empty-value, wildcard, and validation metadata on hosts that implement those contracts;
 - bounded `$PSBoundParameters.ContainsKey('CanonicalParameterName')` queries, including metadata propagation across typed local calls and runtime-free Strict executable argument binding;
 - typed or safely inferred local variables;
 - explicit `return` values and one terminal implicit-output expression;
@@ -261,7 +261,7 @@ The current subset supports:
 - scalar string `-split` and string-array `-join`;
 - expandable strings containing statically typed string variables, with null strings rendered as empty text;
 - case-insensitive homogeneous string dictionaries created from ordinary or `[ordered]` string hashtable literals, including lookup and simple index assignment, plus conservative `IDictionary` parameter lookup and mutation;
-- empty `CmdletBinding()` metadata and `Parameter(Mandatory)` metadata, with mandatory binding preserved by generated binary cmdlets;
+- conservative `CmdletBinding` positional/default-set/ShouldProcess metadata and parameter binding metadata, with host-only behavior enabled only for generated binary cmdlets;
 - floating-point and decimal arithmetic with compatible operands;
 - explicitly typed integral accumulators and loop counters with checked assignment semantics;
 - unlabeled `break` and `continue` inside supported loops;
@@ -279,7 +279,7 @@ The analyzer rejects dynamic behavior rather than guessing. Current blockers inc
 - commands and pipelines outside the bounded binary-module region contract, including nested closures over unresolved runtime variables;
 - dynamic member names, PowerShell-adapted properties, ambiguous overloads, and general object-property semantics;
 - script blocks, closures, runtime scopes such as `$env:`, and untyped parameters;
-- unsupported parameter attributes, PowerShell default expressions, and `dynamicparam`, `begin`, `process`, or `clean` blocks;
+- dynamic or host-incompatible parameter attributes, PowerShell default expressions, and `dynamicparam`, `begin`, `process`, or `clean` blocks;
 - dynamic `$PSBoundParameters` access, noncanonical or computed keys, dynamic/string throw operands, and `[pscustomobject]` construction outside generated binary modules;
 - nonterminal or nested implicit pipeline output;
 - PowerShell truthiness conversions, element-wise array comparison, and coercion between incompatible CLR types;
@@ -449,7 +449,7 @@ powerforge powershell census `
     --output json
 ```
 
-The current six-root example census reports 1,263 authored files and 1,353 whole script/function units with zero parse errors. Its post-emission view separates 1,235 authored functions from 118 top-level script or module-initialization units: 133 functions pass structural analysis, 103 survive graph and artifact shaping as typed CLR methods, and 30 analyzer-eligible functions are routed back to fallback. Post-emission function coverage is therefore 8.34%. The per-root emitted/total function split is PowerInfoBlox 2/57, PSSharedGoods 15/281, PSWriteHTML 5/238, O365Essentials 76/282, ADEssentials 4/247, and PSWriteWord 1/130. These repositories are replaceable regression workloads, not compiler design targets; PowerForge support remains based on generic language, binding, type-system, host, and artifact contracts.
+The current six-root example census reports 1,263 authored files and 1,353 whole script/function units with zero parse errors. Its post-emission view separates 1,235 authored functions from 118 top-level script or module-initialization units: 220 functions pass structural analysis, 126 survive graph and artifact shaping as typed CLR methods, and 94 analyzer-eligible functions are routed back to fallback. Post-emission function coverage is therefore 10.20%. The per-root emitted/total function split is PowerInfoBlox 2/57, PSSharedGoods 18/281, PSWriteHTML 17/238, O365Essentials 77/282, ADEssentials 6/247, and PSWriteWord 6/130. These repositories are replaceable regression workloads, not compiler design targets; PowerForge support remains based on generic language, binding, type-system, host, and artifact contracts.
 
 Low initial coverage is not hidden by Hybrid mode. It is written to the manifest, and every fallback has a diagnostic explaining what needs compiler support. Diagnostics are deliberately blocker-masked to avoid cascades, so accepting one outer construct can reveal deeper runtime semantics without increasing coverage. Roadmap priority therefore comes from repeated full-corpus passes and executable differential proof, not raw syntax-occurrence counts. Census baselines also carry a portable SHA-256 fingerprint over relative source paths and exact file content, so a changed corpus cannot silently pass merely because its aggregate counts stayed equal.
 
@@ -466,14 +466,14 @@ The current six-root run produces this leading emitted-function planning frontie
 
 | Feature ID | Occurrences | Affected units | Visible sole-blocker units | Products | Candidate coverage |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| `parameter.type` | 1,518 | 566 | 57 | 6 | 12.96% |
-| `parameter.metadata` | 1,617 | 357 | 34 | 6 | 11.09% |
-| `parameter.default` | 829 | 357 | 31 | 6 | 10.85% |
-| `function.graph` | 30 | 30 | 30 | 3 | 10.77% |
-| `runtime.scope` | 1,594 | 385 | 29 | 6 | 10.69% |
-| `command.new-htmltab` | 22 | 22 | 22 | 1 | 10.12% |
-| `expression.conversion` | 702 | 237 | 10 | 6 | 9.15% |
-| `syntax.subexpression` | 734 | 191 | 8 | 6 | 8.99% |
+| `parameter.default` | 829 | 357 | 98 | 6 | 18.14% |
+| `function.graph` | 94 | 94 | 94 | 4 | 17.81% |
+| `runtime.scope` | 1,594 | 385 | 40 | 6 | 13.44% |
+| `command.new-htmltab` | 22 | 22 | 22 | 1 | 11.98% |
+| `syntax.memberexpression` | 18 | 18 | 18 | 5 | 11.66% |
+| `expression.conversion` | 500 | 153 | 16 | 5 | 11.50% |
+| `syntax.variableexpression` | 16 | 16 | 16 | 5 | 11.50% |
+| `syntax.subexpression` | 734 | 191 | 15 | 6 | 11.42% |
 
 This changes feature planning materially. `Register-ArgumentCompleter` leads the compatibility whole-unit frontier because it appears in many module-initialization bodies, but it disappears from the emitted-function frontier and must not be treated as 78 potential CLR methods. Likewise, a sample-specific command identifier such as `command.new-htmltab` is evidence for a generic command-boundary shape, not authorization for a product-specific compiler intrinsic. Recommendations must distinguish generic typed IR, a contract-driven PowerShell-backed command region, an authoring change, and behavior that should remain Package/Hybrid-only.
 

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellAdvancedFunctionPolicy.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellAdvancedFunctionPolicy.cs
@@ -27,10 +27,61 @@ internal static class PowerShellAdvancedFunctionPolicy
         return argument is not null && IsTrue(argument.Argument);
     }
 
+    internal static PowerShellCompilationCommandBinding GetBinding(ParamBlockAst? parameterBlock)
+    {
+        var advanced = IsAdvanced(parameterBlock);
+        var cmdletBinding = parameterBlock?.Attributes
+            .OfType<AttributeAst>()
+            .FirstOrDefault(static attribute => IsAttributeNamed(attribute, "CmdletBinding"));
+        if (cmdletBinding is null)
+            return new PowerShellCompilationCommandBinding(advanced);
+
+        var positional = GetBoolean(cmdletBinding, "PositionalBinding", defaultValue: true);
+        var supportsShouldProcess = GetBoolean(cmdletBinding, "SupportsShouldProcess", defaultValue: false);
+        return new PowerShellCompilationCommandBinding(
+            advanced,
+            positional,
+            GetString(cmdletBinding, "DefaultParameterSetName"),
+            supportsShouldProcess,
+            GetString(cmdletBinding, "ConfirmImpact"));
+    }
+
     private static bool IsTrue(ExpressionAst expression)
         => expression is ConstantExpressionAst { Value: true } ||
            expression is VariableExpressionAst variable &&
            variable.VariablePath.UserPath.Equals("true", StringComparison.OrdinalIgnoreCase);
+
+    private static bool GetBoolean(AttributeAst attribute, string name, bool defaultValue)
+    {
+        var argument = attribute.NamedArguments.FirstOrDefault(candidate =>
+            candidate.ArgumentName.Equals(name, StringComparison.OrdinalIgnoreCase));
+        if (argument is null)
+            return defaultValue;
+        try
+        {
+            return argument.Argument.SafeGetValue() is bool value ? value : defaultValue;
+        }
+        catch (InvalidOperationException)
+        {
+            return defaultValue;
+        }
+    }
+
+    private static string GetString(AttributeAst attribute, string name)
+    {
+        var argument = attribute.NamedArguments.FirstOrDefault(candidate =>
+            candidate.ArgumentName.Equals(name, StringComparison.OrdinalIgnoreCase));
+        if (argument is null)
+            return string.Empty;
+        try
+        {
+            return argument.Argument.SafeGetValue() as string ?? string.Empty;
+        }
+        catch (InvalidOperationException)
+        {
+            return string.Empty;
+        }
+    }
 
     private static bool IsAttributeNamed(AttributeAst attribute, string name)
     {

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellBinaryCmdletSourceGenerator.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellBinaryCmdletSourceGenerator.cs
@@ -77,10 +77,7 @@ internal static class PowerShellBinaryCmdletSourceGenerator
             typed.TypeName,
             targetFramework,
             invalid,
-            PowerShellCompilationCapability.PowerShellStreams |
-            PowerShellCompilationCapability.LocalFunctionCalls |
-            PowerShellCompilationCapability.BoundParameters |
-            PowerShellCompilationCapability.PowerShellObjects);
+            PowerShellCompilationCapabilities.BinaryModule);
         return new PowerShellTypedCompilationResult(
             filtered.SourcePath,
             filtered.NamespaceName,
@@ -180,6 +177,44 @@ internal static class PowerShellBinaryCmdletSourceGenerator
                 throw new InvalidOperationException(
                     $"Function '{cmdlet.Method.SourceName}' parameter abbreviation '-{abbreviation}' becomes ambiguous with generated binary-cmdlet common parameters.");
         }
+
+        foreach (var parameter in cmdlet.Method.Parameters)
+        {
+            var duplicateSet = parameter.Bindings
+                .GroupBy(static binding => binding.ParameterSetName, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault(static group => group.Count() > 1);
+            if (duplicateSet is not null)
+                throw new InvalidOperationException(
+                    $"Function '{cmdlet.Method.SourceName}' parameter '${parameter.Name}' declares duplicate metadata for parameter set '{(string.IsNullOrWhiteSpace(duplicateSet.Key) ? "__AllParameterSets" : duplicateSet.Key)}'.");
+        }
+
+        var namedSets = cmdlet.Method.Parameters
+            .SelectMany(static parameter => parameter.Bindings)
+            .Select(static binding => binding.ParameterSetName)
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Append(cmdlet.Method.CommandBinding.DefaultParameterSetName)
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (namedSets.Length > 32)
+            throw new InvalidOperationException($"Function '{cmdlet.Method.SourceName}' declares {namedSets.Length} parameter sets; binary cmdlets support at most 32.");
+
+        var effective = cmdlet.Method.Parameters.SelectMany((parameter, index) =>
+            GetEffectiveBindings(cmdlet.Method, parameter, index).Select(binding => new { parameter.Name, Binding = binding })).ToArray();
+        var duplicatePosition = effective
+            .Where(static item => item.Binding.Position.HasValue)
+            .GroupBy(item => item.Binding.ParameterSetName + "\0" + item.Binding.Position!.Value, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(static group => group.Select(item => item.Name).Distinct(StringComparer.OrdinalIgnoreCase).Count() > 1);
+        if (duplicatePosition is not null)
+            throw new InvalidOperationException(
+                $"Function '{cmdlet.Method.SourceName}' assigns more than one parameter to the same position in parameter set '{(string.IsNullOrWhiteSpace(duplicatePosition.First().Binding.ParameterSetName) ? "__AllParameterSets" : duplicatePosition.First().Binding.ParameterSetName)}'.");
+        var duplicateRemaining = effective
+            .Where(static item => item.Binding.ValueFromRemainingArguments)
+            .GroupBy(static item => item.Binding.ParameterSetName, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(static group => group.Select(item => item.Name).Distinct(StringComparer.OrdinalIgnoreCase).Count() > 1);
+        if (duplicateRemaining is not null)
+            throw new InvalidOperationException(
+                $"Function '{cmdlet.Method.SourceName}' assigns ValueFromRemainingArguments to more than one parameter in parameter set '{(string.IsNullOrWhiteSpace(duplicateRemaining.Key) ? "__AllParameterSets" : duplicateRemaining.Key)}'.");
     }
 
     private static string? FindNewCommonParameterAbbreviation(
@@ -215,7 +250,7 @@ internal static class PowerShellBinaryCmdletSourceGenerator
 
         if (cmdlet.Method.Aliases.Length > 0)
             builder.AppendLine($"[Alias({string.Join(", ", cmdlet.Method.Aliases.Select(PowerShellCSharpLiteral.QuoteString))})]");
-        builder.AppendLine($"[Cmdlet({PowerShellCSharpLiteral.QuoteString(cmdlet.Verb)}, {PowerShellCSharpLiteral.QuoteString(cmdlet.Noun)})]");
+        builder.AppendLine(GenerateCmdletAttribute(cmdlet));
         var outputType = GetCmdletOutputTypeName(cmdlet.Method.ReturnType);
         if (outputType is not null)
             builder.AppendLine($"[OutputType(typeof({GetGeneratedTypeName(outputType)}))]");
@@ -224,11 +259,18 @@ internal static class PowerShellBinaryCmdletSourceGenerator
         for (var index = 0; index < cmdlet.Method.Parameters.Length; index++)
         {
             var parameter = cmdlet.Method.Parameters[index];
-            builder.AppendLine($"    [Parameter(Position = {index}{(parameter.IsMandatory ? ", Mandatory = true" : string.Empty)})]");
+            foreach (var binding in GetEffectiveBindings(cmdlet.Method, parameter, index))
+                builder.AppendLine("    " + GenerateParameterAttribute(binding));
             if (parameter.Aliases.Length > 0)
                 builder.AppendLine($"    [Alias({string.Join(", ", parameter.Aliases.Select(PowerShellCSharpLiteral.QuoteString))})]");
             if (parameter.AllowNull)
                 builder.AppendLine("    [AllowNull]");
+            if (parameter.AllowEmptyString)
+                builder.AppendLine("    [AllowEmptyString]");
+            if (parameter.AllowEmptyCollection)
+                builder.AppendLine("    [AllowEmptyCollection]");
+            if (parameter.SupportsWildcards)
+                builder.AppendLine("    [SupportsWildcards]");
             foreach (var validation in parameter.Validations)
                 builder.AppendLine("    " + GenerateValidationAttribute(validation));
             var propertyType = parameter.IsSwitch ? "SwitchParameter" : GetGeneratedTypeName(parameter.TypeName);
@@ -260,7 +302,10 @@ internal static class PowerShellBinaryCmdletSourceGenerator
             builder.AppendLine("    }");
             builder.AppendLine();
         }
-        builder.AppendLine("    protected override void ProcessRecord()");
+        var lifecycleMethod = cmdlet.Method.Parameters.Any(static parameter => parameter.AcceptsPipelineInput)
+            ? "EndProcessing"
+            : "ProcessRecord";
+        builder.AppendLine($"    protected override void {lifecycleMethod}()");
         builder.AppendLine("    {");
         var arguments = cmdlet.Method.Parameters.Select(parameter =>
             PowerShellCSharpMethodEmitter.SanitizeIdentifier(parameter.Name) + (parameter.IsSwitch ? ".IsPresent" : string.Empty));
@@ -278,6 +323,102 @@ internal static class PowerShellBinaryCmdletSourceGenerator
         builder.AppendLine("    }");
         builder.AppendLine("}");
         builder.AppendLine();
+    }
+
+    private static string GenerateCmdletAttribute(CmdletDescriptor cmdlet)
+    {
+        var arguments = new List<string>
+        {
+            PowerShellCSharpLiteral.QuoteString(cmdlet.Verb),
+            PowerShellCSharpLiteral.QuoteString(cmdlet.Noun)
+        };
+        var binding = cmdlet.Method.CommandBinding;
+        if (!string.IsNullOrWhiteSpace(binding.DefaultParameterSetName))
+            arguments.Add("DefaultParameterSetName = " + PowerShellCSharpLiteral.QuoteString(binding.DefaultParameterSetName));
+        if (binding.SupportsShouldProcess)
+            arguments.Add("SupportsShouldProcess = true");
+        if (!string.IsNullOrWhiteSpace(binding.ConfirmImpact))
+        {
+            if (!Enum.TryParse<ConfirmImpact>(binding.ConfirmImpact, ignoreCase: true, out var impact))
+                throw new InvalidOperationException($"Function '{cmdlet.Method.SourceName}' declares unsupported ConfirmImpact '{binding.ConfirmImpact}'.");
+            arguments.Add("ConfirmImpact = ConfirmImpact." + impact);
+        }
+        return "[Cmdlet(" + string.Join(", ", arguments) + ")]";
+    }
+
+    private static PowerShellCompilationParameterBinding[] GetEffectiveBindings(
+        PowerShellCompiledMethod method,
+        PowerShellCompilationParameter parameter,
+        int parameterIndex)
+    {
+        var namedSets = method.Parameters
+            .SelectMany(static candidate => candidate.Bindings)
+            .Select(static binding => binding.ParameterSetName)
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Append(method.CommandBinding.DefaultParameterSetName)
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var sets = namedSets.Length == 0 ? new[] { string.Empty } : namedSets;
+        var expanded = parameter.Bindings.SelectMany(binding =>
+            string.IsNullOrWhiteSpace(binding.ParameterSetName)
+                ? sets.Select(setName => CloneBinding(binding, setName))
+                : new[] { binding });
+        return expanded.Select(binding =>
+        {
+            var hasExplicitPosition = method.Parameters
+                .SelectMany(candidate => candidate.Bindings)
+                .Any(candidate => BindingAppliesToSet(candidate, binding.ParameterSetName) && candidate.Position.HasValue);
+            var position = binding.Position;
+            if (!position.HasValue && method.CommandBinding.PositionalBinding && !hasExplicitPosition)
+                position = GetImplicitPosition(method, parameterIndex, binding.ParameterSetName);
+            return CloneBinding(binding, binding.ParameterSetName, position);
+        }).ToArray();
+    }
+
+    private static int GetImplicitPosition(PowerShellCompiledMethod method, int parameterIndex, string setName)
+        => method.Parameters
+            .Take(parameterIndex)
+            .Count(parameter => parameter.Bindings.Any(binding => BindingAppliesToSet(binding, setName)));
+
+    private static bool BindingAppliesToSet(PowerShellCompilationParameterBinding binding, string setName)
+        => string.IsNullOrWhiteSpace(binding.ParameterSetName) ||
+           binding.ParameterSetName.Equals(setName, StringComparison.OrdinalIgnoreCase);
+
+    private static PowerShellCompilationParameterBinding CloneBinding(
+        PowerShellCompilationParameterBinding binding,
+        string parameterSetName,
+        int? position = null)
+        => new(
+            parameterSetName,
+            binding.Mandatory,
+            position ?? binding.Position,
+            binding.ValueFromPipeline,
+            binding.ValueFromPipelineByPropertyName,
+            binding.ValueFromRemainingArguments,
+            binding.DontShow,
+            binding.HelpMessage);
+
+    private static string GenerateParameterAttribute(PowerShellCompilationParameterBinding binding)
+    {
+        var arguments = new List<string>();
+        if (!string.IsNullOrWhiteSpace(binding.ParameterSetName))
+            arguments.Add("ParameterSetName = " + PowerShellCSharpLiteral.QuoteString(binding.ParameterSetName));
+        if (binding.Mandatory)
+            arguments.Add("Mandatory = true");
+        if (binding.Position.HasValue)
+            arguments.Add("Position = " + binding.Position.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        if (binding.ValueFromPipeline)
+            arguments.Add("ValueFromPipeline = true");
+        if (binding.ValueFromPipelineByPropertyName)
+            arguments.Add("ValueFromPipelineByPropertyName = true");
+        if (binding.ValueFromRemainingArguments)
+            arguments.Add("ValueFromRemainingArguments = true");
+        if (binding.DontShow)
+            arguments.Add("DontShow = true");
+        if (!string.IsNullOrWhiteSpace(binding.HelpMessage))
+            arguments.Add("HelpMessage = " + PowerShellCSharpLiteral.QuoteString(binding.HelpMessage));
+        return "[Parameter(" + string.Join(", ", arguments) + ")]";
     }
 
     private static string GenerateValidationAttribute(PowerShellCompilationValidation validation)

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpMethodEmitter.LocalFunctions.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpMethodEmitter.LocalFunctions.cs
@@ -59,6 +59,9 @@ internal sealed partial class PowerShellCSharpMethodEmitter
             throw Error(command, $"Local function '{signature.SourceName}' emits PowerShell command-region success output whose pipeline cardinality cannot be preserved when the call result is consumed.");
         if (signature.ReturnType.IsArray && !IsDirectLocalFunctionOutput(command))
             throw Error(command, $"Local function '{signature.SourceName}' returns an array whose PowerShell pipeline cardinality cannot be preserved when the result is consumed directly.");
+        if (signature.Parameters.SelectMany(static parameter => parameter.Bindings)
+            .Any(static binding => !string.IsNullOrWhiteSpace(binding.ParameterSetName)))
+            throw Error(command, $"Local function '{signature.SourceName}' uses named parameter sets whose selection must remain on the PowerShell binding path.");
 
         var bound = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var positionalIndex = 0;
@@ -93,6 +96,9 @@ internal sealed partial class PowerShellCSharpMethodEmitter
 
             if (elements[index] is not ExpressionAst positional)
                 throw Error(elements[index], "Typed local function calls accept only scalar named or positional arguments; splatting and dynamic command elements require PowerShell.");
+            if (!signature.CommandBinding.PositionalBinding ||
+                signature.Parameters.SelectMany(static parameter => parameter.Bindings).Any(static binding => binding.Position.HasValue))
+                throw Error(positional, $"Local function '{signature.SourceName}' uses an explicit positional-binding contract that is not represented by source-order typed calls.");
             while (positionalIndex < signature.Parameters.Length && bound.ContainsKey(signature.Parameters[positionalIndex].Name))
                 positionalIndex++;
             if (positionalIndex >= signature.Parameters.Length)

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpMethodEmitter.Validation.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpMethodEmitter.Validation.cs
@@ -15,7 +15,7 @@ internal sealed partial class PowerShellCSharpMethodEmitter
 
             var parameterType = GetCompiledParameterType(parameter);
             var identifier = GetVariableIdentifier(name);
-            if (metadata.IsMandatory && parameterType == typeof(string))
+            if (metadata.IsMandatory && parameterType == typeof(string) && !metadata.AllowEmptyString)
             {
                 var condition = metadata.AllowNull
                     ? $"{identifier} is not null && {identifier}.Length == 0"
@@ -30,8 +30,11 @@ internal sealed partial class PowerShellCSharpMethodEmitter
                     AppendLine($"if ({identifier} is null)");
                     AppendLine($"    throw new global::System.ArgumentException({PowerShellCSharpLiteral.QuoteString($"Mandatory parameter '-{metadata.Name}' does not allow null values.")}, {PowerShellCSharpLiteral.QuoteString(metadata.Name)});");
                 }
-                AppendLine($"if ({identifier} is not null && {identifier}.Length == 0)");
-                AppendLine($"    throw new global::System.ArgumentException({PowerShellCSharpLiteral.QuoteString($"Mandatory parameter '-{metadata.Name}' does not allow an empty collection.")}, {PowerShellCSharpLiteral.QuoteString(metadata.Name)});");
+                if (!metadata.AllowEmptyCollection)
+                {
+                    AppendLine($"if ({identifier} is not null && {identifier}.Length == 0)");
+                    AppendLine($"    throw new global::System.ArgumentException({PowerShellCSharpLiteral.QuoteString($"Mandatory parameter '-{metadata.Name}' does not allow an empty collection.")}, {PowerShellCSharpLiteral.QuoteString(metadata.Name)});");
+                }
             }
             else if (metadata.IsMandatory && !metadata.AllowNull && !parameterType.IsValueType)
             {

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpMethodEmitter.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpMethodEmitter.cs
@@ -85,7 +85,7 @@ internal sealed partial class PowerShellCSharpMethodEmitter
             EmitExpression,
             CanAssign,
             GetTypeName,
-            type => PowerShellGeneratedTypePolicy.IsSupported(type, _targetFramework),
+            type => PowerShellCompilationParameterTypePolicy.CanUseInMethod(type, _targetFramework, _capabilities),
             member => string.IsNullOrWhiteSpace(_targetFramework) || PowerShellGeneratedMemberPolicy.IsSupported(member, _targetFramework!),
             CanNormalizeNullStringReceiver,
             Error);
@@ -99,7 +99,7 @@ internal sealed partial class PowerShellCSharpMethodEmitter
         {
             var name = parameter.Name.VariablePath.UserPath;
             var parameterType = GetCompiledParameterType(parameter);
-            if (!PowerShellGeneratedTypePolicy.IsSupported(parameterType, _targetFramework))
+            if (!PowerShellCompilationParameterTypePolicy.CanUseInMethod(parameterType, _targetFramework, _capabilities))
                 throw Error(parameter, $"Parameter '${name}' uses CLR type '{parameterType.FullName}' outside the generated project reference set.");
             if (_variables.ContainsKey(name))
                 throw Error(parameter, $"Parameter '${name}' duplicates another parameter under PowerShell's case-insensitive naming rules.");

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationAnalyzer.Metadata.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationAnalyzer.Metadata.cs
@@ -1,0 +1,200 @@
+using System.Globalization;
+using System.Management.Automation.Language;
+
+namespace PowerForge;
+
+public sealed partial class PowerShellCompilationAnalyzer
+{
+    private static bool IsSupportedMetadataAttribute(
+        AttributeAst attribute,
+        PowerShellCompilationCapability capabilities)
+    {
+        if (IsAttributeNamed(attribute, "CmdletBinding"))
+            return attribute.PositionalArguments.Count == 0 && attribute.NamedArguments.All(argument =>
+                IsSupportedCmdletBindingNamedArgument(argument, capabilities));
+        if (IsAttributeNamed(attribute, "Parameter"))
+            return attribute.PositionalArguments.Count == 0 && attribute.NamedArguments.All(argument =>
+                IsSupportedParameterNamedArgument(argument, capabilities));
+        if (IsAttributeNamed(attribute, "Alias"))
+            return attribute.NamedArguments.Count == 0 && attribute.PositionalArguments.Count > 0 &&
+                   attribute.PositionalArguments.All(static argument => argument is StringConstantExpressionAst { Value.Length: > 0 });
+        if (IsAttributeNamed(attribute, "AllowNull") ||
+            IsAttributeNamed(attribute, "AllowEmptyString") ||
+            IsAttributeNamed(attribute, "AllowEmptyCollection") ||
+            IsAttributeNamed(attribute, "SupportsWildcards") ||
+            IsAttributeNamed(attribute, "ValidateNotNull") ||
+            IsAttributeNamed(attribute, "ValidateNotNullOrEmpty"))
+            return attribute.PositionalArguments.Count == 0 && attribute.NamedArguments.Count == 0;
+        if (IsAttributeNamed(attribute, "ValidateSet"))
+            return attribute.NamedArguments.Count == 0 && attribute.PositionalArguments.Count > 0 &&
+                   attribute.PositionalArguments.All(static argument => argument is StringConstantExpressionAst);
+        if (IsAttributeNamed(attribute, "ValidatePattern"))
+            return attribute.NamedArguments.Count == 0 && attribute.PositionalArguments.Count == 1 &&
+                   attribute.PositionalArguments[0] is StringConstantExpressionAst;
+        if (IsAttributeNamed(attribute, "ValidateRange"))
+            return attribute.NamedArguments.Count == 0 && attribute.PositionalArguments.Count == 2 &&
+                   attribute.PositionalArguments.All(static argument => TryGetInvariantNumericLiteral(argument, out _));
+        return false;
+    }
+
+    private static bool IsSupportedCmdletBindingNamedArgument(
+        NamedAttributeArgumentAst argument,
+        PowerShellCompilationCapability capabilities)
+    {
+        if (argument.ArgumentName.Equals("PositionalBinding", StringComparison.OrdinalIgnoreCase))
+            return TryGetBooleanAttributeValue(argument, out _);
+        if (!capabilities.HasFlag(PowerShellCompilationCapability.PipelineParameterBinding))
+            return false;
+        if (argument.ArgumentName.Equals("SupportsShouldProcess", StringComparison.OrdinalIgnoreCase))
+            return TryGetBooleanAttributeValue(argument, out _);
+        if (argument.ArgumentName.Equals("DefaultParameterSetName", StringComparison.OrdinalIgnoreCase))
+            return TryGetStringAttributeValue(argument, out var defaultSet) && !string.IsNullOrWhiteSpace(defaultSet);
+        if (!argument.ArgumentName.Equals("ConfirmImpact", StringComparison.OrdinalIgnoreCase) ||
+            !TryGetStringAttributeValue(argument, out var impact))
+            return false;
+        return impact.Equals("None", StringComparison.OrdinalIgnoreCase) ||
+               impact.Equals("Low", StringComparison.OrdinalIgnoreCase) ||
+               impact.Equals("Medium", StringComparison.OrdinalIgnoreCase) ||
+               impact.Equals("High", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsSupportedParameterNamedArgument(
+        NamedAttributeArgumentAst argument,
+        PowerShellCompilationCapability capabilities)
+    {
+        if (argument.ArgumentName.Equals("Mandatory", StringComparison.OrdinalIgnoreCase))
+            return TryGetBooleanAttributeValue(argument, out _);
+        if (argument.ArgumentName.Equals("ValueFromRemainingArguments", StringComparison.OrdinalIgnoreCase) ||
+            argument.ArgumentName.Equals("DontShow", StringComparison.OrdinalIgnoreCase) ||
+            argument.ArgumentName.Equals("ValueFromPipeline", StringComparison.OrdinalIgnoreCase) ||
+            argument.ArgumentName.Equals("ValueFromPipelineByPropertyName", StringComparison.OrdinalIgnoreCase))
+            return capabilities.HasFlag(PowerShellCompilationCapability.PipelineParameterBinding) &&
+                   TryGetBooleanAttributeValue(argument, out _);
+        if (argument.ArgumentName.Equals("ParameterSetName", StringComparison.OrdinalIgnoreCase))
+            return capabilities.HasFlag(PowerShellCompilationCapability.PipelineParameterBinding) &&
+                   TryGetStringAttributeValue(argument, out var setName) && !string.IsNullOrWhiteSpace(setName);
+        if (argument.ArgumentName.Equals("HelpMessage", StringComparison.OrdinalIgnoreCase))
+            return TryGetStringAttributeValue(argument, out _);
+        return argument.ArgumentName.Equals("Position", StringComparison.OrdinalIgnoreCase) &&
+               TryGetIntegerAttributeValue(argument, out var position) && position >= 0;
+    }
+
+    private static string[] GetAliases(ParameterAst parameter)
+        => parameter.Attributes
+            .OfType<AttributeAst>()
+            .Where(static attribute => IsAttributeNamed(attribute, "Alias"))
+            .SelectMany(static attribute => attribute.PositionalArguments.OfType<StringConstantExpressionAst>())
+            .Select(static argument => argument.Value)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private static bool HasMetadataAttribute(ParameterAst parameter, string name)
+        => parameter.Attributes.OfType<AttributeAst>().Any(attribute => IsAttributeNamed(attribute, name));
+
+    private static PowerShellCompilationValidation[] GetValidations(ParameterAst parameter)
+    {
+        var validations = new List<PowerShellCompilationValidation>();
+        foreach (var attribute in parameter.Attributes.OfType<AttributeAst>())
+        {
+            if (IsAttributeNamed(attribute, "ValidateNotNull"))
+                validations.Add(new PowerShellCompilationValidation(PowerShellCompilationValidationKind.NotNull));
+            else if (IsAttributeNamed(attribute, "ValidateNotNullOrEmpty"))
+                validations.Add(new PowerShellCompilationValidation(PowerShellCompilationValidationKind.NotNullOrEmpty));
+            else if (IsAttributeNamed(attribute, "ValidateSet"))
+                validations.Add(new PowerShellCompilationValidation(
+                    PowerShellCompilationValidationKind.Set,
+                    attribute.PositionalArguments.OfType<StringConstantExpressionAst>().Select(static argument => argument.Value).ToArray()));
+            else if (IsAttributeNamed(attribute, "ValidatePattern") &&
+                     attribute.PositionalArguments.Count == 1 &&
+                     attribute.PositionalArguments[0] is StringConstantExpressionAst pattern)
+                validations.Add(new PowerShellCompilationValidation(PowerShellCompilationValidationKind.Pattern, new[] { pattern.Value }));
+            else if (IsAttributeNamed(attribute, "ValidateRange") && attribute.PositionalArguments.Count == 2)
+                validations.Add(new PowerShellCompilationValidation(
+                    PowerShellCompilationValidationKind.Range,
+                    attribute.PositionalArguments.Select(argument =>
+                        TryGetInvariantNumericLiteral(argument, out var literal) ? literal : string.Empty).ToArray()));
+        }
+        return validations.ToArray();
+    }
+
+    private static bool TryGetInvariantNumericLiteral(ExpressionAst expression, out string literal)
+    {
+        object? value;
+        try
+        {
+            value = expression.SafeGetValue();
+        }
+        catch (InvalidOperationException)
+        {
+            literal = string.Empty;
+            return false;
+        }
+        if (value is not byte and not sbyte and not short and not ushort and not int and not uint and not long and not ulong and not float and not double and not decimal)
+        {
+            literal = string.Empty;
+            return false;
+        }
+        literal = Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+        return literal.Length > 0;
+    }
+
+    private static bool TryGetBooleanAttributeValue(NamedAttributeArgumentAst argument, out bool value)
+    {
+        try
+        {
+            if (argument.Argument.SafeGetValue() is bool resolved)
+            {
+                value = resolved;
+                return true;
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Dynamic attribute arguments remain on the PowerShell runtime path.
+        }
+        value = false;
+        return false;
+    }
+
+    private static bool TryGetStringAttributeValue(NamedAttributeArgumentAst argument, out string value)
+    {
+        try
+        {
+            if (argument.Argument.SafeGetValue() is string resolved)
+            {
+                value = resolved;
+                return true;
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Dynamic attribute arguments remain on the PowerShell runtime path.
+        }
+        value = string.Empty;
+        return false;
+    }
+
+    private static bool TryGetIntegerAttributeValue(NamedAttributeArgumentAst argument, out int value)
+    {
+        try
+        {
+            var resolved = argument.Argument.SafeGetValue();
+            if (resolved is int direct)
+            {
+                value = direct;
+                return true;
+            }
+            if (resolved is IConvertible convertible)
+            {
+                value = convertible.ToInt32(CultureInfo.InvariantCulture);
+                return true;
+            }
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or FormatException or OverflowException)
+        {
+            // Dynamic or out-of-range attribute arguments remain on the PowerShell runtime path.
+        }
+        value = 0;
+        return false;
+    }
+}

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationAnalyzer.Parameters.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationAnalyzer.Parameters.cs
@@ -43,6 +43,7 @@ public sealed partial class PowerShellCompilationAnalyzer
         string file,
         List<PowerShellCompilationDiagnostic> diagnostics,
         HashSet<string> localVariables,
+        string? targetFramework,
         PowerShellCompilationCapability capabilities,
         ISet<string>? localFunctionNames,
         bool isScriptUnit)
@@ -57,18 +58,34 @@ public sealed partial class PowerShellCompilationAnalyzer
         foreach (var parameter in paramBlock.Parameters)
         {
             var type = parameter.StaticType;
-            if (!IsSupportedParameterType(type))
+            var hasExplicitType = parameter.Attributes.OfType<TypeConstraintAst>().Any();
+            var typeCapabilities = hasExplicitType
+                ? PowerShellCompilationParameterTypePolicy.Classify(type, targetFramework)
+                : PowerShellCompilationParameterTypeCapability.None;
+            if (!typeCapabilities.HasFlag(PowerShellCompilationParameterTypeCapability.ClrMethod))
             {
                 diagnostics.Add(CreateDiagnostic(
                     PowerShellCompilationDiagnosticCode.UnsupportedParameterType,
-                    $"Parameter '${parameter.Name.VariablePath.UserPath}' must declare a supported scalar or one-dimensional array type; resolved type was '{type.FullName}'.",
+                    hasExplicitType
+                        ? $"Parameter '${parameter.Name.VariablePath.UserPath}' uses CLR type '{type.FullName}', which cannot be represented by the generated typed method surface."
+                        : $"Parameter '${parameter.Name.VariablePath.UserPath}' is untyped; add an explicit type before compiling it to a CLR method.",
+                    file,
+                    parameter.Extent,
+                    PowerShellCompilationFeatureIds.ParameterType));
+            }
+            else if (typeCapabilities.HasFlag(PowerShellCompilationParameterTypeCapability.PowerShellHost) &&
+                     !capabilities.HasFlag(PowerShellCompilationCapability.PowerShellHostTypes))
+            {
+                diagnostics.Add(CreateDiagnostic(
+                    PowerShellCompilationDiagnosticCode.UnsupportedParameterType,
+                    $"Parameter '${parameter.Name.VariablePath.UserPath}' uses PowerShell host type '{type.FullName}', which requires a binary-module host capability.",
                     file,
                     parameter.Extent,
                     PowerShellCompilationFeatureIds.ParameterType));
             }
             else if (isScriptUnit &&
                      capabilities.HasFlag(PowerShellCompilationCapability.ExecutableParameterBinding) &&
-                     !PowerShellTypedExecutableParameterPolicy.IsSupported(type))
+                     !typeCapabilities.HasFlag(PowerShellCompilationParameterTypeCapability.ProcessArgument))
             {
                 diagnostics.Add(CreateDiagnostic(
                     PowerShellCompilationDiagnosticCode.UnsupportedParameterType,
@@ -79,15 +96,21 @@ public sealed partial class PowerShellCompilationAnalyzer
             }
 
             var isSwitch = type == typeof(System.Management.Automation.SwitchParameter);
+            var bindings = GetParameterBindings(parameter);
             result.Add(new PowerShellCompilationParameter(
                 parameter.Name.VariablePath.UserPath,
                 (isSwitch ? typeof(bool) : type).FullName ?? type.Name,
                 parameter.DefaultValue is not null,
-                IsMandatoryParameter(parameter),
+                bindings.Length > 0 && bindings.All(static binding => binding.Mandatory),
                 isSwitch,
                 GetAliases(parameter),
                 HasMetadataAttribute(parameter, "AllowNull"),
-                GetValidations(parameter)));
+                GetValidations(parameter),
+                typeCapabilities,
+                bindings,
+                HasMetadataAttribute(parameter, "AllowEmptyString"),
+                HasMetadataAttribute(parameter, "AllowEmptyCollection"),
+                HasMetadataAttribute(parameter, "SupportsWildcards")));
 
             foreach (var attribute in parameter.Attributes.Where(static attribute => attribute is not TypeConstraintAst))
                 AnalyzeNode(attribute, unitRoot, file, diagnostics, localVariables, capabilities, localFunctionNames);
@@ -107,8 +130,50 @@ public sealed partial class PowerShellCompilationAnalyzer
         return result.ToArray();
     }
 
-    private static bool IsSupportedParameterType(Type type)
-        => type == typeof(System.Management.Automation.SwitchParameter) ||
-           SupportedParameterTypes.Contains(type) ||
-           type.IsArray && type.GetArrayRank() == 1 && SupportedParameterTypes.Contains(type.GetElementType()!);
+    private static PowerShellCompilationParameterBinding[] GetParameterBindings(ParameterAst parameter)
+    {
+        var attributes = parameter.Attributes
+            .OfType<AttributeAst>()
+            .Where(static attribute => IsAttributeNamed(attribute, "Parameter"))
+            .ToArray();
+        if (attributes.Length == 0)
+            return new[] { new PowerShellCompilationParameterBinding() };
+
+        return attributes.Select(attribute =>
+        {
+            var setName = GetNamedString(attribute, "ParameterSetName");
+            if (setName.Equals("__AllParameterSets", StringComparison.OrdinalIgnoreCase))
+                setName = string.Empty;
+            return new PowerShellCompilationParameterBinding(
+                setName,
+                GetNamedBoolean(attribute, "Mandatory"),
+                GetNamedInteger(attribute, "Position"),
+                GetNamedBoolean(attribute, "ValueFromPipeline"),
+                GetNamedBoolean(attribute, "ValueFromPipelineByPropertyName"),
+                GetNamedBoolean(attribute, "ValueFromRemainingArguments"),
+                GetNamedBoolean(attribute, "DontShow"),
+                GetNamedString(attribute, "HelpMessage"));
+        }).ToArray();
+    }
+
+    private static bool GetNamedBoolean(AttributeAst attribute, string name)
+    {
+        var argument = attribute.NamedArguments.FirstOrDefault(candidate =>
+            candidate.ArgumentName.Equals(name, StringComparison.OrdinalIgnoreCase));
+        return argument is not null && TryGetBooleanAttributeValue(argument, out var value) && value;
+    }
+
+    private static int? GetNamedInteger(AttributeAst attribute, string name)
+    {
+        var argument = attribute.NamedArguments.FirstOrDefault(candidate =>
+            candidate.ArgumentName.Equals(name, StringComparison.OrdinalIgnoreCase));
+        return argument is not null && TryGetIntegerAttributeValue(argument, out var value) ? value : null;
+    }
+
+    private static string GetNamedString(AttributeAst attribute, string name)
+    {
+        var argument = attribute.NamedArguments.FirstOrDefault(candidate =>
+            candidate.ArgumentName.Equals(name, StringComparison.OrdinalIgnoreCase));
+        return argument is not null && TryGetStringAttributeValue(argument, out var value) ? value : string.Empty;
+    }
 }

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationAnalyzer.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationAnalyzer.cs
@@ -1,5 +1,4 @@
 using System.Management.Automation.Language;
-using System.Globalization;
 
 namespace PowerForge;
 
@@ -23,13 +22,6 @@ public sealed partial class PowerShellCompilationAnalyzer
     private static readonly HashSet<string> SupportedAssignmentOperators = new(StringComparer.Ordinal)
     {
         "Equals", "PlusEquals", "MinusEquals", "MultiplyEquals", "DivideEquals", "RemEquals"
-    };
-
-    private static readonly HashSet<Type> SupportedParameterTypes = new()
-    {
-        typeof(bool), typeof(byte), typeof(sbyte), typeof(short), typeof(ushort), typeof(int), typeof(uint),
-        typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal), typeof(char), typeof(string),
-        typeof(System.Collections.IDictionary), typeof(System.Collections.Hashtable), typeof(System.Collections.Specialized.OrderedDictionary)
     };
 
     private static PowerShellCompilationFilePlan AnalyzeFile(
@@ -60,7 +52,7 @@ public sealed partial class PowerShellCompilationAnalyzer
             excludeModuleExports: Path.GetExtension(file).Equals(".psm1", StringComparison.OrdinalIgnoreCase));
         if (topLevelStatements.Length > 0 || ast.ParamBlock is not null || HasUnsupportedNamedBlocks(ast))
         {
-            var scriptUnit = AnalyzeUnit("<script>", PowerShellCompilationUnitKind.Script, ast, file, topLevelStatements, capabilities, localFunctionNames);
+            var scriptUnit = AnalyzeUnit("<script>", PowerShellCompilationUnitKind.Script, ast, file, topLevelStatements, targetFramework, capabilities, localFunctionNames);
             if (scriptUnit.IsCompilable && !RequiresArtifactGraphEmission(topLevelStatements, capabilities, localFunctionNames))
             {
                 try
@@ -101,6 +93,7 @@ public sealed partial class PowerShellCompilationAnalyzer
                 function.Body,
                 file,
                 GetEndStatements(function.Body, excludeFunctionDefinitions: false, excludeModuleExports: false),
+                targetFramework,
                 capabilities,
                 localFunctionNames);
             if (function.IsFilter)
@@ -228,6 +221,7 @@ public sealed partial class PowerShellCompilationAnalyzer
         ScriptBlockAst root,
         string file,
         IReadOnlyCollection<StatementAst> executableStatements,
+        string? targetFramework,
         PowerShellCompilationCapability capabilities,
         ISet<string>? localFunctionNames)
     {
@@ -239,6 +233,7 @@ public sealed partial class PowerShellCompilationAnalyzer
             file,
             diagnostics,
             localVariables,
+            targetFramework,
             capabilities,
             localFunctionNames,
             kind == PowerShellCompilationUnitKind.Script);
@@ -296,7 +291,7 @@ public sealed partial class PowerShellCompilationAnalyzer
                         candidate.Extent,
                         PowerShellCompilationFeatureIds.ScriptBlock));
                     break;
-                case AttributeAst attribute when IsSupportedMetadataAttribute(attribute):
+                case AttributeAst attribute when IsSupportedMetadataAttribute(attribute, capabilities):
                     break;
                 case AttributeAst attribute:
                     diagnostics.Add(CreateDiagnostic(
@@ -306,7 +301,7 @@ public sealed partial class PowerShellCompilationAnalyzer
                         attribute.Extent,
                         PowerShellCompilationFeatureIds.ParameterMetadata));
                     break;
-                case ConvertExpressionAst conversion when conversion.Parent is AssignmentStatementAst assignment && ReferenceEquals(assignment.Left, conversion) && !IsSupportedParameterType(conversion.StaticType):
+                case ConvertExpressionAst conversion when conversion.Parent is AssignmentStatementAst assignment && ReferenceEquals(assignment.Left, conversion) && !PowerShellCompilationParameterTypePolicy.CanUseInMethod(conversion.StaticType, targetFramework: null, capabilities):
                     diagnostics.Add(CreateDiagnostic(
                         PowerShellCompilationDiagnosticCode.UnsupportedSyntax,
                         $"Typed local declaration '{conversion.StaticType.FullName}' is not supported by the typed compiler.",
@@ -548,121 +543,6 @@ public sealed partial class PowerShellCompilationAnalyzer
     private static bool IsOrderedHashtableConversion(ConvertExpressionAst conversion)
         => conversion.StaticType == typeof(System.Collections.Specialized.OrderedDictionary) &&
            conversion.Child is HashtableAst;
-
-    private static bool IsMandatoryParameter(ParameterAst parameter)
-        => parameter.Attributes
-            .OfType<AttributeAst>()
-            .Where(static attribute => IsAttributeNamed(attribute, "Parameter"))
-            .SelectMany(static attribute => attribute.NamedArguments)
-            .Any(static argument =>
-                argument.ArgumentName.Equals("Mandatory", StringComparison.OrdinalIgnoreCase) &&
-                TryGetBooleanAttributeValue(argument, out var value) && value);
-
-    private static bool IsSupportedMetadataAttribute(AttributeAst attribute)
-    {
-        if (IsAttributeNamed(attribute, "CmdletBinding"))
-            return attribute.PositionalArguments.Count == 0 && attribute.NamedArguments.Count == 0;
-        if (IsAttributeNamed(attribute, "Parameter"))
-        {
-            return attribute.PositionalArguments.Count == 0 && attribute.NamedArguments.All(static argument =>
-                argument.ArgumentName.Equals("Mandatory", StringComparison.OrdinalIgnoreCase) &&
-                TryGetBooleanAttributeValue(argument, out _));
-        }
-        if (IsAttributeNamed(attribute, "Alias"))
-            return attribute.NamedArguments.Count == 0 && attribute.PositionalArguments.Count > 0 &&
-                   attribute.PositionalArguments.All(static argument => argument is StringConstantExpressionAst { Value.Length: > 0 });
-        if (IsAttributeNamed(attribute, "AllowNull") ||
-            IsAttributeNamed(attribute, "ValidateNotNull") ||
-            IsAttributeNamed(attribute, "ValidateNotNullOrEmpty"))
-            return attribute.PositionalArguments.Count == 0 && attribute.NamedArguments.Count == 0;
-        if (IsAttributeNamed(attribute, "ValidateSet"))
-            return attribute.NamedArguments.Count == 0 && attribute.PositionalArguments.Count > 0 &&
-                   attribute.PositionalArguments.All(static argument => argument is StringConstantExpressionAst);
-        if (IsAttributeNamed(attribute, "ValidatePattern"))
-            return attribute.NamedArguments.Count == 0 && attribute.PositionalArguments.Count == 1 &&
-                   attribute.PositionalArguments[0] is StringConstantExpressionAst;
-        if (IsAttributeNamed(attribute, "ValidateRange"))
-            return attribute.NamedArguments.Count == 0 && attribute.PositionalArguments.Count == 2 &&
-                   attribute.PositionalArguments.All(static argument => TryGetInvariantNumericLiteral(argument, out _));
-        return false;
-    }
-
-    private static string[] GetAliases(ParameterAst parameter)
-        => parameter.Attributes
-            .OfType<AttributeAst>()
-            .Where(static attribute => IsAttributeNamed(attribute, "Alias"))
-            .SelectMany(static attribute => attribute.PositionalArguments.OfType<StringConstantExpressionAst>())
-            .Select(static argument => argument.Value)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-
-    private static bool HasMetadataAttribute(ParameterAst parameter, string name)
-        => parameter.Attributes.OfType<AttributeAst>().Any(attribute => IsAttributeNamed(attribute, name));
-
-    private static PowerShellCompilationValidation[] GetValidations(ParameterAst parameter)
-    {
-        var validations = new List<PowerShellCompilationValidation>();
-        foreach (var attribute in parameter.Attributes.OfType<AttributeAst>())
-        {
-            if (IsAttributeNamed(attribute, "ValidateNotNull"))
-                validations.Add(new PowerShellCompilationValidation(PowerShellCompilationValidationKind.NotNull));
-            else if (IsAttributeNamed(attribute, "ValidateNotNullOrEmpty"))
-                validations.Add(new PowerShellCompilationValidation(PowerShellCompilationValidationKind.NotNullOrEmpty));
-            else if (IsAttributeNamed(attribute, "ValidateSet"))
-                validations.Add(new PowerShellCompilationValidation(
-                    PowerShellCompilationValidationKind.Set,
-                    attribute.PositionalArguments.OfType<StringConstantExpressionAst>().Select(static argument => argument.Value).ToArray()));
-            else if (IsAttributeNamed(attribute, "ValidatePattern") &&
-                     attribute.PositionalArguments.Count == 1 &&
-                     attribute.PositionalArguments[0] is StringConstantExpressionAst pattern)
-                validations.Add(new PowerShellCompilationValidation(PowerShellCompilationValidationKind.Pattern, new[] { pattern.Value }));
-            else if (IsAttributeNamed(attribute, "ValidateRange") && attribute.PositionalArguments.Count == 2)
-                validations.Add(new PowerShellCompilationValidation(
-                    PowerShellCompilationValidationKind.Range,
-                    attribute.PositionalArguments.Select(argument =>
-                        TryGetInvariantNumericLiteral(argument, out var literal) ? literal : string.Empty).ToArray()));
-        }
-        return validations.ToArray();
-    }
-
-    private static bool TryGetInvariantNumericLiteral(ExpressionAst expression, out string literal)
-    {
-        object? value;
-        try
-        {
-            value = expression.SafeGetValue();
-        }
-        catch (InvalidOperationException)
-        {
-            literal = string.Empty;
-            return false;
-        }
-        if (value is not byte and not sbyte and not short and not ushort and not int and not uint and not long and not ulong and not float and not double and not decimal)
-        {
-            literal = string.Empty;
-            return false;
-        }
-        literal = Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
-        return literal.Length > 0;
-    }
-
-    private static bool TryGetBooleanAttributeValue(NamedAttributeArgumentAst argument, out bool value)
-    {
-        try
-        {
-            if (argument.Argument.SafeGetValue() is bool resolved)
-            {
-                value = resolved;
-                return true;
-            }
-        }
-        catch (InvalidOperationException)
-        {
-            // Dynamic attribute arguments remain on the PowerShell runtime path.
-        }
-        value = false;
-        return false;
-    }
 
     private static bool IsAttributeNamed(AttributeAst attribute, string name)
         => attribute.TypeName.Name.Equals(name, StringComparison.OrdinalIgnoreCase) ||

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationCensusRunner.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationCensusRunner.cs
@@ -96,10 +96,7 @@ public sealed class PowerShellCompilationCensusRunner
                     resolved.CompilationSourceFiles,
                     Directory.Exists(path) ? path : Path.GetDirectoryName(path) ?? Directory.GetCurrentDirectory(),
                     targetFramework,
-                    PowerShellCompilationCapability.PowerShellStreams |
-                    PowerShellCompilationCapability.LocalFunctionCalls |
-                    PowerShellCompilationCapability.BoundParameters |
-                    PowerShellCompilationCapability.PowerShellObjects);
+                    PowerShellCompilationCapabilities.BinaryModule);
             var emitted = new PowerShellTypedCompilationTranspiler().TranspileForBinaryModule(
                 resolved.CompilationSourceFiles,
                 "PowerForge.Census",
@@ -116,10 +113,7 @@ public sealed class PowerShellCompilationCensusRunner
                     source,
                     PowerShellCompilationMode.Analyze,
                     targetFramework: targetFramework,
-                    capabilities: PowerShellCompilationCapability.PowerShellStreams |
-                                  PowerShellCompilationCapability.LocalFunctionCalls |
-                                  PowerShellCompilationCapability.BoundParameters |
-                                  PowerShellCompilationCapability.PowerShellObjects)).Files)
+                    capabilities: PowerShellCompilationCapabilities.BinaryModule)).Files)
                 .Select(MarkRuntimeOnly)
                 .ToArray();
             var files = compiledFiles.Concat(runtimeOnlyFiles).ToArray();
@@ -140,10 +134,7 @@ public sealed class PowerShellCompilationCensusRunner
                 PowerShellCompilationMode.Analyze,
                 recurse: false,
                 targetFramework: targetFramework,
-                capabilities: PowerShellCompilationCapability.PowerShellStreams |
-                              PowerShellCompilationCapability.LocalFunctionCalls |
-                                  PowerShellCompilationCapability.BoundParameters |
-                                  PowerShellCompilationCapability.PowerShellObjects));
+                capabilities: PowerShellCompilationCapabilities.BinaryModule));
             sourceFiles = plan.Files.Length;
             sourceFingerprint = ComputeSourceFingerprint(plan.Files.Select(static file => file.FullPath), path);
             coverage = BuildCoverageBreakdown(

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationParameterTypePolicy.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationParameterTypePolicy.cs
@@ -1,0 +1,55 @@
+using System.Management.Automation;
+
+namespace PowerForge;
+
+/// <summary>Classifies parameter types by the generated surface that can preserve them.</summary>
+internal static class PowerShellCompilationParameterTypePolicy
+{
+    private static readonly HashSet<Type> PowerShellHostTypes = new()
+    {
+        typeof(PSCredential),
+        typeof(PSObject),
+        typeof(PSCustomObject),
+        typeof(ScriptBlock)
+    };
+
+    internal static PowerShellCompilationParameterTypeCapability Classify(Type type, string? targetFramework)
+    {
+        var compiledType = GetCompiledType(type);
+        if (compiledType.IsArray)
+        {
+            if (compiledType.GetArrayRank() != 1)
+                return PowerShellCompilationParameterTypeCapability.None;
+            var element = Classify(compiledType.GetElementType()!, targetFramework);
+            return element.HasFlag(PowerShellCompilationParameterTypeCapability.ClrMethod)
+                ? element
+                : PowerShellCompilationParameterTypeCapability.None;
+        }
+
+        var result = PowerShellCompilationParameterTypeCapability.None;
+        if (PowerShellGeneratedTypePolicy.IsSupported(compiledType, targetFramework))
+            result |= PowerShellCompilationParameterTypeCapability.ClrMethod;
+        else if (PowerShellHostTypes.Contains(compiledType))
+            result |= PowerShellCompilationParameterTypeCapability.ClrMethod |
+                      PowerShellCompilationParameterTypeCapability.PowerShellHost;
+
+        if (PowerShellTypedExecutableParameterPolicy.IsSupported(compiledType))
+            result |= PowerShellCompilationParameterTypeCapability.ProcessArgument;
+        return result;
+    }
+
+    internal static bool CanUseInMethod(
+        Type type,
+        string? targetFramework,
+        PowerShellCompilationCapability capabilities)
+    {
+        var classified = Classify(type, targetFramework);
+        if (!classified.HasFlag(PowerShellCompilationParameterTypeCapability.ClrMethod))
+            return false;
+        return !classified.HasFlag(PowerShellCompilationParameterTypeCapability.PowerShellHost) ||
+               capabilities.HasFlag(PowerShellCompilationCapability.PowerShellHostTypes);
+    }
+
+    internal static Type GetCompiledType(Type type)
+        => type == typeof(SwitchParameter) ? typeof(bool) : type;
+}

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellGeneratedTypePolicy.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellGeneratedTypePolicy.cs
@@ -31,10 +31,11 @@ internal static class PowerShellGeneratedTypePolicy
             return type.GetArrayRank() == 1 && IsSupported(type.GetElementType()!, targetFramework);
         if (type.IsGenericType)
         {
-            if (type.GetGenericTypeDefinition() != typeof(Dictionary<,>))
+            var definition = type.GetGenericTypeDefinition();
+            if (definition != typeof(Dictionary<,>) && definition != typeof(Nullable<>))
                 return false;
             return type.GetGenericArguments().All(argument => IsSupported(argument, targetFramework)) &&
-                   IsSupportedNonGeneric(type.GetGenericTypeDefinition(), targetFramework);
+                   IsSupportedNonGeneric(definition, targetFramework);
         }
         if (type.IsByRef || type.IsPointer)
             return false;

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellHybridFunctionCollisionResolver.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellHybridFunctionCollisionResolver.cs
@@ -60,10 +60,7 @@ internal static class PowerShellHybridFunctionCollisionResolver
             typed.TypeName,
             targetFramework,
             excludedMethods,
-            PowerShellCompilationCapability.PowerShellStreams |
-            PowerShellCompilationCapability.LocalFunctionCalls |
-            PowerShellCompilationCapability.BoundParameters |
-            PowerShellCompilationCapability.PowerShellObjects);
+            PowerShellCompilationCapabilities.BinaryModule);
         var diagnostics = excludedNames.Select(name =>
         {
             var definition = definitions

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellTypedCompilationTranspiler.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellTypedCompilationTranspiler.cs
@@ -37,10 +37,7 @@ public sealed class PowerShellTypedCompilationTranspiler
             typeName,
             targetFramework,
             excludedMethods: null,
-            PowerShellCompilationCapability.PowerShellStreams |
-            PowerShellCompilationCapability.LocalFunctionCalls |
-            PowerShellCompilationCapability.BoundParameters |
-            PowerShellCompilationCapability.PowerShellObjects);
+            PowerShellCompilationCapabilities.BinaryModule);
 
     internal PowerShellTypedCompilationResult TranspileExcluding(
         IEnumerable<string> sourcePaths,
@@ -370,7 +367,8 @@ public sealed class PowerShellTypedCompilationTranspiler
             emitted.RequiresPowerShellCommandRegions,
             GetFunctionAliases(source.Function),
             emitted.RequiresPowerShellBoundParameters,
-            PowerShellAdvancedFunctionPolicy.IsAdvanced(source.Function));
+            PowerShellAdvancedFunctionPolicy.IsAdvanced(source.Function),
+            PowerShellAdvancedFunctionPolicy.GetBinding(source.Function.Body.ParamBlock));
 
     private static PowerShellLocalFunctionSignature CreateSignature(FunctionSource source, PowerShellCSharpMethodEmission emitted)
         => new(
@@ -389,13 +387,15 @@ public sealed class PowerShellTypedCompilationTranspiler
                         metadata.IsSwitch,
                         metadata.Aliases,
                         metadata.AllowNull,
-                        metadata.Validations);
+                        metadata.Validations,
+                        metadata.Bindings);
                 })
                 .ToArray(),
             PowerShellAdvancedFunctionPolicy.IsAdvanced(source.Function),
             emitted.RequiresPowerShellBoundParameters,
             emitted.RequiresPowerShellStreams,
-            emitted.RequiresPowerShellCommandRegions);
+            emitted.RequiresPowerShellCommandRegions,
+            PowerShellAdvancedFunctionPolicy.GetBinding(source.Function.Body.ParamBlock));
 
     private static PowerShellCompilationDiagnostic CreateDiagnostic(FunctionSource source, Ast node, string message)
         => new(

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellTypedExecutableCompiler.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellTypedExecutableCompiler.cs
@@ -137,7 +137,8 @@ internal static class PowerShellTypedExecutableCompiler
             PowerShellAdvancedFunctionPolicy.IsAdvanced(definition.Function),
             method.RequiresPowerShellBoundParameters,
             method.RequiresPowerShellStreams,
-            method.RequiresPowerShellCommandRegions);
+            method.RequiresPowerShellCommandRegions,
+            PowerShellAdvancedFunctionPolicy.GetBinding(definition.Function.Body.ParamBlock));
         methods.Add(method);
         methodDescriptions.Add(CreateMethodDescription(definition.Unit, method, definition.Path));
         states[name] = VisitState.Complete;
@@ -170,7 +171,8 @@ internal static class PowerShellTypedExecutableCompiler
             metadata.IsSwitch,
             metadata.Aliases,
             metadata.AllowNull,
-            metadata.Validations);
+            metadata.Validations,
+            metadata.Bindings);
     }
 
     private static void ValidateCommands(string path, IEnumerable<StatementAst> statements, IReadOnlyDictionary<string, LocalDefinition> definitions)
@@ -269,7 +271,8 @@ internal sealed class PowerShellLocalFunctionSignature
         bool isAdvancedFunction,
         bool requiresPowerShellBoundParameters = false,
         bool requiresPowerShellStreams = false,
-        bool requiresPowerShellCommandRegions = false)
+        bool requiresPowerShellCommandRegions = false,
+        PowerShellCompilationCommandBinding? commandBinding = null)
     {
         SourceName = sourceName;
         GeneratedName = generatedName;
@@ -279,6 +282,7 @@ internal sealed class PowerShellLocalFunctionSignature
         RequiresPowerShellBoundParameters = requiresPowerShellBoundParameters;
         RequiresPowerShellStreams = requiresPowerShellStreams;
         RequiresPowerShellCommandRegions = requiresPowerShellCommandRegions;
+        CommandBinding = commandBinding ?? new PowerShellCompilationCommandBinding(isAdvancedFunction);
     }
     internal string SourceName { get; }
     internal string GeneratedName { get; }
@@ -288,6 +292,7 @@ internal sealed class PowerShellLocalFunctionSignature
     internal bool RequiresPowerShellBoundParameters { get; }
     internal bool RequiresPowerShellStreams { get; }
     internal bool RequiresPowerShellCommandRegions { get; }
+    internal PowerShellCompilationCommandBinding CommandBinding { get; }
 }
 
 internal sealed class PowerShellLocalFunctionParameter
@@ -299,7 +304,8 @@ internal sealed class PowerShellLocalFunctionParameter
         bool isSwitch,
         string[] aliases,
         bool allowNull,
-        PowerShellCompilationValidation[] validations)
+        PowerShellCompilationValidation[] validations,
+        PowerShellCompilationParameterBinding[]? bindings = null)
     {
         Name = name;
         Type = type;
@@ -308,6 +314,7 @@ internal sealed class PowerShellLocalFunctionParameter
         Aliases = aliases;
         AllowNull = allowNull;
         Validations = validations;
+        Bindings = bindings ?? new[] { new PowerShellCompilationParameterBinding(mandatory: isMandatory) };
     }
     internal string Name { get; }
     internal Type Type { get; }
@@ -316,4 +323,5 @@ internal sealed class PowerShellLocalFunctionParameter
     internal string[] Aliases { get; }
     internal bool AllowNull { get; }
     internal PowerShellCompilationValidation[] Validations { get; }
+    internal PowerShellCompilationParameterBinding[] Bindings { get; }
 }

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellTypedExecutableEmitter.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellTypedExecutableEmitter.cs
@@ -38,15 +38,25 @@ internal static class PowerShellTypedExecutableEmitter
         foreach (var parameter in parameters)
             PowerShellTypedExecutableParameterPolicy.EnsureSupported(parameter);
         var analyzedParameters = scriptUnit.Parameters.ToDictionary(static parameter => parameter.Name, StringComparer.OrdinalIgnoreCase);
-        var parameterSpecs = string.Join(Environment.NewLine, parameters.Select(parameter =>
+        var commandBinding = PowerShellAdvancedFunctionPolicy.GetBinding(ast.ParamBlock);
+        var hasExplicitPositions = analyzedParameters.Values
+            .SelectMany(static parameter => parameter.Bindings)
+            .Any(static binding => binding.Position.HasValue);
+        var parameterSpecs = string.Join(Environment.NewLine, parameters.Select((parameter, index) =>
         {
             var metadata = analyzedParameters[parameter.Name.VariablePath.UserPath];
+            var position = metadata.Bindings.Select(static binding => binding.Position).FirstOrDefault(static value => value.HasValue);
+            if (!position.HasValue && commandBinding.PositionalBinding && !hasExplicitPositions)
+                position = index;
             return "        new ParameterSpec(" + PowerShellCSharpLiteral.QuoteString(metadata.Name) + ", typeof(" +
                    PowerShellCSharpMethodEmitter.GetTypeName(GetCompiledParameterType(parameter)) + "), " +
                    (metadata.IsMandatory ? "true" : "false") + ", " +
                    (metadata.IsSwitch ? "true" : "false") + ", " +
+                   (position.HasValue ? position.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : "null") + ", " +
                    GenerateStringArray(metadata.Aliases) + ", " +
                    (metadata.AllowNull ? "true" : "false") + ", " +
+                   (metadata.AllowEmptyString ? "true" : "false") + ", " +
+                   (metadata.AllowEmptyCollection ? "true" : "false") + ", " +
                    GenerateValidations(metadata.Validations) + "),";
         }));
         var arguments = parameters.Select(parameter =>

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellTypedExecutableParameterPolicy.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellTypedExecutableParameterPolicy.cs
@@ -26,8 +26,14 @@ internal static class PowerShellTypedExecutableParameterPolicy
         => type == typeof(System.Management.Automation.SwitchParameter) ? typeof(bool) : type;
 
     private static bool IsScalar(Type type)
-        => type == typeof(bool) || type == typeof(byte) || type == typeof(sbyte) ||
-           type == typeof(short) || type == typeof(ushort) || type == typeof(int) || type == typeof(uint) ||
-           type == typeof(long) || type == typeof(ulong) || type == typeof(float) || type == typeof(double) ||
-           type == typeof(decimal) || type == typeof(char) || type == typeof(string);
+    {
+        var scalar = Nullable.GetUnderlyingType(type) ?? type;
+        return scalar.IsEnum ||
+           scalar == typeof(bool) || scalar == typeof(byte) || scalar == typeof(sbyte) ||
+           scalar == typeof(short) || scalar == typeof(ushort) || scalar == typeof(int) || scalar == typeof(uint) ||
+           scalar == typeof(long) || scalar == typeof(ulong) || scalar == typeof(float) || scalar == typeof(double) ||
+           scalar == typeof(decimal) || scalar == typeof(char) || scalar == typeof(string) ||
+           scalar == typeof(DateTime) || scalar == typeof(DateTimeOffset) || scalar == typeof(TimeSpan) ||
+           scalar == typeof(Guid) || scalar == typeof(Uri) || scalar == typeof(Version);
+    }
 }

--- a/PowerForge.PowerShell/Templates/Compilation/TypedExecutableProgram.cs.template
+++ b/PowerForge.PowerShell/Templates/Compilation/TypedExecutableProgram.cs.template
@@ -14,6 +14,10 @@ internal static class Program
     {
 {{PARAMETER_SPECS}}
     };
+    private static readonly ParameterSpec[] PositionalParameters = Parameters
+        .Where(static parameter => parameter.Position.HasValue)
+        .OrderBy(static parameter => parameter.Position!.Value)
+        .ToArray();
 
     private static readonly string[][] UnsupportedCommonParameterNames =
     {
@@ -70,15 +74,15 @@ internal static class Program
                 continue;
             }
 
-            while (positionalIndex < Parameters.Length && raw[Parameters[positionalIndex].Name].Count > 0)
+            while (positionalIndex < PositionalParameters.Length && raw[PositionalParameters[positionalIndex].Name].Count > 0)
                 positionalIndex++;
-            if (positionalIndex >= Parameters.Length)
+            if (positionalIndex >= PositionalParameters.Length)
             {
                 if (AcceptsSurplusPositionalArguments)
                     continue;
                 throw new ArgumentException($"Unexpected positional argument '{token}'.");
             }
-            var positional = Parameters[positionalIndex];
+            var positional = PositionalParameters[positionalIndex];
             AddRawValue(raw, positional, token);
             positionalIndex++;
         }
@@ -100,7 +104,7 @@ internal static class Program
                     : null!;
                 continue;
             }
-            if (parameter.IsRequired && parameter.Type == typeof(string) && values[0].Length == 0)
+            if (parameter.IsRequired && parameter.Type == typeof(string) && values[0].Length == 0 && !parameter.AllowEmptyString)
                 throw new ArgumentException($"Required parameter '--{parameter.Name}' cannot be an empty string.");
             if (parameter.IsArray)
             {
@@ -155,22 +159,30 @@ internal static class Program
     {
         try
         {
-            if (type == typeof(string)) return value;
-            if (type == typeof(bool)) return bool.Parse(value);
-            if (type == typeof(byte)) return byte.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
-            if (type == typeof(sbyte)) return sbyte.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
-            if (type == typeof(short)) return short.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
-            if (type == typeof(ushort)) return ushort.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
-            if (type == typeof(int)) return int.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
-            if (type == typeof(uint)) return uint.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
-            if (type == typeof(long)) return long.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
-            if (type == typeof(ulong)) return ulong.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
-            if (type == typeof(float)) return float.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
-            if (type == typeof(double)) return double.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
-            if (type == typeof(decimal)) return decimal.Parse(value, NumberStyles.Number, CultureInfo.InvariantCulture);
-            if (type == typeof(char) && value.Length == 1) return value[0];
+            var scalar = Nullable.GetUnderlyingType(type) ?? type;
+            if (scalar == typeof(string)) return value;
+            if (scalar == typeof(bool)) return bool.Parse(value);
+            if (scalar == typeof(byte)) return byte.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
+            if (scalar == typeof(sbyte)) return sbyte.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
+            if (scalar == typeof(short)) return short.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
+            if (scalar == typeof(ushort)) return ushort.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
+            if (scalar == typeof(int)) return int.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
+            if (scalar == typeof(uint)) return uint.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
+            if (scalar == typeof(long)) return long.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
+            if (scalar == typeof(ulong)) return ulong.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
+            if (scalar == typeof(float)) return float.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
+            if (scalar == typeof(double)) return double.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
+            if (scalar == typeof(decimal)) return decimal.Parse(value, NumberStyles.Number, CultureInfo.InvariantCulture);
+            if (scalar == typeof(char) && value.Length == 1) return value[0];
+            if (scalar.IsEnum) return Enum.Parse(scalar, value, ignoreCase: true);
+            if (scalar == typeof(DateTime)) return DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+            if (scalar == typeof(DateTimeOffset)) return DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+            if (scalar == typeof(TimeSpan)) return TimeSpan.Parse(value, CultureInfo.InvariantCulture);
+            if (scalar == typeof(Guid)) return Guid.Parse(value);
+            if (scalar == typeof(Uri)) return new Uri(value, UriKind.RelativeOrAbsolute);
+            if (scalar == typeof(Version)) return Version.Parse(value);
         }
-        catch (Exception exception) when (exception is FormatException or OverflowException)
+        catch (Exception exception) when (exception is ArgumentException or FormatException or OverflowException)
         {
             throw new ArgumentException($"Value '{value}' is invalid for parameter '--{parameterName}' ({type.Name}).", exception);
         }
@@ -179,28 +191,9 @@ internal static class Program
 
     private static object ParseArray(IReadOnlyList<string> values, Type elementType, string parameterName)
     {
-        if (elementType == typeof(string)) return ParseArray<string>(values, elementType, parameterName);
-        if (elementType == typeof(bool)) return ParseArray<bool>(values, elementType, parameterName);
-        if (elementType == typeof(byte)) return ParseArray<byte>(values, elementType, parameterName);
-        if (elementType == typeof(sbyte)) return ParseArray<sbyte>(values, elementType, parameterName);
-        if (elementType == typeof(short)) return ParseArray<short>(values, elementType, parameterName);
-        if (elementType == typeof(ushort)) return ParseArray<ushort>(values, elementType, parameterName);
-        if (elementType == typeof(int)) return ParseArray<int>(values, elementType, parameterName);
-        if (elementType == typeof(uint)) return ParseArray<uint>(values, elementType, parameterName);
-        if (elementType == typeof(long)) return ParseArray<long>(values, elementType, parameterName);
-        if (elementType == typeof(ulong)) return ParseArray<ulong>(values, elementType, parameterName);
-        if (elementType == typeof(float)) return ParseArray<float>(values, elementType, parameterName);
-        if (elementType == typeof(double)) return ParseArray<double>(values, elementType, parameterName);
-        if (elementType == typeof(decimal)) return ParseArray<decimal>(values, elementType, parameterName);
-        if (elementType == typeof(char)) return ParseArray<char>(values, elementType, parameterName);
-        throw new ArgumentException($"Parameter '--{parameterName}' uses unsupported CLR array element type '{elementType.FullName}'.");
-    }
-
-    private static T[] ParseArray<T>(IReadOnlyList<string> values, Type elementType, string parameterName)
-    {
-        var result = new T[values.Count];
+        var result = Array.CreateInstance(elementType, values.Count);
         for (var index = 0; index < values.Count; index++)
-            result[index] = (T)ParseScalar(values[index], elementType, parameterName);
+            result.SetValue(ParseScalar(values[index], elementType, parameterName), index);
         return result;
     }
 
@@ -297,16 +290,22 @@ internal static class Program
             Type type,
             bool isRequired,
             bool isSwitch,
+            int? position,
             string[] aliases,
             bool allowNull,
+            bool allowEmptyString,
+            bool allowEmptyCollection,
             ValidationSpec[] validations)
         {
             Name = name;
             Type = type;
             IsRequired = isRequired;
             IsSwitch = isSwitch;
+            Position = position;
             Aliases = aliases;
             AllowNull = allowNull;
+            AllowEmptyString = allowEmptyString;
+            AllowEmptyCollection = allowEmptyCollection;
             Validations = validations;
         }
 
@@ -314,8 +313,11 @@ internal static class Program
         internal Type Type { get; }
         internal bool IsRequired { get; }
         internal bool IsSwitch { get; }
+        internal int? Position { get; }
         internal string[] Aliases { get; }
         internal bool AllowNull { get; }
+        internal bool AllowEmptyString { get; }
+        internal bool AllowEmptyCollection { get; }
         internal ValidationSpec[] Validations { get; }
         internal bool IsArray => Type.IsArray;
     }

--- a/PowerForge.Tests/PowerShellCompilationParameterContractV2Tests.cs
+++ b/PowerForge.Tests/PowerShellCompilationParameterContractV2Tests.cs
@@ -1,0 +1,146 @@
+using PowerForge;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class PowerShellCompilationArtifactBuilderTests
+{
+    [Fact]
+    public void Analyze_ClassifiesHostTypesAndPreservesParameterSetBindings()
+    {
+        using var fixture = ArtifactFixture.Create(
+            "function Get-Contract { [CmdletBinding(DefaultParameterSetName='Name', PositionalBinding=$false)] " +
+            "param([Parameter(ParameterSetName='Name', Mandatory, Position=2, ValueFromPipelineByPropertyName, HelpMessage='A name')] " +
+            "[AllowEmptyString()] [SupportsWildcards()] [string] $Name, " +
+            "[Parameter(ParameterSetName='Credential', Mandatory)] [PSCredential] $Credential) return $Name }",
+            ".psm1");
+
+        var plan = new PowerShellCompilationAnalyzer().Analyze(new PowerShellCompilationSpec(
+            fixture.ScriptPath,
+            targetFramework: "net10.0",
+            capabilities: PowerShellCompilationCapabilities.BinaryModule));
+
+        var unit = Assert.Single(Assert.Single(plan.Files).Units);
+        Assert.True(unit.IsCompilable, string.Join(Environment.NewLine, unit.Diagnostics.Select(static diagnostic => diagnostic.Message)));
+        var name = unit.Parameters[0];
+        var binding = Assert.Single(name.Bindings);
+        Assert.Equal("Name", binding.ParameterSetName);
+        Assert.True(binding.Mandatory);
+        Assert.Equal(2, binding.Position);
+        Assert.True(binding.ValueFromPipelineByPropertyName);
+        Assert.Equal("A name", binding.HelpMessage);
+        Assert.True(name.AllowEmptyString);
+        Assert.True(name.SupportsWildcards);
+        var credential = unit.Parameters[1];
+        Assert.True(credential.TypeCapabilities.HasFlag(PowerShellCompilationParameterTypeCapability.PowerShellHost));
+        Assert.False(credential.TypeCapabilities.HasFlag(PowerShellCompilationParameterTypeCapability.ProcessArgument));
+    }
+
+    [Fact]
+    public void Analyze_RejectsPowerShellOnlyBindingAndHostTypesWithoutHostCapability()
+    {
+        using var fixture = ArtifactFixture.Create(
+            "function Get-Contract { param([Parameter(ValueFromPipeline)][PSCredential] $Credential) return $Credential }");
+
+        var plan = new PowerShellCompilationAnalyzer().Analyze(new PowerShellCompilationSpec(
+            fixture.ScriptPath,
+            targetFramework: "net10.0"));
+
+        var unit = Assert.Single(Assert.Single(plan.Files).Units);
+        Assert.Contains(unit.Diagnostics, static diagnostic => diagnostic.FeatureId == PowerShellCompilationFeatureIds.ParameterType);
+        Assert.Contains(unit.Diagnostics, static diagnostic => diagnostic.FeatureId == PowerShellCompilationFeatureIds.ParameterMetadata);
+    }
+
+    [Fact]
+    public void Build_BinaryModulePreservesParameterSetsPositionsAndImplicitEndPipelineSemantics()
+    {
+        using var fixture = ArtifactFixture.Create(
+            "function Select-ContractValue { [CmdletBinding(DefaultParameterSetName='Value', PositionalBinding=$false)] " +
+            "param([Parameter(ParameterSetName='Value', Mandatory, Position=2, ValueFromPipeline)] " +
+            "[AllowEmptyString()] [string] $Value) return $Value }",
+            ".psm1");
+        var result = new PowerShellCompilationArtifactBuilder().Build(new PowerShellCompilationBuildSpec(
+            fixture.ScriptPath,
+            fixture.OutputPath,
+            "PowerForge.ParameterContractV2",
+            PowerShellCompilationArtifactKind.BinaryModule,
+            PowerShellCompilationMode.Strict)
+        {
+            EmitSource = true
+        });
+
+        Assert.True(result.Succeeded, result.Error + Environment.NewLine + result.BuildOutput);
+        var output = RunModuleProof(
+            result.ArtifactPath!,
+            "$command = Get-Command Select-ContractValue; " +
+            "$parameter = $command.Parameters['Value']; " +
+            "$attribute = $parameter.Attributes | Where-Object { $_ -is [Management.Automation.ParameterAttribute] }; " +
+            "$attribute.ParameterSetName; $attribute.Position; $attribute.ValueFromPipeline; @('first','last') | Select-ContractValue");
+        Assert.Equal(new[] { "Value", "2", "True", "last" }, output.Split(Environment.NewLine));
+        var generated = File.ReadAllText(Path.Combine(result.GeneratedSourcePath!, "CompiledCmdlets.cs"));
+        Assert.Contains("protected override void EndProcessing()", generated, StringComparison.Ordinal);
+        Assert.Contains("[AllowEmptyString]", generated, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Build_BinaryModuleAcceptsConservativePowerShellHostParameterTypes()
+    {
+        using var fixture = ArtifactFixture.Create(
+            "function Get-TypedCredential { param([PSCredential] $Credential) return $Credential }",
+            ".psm1");
+        var result = new PowerShellCompilationArtifactBuilder().Build(new PowerShellCompilationBuildSpec(
+            fixture.ScriptPath,
+            fixture.OutputPath,
+            "PowerForge.HostParameterType",
+            PowerShellCompilationArtifactKind.BinaryModule,
+            PowerShellCompilationMode.Strict));
+
+        Assert.True(result.Succeeded, result.Error + Environment.NewLine + result.BuildOutput);
+        Assert.Equal(
+            "user",
+            RunModuleProof(
+                result.ArtifactPath!,
+                "$secret = ConvertTo-SecureString x -AsPlainText -Force; " +
+                "$credential = [PSCredential]::new('user', $secret); " +
+                "(Get-TypedCredential -Credential $credential).UserName"));
+    }
+
+    [Fact]
+    public void Build_StrictExecutableBindsExplicitPositionAndGuid()
+    {
+        using var fixture = ArtifactFixture.Create(
+            "[CmdletBinding(PositionalBinding=$false)] param([Parameter(Position=2)][Guid] $Id) return $Id.ToString()");
+        var result = new PowerShellCompilationArtifactBuilder().Build(new PowerShellCompilationBuildSpec(
+            fixture.ScriptPath,
+            fixture.OutputPath,
+            "PowerForge.GuidArgument",
+            PowerShellCompilationArtifactKind.Executable,
+            PowerShellCompilationMode.Strict));
+
+        Assert.True(result.Succeeded, result.Error + Environment.NewLine + result.BuildOutput);
+        const string id = "2f7d93d8-8723-4ced-8f5f-86b155df3a10";
+        var accepted = RunProcess(result.ArtifactPath!, id);
+        Assert.Equal((0, id), (accepted.ExitCode, accepted.StandardOutput.Trim()));
+    }
+
+    [Fact]
+    public void Transpile_KeepsNamedParameterSetSelectionOutOfTypedLocalCalls()
+    {
+        using var fixture = ArtifactFixture.Create(
+            "function Get-ByContract { [CmdletBinding(DefaultParameterSetName='Name')] " +
+            "param([Parameter(ParameterSetName='Name', Mandatory)][string] $Name) return $Name }; " +
+            "function Get-ContractCaller { return Get-ByContract -Name 'value' }",
+            ".psm1");
+
+        var result = new PowerShellTypedCompilationTranspiler().TranspileForBinaryModule(
+            new[] { fixture.ScriptPath },
+            "PowerForge.ParameterSetGraph",
+            "CompiledPowerShell",
+            "net10.0");
+
+        Assert.Contains(result.Methods, static method => method.SourceName == "Get-ByContract");
+        Assert.DoesNotContain(result.Methods, static method => method.SourceName == "Get-ContractCaller");
+        Assert.Contains(result.Diagnostics, static diagnostic =>
+            diagnostic.Message.Contains("parameter sets", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/PowerForge/Models/PowerShellCompilation/PowerShellCompilationArtifact.cs
+++ b/PowerForge/Models/PowerShellCompilation/PowerShellCompilationArtifact.cs
@@ -83,14 +83,9 @@ public sealed class PowerShellCompilationBuildSpec
         if (!Enum.IsDefined(typeof(PowerShellCompilationArtifactKind), kind)) throw new ArgumentOutOfRangeException(nameof(kind));
         if (!Enum.IsDefined(typeof(PowerShellCompilationMode), mode)) throw new ArgumentOutOfRangeException(nameof(mode));
         return kind == PowerShellCompilationArtifactKind.BinaryModule
-            ? PowerShellCompilationCapability.PowerShellStreams |
-              PowerShellCompilationCapability.LocalFunctionCalls |
-              PowerShellCompilationCapability.BoundParameters |
-              PowerShellCompilationCapability.PowerShellObjects
+            ? PowerShellCompilationCapabilities.BinaryModule
             : kind == PowerShellCompilationArtifactKind.Executable && mode == PowerShellCompilationMode.Strict
-                ? PowerShellCompilationCapability.LocalFunctionCalls |
-                  PowerShellCompilationCapability.BoundParameters |
-                  PowerShellCompilationCapability.ExecutableParameterBinding
+                ? PowerShellCompilationCapabilities.TypedExecutable
                 : PowerShellCompilationCapability.None;
     }
 

--- a/PowerForge/Models/PowerShellCompilation/PowerShellCompilationParameterContract.cs
+++ b/PowerForge/Models/PowerShellCompilation/PowerShellCompilationParameterContract.cs
@@ -1,0 +1,122 @@
+using System;
+
+namespace PowerForge;
+
+/// <summary>Canonical capability sets for generated PowerShell compilation hosts.</summary>
+public static class PowerShellCompilationCapabilities
+{
+    /// <summary>Capabilities supplied by generated binary cmdlets.</summary>
+    public const PowerShellCompilationCapability BinaryModule =
+        PowerShellCompilationCapability.PowerShellStreams |
+        PowerShellCompilationCapability.LocalFunctionCalls |
+        PowerShellCompilationCapability.BoundParameters |
+        PowerShellCompilationCapability.PowerShellObjects |
+        PowerShellCompilationCapability.PipelineParameterBinding |
+        PowerShellCompilationCapability.PowerShellHostTypes;
+
+    /// <summary>Capabilities supplied by a runtime-independent typed executable.</summary>
+    public const PowerShellCompilationCapability TypedExecutable =
+        PowerShellCompilationCapability.LocalFunctionCalls |
+        PowerShellCompilationCapability.BoundParameters |
+        PowerShellCompilationCapability.ExecutableParameterBinding;
+}
+
+/// <summary>Surfaces on which a resolved parameter type can be represented without changing its meaning.</summary>
+[Flags]
+public enum PowerShellCompilationParameterTypeCapability
+{
+    /// <summary>The type is not supported by a typed parameter surface.</summary>
+    None = 0,
+
+    /// <summary>The type can appear in a generated CLR method signature.</summary>
+    ClrMethod = 1,
+
+    /// <summary>The type can be parsed by the runtime-independent executable argument binder.</summary>
+    ProcessArgument = 2,
+
+    /// <summary>The type requires a generated host that references System.Management.Automation.</summary>
+    PowerShellHost = 4
+}
+
+/// <summary>One authored <c>Parameter</c> attribute binding for a parameter set.</summary>
+public sealed class PowerShellCompilationParameterBinding
+{
+    /// <summary>Creates a parameter-set binding.</summary>
+    public PowerShellCompilationParameterBinding(
+        string? parameterSetName = null,
+        bool mandatory = false,
+        int? position = null,
+        bool valueFromPipeline = false,
+        bool valueFromPipelineByPropertyName = false,
+        bool valueFromRemainingArguments = false,
+        bool dontShow = false,
+        string? helpMessage = null)
+    {
+        ParameterSetName = parameterSetName ?? string.Empty;
+        Mandatory = mandatory;
+        Position = position;
+        ValueFromPipeline = valueFromPipeline;
+        ValueFromPipelineByPropertyName = valueFromPipelineByPropertyName;
+        ValueFromRemainingArguments = valueFromRemainingArguments;
+        DontShow = dontShow;
+        HelpMessage = helpMessage ?? string.Empty;
+    }
+
+    /// <summary>Authored parameter-set name, or an empty string for all parameter sets.</summary>
+    public string ParameterSetName { get; }
+
+    /// <summary>Whether the parameter is mandatory in this parameter set.</summary>
+    public bool Mandatory { get; }
+
+    /// <summary>Explicit zero-based position, or null when source leaves position implicit.</summary>
+    public int? Position { get; }
+
+    /// <summary>Whether values bind from pipeline objects in this parameter set.</summary>
+    public bool ValueFromPipeline { get; }
+
+    /// <summary>Whether values bind from pipeline-object properties in this parameter set.</summary>
+    public bool ValueFromPipelineByPropertyName { get; }
+
+    /// <summary>Whether remaining positional values bind to this parameter.</summary>
+    public bool ValueFromRemainingArguments { get; }
+
+    /// <summary>Whether discovery UIs should hide this parameter.</summary>
+    public bool DontShow { get; }
+
+    /// <summary>Literal help text preserved from source.</summary>
+    public string HelpMessage { get; }
+}
+
+/// <summary>Binding behavior declared by an advanced function.</summary>
+public sealed class PowerShellCompilationCommandBinding
+{
+    /// <summary>Creates an advanced-function binding description.</summary>
+    public PowerShellCompilationCommandBinding(
+        bool isAdvancedFunction = false,
+        bool positionalBinding = true,
+        string? defaultParameterSetName = null,
+        bool supportsShouldProcess = false,
+        string? confirmImpact = null)
+    {
+        IsAdvancedFunction = isAdvancedFunction;
+        PositionalBinding = positionalBinding;
+        DefaultParameterSetName = defaultParameterSetName ?? string.Empty;
+        SupportsShouldProcess = supportsShouldProcess;
+        ConfirmImpact = confirmImpact ?? string.Empty;
+    }
+
+    /// <summary>Whether source uses advanced-function binding.</summary>
+    public bool IsAdvancedFunction { get; }
+
+    /// <summary>Whether parameters without explicit positions receive source-order positions.</summary>
+    public bool PositionalBinding { get; }
+
+    /// <summary>Default parameter set, or an empty string when none is declared.</summary>
+    public string DefaultParameterSetName { get; }
+
+    /// <summary>Whether the generated command advertises ShouldProcess support.</summary>
+    public bool SupportsShouldProcess { get; }
+
+    /// <summary>Literal ConfirmImpact name, or an empty string when source uses the default.</summary>
+    public string ConfirmImpact { get; }
+}

--- a/PowerForge/Models/PowerShellCompilation/PowerShellCompilationPlan.cs
+++ b/PowerForge/Models/PowerShellCompilation/PowerShellCompilationPlan.cs
@@ -35,7 +35,13 @@ public enum PowerShellCompilationCapability
     PowerShellObjects = 8,
 
     /// <summary>Strict executable entry-point parameters must be bindable from process arguments.</summary>
-    ExecutableParameterBinding = 16
+    ExecutableParameterBinding = 16,
+
+    /// <summary>Generated binary cmdlets can preserve PowerShell pipeline parameter binding.</summary>
+    PipelineParameterBinding = 32,
+
+    /// <summary>Generated methods may reference a conservative set of PowerShell host types.</summary>
+    PowerShellHostTypes = 64
 }
 
 /// <summary>
@@ -108,7 +114,12 @@ public sealed class PowerShellCompilationParameter
         bool isSwitch,
         string[]? aliases,
         bool allowNull,
-        PowerShellCompilationValidation[]? validations)
+        PowerShellCompilationValidation[]? validations,
+        PowerShellCompilationParameterTypeCapability typeCapabilities = PowerShellCompilationParameterTypeCapability.ClrMethod,
+        PowerShellCompilationParameterBinding[]? bindings = null,
+        bool allowEmptyString = false,
+        bool allowEmptyCollection = false,
+        bool supportsWildcards = false)
     {
         Name = name ?? string.Empty;
         TypeName = typeName ?? string.Empty;
@@ -118,6 +129,11 @@ public sealed class PowerShellCompilationParameter
         Aliases = aliases ?? Array.Empty<string>();
         AllowNull = allowNull;
         Validations = validations ?? Array.Empty<PowerShellCompilationValidation>();
+        TypeCapabilities = typeCapabilities;
+        Bindings = bindings ?? new[] { new PowerShellCompilationParameterBinding(mandatory: isMandatory) };
+        AllowEmptyString = allowEmptyString;
+        AllowEmptyCollection = allowEmptyCollection;
+        SupportsWildcards = supportsWildcards;
     }
 
     /// <summary>PowerShell parameter name without the dollar prefix.</summary>
@@ -143,6 +159,25 @@ public sealed class PowerShellCompilationParameter
 
     /// <summary>Validation metadata preserved for generated executable and cmdlet binders.</summary>
     public PowerShellCompilationValidation[] Validations { get; }
+
+    /// <summary>Typed surfaces that can represent this resolved parameter type.</summary>
+    public PowerShellCompilationParameterTypeCapability TypeCapabilities { get; }
+
+    /// <summary>Authored parameter-set bindings. An implicit all-sets binding is used when no attribute is present.</summary>
+    public PowerShellCompilationParameterBinding[] Bindings { get; }
+
+    /// <summary>Whether an explicitly bound empty string is allowed.</summary>
+    public bool AllowEmptyString { get; }
+
+    /// <summary>Whether an explicitly bound empty collection is allowed.</summary>
+    public bool AllowEmptyCollection { get; }
+
+    /// <summary>Whether tooling should interpret the value as supporting wildcard syntax.</summary>
+    public bool SupportsWildcards { get; }
+
+    /// <summary>Whether any parameter-set binding accepts pipeline input.</summary>
+    public bool AcceptsPipelineInput => Bindings.Any(static binding =>
+        binding.ValueFromPipeline || binding.ValueFromPipelineByPropertyName);
 }
 
 /// <summary>Supported PowerShell validation metadata preserved by typed compilation.</summary>
@@ -292,7 +327,10 @@ public sealed class PowerShellCompilationSpec
         if ((capabilities & ~(PowerShellCompilationCapability.PowerShellStreams |
                               PowerShellCompilationCapability.LocalFunctionCalls |
                               PowerShellCompilationCapability.BoundParameters |
-                              PowerShellCompilationCapability.PowerShellObjects)) != 0)
+                              PowerShellCompilationCapability.PowerShellObjects |
+                              PowerShellCompilationCapability.ExecutableParameterBinding |
+                              PowerShellCompilationCapability.PipelineParameterBinding |
+                              PowerShellCompilationCapability.PowerShellHostTypes)) != 0)
             throw new ArgumentOutOfRangeException(nameof(capabilities));
         var normalizedTargetFramework = targetFramework?.Trim();
         if (normalizedTargetFramework is not null && normalizedTargetFramework.Length > 0)

--- a/PowerForge/Models/PowerShellCompilation/PowerShellTypedCompilationResult.cs
+++ b/PowerForge/Models/PowerShellCompilation/PowerShellTypedCompilationResult.cs
@@ -31,7 +31,8 @@ public sealed class PowerShellCompiledMethod
         bool requiresPowerShellCommandRegions = false,
         string[]? aliases = null,
         bool requiresPowerShellBoundParameters = false,
-        bool isAdvancedFunction = false)
+        bool isAdvancedFunction = false,
+        PowerShellCompilationCommandBinding? commandBinding = null)
     {
         SourceName = sourceName ?? string.Empty;
         GeneratedName = generatedName ?? string.Empty;
@@ -44,6 +45,7 @@ public sealed class PowerShellCompiledMethod
         Aliases = aliases ?? Array.Empty<string>();
         RequiresPowerShellBoundParameters = requiresPowerShellBoundParameters;
         IsAdvancedFunction = isAdvancedFunction;
+        CommandBinding = commandBinding ?? new PowerShellCompilationCommandBinding(isAdvancedFunction);
     }
 
     /// <summary>Original PowerShell function name.</summary>
@@ -78,6 +80,9 @@ public sealed class PowerShellCompiledMethod
 
     /// <summary>Whether the source function uses advanced-function parameter binding.</summary>
     public bool IsAdvancedFunction { get; }
+
+    /// <summary>Advanced-function and positional binding behavior preserved for the generated command.</summary>
+    public PowerShellCompilationCommandBinding CommandBinding { get; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

- classifies parameter types by CLR method, PowerShell-host, and process-binding capability
- preserves aliases, parameter sets, positions, pipeline binding, remaining arguments, help text, and supported validation metadata
- emits equivalent binary-cmdlet and runtime-free argument binding only when the requested target can honor the contract

Unsupported host or binding semantics remain explicit fallback instead of being silently weakened.

## Stack

Builds on #811. Followed by #813.

## Validation

On the complete stack:

- `dotnet build .\PowerForge.PowerShell\PowerForge.PowerShell.csproj -c Release --no-restore` (net472, net8.0, and net10.0; zero warnings/errors)
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~PowerShellCompilation"` (450 passed)