### PR TITLE
Preserve literal PowerShell parameter defaults

### DIFF
--- a/Docs/PowerForge.PowerShellCompilation.md
+++ b/Docs/PowerForge.PowerShellCompilation.md
@@ -449,7 +449,7 @@ powerforge powershell census `
     --output json
 ```
 
-The current six-root example census reports 1,263 authored files and 1,353 whole script/function units with zero parse errors. Its post-emission view separates 1,235 authored functions from 118 top-level script or module-initialization units: 220 functions pass structural analysis, 126 survive graph and artifact shaping as typed CLR methods, and 94 analyzer-eligible functions are routed back to fallback. Post-emission function coverage is therefore 10.20%. The per-root emitted/total function split is PowerInfoBlox 2/57, PSSharedGoods 18/281, PSWriteHTML 17/238, O365Essentials 77/282, ADEssentials 6/247, and PSWriteWord 6/130. These repositories are replaceable regression workloads, not compiler design targets; PowerForge support remains based on generic language, binding, type-system, host, and artifact contracts.
+The current six-root example census reports 1,263 authored files and 1,353 whole script/function units with zero parse errors. Its post-emission view separates 1,235 authored functions from 118 top-level script or module-initialization units: 254 functions pass structural analysis, 130 survive graph and artifact shaping as typed CLR methods, and 124 analyzer-eligible functions are routed back to fallback. Post-emission function coverage is therefore 10.53%. The per-root emitted/total function split is PowerInfoBlox 2/57, PSSharedGoods 18/281, PSWriteHTML 18/238, O365Essentials 78/282, ADEssentials 7/247, and PSWriteWord 7/130. These repositories are replaceable regression workloads, not compiler design targets; PowerForge support remains based on generic language, binding, type-system, host, and artifact contracts.
 
 Low initial coverage is not hidden by Hybrid mode. It is written to the manifest, and every fallback has a diagnostic explaining what needs compiler support. Diagnostics are deliberately blocker-masked to avoid cascades, so accepting one outer construct can reveal deeper runtime semantics without increasing coverage. Roadmap priority therefore comes from repeated full-corpus passes and executable differential proof, not raw syntax-occurrence counts. Census baselines also carry a portable SHA-256 fingerprint over relative source paths and exact file content, so a changed corpus cannot silently pass merely because its aggregate counts stayed equal.
 
@@ -466,14 +466,16 @@ The current six-root run produces this leading emitted-function planning frontie
 
 | Feature ID | Occurrences | Affected units | Visible sole-blocker units | Products | Candidate coverage |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| `parameter.default` | 829 | 357 | 98 | 6 | 18.14% |
-| `function.graph` | 94 | 94 | 94 | 4 | 17.81% |
-| `runtime.scope` | 1,594 | 385 | 40 | 6 | 13.44% |
-| `command.new-htmltab` | 22 | 22 | 22 | 1 | 11.98% |
-| `syntax.memberexpression` | 18 | 18 | 18 | 5 | 11.66% |
-| `expression.conversion` | 500 | 153 | 16 | 5 | 11.50% |
-| `syntax.variableexpression` | 16 | 16 | 16 | 5 | 11.50% |
-| `syntax.subexpression` | 734 | 191 | 15 | 6 | 11.42% |
+| `function.graph` | 124 | 124 | 124 | 4 | 20.57% |
+| `runtime.scope` | 1,594 | 385 | 46 | 6 | 14.25% |
+| `syntax.invokememberexpression` | 32 | 32 | 32 | 3 | 13.12% |
+| `syntax.memberexpression` | 24 | 24 | 24 | 5 | 12.47% |
+| `command.new-htmltab` | 22 | 22 | 22 | 1 | 12.31% |
+| `assignment.target` | 788 | 164 | 20 | 6 | 12.15% |
+| `syntax.subexpression` | 734 | 191 | 19 | 6 | 12.06% |
+| `syntax.variableexpression` | 19 | 19 | 19 | 5 | 12.06% |
+| `expression.conversion` | 500 | 153 | 16 | 5 | 11.82% |
+| `parameter.default` | 181 | 114 | 13 | 5 | 11.58% |
 
 This changes feature planning materially. `Register-ArgumentCompleter` leads the compatibility whole-unit frontier because it appears in many module-initialization bodies, but it disappears from the emitted-function frontier and must not be treated as 78 potential CLR methods. Likewise, a sample-specific command identifier such as `command.new-htmltab` is evidence for a generic command-boundary shape, not authorization for a product-specific compiler intrinsic. Recommendations must distinguish generic typed IR, a contract-driven PowerShell-backed command region, an authoring change, and behavior that should remain Package/Hybrid-only.
 

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpLiteral.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpLiteral.cs
@@ -5,6 +5,67 @@ namespace PowerForge;
 
 internal static class PowerShellCSharpLiteral
 {
+    internal static string Emit(PowerShellCompilationLiteral literal, Type targetType, Func<Type, string> getTypeName)
+    {
+        if (literal is null) throw new ArgumentNullException(nameof(literal));
+        if (targetType is null) throw new ArgumentNullException(nameof(targetType));
+        if (getTypeName is null) throw new ArgumentNullException(nameof(getTypeName));
+
+        if (literal.Kind == PowerShellCompilationLiteralKind.Null)
+            return "default!";
+        if (literal.Kind == PowerShellCompilationLiteralKind.Array)
+        {
+            var elementType = targetType.GetElementType()
+                ?? throw new InvalidOperationException($"Literal target '{targetType.FullName}' is not an array.");
+            var elements = literal.Elements.Select(element => Emit(element, elementType, getTypeName));
+            return $"new {getTypeName(elementType)}[] {{ {string.Join(", ", elements)} }}";
+        }
+
+        var scalarType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+        var scalar = EmitScalar(literal, scalarType, getTypeName);
+        return Nullable.GetUnderlyingType(targetType) is null
+            ? scalar
+            : $"new {getTypeName(targetType)}({scalar})";
+    }
+
+    private static string EmitScalar(PowerShellCompilationLiteral literal, Type type, Func<Type, string> getTypeName)
+    {
+        var value = literal.Value ?? throw new InvalidOperationException($"Literal '{literal.Kind}' has no invariant value.");
+        var quoted = QuoteString(value);
+        var invariant = "global::System.Globalization.CultureInfo.InvariantCulture";
+        return literal.Kind switch
+        {
+            PowerShellCompilationLiteralKind.Boolean => value,
+            PowerShellCompilationLiteralKind.SignedInteger or PowerShellCompilationLiteralKind.UnsignedInteger =>
+                $"{getTypeName(type)}.Parse({quoted}, global::System.Globalization.NumberStyles.Integer, {invariant})",
+            PowerShellCompilationLiteralKind.FloatingPoint =>
+                $"{getTypeName(type)}.Parse({quoted}, global::System.Globalization.NumberStyles.Float, {invariant})",
+            PowerShellCompilationLiteralKind.Decimal =>
+                $"global::System.Decimal.Parse({quoted}, global::System.Globalization.NumberStyles.Float, {invariant})",
+            PowerShellCompilationLiteralKind.Character => QuoteChar(value.Single()),
+            PowerShellCompilationLiteralKind.String => quoted,
+            PowerShellCompilationLiteralKind.Enum => EmitEnum(value, type, getTypeName, invariant),
+            PowerShellCompilationLiteralKind.Guid => $"new global::System.Guid({quoted})",
+            PowerShellCompilationLiteralKind.DateTime =>
+                $"global::System.DateTime.ParseExact({quoted}, \"O\", {invariant}, global::System.Globalization.DateTimeStyles.RoundtripKind)",
+            PowerShellCompilationLiteralKind.DateTimeOffset =>
+                $"global::System.DateTimeOffset.ParseExact({quoted}, \"O\", {invariant}, global::System.Globalization.DateTimeStyles.None)",
+            PowerShellCompilationLiteralKind.TimeSpan =>
+                $"global::System.TimeSpan.ParseExact({quoted}, \"c\", {invariant})",
+            PowerShellCompilationLiteralKind.Uri =>
+                $"new global::System.Uri({quoted}, global::System.UriKind.RelativeOrAbsolute)",
+            PowerShellCompilationLiteralKind.Version => $"new global::System.Version({quoted})",
+            _ => throw new InvalidOperationException($"Literal kind '{literal.Kind}' cannot be emitted as a scalar.")
+        };
+    }
+
+    private static string EmitEnum(string value, Type enumType, Func<Type, string> getTypeName, string invariant)
+    {
+        var underlyingType = Enum.GetUnderlyingType(enumType);
+        var parsed = $"{getTypeName(underlyingType)}.Parse({QuoteString(value)}, global::System.Globalization.NumberStyles.Integer, {invariant})";
+        return $"({getTypeName(enumType)}){parsed}";
+    }
+
     internal static string QuoteString(string value)
         => "\"" + EscapeStringContent(value) + "\"";
 

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpMethodEmitter.Defaults.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpMethodEmitter.Defaults.cs
@@ -1,0 +1,21 @@
+using System.Management.Automation.Language;
+
+namespace PowerForge;
+
+internal sealed partial class PowerShellCSharpMethodEmitter
+{
+    private void EmitParameterDefaults(IReadOnlyList<ParameterAst> parameters)
+    {
+        foreach (var parameter in parameters)
+        {
+            var name = parameter.Name.VariablePath.UserPath;
+            if (!_parameterMetadata.TryGetValue(name, out var metadata) || metadata.DefaultValue is null)
+                continue;
+
+            var type = GetCompiledParameterType(parameter);
+            var identifier = GetVariableIdentifier(name);
+            AppendLine($"if (!__boundParameters.Contains({PowerShellCSharpLiteral.QuoteString(metadata.Name)}))");
+            AppendLine($"    {identifier} = {PowerShellCSharpLiteral.Emit(metadata.DefaultValue, type, GetTypeName)};");
+        }
+    }
+}

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpMethodEmitter.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpMethodEmitter.cs
@@ -113,7 +113,8 @@ internal sealed partial class PowerShellCSharpMethodEmitter
 
         var statements = _statements ?? _body.EndBlock?.Statements.ToArray() ?? Array.Empty<StatementAst>();
         _requiresBoundParameters = _capabilities.HasFlag(PowerShellCompilationCapability.BoundParameters) &&
-            (_parameterMetadata.Values.Any(static parameter => !parameter.IsMandatory && parameter.Validations.Length > 0) ||
+            (_parameterMetadata.Values.Any(static parameter => parameter.DefaultValue is not null) ||
+             _parameterMetadata.Values.Any(static parameter => !parameter.IsMandatory && parameter.Validations.Length > 0) ||
              statements.SelectMany(static statement => statement.FindAll(static node => node is InvokeMemberExpressionAst, searchNestedScriptBlocks: false))
                  .OfType<InvokeMemberExpressionAst>()
                  .Any(static invocation => PowerShellBoundParametersPolicy.TryGetContainsKey(invocation, out _)));
@@ -157,6 +158,7 @@ internal sealed partial class PowerShellCSharpMethodEmitter
         AppendLine("checked");
         AppendLine("{");
         _indent++;
+        EmitParameterDefaults(parameters);
         foreach (var parameter in parameters.Where(static parameter => GetCompiledParameterType(parameter) == typeof(string)))
         {
             var identifier = GetVariableIdentifier(parameter.Name.VariablePath.UserPath);

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationAnalyzer.Parameters.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationAnalyzer.Parameters.cs
@@ -97,6 +97,22 @@ public sealed partial class PowerShellCompilationAnalyzer
 
             var isSwitch = type == typeof(System.Management.Automation.SwitchParameter);
             var bindings = GetParameterBindings(parameter);
+            PowerShellCompilationLiteral? defaultValue = null;
+            if (parameter.DefaultValue is not null &&
+                (!capabilities.HasFlag(PowerShellCompilationCapability.BoundParameters) ||
+                 !PowerShellCompilationLiteralPolicy.TryResolve(
+                     parameter.DefaultValue,
+                     isSwitch ? typeof(bool) : type,
+                     out defaultValue)))
+            {
+                diagnostics.Add(CreateDiagnostic(
+                    PowerShellCompilationDiagnosticCode.UnsupportedSyntax,
+                    $"Parameter '${parameter.Name.VariablePath.UserPath}' declares a default value that cannot be preserved by this typed target.",
+                    file,
+                    parameter.DefaultValue.Extent,
+                    PowerShellCompilationFeatureIds.ParameterDefault));
+                AnalyzeNode(parameter.DefaultValue, unitRoot, file, diagnostics, localVariables, capabilities, localFunctionNames);
+            }
             result.Add(new PowerShellCompilationParameter(
                 parameter.Name.VariablePath.UserPath,
                 (isSwitch ? typeof(bool) : type).FullName ?? type.Name,
@@ -110,20 +126,11 @@ public sealed partial class PowerShellCompilationAnalyzer
                 bindings,
                 HasMetadataAttribute(parameter, "AllowEmptyString"),
                 HasMetadataAttribute(parameter, "AllowEmptyCollection"),
-                HasMetadataAttribute(parameter, "SupportsWildcards")));
+                HasMetadataAttribute(parameter, "SupportsWildcards"),
+                defaultValue));
 
             foreach (var attribute in parameter.Attributes.Where(static attribute => attribute is not TypeConstraintAst))
                 AnalyzeNode(attribute, unitRoot, file, diagnostics, localVariables, capabilities, localFunctionNames);
-            if (parameter.DefaultValue is not null)
-            {
-                diagnostics.Add(CreateDiagnostic(
-                    PowerShellCompilationDiagnosticCode.UnsupportedSyntax,
-                    $"Parameter '${parameter.Name.VariablePath.UserPath}' declares a PowerShell default value, which is not supported by the typed compiler.",
-                    file,
-                    parameter.DefaultValue.Extent,
-                    PowerShellCompilationFeatureIds.ParameterDefault));
-                AnalyzeNode(parameter.DefaultValue, unitRoot, file, diagnostics, localVariables, capabilities, localFunctionNames);
-            }
         }
 
         ValidateParameterBindingNames(paramBlock, file, diagnostics);

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationLiteralPolicy.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationLiteralPolicy.cs
@@ -1,0 +1,131 @@
+using System.Globalization;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace PowerForge;
+
+/// <summary>Resolves only parser-safe constants and records their target-typed value.</summary>
+internal static class PowerShellCompilationLiteralPolicy
+{
+    internal static bool TryResolve(ExpressionAst expression, Type targetType, out PowerShellCompilationLiteral? literal)
+    {
+        literal = null;
+        object? raw;
+        try
+        {
+            raw = expression.SafeGetValue();
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or RuntimeException)
+        {
+            return false;
+        }
+
+        var compiledType = PowerShellCompilationParameterTypePolicy.GetCompiledType(targetType);
+        object? converted;
+        try
+        {
+            converted = LanguagePrimitives.ConvertTo(raw, compiledType, CultureInfo.InvariantCulture);
+        }
+        catch (Exception exception) when (exception is PSInvalidCastException or InvalidCastException or ArgumentException or FormatException or OverflowException)
+        {
+            return false;
+        }
+        return TryEncode(converted, compiledType, out literal);
+    }
+
+    private static bool TryEncode(object? value, Type targetType, out PowerShellCompilationLiteral? literal)
+    {
+        if (value is null)
+        {
+            if (targetType.IsValueType && Nullable.GetUnderlyingType(targetType) is null)
+            {
+                literal = null;
+                return false;
+            }
+            literal = new PowerShellCompilationLiteral(PowerShellCompilationLiteralKind.Null, GetTypeName(targetType));
+            return true;
+        }
+
+        if (targetType.IsArray && targetType.GetArrayRank() == 1 && value is Array array)
+        {
+            var elementType = targetType.GetElementType()!;
+            var elements = new List<PowerShellCompilationLiteral>(array.Length);
+            foreach (var item in array)
+            {
+                if (!TryEncode(item, elementType, out var element) || element is null)
+                {
+                    literal = null;
+                    return false;
+                }
+                elements.Add(element);
+            }
+            literal = new PowerShellCompilationLiteral(
+                PowerShellCompilationLiteralKind.Array,
+                GetTypeName(targetType),
+                elements: elements.ToArray());
+            return true;
+        }
+
+        var scalar = Nullable.GetUnderlyingType(targetType) ?? targetType;
+        var typeName = GetTypeName(targetType);
+        var kind = GetKind(scalar);
+        if (!kind.HasValue)
+        {
+            literal = null;
+            return false;
+        }
+        var invariant = GetInvariantValue(value, scalar, kind.Value);
+        if (invariant is null)
+        {
+            literal = null;
+            return false;
+        }
+        literal = new PowerShellCompilationLiteral(kind.Value, typeName, invariant);
+        return true;
+    }
+
+    private static PowerShellCompilationLiteralKind? GetKind(Type type)
+    {
+        if (type.IsEnum) return PowerShellCompilationLiteralKind.Enum;
+        if (type == typeof(bool)) return PowerShellCompilationLiteralKind.Boolean;
+        if (type == typeof(sbyte) || type == typeof(short) || type == typeof(int) || type == typeof(long)) return PowerShellCompilationLiteralKind.SignedInteger;
+        if (type == typeof(byte) || type == typeof(ushort) || type == typeof(uint) || type == typeof(ulong)) return PowerShellCompilationLiteralKind.UnsignedInteger;
+        if (type == typeof(float) || type == typeof(double)) return PowerShellCompilationLiteralKind.FloatingPoint;
+        if (type == typeof(decimal)) return PowerShellCompilationLiteralKind.Decimal;
+        if (type == typeof(char)) return PowerShellCompilationLiteralKind.Character;
+        if (type == typeof(string)) return PowerShellCompilationLiteralKind.String;
+        if (type == typeof(Guid)) return PowerShellCompilationLiteralKind.Guid;
+        if (type == typeof(DateTime)) return PowerShellCompilationLiteralKind.DateTime;
+        if (type == typeof(DateTimeOffset)) return PowerShellCompilationLiteralKind.DateTimeOffset;
+        if (type == typeof(TimeSpan)) return PowerShellCompilationLiteralKind.TimeSpan;
+        if (type == typeof(Uri)) return PowerShellCompilationLiteralKind.Uri;
+        if (type == typeof(Version)) return PowerShellCompilationLiteralKind.Version;
+        return null;
+    }
+
+    private static string? GetInvariantValue(object value, Type type, PowerShellCompilationLiteralKind kind)
+        => kind switch
+        {
+            PowerShellCompilationLiteralKind.Boolean => (bool)value ? "true" : "false",
+            PowerShellCompilationLiteralKind.Enum => GetEnumInvariant(value, type),
+            PowerShellCompilationLiteralKind.DateTime => ((DateTime)value).ToString("O", CultureInfo.InvariantCulture),
+            PowerShellCompilationLiteralKind.DateTimeOffset => ((DateTimeOffset)value).ToString("O", CultureInfo.InvariantCulture),
+            PowerShellCompilationLiteralKind.TimeSpan => ((TimeSpan)value).ToString("c", CultureInfo.InvariantCulture),
+            PowerShellCompilationLiteralKind.Guid => ((Guid)value).ToString("D"),
+            PowerShellCompilationLiteralKind.Uri => ((Uri)value).OriginalString,
+            PowerShellCompilationLiteralKind.Version => ((Version)value).ToString(),
+            PowerShellCompilationLiteralKind.Character => value.ToString(),
+            PowerShellCompilationLiteralKind.String => (string)value,
+            _ => value is IFormattable formattable ? formattable.ToString(null, CultureInfo.InvariantCulture) : null
+        };
+
+    private static string GetEnumInvariant(object value, Type enumType)
+    {
+        var underlying = Enum.GetUnderlyingType(enumType);
+        return underlying == typeof(sbyte) || underlying == typeof(short) || underlying == typeof(int) || underlying == typeof(long)
+            ? Convert.ToInt64(value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture)
+            : Convert.ToUInt64(value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string GetTypeName(Type type) => type.FullName ?? type.Name;
+}

--- a/PowerForge.Tests/PowerShellCompilationCensusTests.cs
+++ b/PowerForge.Tests/PowerShellCompilationCensusTests.cs
@@ -22,16 +22,10 @@ public sealed class PowerShellCompilationCensusTests
 
             var match = Assert.Single(result.Frontier, impact => impact.FeatureId == "operator.imatch");
             Assert.Equal(2, match.AffectedUnits);
-            Assert.Equal(1, match.VisibleSoleBlockerUnits);
-            Assert.Equal(2, match.CandidateCompilableUnits);
-            Assert.Equal(2d / 3d * 100d, match.CandidateCoveragePercentage, precision: 6);
-            var parameterDefault = Assert.Single(result.Frontier, impact => impact.FeatureId == PowerShellCompilationFeatureIds.ParameterDefault);
-            Assert.Equal(1, parameterDefault.AffectedUnits);
-            Assert.Equal(0, parameterDefault.VisibleSoleBlockerUnits);
-            Assert.Contains(result.CoBlockers, pair =>
-                pair.AffectedUnits == 1 &&
-                new[] { pair.FirstFeatureId, pair.SecondFeatureId }.Contains("operator.imatch") &&
-                new[] { pair.FirstFeatureId, pair.SecondFeatureId }.Contains(PowerShellCompilationFeatureIds.ParameterDefault));
+            Assert.Equal(2, match.VisibleSoleBlockerUnits);
+            Assert.Equal(3, match.CandidateCompilableUnits);
+            Assert.Equal(100d, match.CandidateCoveragePercentage, precision: 6);
+            Assert.DoesNotContain(result.Frontier, impact => impact.FeatureId == PowerShellCompilationFeatureIds.ParameterDefault);
             Assert.Equal(result.Frontier.Select(static impact => impact.FeatureId).Distinct(StringComparer.Ordinal).Count(), result.Frontier.Length);
         }
         finally

--- a/PowerForge.Tests/PowerShellCompilationLiteralDefaultTests.cs
+++ b/PowerForge.Tests/PowerShellCompilationLiteralDefaultTests.cs
@@ -1,0 +1,173 @@
+using PowerForge;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class PowerShellCompilationArtifactBuilderTests
+{
+    [Fact]
+    public void Analyze_PreservesTargetTypedLiteralDefaults()
+    {
+        using var fixture = ArtifactFixture.Create(
+            "function Get-LiteralDefaults { param([int] $Count = 7, [string] $Name = $null, " +
+            "[int[]] $Values = @(2, 3), [DayOfWeek] $Day = 'Friday') return $Count }",
+            ".psm1");
+
+        var plan = new PowerShellCompilationAnalyzer().Analyze(new PowerShellCompilationSpec(
+            fixture.ScriptPath,
+            targetFramework: "net10.0",
+            capabilities: PowerShellCompilationCapabilities.BinaryModule));
+
+        var unit = Assert.Single(Assert.Single(plan.Files).Units);
+        Assert.True(unit.IsCompilable, string.Join(Environment.NewLine, unit.Diagnostics.Select(static diagnostic => diagnostic.Message)));
+        Assert.Collection(
+            unit.Parameters,
+            parameter =>
+            {
+                Assert.Equal(PowerShellCompilationLiteralKind.SignedInteger, parameter.DefaultValue?.Kind);
+                Assert.Equal("7", parameter.DefaultValue?.Value);
+            },
+            parameter =>
+            {
+                Assert.Equal(PowerShellCompilationLiteralKind.String, parameter.DefaultValue?.Kind);
+                Assert.Equal(string.Empty, parameter.DefaultValue?.Value);
+            },
+            parameter =>
+            {
+                Assert.Equal(PowerShellCompilationLiteralKind.Array, parameter.DefaultValue?.Kind);
+                Assert.Equal(new[] { "2", "3" }, parameter.DefaultValue?.Elements.Select(static element => element.Value));
+            },
+            parameter =>
+            {
+                Assert.Equal(PowerShellCompilationLiteralKind.Enum, parameter.DefaultValue?.Kind);
+                Assert.Equal(((int)DayOfWeek.Friday).ToString(), parameter.DefaultValue?.Value);
+            });
+        Assert.DoesNotContain(unit.Diagnostics, static diagnostic => diagnostic.FeatureId == PowerShellCompilationFeatureIds.ParameterDefault);
+    }
+
+    [Fact]
+    public void Analyze_LeavesRuntimeEvaluatedDefaultOnFallbackPath()
+    {
+        using var fixture = ArtifactFixture.Create(
+            "function Get-DynamicDefault { param([DateTime] $When = (Get-Date)) return $When }",
+            ".psm1");
+
+        var plan = new PowerShellCompilationAnalyzer().Analyze(new PowerShellCompilationSpec(
+            fixture.ScriptPath,
+            targetFramework: "net10.0",
+            capabilities: PowerShellCompilationCapabilities.BinaryModule));
+
+        var unit = Assert.Single(Assert.Single(plan.Files).Units);
+        Assert.False(unit.IsCompilable);
+        Assert.Null(Assert.Single(unit.Parameters).DefaultValue);
+        Assert.Contains(unit.Diagnostics, static diagnostic => diagnostic.FeatureId == PowerShellCompilationFeatureIds.ParameterDefault);
+    }
+
+    [Fact]
+    public void Build_StrictExecutableDistinguishesOmittedDefaultFromExplicitZero()
+    {
+        using var fixture = ArtifactFixture.Create("param([int] $Count = 7); return $Count");
+        var result = new PowerShellCompilationArtifactBuilder().Build(new PowerShellCompilationBuildSpec(
+            fixture.ScriptPath,
+            fixture.OutputPath,
+            "PowerForge.LiteralDefaultExecutable",
+            PowerShellCompilationArtifactKind.Executable,
+            PowerShellCompilationMode.Strict));
+
+        Assert.True(result.Succeeded, result.Error + Environment.NewLine + result.BuildOutput);
+        var omitted = RunProcess(result.ArtifactPath!);
+        var bound = RunProcess(result.ArtifactPath!, "--Count=0");
+        Assert.Equal((0, "7"), (omitted.ExitCode, omitted.StandardOutput.Trim()));
+        Assert.Equal((0, "0"), (bound.ExitCode, bound.StandardOutput.Trim()));
+    }
+
+    [Fact]
+    public void Build_StrictBinaryModulePreservesScalarAndArrayDefaultsWithoutOverwritingExplicitValues()
+    {
+        using var fixture = ArtifactFixture.Create(
+            "function Get-DefaultName { param([string] $Name = 'fallback') return $Name }; " +
+            "function Get-DefaultTotal { param([int[]] $Numbers = @(2, 3)) [int] $total = 0; " +
+            "foreach ($number in $Numbers) { $total += $number }; return $total }",
+            ".psm1");
+        var result = new PowerShellCompilationArtifactBuilder().Build(new PowerShellCompilationBuildSpec(
+            fixture.ScriptPath,
+            fixture.OutputPath,
+            "PowerForge.LiteralDefaultModule",
+            PowerShellCompilationArtifactKind.BinaryModule,
+            PowerShellCompilationMode.Strict));
+
+        Assert.True(result.Succeeded, result.Error + Environment.NewLine + result.BuildOutput);
+        var output = RunModuleProof(
+            result.ArtifactPath!,
+            "'<'+(Get-DefaultName)+'>'; '<'+(Get-DefaultName -Name '')+'>'; " +
+            "Get-DefaultTotal; Get-DefaultTotal -Numbers @()");
+        Assert.Equal(new[] { "<fallback>", "<>", "5", "0" }, output.Split(Environment.NewLine));
+    }
+
+    [Fact]
+    public void Build_StrictBinaryModulePropagatesBoundStateThroughTypedLocalDefaultCall()
+    {
+        using var fixture = ArtifactFixture.Create(
+            "function Get-InnerDefault { param([int] $Number = 7) return $Number }; " +
+            "function Get-OuterDefault { return Get-InnerDefault }; " +
+            "function Get-ExplicitDefault { return Get-InnerDefault -Number 0 }",
+            ".psm1");
+        var result = new PowerShellCompilationArtifactBuilder().Build(new PowerShellCompilationBuildSpec(
+            fixture.ScriptPath,
+            fixture.OutputPath,
+            "PowerForge.LocalLiteralDefault",
+            PowerShellCompilationArtifactKind.BinaryModule,
+            PowerShellCompilationMode.Strict));
+
+        Assert.True(result.Succeeded, result.Error + Environment.NewLine + result.BuildOutput);
+        var output = RunModuleProof(result.ArtifactPath!, "Get-OuterDefault; Get-ExplicitDefault");
+        Assert.Equal(new[] { "7", "0" }, output.Split(Environment.NewLine));
+    }
+
+    [Fact]
+    public void Build_StrictBinaryModuleEmitsPortableScalarLiteralFamilies()
+    {
+        using var fixture = ArtifactFixture.Create(
+            "function Get-TokenDefault { param([Guid] $Token = '2f7d93d8-8723-4ced-8f5f-86b155df3a10') return $Token }; " +
+            "function Get-MomentDefault { param([DateTime] $Moment = '2020-01-02T03:04:05.0000000') return $Moment }; " +
+            "function Get-RecordedDefault { param([DateTimeOffset] $Recorded = '2020-01-02T03:04:05.0000000+02:00') return $Recorded }; " +
+            "function Get-SpanDefault { param([TimeSpan] $Span = '01:02:03') return $Span }; " +
+            "function Get-LinkDefault { param([Uri] $Link = 'relative/path') return $Link }; " +
+            "function Get-BuildDefault { param([Version] $Build = '1.2.3.4') return $Build }; " +
+            "function Get-NameDefault { param([DayOfWeek] $Name = 'Friday') return $Name }; " +
+            "function Get-AmountDefault { param([decimal] $Amount = 1.25) return $Amount }; " +
+            "function Get-LetterDefault { param([char] $Letter = 'x') return $Letter }; " +
+            "function Get-NullableDefault { param([Nullable[int]] $Number = 7) return $Number }",
+            ".psm1");
+        var result = new PowerShellCompilationArtifactBuilder().Build(new PowerShellCompilationBuildSpec(
+            fixture.ScriptPath,
+            fixture.OutputPath,
+            "PowerForge.PortableLiteralFamilies",
+            PowerShellCompilationArtifactKind.BinaryModule,
+            PowerShellCompilationMode.Strict));
+
+        Assert.True(result.Succeeded, result.Error + Environment.NewLine + result.BuildOutput);
+        var output = RunModuleProof(
+            result.ArtifactPath!,
+            "(Get-TokenDefault).ToString(); (Get-MomentDefault).ToString('O'); " +
+            "(Get-RecordedDefault).ToString('O'); (Get-SpanDefault).ToString('c'); " +
+            "(Get-LinkDefault).OriginalString; (Get-BuildDefault).ToString(); " +
+            "(Get-NameDefault).ToString(); (Get-AmountDefault).ToString([Globalization.CultureInfo]::InvariantCulture); " +
+            "(Get-LetterDefault).ToString(); (Get-NullableDefault).ToString()");
+        Assert.Equal(
+            new[]
+            {
+                "2f7d93d8-8723-4ced-8f5f-86b155df3a10",
+                "2020-01-02T03:04:05.0000000",
+                "2020-01-02T03:04:05.0000000+02:00",
+                "01:02:03",
+                "relative/path",
+                "1.2.3.4",
+                "Friday",
+                "1.25",
+                "x",
+                "7"
+            },
+            output.Split(Environment.NewLine));
+    }
+}

--- a/PowerForge/Models/PowerShellCompilation/PowerShellCompilationLiteral.cs
+++ b/PowerForge/Models/PowerShellCompilation/PowerShellCompilationLiteral.cs
@@ -1,0 +1,71 @@
+using System;
+
+namespace PowerForge;
+
+/// <summary>Kinds of target-typed constant values preserved by the compiler.</summary>
+public enum PowerShellCompilationLiteralKind
+{
+    /// <summary>A null reference or nullable value.</summary>
+    Null,
+    /// <summary>A Boolean value.</summary>
+    Boolean,
+    /// <summary>A signed integral value.</summary>
+    SignedInteger,
+    /// <summary>An unsigned integral value.</summary>
+    UnsignedInteger,
+    /// <summary>A single- or double-precision floating-point value.</summary>
+    FloatingPoint,
+    /// <summary>A decimal value.</summary>
+    Decimal,
+    /// <summary>A character value.</summary>
+    Character,
+    /// <summary>A string value.</summary>
+    String,
+    /// <summary>An enum value represented by its invariant underlying integer.</summary>
+    Enum,
+    /// <summary>A GUID value.</summary>
+    Guid,
+    /// <summary>A date and time value.</summary>
+    DateTime,
+    /// <summary>A date, time, and offset value.</summary>
+    DateTimeOffset,
+    /// <summary>A time interval.</summary>
+    TimeSpan,
+    /// <summary>A URI value.</summary>
+    Uri,
+    /// <summary>A version value.</summary>
+    Version,
+    /// <summary>A one-dimensional target-typed array.</summary>
+    Array
+}
+
+/// <summary>A safely evaluated, target-typed PowerShell constant.</summary>
+public sealed class PowerShellCompilationLiteral
+{
+    /// <summary>Creates a compilation literal.</summary>
+    public PowerShellCompilationLiteral(
+        PowerShellCompilationLiteralKind kind,
+        string typeName,
+        string? value = null,
+        PowerShellCompilationLiteral[]? elements = null)
+    {
+        if (!Enum.IsDefined(typeof(PowerShellCompilationLiteralKind), kind))
+            throw new ArgumentOutOfRangeException(nameof(kind));
+        Kind = kind;
+        TypeName = typeName ?? string.Empty;
+        Value = value ?? string.Empty;
+        Elements = elements ?? Array.Empty<PowerShellCompilationLiteral>();
+    }
+
+    /// <summary>Constant representation kind.</summary>
+    public PowerShellCompilationLiteralKind Kind { get; }
+
+    /// <summary>Resolved CLR type name after PowerShell parameter conversion.</summary>
+    public string TypeName { get; }
+
+    /// <summary>Invariant scalar representation.</summary>
+    public string Value { get; }
+
+    /// <summary>Target-typed array elements.</summary>
+    public PowerShellCompilationLiteral[] Elements { get; }
+}

--- a/PowerForge/Models/PowerShellCompilation/PowerShellCompilationPlan.cs
+++ b/PowerForge/Models/PowerShellCompilation/PowerShellCompilationPlan.cs
@@ -119,7 +119,8 @@ public sealed class PowerShellCompilationParameter
         PowerShellCompilationParameterBinding[]? bindings = null,
         bool allowEmptyString = false,
         bool allowEmptyCollection = false,
-        bool supportsWildcards = false)
+        bool supportsWildcards = false,
+        PowerShellCompilationLiteral? defaultValue = null)
     {
         Name = name ?? string.Empty;
         TypeName = typeName ?? string.Empty;
@@ -134,6 +135,7 @@ public sealed class PowerShellCompilationParameter
         AllowEmptyString = allowEmptyString;
         AllowEmptyCollection = allowEmptyCollection;
         SupportsWildcards = supportsWildcards;
+        DefaultValue = defaultValue;
     }
 
     /// <summary>PowerShell parameter name without the dollar prefix.</summary>
@@ -174,6 +176,9 @@ public sealed class PowerShellCompilationParameter
 
     /// <summary>Whether tooling should interpret the value as supporting wildcard syntax.</summary>
     public bool SupportsWildcards { get; }
+
+    /// <summary>Safely resolved target-typed default, or null when no supported default was declared.</summary>
+    public PowerShellCompilationLiteral? DefaultValue { get; }
 
     /// <summary>Whether any parameter-set binding accepts pipeline input.</summary>
     public bool AcceptsPipelineInput => Bindings.Any(static binding =>


### PR DESCRIPTION
## Summary

- models supported scalar, enum, nullable, and array defaults as typed literals
- distinguishes an omitted parameter from an explicitly bound value
- applies defaults and validation consistently across generated modules, executables, and typed local calls

Dynamic defaults continue to use PowerShell fallback.

## Stack

Builds on #812. Followed by #814.

## Validation

On the complete stack:

- `dotnet build .\PowerForge.PowerShell\PowerForge.PowerShell.csproj -c Release --no-restore` (net472, net8.0, and net10.0; zero warnings/errors)
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~PowerShellCompilation"` (450 passed)