### PR TITLE
Add safe PowerShell runtime state intrinsics

### DIFF
--- a/Docs/PowerForge.PowerShellCompilation.md
+++ b/Docs/PowerForge.PowerShellCompilation.md
@@ -253,6 +253,7 @@ The current subset supports:
 - capability-classified CLR, PowerShell-host, process-bindable, `SwitchParameter`, nullable, enum, and one-dimensional typed-array parameters;
 - preserved function and parameter aliases plus parameter-set, position, pipeline, remaining-argument, literal-help, empty-value, wildcard, and validation metadata on hosts that implement those contracts;
 - bounded `$PSBoundParameters.ContainsKey('CanonicalParameterName')` queries, including metadata propagation across typed local calls and runtime-free Strict executable argument binding;
+- target-backed `$PSEdition` plus PowerShell Core `$IsCoreCLR`, `$IsWindows`, `$IsLinux`, and `$IsMacOS` facts in runtime-free artifacts; generated binary cmdlets can additionally inject the live `$PSVersionTable.PSVersion`, `$WhatIfPreference`, and one- or two-argument `$PSCmdlet.ShouldProcess(...)` contracts through typed local call graphs;
 - typed or safely inferred local variables;
 - explicit `return` values and one terminal implicit-output expression;
 - `if`/`elseif`/`else`, conservative scalar `switch`, `for`, `while`, `foreach` over typed arrays or an explicitly typed scalar string, ordered CLR exception catches with bounded `finally` blocks, typed CLR exception throws, and bare rethrow inside a supported catch;
@@ -281,6 +282,7 @@ The analyzer rejects dynamic behavior rather than guessing. Current blockers inc
 - commands and pipelines outside the bounded binary-module region contract, including nested closures over unresolved runtime variables;
 - dynamic member names, PowerShell-adapted properties, ambiguous overloads, and general object-property semantics;
 - script blocks, closures, runtime scopes such as `$env:`, and untyped parameters;
+- automatic or preference variables outside the explicit read-only intrinsic set, arbitrary `$PSVersionTable` keys, and `$PSCmdlet` interactions other than the bounded `ShouldProcess` overloads;
 - dynamic or host-incompatible parameter attributes, PowerShell default expressions, and `dynamicparam`, `begin`, `process`, or `clean` blocks;
 - dynamic `$PSBoundParameters` access, noncanonical or computed keys, dynamic/string throw operands, and `[pscustomobject]` construction outside generated binary modules;
 - nonterminal or nested implicit pipeline output;
@@ -451,7 +453,7 @@ powerforge powershell census `
     --output json
 ```
 
-The current six-root example census reports 1,263 authored files and 1,353 whole script/function units with zero parse errors. Its post-emission view separates 1,235 authored functions from 118 top-level script or module-initialization units: 284 functions pass structural analysis, 140 survive graph and artifact shaping as typed CLR methods, and 144 analyzer-eligible functions are routed back to fallback. Post-emission function coverage is therefore 11.34%. The per-root emitted/total function split is PowerInfoBlox 3/57, PSSharedGoods 20/281, PSWriteHTML 18/238, O365Essentials 82/282, ADEssentials 10/247, and PSWriteWord 7/130. These repositories are replaceable regression workloads, not compiler design targets; PowerForge support remains based on generic language, binding, type-system, host, and artifact contracts.
+The current six-root example census reports 1,263 authored files and 1,353 whole script/function units with zero parse errors. Its post-emission view separates 1,235 authored functions from 118 top-level script or module-initialization units: 286 functions pass structural analysis, 140 survive graph and artifact shaping as typed CLR methods, and 146 analyzer-eligible functions are routed back to fallback. Post-emission function coverage is therefore 11.34%. The per-root emitted/total function split is PowerInfoBlox 3/57, PSSharedGoods 20/281, PSWriteHTML 18/238, O365Essentials 82/282, ADEssentials 10/247, and PSWriteWord 7/130. These repositories are replaceable regression workloads, not compiler design targets; PowerForge support remains based on generic language, binding, type-system, host, and artifact contracts.
 
 Low initial coverage is not hidden by Hybrid mode. It is written to the manifest, and every fallback has a diagnostic explaining what needs compiler support. Diagnostics are deliberately blocker-masked to avoid cascades, so accepting one outer construct can reveal deeper runtime semantics without increasing coverage. Roadmap priority therefore comes from repeated full-corpus passes and executable differential proof, not raw syntax-occurrence counts. Census baselines also carry a portable SHA-256 fingerprint over relative source paths and exact file content, so a changed corpus cannot silently pass merely because its aggregate counts stayed equal.
 

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellBinaryCmdletSourceGenerator.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellBinaryCmdletSourceGenerator.cs
@@ -313,6 +313,16 @@ internal static class PowerShellBinaryCmdletSourceGenerator
             arguments = arguments.Concat(new[] { "WriteVerbose", "WriteDebug", "WriteWarning" });
         if (cmdlet.Method.RequiresPowerShellCommandRegions)
             arguments = arguments.Append("InvokePowerShellRegion");
+        if (cmdlet.Method.RequiresPowerShellRuntimeState)
+        {
+            arguments = arguments.Concat(new[]
+            {
+                "target => ShouldProcess(target)",
+                "(target, action) => ShouldProcess(target, action)",
+                "((global::System.Collections.IDictionary)SessionState.PSVariable.GetValue(\"PSVersionTable\"))[\"PSVersion\"]!",
+                "MyInvocation.BoundParameters.ContainsKey(\"WhatIf\") || global::System.Management.Automation.LanguagePrimitives.IsTrue(SessionState.PSVariable.GetValue(\"WhatIfPreference\"))"
+            });
+        }
         if (cmdlet.Method.RequiresPowerShellBoundParameters)
             arguments = arguments.Append("new global::System.Collections.Generic.HashSet<string>(MyInvocation.BoundParameters.Keys, global::System.StringComparer.OrdinalIgnoreCase)");
         var invocation = $"{typed.TypeName}.{cmdlet.Method.GeneratedName}({string.Join(", ", arguments)})";

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpMethodEmitter.LocalFunctions.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpMethodEmitter.LocalFunctions.cs
@@ -43,6 +43,8 @@ internal sealed partial class PowerShellCSharpMethodEmitter
             arguments.AddRange(new[] { "__writeVerbose", "__writeDebug", "__writeWarning" });
         if (call.Signature.RequiresPowerShellCommandRegions)
             arguments.Add("__invokePowerShellRegion");
+        if (call.Signature.RequiresPowerShellRuntimeState)
+            arguments.AddRange(new[] { "__shouldProcessTarget", "__shouldProcessAction", "__psVersion", "__whatIfPreference" });
         if (call.Signature.RequiresPowerShellBoundParameters)
             arguments.Add(EmitBoundParameterSet(call.BoundParameterNames));
         return $"{call.Signature.GeneratedName}({string.Join(", ", arguments)})";

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpMethodEmitter.RuntimeState.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpMethodEmitter.RuntimeState.cs
@@ -1,0 +1,28 @@
+using System.Management.Automation.Language;
+
+namespace PowerForge;
+
+internal sealed partial class PowerShellCSharpMethodEmitter
+{
+    private bool TryGetRuntimeStateIntrinsic(Ast ast, out PowerShellRuntimeStateIntrinsicKind kind)
+        => PowerShellRuntimeStateIntrinsicPolicy.TryClassify(ast, _body, _targetFramework, _capabilities, out kind);
+
+    private string EmitRuntimeStateIntrinsic(Ast ast)
+    {
+        if (!TryGetRuntimeStateIntrinsic(ast, out var kind))
+            throw Error(ast, "The runtime-state expression is outside the bounded intrinsic contract.");
+        if (kind is PowerShellRuntimeStateIntrinsicKind.ShouldProcessTarget or PowerShellRuntimeStateIntrinsicKind.ShouldProcessAction)
+        {
+            var invocation = (InvokeMemberExpressionAst)ast;
+            if (invocation.Arguments.Any(argument => InferExpressionType(argument) != typeof(string)))
+                throw Error(invocation, "$PSCmdlet.ShouldProcess currently requires one or two scalar String arguments.");
+            var arguments = invocation.Arguments.Select(EmitExpression).ToArray();
+            return kind == PowerShellRuntimeStateIntrinsicKind.ShouldProcessTarget
+                ? $"__shouldProcessTarget({arguments[0]})"
+                : $"__shouldProcessAction({arguments[0]}, {arguments[1]})";
+        }
+        if (string.IsNullOrWhiteSpace(_targetFramework))
+            throw Error(ast, "Runtime-state intrinsic emission requires an explicit target framework.");
+        return PowerShellRuntimeStateIntrinsicPolicy.EmitStatic(kind, _targetFramework!);
+    }
+}

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpMethodEmitter.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCSharpMethodEmitter.cs
@@ -27,6 +27,7 @@ internal sealed partial class PowerShellCSharpMethodEmitter
     private readonly IReadOnlyDictionary<string, PowerShellCompilationParameter> _parameterMetadata;
     private bool _requiresPowerShellStreams;
     private bool _requiresPowerShellCommandRegions;
+    private bool _requiresPowerShellRuntimeState;
     private bool _requiresBoundParameters;
     private int _indent = 1;
     private int _switchIndex;
@@ -134,6 +135,9 @@ internal sealed partial class PowerShellCSharpMethodEmitter
             (runtimeTailStart >= 0 ||
              typedStatements.Any(statement => PowerShellCommandIslandPolicy.IsRuntimeRegion(statement, _body, _localFunctionNames, availableVariables)) ||
              calledLocalFunctions.Any(static signature => signature.RequiresPowerShellCommandRegions));
+        _requiresPowerShellRuntimeState = _capabilities.HasFlag(PowerShellCompilationCapability.RuntimeStateIntrinsics) &&
+            (PowerShellRuntimeStateIntrinsicPolicy.RequiresHostBinding(typedStatements, _body, _targetFramework, _capabilities) ||
+             calledLocalFunctions.Any(static signature => signature.RequiresPowerShellRuntimeState));
         ValidateVariableReferences(typedStatements);
         var returnType = runtimeTailStart >= 0 ? typeof(void) : InferReturnType(typedStatements);
         if (returnType != typeof(void) && !HasTerminalValue(statements))
@@ -148,6 +152,13 @@ internal sealed partial class PowerShellCSharpMethodEmitter
         }
         if (_requiresPowerShellCommandRegions)
             parameterParts.Add("global::System.Action<string, object?[]> __invokePowerShellRegion");
+        if (_requiresPowerShellRuntimeState)
+        {
+            parameterParts.Add("global::System.Func<string, bool> __shouldProcessTarget");
+            parameterParts.Add("global::System.Func<string, string, bool> __shouldProcessAction");
+            parameterParts.Add("object __psVersion");
+            parameterParts.Add("bool __whatIfPreference");
+        }
         if (_requiresBoundParameters)
             parameterParts.Add("global::System.Collections.Generic.ISet<string> __boundParameters");
         var parameterSource = string.Join(", ", parameterParts);
@@ -202,7 +213,8 @@ internal sealed partial class PowerShellCSharpMethodEmitter
             _builder.ToString().TrimEnd(),
             _requiresPowerShellStreams,
             _requiresPowerShellCommandRegions,
-            _requiresBoundParameters);
+            _requiresBoundParameters,
+            _requiresPowerShellRuntimeState);
     }
 
     private void EmitRuntimeRegion(IReadOnlyList<StatementAst> statements)
@@ -516,6 +528,7 @@ internal sealed partial class PowerShellCSharpMethodEmitter
             StringConstantExpressionAst text => EmitString(text.Value),
             ExpandableStringExpressionAst expandable => EmitExpandableString(expandable),
             ConstantExpressionAst constant => EmitConstant(constant),
+            VariableExpressionAst variable when TryGetRuntimeStateIntrinsic(variable, out _) => EmitRuntimeStateIntrinsic(variable),
             VariableExpressionAst variable => EmitVariable(variable),
             ParenExpressionAst parenthesized => $"({EmitExpression(parenthesized.Pipeline)})",
             ConvertExpressionAst conversion when IsOrderedHashtableConversion(conversion) => EmitOrderedStringDictionary(conversion),
@@ -533,8 +546,11 @@ internal sealed partial class PowerShellCSharpMethodEmitter
             AssignmentStatementAst assignment => EmitAssignmentExpression(assignment),
             InvokeMemberExpressionAst invocation when PowerShellBoundParametersPolicy.TryGetContainsKey(invocation, out var parameterName) =>
                 EmitBoundParameterContainsKey(invocation, parameterName),
+            InvokeMemberExpressionAst invocation when TryGetRuntimeStateIntrinsic(invocation, out _) => EmitRuntimeStateIntrinsic(invocation),
             InvokeMemberExpressionAst invocation => EmitMemberInvocation(invocation),
+            MemberExpressionAst member when TryGetRuntimeStateIntrinsic(member, out _) => EmitRuntimeStateIntrinsic(member),
             MemberExpressionAst member => EmitMemberAccess(member),
+            IndexExpressionAst index when TryGetRuntimeStateIntrinsic(index, out _) => EmitRuntimeStateIntrinsic(index),
             IndexExpressionAst index => _memberEmitter.EmitIndex(index),
             PipelineAst pipeline when IsLocalFunctionPipeline(pipeline) => EmitLocalFunctionCall(pipeline),
             CommandAst command when IsLocalFunctionCommand(command) => EmitLocalFunctionCall(command),
@@ -551,7 +567,7 @@ internal sealed partial class PowerShellCSharpMethodEmitter
         var cursor = 0;
         foreach (var nested in expandable.NestedExpressions)
         {
-            if (nested is not VariableExpressionAst variable || InferVariableType(variable) != typeof(string))
+            if (nested is not VariableExpressionAst variable || InferExpressionType(variable) != typeof(string))
                 throw Error(nested, "Typed expandable strings currently accept only statically typed string variables; subexpressions and runtime string conversion remain on the PowerShell path.");
             var token = nested.Extent.Text;
             var tokenIndex = expandable.Value.IndexOf(token, cursor, StringComparison.Ordinal);
@@ -559,7 +575,7 @@ internal sealed partial class PowerShellCSharpMethodEmitter
                 throw Error(nested, "Expandable string source could not be mapped losslessly to its parsed interpolation token.");
             if (tokenIndex > cursor)
                 parts.Add(EmitString(expandable.Value.Substring(cursor, tokenIndex - cursor)));
-            parts.Add($"({EmitVariable(variable)} ?? string.Empty)");
+            parts.Add($"({EmitExpression(variable)} ?? string.Empty)");
             cursor = tokenIndex + token.Length;
         }
         if (cursor < expandable.Value.Length)
@@ -641,6 +657,8 @@ internal sealed partial class PowerShellCSharpMethodEmitter
             StringConstantExpressionAst => typeof(string),
             ExpandableStringExpressionAst => typeof(string),
             ConstantExpressionAst constant => constant.Value?.GetType() ?? typeof(object),
+            VariableExpressionAst variable when TryGetRuntimeStateIntrinsic(variable, out var intrinsic) =>
+                PowerShellRuntimeStateIntrinsicPolicy.GetType(intrinsic),
             VariableExpressionAst variable => InferVariableType(variable),
             ParenExpressionAst parenthesized => InferExpressionType(parenthesized.Pipeline),
             ConvertExpressionAst conversion when IsOrderedHashtableConversion(conversion) => InferOrderedStringDictionaryType(conversion),
@@ -660,8 +678,14 @@ internal sealed partial class PowerShellCSharpMethodEmitter
             AssignmentStatementAst assignment => InferExpressionType(assignment.Right),
             InvokeMemberExpressionAst invocation when PowerShellBoundParametersPolicy.TryGetContainsKey(invocation, out _) =>
                 EnsureBoundParametersAvailable(invocation),
+            InvokeMemberExpressionAst invocation when TryGetRuntimeStateIntrinsic(invocation, out var intrinsic) =>
+                PowerShellRuntimeStateIntrinsicPolicy.GetType(intrinsic),
             InvokeMemberExpressionAst invocation => InferMemberInvocationType(invocation),
+            MemberExpressionAst member when TryGetRuntimeStateIntrinsic(member, out var intrinsic) =>
+                PowerShellRuntimeStateIntrinsicPolicy.GetType(intrinsic),
             MemberExpressionAst member => InferMemberAccessType(member),
+            IndexExpressionAst index when TryGetRuntimeStateIntrinsic(index, out var intrinsic) =>
+                PowerShellRuntimeStateIntrinsicPolicy.GetType(intrinsic),
             IndexExpressionAst index => _memberEmitter.InferIndexType(index),
             PipelineAst pipeline when IsLocalFunctionPipeline(pipeline) => InferLocalFunctionType(pipeline),
             CommandAst command when IsLocalFunctionCommand(command) => InferLocalFunctionType(command),

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationAnalyzer.Parameters.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationAnalyzer.Parameters.cs
@@ -52,7 +52,7 @@ public sealed partial class PowerShellCompilationAnalyzer
             return Array.Empty<PowerShellCompilationParameter>();
 
         foreach (var attribute in paramBlock.Attributes)
-            AnalyzeNode(attribute, unitRoot, file, diagnostics, localVariables, capabilities, localFunctionNames);
+            AnalyzeNode(attribute, unitRoot, file, diagnostics, localVariables, targetFramework, capabilities, localFunctionNames);
 
         var result = new List<PowerShellCompilationParameter>();
         foreach (var parameter in paramBlock.Parameters)
@@ -111,7 +111,7 @@ public sealed partial class PowerShellCompilationAnalyzer
                     file,
                     parameter.DefaultValue.Extent,
                     PowerShellCompilationFeatureIds.ParameterDefault));
-                AnalyzeNode(parameter.DefaultValue, unitRoot, file, diagnostics, localVariables, capabilities, localFunctionNames);
+                AnalyzeNode(parameter.DefaultValue, unitRoot, file, diagnostics, localVariables, targetFramework, capabilities, localFunctionNames);
             }
             result.Add(new PowerShellCompilationParameter(
                 parameter.Name.VariablePath.UserPath,
@@ -130,7 +130,7 @@ public sealed partial class PowerShellCompilationAnalyzer
                 defaultValue));
 
             foreach (var attribute in parameter.Attributes.Where(static attribute => attribute is not TypeConstraintAst))
-                AnalyzeNode(attribute, unitRoot, file, diagnostics, localVariables, capabilities, localFunctionNames);
+                AnalyzeNode(attribute, unitRoot, file, diagnostics, localVariables, targetFramework, capabilities, localFunctionNames);
         }
 
         ValidateParameterBindingNames(paramBlock, file, diagnostics);

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationAnalyzer.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellCompilationAnalyzer.cs
@@ -238,14 +238,14 @@ public sealed partial class PowerShellCompilationAnalyzer
             localFunctionNames,
             kind == PowerShellCompilationUnitKind.Script);
 
-        AnalyzeUnsupportedNamedBlock(root.DynamicParamBlock, "dynamicparam", root, file, diagnostics, localVariables, capabilities, localFunctionNames);
-        AnalyzeUnsupportedNamedBlock(root.BeginBlock, "begin", root, file, diagnostics, localVariables, capabilities, localFunctionNames);
-        AnalyzeUnsupportedNamedBlock(root.ProcessBlock, "process", root, file, diagnostics, localVariables, capabilities, localFunctionNames);
-        AnalyzeUnsupportedNamedBlock(GetNamedBlock(root, "CleanBlock"), "clean", root, file, diagnostics, localVariables, capabilities, localFunctionNames);
+        AnalyzeUnsupportedNamedBlock(root.DynamicParamBlock, "dynamicparam", root, file, diagnostics, localVariables, targetFramework, capabilities, localFunctionNames);
+        AnalyzeUnsupportedNamedBlock(root.BeginBlock, "begin", root, file, diagnostics, localVariables, targetFramework, capabilities, localFunctionNames);
+        AnalyzeUnsupportedNamedBlock(root.ProcessBlock, "process", root, file, diagnostics, localVariables, targetFramework, capabilities, localFunctionNames);
+        AnalyzeUnsupportedNamedBlock(GetNamedBlock(root, "CleanBlock"), "clean", root, file, diagnostics, localVariables, targetFramework, capabilities, localFunctionNames);
 
         foreach (var statement in executableStatements)
         {
-            AnalyzeNode(statement, root, file, diagnostics, localVariables, capabilities, localFunctionNames);
+            AnalyzeNode(statement, root, file, diagnostics, localVariables, targetFramework, capabilities, localFunctionNames);
         }
 
         return new PowerShellCompilationUnitPlan(
@@ -263,6 +263,7 @@ public sealed partial class PowerShellCompilationAnalyzer
         string file,
         List<PowerShellCompilationDiagnostic> diagnostics,
         HashSet<string> localVariables,
+        string? targetFramework,
         PowerShellCompilationCapability capabilities,
         ISet<string>? localFunctionNames)
     {
@@ -352,6 +353,10 @@ public sealed partial class PowerShellCompilationAnalyzer
                     capabilities.HasFlag(PowerShellCompilationCapability.BoundParameters) &&
                     PowerShellBoundParametersPolicy.IsReference(variable) &&
                     PowerShellBoundParametersPolicy.IsSupportedReference(variable):
+                    break;
+                case VariableExpressionAst variable when
+                    unitRoot is ScriptBlockAst body &&
+                    PowerShellRuntimeStateIntrinsicPolicy.IsSupportedReference(variable, body, targetFramework, capabilities):
                     break;
                 case VariableExpressionAst variable when IsRuntimeVariable(variable, localVariables):
                     diagnostics.Add(CreateDiagnostic(
@@ -607,6 +612,7 @@ public sealed partial class PowerShellCompilationAnalyzer
         string file,
         List<PowerShellCompilationDiagnostic> diagnostics,
         HashSet<string> localVariables,
+        string? targetFramework,
         PowerShellCompilationCapability capabilities,
         ISet<string>? localFunctionNames)
     {
@@ -620,7 +626,7 @@ public sealed partial class PowerShellCompilationAnalyzer
             block.Extent,
             PowerShellCompilationFeatureIds.PipelineLifecycle));
         foreach (var statement in block.Statements)
-            AnalyzeNode(statement, unitRoot, file, diagnostics, localVariables, capabilities, localFunctionNames);
+            AnalyzeNode(statement, unitRoot, file, diagnostics, localVariables, targetFramework, capabilities, localFunctionNames);
     }
 
     private static bool HasBlockingAncestor(Ast candidate, Ast statementRoot, Ast unitRoot)

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellRuntimeStateIntrinsicPolicy.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellRuntimeStateIntrinsicPolicy.cs
@@ -1,0 +1,164 @@
+using System.Management.Automation.Language;
+
+namespace PowerForge;
+
+internal enum PowerShellRuntimeStateIntrinsicKind
+{
+    None,
+    PSEdition,
+    IsCoreClr,
+    IsWindows,
+    IsLinux,
+    IsMacOS,
+    PSVersion,
+    WhatIfPreference,
+    ShouldProcessTarget,
+    ShouldProcessAction
+}
+
+internal static class PowerShellRuntimeStateIntrinsicPolicy
+{
+    internal static bool TryClassify(
+        Ast ast,
+        ScriptBlockAst body,
+        string? targetFramework,
+        PowerShellCompilationCapability capabilities,
+        out PowerShellRuntimeStateIntrinsicKind kind)
+    {
+        kind = PowerShellRuntimeStateIntrinsicKind.None;
+        if (!capabilities.HasFlag(PowerShellCompilationCapability.RuntimeStateIntrinsics))
+            return false;
+
+        if (ast is VariableExpressionAst variable)
+        {
+            var name = variable.VariablePath.UserPath;
+            if (name.Equals("PSEdition", StringComparison.OrdinalIgnoreCase) && IsKnownTarget(targetFramework))
+                kind = PowerShellRuntimeStateIntrinsicKind.PSEdition;
+            else if (IsCoreTarget(targetFramework) && name.Equals("IsCoreCLR", StringComparison.OrdinalIgnoreCase))
+                kind = PowerShellRuntimeStateIntrinsicKind.IsCoreClr;
+            else if (IsCoreTarget(targetFramework) && name.Equals("IsWindows", StringComparison.OrdinalIgnoreCase))
+                kind = PowerShellRuntimeStateIntrinsicKind.IsWindows;
+            else if (IsCoreTarget(targetFramework) && name.Equals("IsLinux", StringComparison.OrdinalIgnoreCase))
+                kind = PowerShellRuntimeStateIntrinsicKind.IsLinux;
+            else if (IsCoreTarget(targetFramework) && name.Equals("IsMacOS", StringComparison.OrdinalIgnoreCase))
+                kind = PowerShellRuntimeStateIntrinsicKind.IsMacOS;
+            else if (name.Equals("WhatIfPreference", StringComparison.OrdinalIgnoreCase) && SupportsShouldProcess(body, capabilities))
+                kind = PowerShellRuntimeStateIntrinsicKind.WhatIfPreference;
+            return kind != PowerShellRuntimeStateIntrinsicKind.None;
+        }
+
+        if (TryGetVersionTableMember(ast, out var member))
+        {
+            if (member.Equals("PSEdition", StringComparison.OrdinalIgnoreCase) && IsKnownTarget(targetFramework))
+                kind = PowerShellRuntimeStateIntrinsicKind.PSEdition;
+            else if (member.Equals("PSVersion", StringComparison.OrdinalIgnoreCase) &&
+                     capabilities.HasFlag(PowerShellCompilationCapability.PowerShellHostTypes))
+                kind = PowerShellRuntimeStateIntrinsicKind.PSVersion;
+            return kind != PowerShellRuntimeStateIntrinsicKind.None;
+        }
+
+        if (ast is InvokeMemberExpressionAst invocation &&
+            invocation.Expression is VariableExpressionAst receiver &&
+            receiver.VariablePath.UserPath.Equals("PSCmdlet", StringComparison.OrdinalIgnoreCase) &&
+            invocation.Member is StringConstantExpressionAst { Value: var method } &&
+            method.Equals("ShouldProcess", StringComparison.OrdinalIgnoreCase) &&
+            SupportsShouldProcess(body, capabilities) &&
+            invocation.Arguments.Count is 1 or 2)
+        {
+            kind = invocation.Arguments.Count == 1
+                ? PowerShellRuntimeStateIntrinsicKind.ShouldProcessTarget
+                : PowerShellRuntimeStateIntrinsicKind.ShouldProcessAction;
+            return true;
+        }
+
+        return false;
+    }
+
+    internal static bool IsSupportedReference(
+        VariableExpressionAst variable,
+        ScriptBlockAst body,
+        string? targetFramework,
+        PowerShellCompilationCapability capabilities)
+    {
+        if (TryClassify(variable, body, targetFramework, capabilities, out _)) return true;
+        return (variable.Parent is MemberExpressionAst or IndexExpressionAst or InvokeMemberExpressionAst) &&
+               TryClassify(variable.Parent, body, targetFramework, capabilities, out _);
+    }
+
+    internal static bool RequiresHostBinding(
+        IEnumerable<StatementAst> statements,
+        ScriptBlockAst body,
+        string? targetFramework,
+        PowerShellCompilationCapability capabilities)
+        => statements.SelectMany(static statement => statement.FindAll(
+                static node => node is VariableExpressionAst or MemberExpressionAst or IndexExpressionAst or InvokeMemberExpressionAst,
+                searchNestedScriptBlocks: false))
+            .Any(node => TryClassify(node, body, targetFramework, capabilities, out var kind) &&
+                         kind is PowerShellRuntimeStateIntrinsicKind.PSVersion or
+                             PowerShellRuntimeStateIntrinsicKind.WhatIfPreference or
+                             PowerShellRuntimeStateIntrinsicKind.ShouldProcessTarget or
+                             PowerShellRuntimeStateIntrinsicKind.ShouldProcessAction);
+
+    internal static Type GetType(PowerShellRuntimeStateIntrinsicKind kind)
+        => kind switch
+        {
+            PowerShellRuntimeStateIntrinsicKind.PSEdition => typeof(string),
+            PowerShellRuntimeStateIntrinsicKind.PSVersion => typeof(object),
+            PowerShellRuntimeStateIntrinsicKind.IsCoreClr or
+            PowerShellRuntimeStateIntrinsicKind.IsWindows or
+            PowerShellRuntimeStateIntrinsicKind.IsLinux or
+            PowerShellRuntimeStateIntrinsicKind.IsMacOS or
+            PowerShellRuntimeStateIntrinsicKind.WhatIfPreference or
+            PowerShellRuntimeStateIntrinsicKind.ShouldProcessTarget or
+            PowerShellRuntimeStateIntrinsicKind.ShouldProcessAction => typeof(bool),
+            _ => typeof(object)
+        };
+
+    internal static string EmitStatic(PowerShellRuntimeStateIntrinsicKind kind, string targetFramework)
+        => kind switch
+        {
+            PowerShellRuntimeStateIntrinsicKind.PSEdition => targetFramework.Equals("net472", StringComparison.OrdinalIgnoreCase) ? "\"Desktop\"" : "\"Core\"",
+            PowerShellRuntimeStateIntrinsicKind.IsCoreClr => "true",
+            PowerShellRuntimeStateIntrinsicKind.IsWindows => "global::System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(global::System.Runtime.InteropServices.OSPlatform.Windows)",
+            PowerShellRuntimeStateIntrinsicKind.IsLinux => "global::System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(global::System.Runtime.InteropServices.OSPlatform.Linux)",
+            PowerShellRuntimeStateIntrinsicKind.IsMacOS => "global::System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(global::System.Runtime.InteropServices.OSPlatform.OSX)",
+            PowerShellRuntimeStateIntrinsicKind.PSVersion => "__psVersion",
+            PowerShellRuntimeStateIntrinsicKind.WhatIfPreference => "__whatIfPreference",
+            _ => throw new InvalidOperationException($"Runtime-state intrinsic '{kind}' requires expression-specific emission.")
+        };
+
+    private static bool TryGetVersionTableMember(Ast ast, out string member)
+    {
+        member = string.Empty;
+        if (ast is MemberExpressionAst
+            {
+                Expression: VariableExpressionAst variable,
+                Member: StringConstantExpressionAst { Value: var property }
+            } && variable.VariablePath.UserPath.Equals("PSVersionTable", StringComparison.OrdinalIgnoreCase))
+        {
+            member = property;
+            return true;
+        }
+        if (ast is IndexExpressionAst
+        {
+                Target: VariableExpressionAst indexedVariable,
+                Index: StringConstantExpressionAst { Value: var key }
+            } && indexedVariable.VariablePath.UserPath.Equals("PSVersionTable", StringComparison.OrdinalIgnoreCase))
+        {
+            member = key;
+            return true;
+        }
+        return false;
+    }
+
+    private static bool SupportsShouldProcess(ScriptBlockAst body, PowerShellCompilationCapability capabilities)
+        => capabilities.HasFlag(PowerShellCompilationCapability.PowerShellStreams) &&
+           PowerShellAdvancedFunctionPolicy.SupportsShouldProcess(body.ParamBlock);
+
+    private static bool IsKnownTarget(string? targetFramework)
+        => targetFramework?.Equals("net472", StringComparison.OrdinalIgnoreCase) == true || IsCoreTarget(targetFramework);
+
+    private static bool IsCoreTarget(string? targetFramework)
+        => targetFramework?.Equals("net8.0", StringComparison.OrdinalIgnoreCase) == true ||
+           targetFramework?.Equals("net10.0", StringComparison.OrdinalIgnoreCase) == true;
+}

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellTypedCompilationTranspiler.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellTypedCompilationTranspiler.cs
@@ -389,7 +389,8 @@ public sealed class PowerShellTypedCompilationTranspiler
             GetFunctionAliases(source.Function),
             emitted.RequiresPowerShellBoundParameters,
             PowerShellAdvancedFunctionPolicy.IsAdvanced(source.Function),
-            PowerShellAdvancedFunctionPolicy.GetBinding(source.Function.Body.ParamBlock));
+            PowerShellAdvancedFunctionPolicy.GetBinding(source.Function.Body.ParamBlock),
+            emitted.RequiresPowerShellRuntimeState);
 
     private static PowerShellLocalFunctionSignature CreateSignature(FunctionSource source, PowerShellCSharpMethodEmission emitted)
         => CreateSignature(
@@ -398,7 +399,8 @@ public sealed class PowerShellTypedCompilationTranspiler
             emitted.ReturnType,
             emitted.RequiresPowerShellBoundParameters,
             emitted.RequiresPowerShellStreams,
-            emitted.RequiresPowerShellCommandRegions);
+            emitted.RequiresPowerShellCommandRegions,
+            emitted.RequiresPowerShellRuntimeState);
 
     private static PowerShellLocalFunctionSignature CreateProvisionalSignature(FunctionSource source, Type returnType)
         => CreateSignature(
@@ -407,7 +409,8 @@ public sealed class PowerShellTypedCompilationTranspiler
             returnType,
             requiresPowerShellBoundParameters: false,
             requiresPowerShellStreams: false,
-            requiresPowerShellCommandRegions: false);
+            requiresPowerShellCommandRegions: false,
+            requiresPowerShellRuntimeState: false);
 
     private static PowerShellLocalFunctionSignature CreateSignature(
         FunctionSource source,
@@ -415,7 +418,8 @@ public sealed class PowerShellTypedCompilationTranspiler
         Type returnType,
         bool requiresPowerShellBoundParameters,
         bool requiresPowerShellStreams,
-        bool requiresPowerShellCommandRegions)
+        bool requiresPowerShellCommandRegions,
+        bool requiresPowerShellRuntimeState)
         => new(
             source.Function.Name,
             generatedName,
@@ -440,7 +444,8 @@ public sealed class PowerShellTypedCompilationTranspiler
             requiresPowerShellBoundParameters,
             requiresPowerShellStreams,
             requiresPowerShellCommandRegions,
-            PowerShellAdvancedFunctionPolicy.GetBinding(source.Function.Body.ParamBlock));
+            PowerShellAdvancedFunctionPolicy.GetBinding(source.Function.Body.ParamBlock),
+            requiresPowerShellRuntimeState);
 
     private static PowerShellCompilationDiagnostic CreateDiagnostic(FunctionSource source, Ast node, string message)
         => new(
@@ -569,7 +574,8 @@ internal sealed class PowerShellCSharpMethodEmission
         string source,
         bool requiresPowerShellStreams = false,
         bool requiresPowerShellCommandRegions = false,
-        bool requiresPowerShellBoundParameters = false)
+        bool requiresPowerShellBoundParameters = false,
+        bool requiresPowerShellRuntimeState = false)
     {
         GeneratedName = generatedName;
         ReturnType = returnType;
@@ -577,6 +583,7 @@ internal sealed class PowerShellCSharpMethodEmission
         RequiresPowerShellStreams = requiresPowerShellStreams;
         RequiresPowerShellCommandRegions = requiresPowerShellCommandRegions;
         RequiresPowerShellBoundParameters = requiresPowerShellBoundParameters;
+        RequiresPowerShellRuntimeState = requiresPowerShellRuntimeState;
     }
 
     internal string GeneratedName { get; }
@@ -585,4 +592,5 @@ internal sealed class PowerShellCSharpMethodEmission
     internal bool RequiresPowerShellStreams { get; }
     internal bool RequiresPowerShellCommandRegions { get; }
     internal bool RequiresPowerShellBoundParameters { get; }
+    internal bool RequiresPowerShellRuntimeState { get; }
 }

--- a/PowerForge.PowerShell/Services/Compilation/PowerShellTypedExecutableCompiler.cs
+++ b/PowerForge.PowerShell/Services/Compilation/PowerShellTypedExecutableCompiler.cs
@@ -88,7 +88,8 @@ internal static class PowerShellTypedExecutableCompiler
             statements,
             targetFramework,
             PowerShellCompilationCapability.LocalFunctionCalls |
-            PowerShellCompilationCapability.BoundParameters,
+            PowerShellCompilationCapability.BoundParameters |
+            PowerShellCompilationCapability.RuntimeStateIntrinsics,
             signatures,
             entryUnit.Parameters).Emit();
         methodDescriptions.Add(CreateMethodDescription(entryUnit, entryMethod, entryPoint));
@@ -115,7 +116,8 @@ internal static class PowerShellTypedExecutableCompiler
         }
         const PowerShellCompilationCapability capabilities =
             PowerShellCompilationCapability.LocalFunctionCalls |
-            PowerShellCompilationCapability.BoundParameters;
+            PowerShellCompilationCapability.BoundParameters |
+            PowerShellCompilationCapability.RuntimeStateIntrinsics;
         if (PowerShellRecursiveFunctionPolicy.TryGetDeclaredReturnType(
                 definition.Function,
                 definition.Unit,
@@ -303,7 +305,8 @@ internal sealed class PowerShellLocalFunctionSignature
         bool requiresPowerShellBoundParameters = false,
         bool requiresPowerShellStreams = false,
         bool requiresPowerShellCommandRegions = false,
-        PowerShellCompilationCommandBinding? commandBinding = null)
+        PowerShellCompilationCommandBinding? commandBinding = null,
+        bool requiresPowerShellRuntimeState = false)
     {
         SourceName = sourceName;
         GeneratedName = generatedName;
@@ -313,6 +316,7 @@ internal sealed class PowerShellLocalFunctionSignature
         RequiresPowerShellBoundParameters = requiresPowerShellBoundParameters;
         RequiresPowerShellStreams = requiresPowerShellStreams;
         RequiresPowerShellCommandRegions = requiresPowerShellCommandRegions;
+        RequiresPowerShellRuntimeState = requiresPowerShellRuntimeState;
         CommandBinding = commandBinding ?? new PowerShellCompilationCommandBinding(isAdvancedFunction);
     }
     internal string SourceName { get; }
@@ -323,6 +327,7 @@ internal sealed class PowerShellLocalFunctionSignature
     internal bool RequiresPowerShellBoundParameters { get; }
     internal bool RequiresPowerShellStreams { get; }
     internal bool RequiresPowerShellCommandRegions { get; }
+    internal bool RequiresPowerShellRuntimeState { get; }
     internal PowerShellCompilationCommandBinding CommandBinding { get; }
 }
 

--- a/PowerForge.Tests/PowerShellCompilationRuntimeStateTests.cs
+++ b/PowerForge.Tests/PowerShellCompilationRuntimeStateTests.cs
@@ -1,0 +1,152 @@
+using System.Runtime.InteropServices;
+using PowerForge;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class PowerShellCompilationArtifactHardeningTests
+{
+    [Fact]
+    public void Build_StrictExecutableLowersTargetAndPlatformStateWithoutPowerShellRuntime()
+    {
+        using var fixture = ArtifactFixture.Create(
+            "return (($PSEdition -eq 'Core') -and $IsCoreCLR -and ($IsWindows -or $IsLinux -or $IsMacOS))");
+        var result = new PowerShellCompilationArtifactBuilder().Build(new PowerShellCompilationBuildSpec(
+            fixture.ScriptPath,
+            fixture.OutputPath,
+            "PowerForge.RuntimeStateExecutable",
+            PowerShellCompilationArtifactKind.Executable,
+            PowerShellCompilationMode.Strict)
+        {
+            TargetFramework = "net10.0"
+        });
+
+        Assert.True(
+            result.Succeeded,
+            result.Error + Environment.NewLine + result.BuildOutput + Environment.NewLine +
+            string.Join(Environment.NewLine, result.Manifest?.Diagnostics.Select(static diagnostic => diagnostic.Message) ?? Array.Empty<string>()));
+        var run = Run(result.ArtifactPath!, Array.Empty<string>());
+        Assert.Equal((0, "True", string.Empty), (run.ExitCode, run.StandardOutput.Trim(), run.StandardError.Trim()));
+        Assert.False(result.Manifest!.RequiresPowerShellRuntime);
+    }
+
+    [Theory]
+    [InlineData("net8.0", "pwsh")]
+    [InlineData("net472", "powershell.exe")]
+    public void Build_BinaryModulePreservesEditionAndVersionState(string targetFramework, string host)
+    {
+        if (targetFramework == "net472" && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        using var fixture = ArtifactFixture.Create(
+            "function Get-EditionState { return $PSEdition }; " +
+            "function Get-VersionState { return $PSVersionTable.PSVersion.ToString() }",
+            ".psm1");
+        var result = new PowerShellCompilationArtifactBuilder().Build(new PowerShellCompilationBuildSpec(
+            fixture.ScriptPath,
+            fixture.OutputPath,
+            "PowerForge.RuntimeStateModule",
+            PowerShellCompilationArtifactKind.BinaryModule,
+            PowerShellCompilationMode.Strict)
+        {
+            TargetFramework = targetFramework
+        });
+
+        Assert.True(
+            result.Succeeded,
+            result.Error + Environment.NewLine + result.BuildOutput + Environment.NewLine +
+            string.Join(Environment.NewLine, result.Manifest?.Diagnostics.Select(static diagnostic => diagnostic.Message) ?? Array.Empty<string>()));
+        const string calls = "Get-EditionState; Get-VersionState";
+        var original = Run(host, "-NoProfile", "-NonInteractive", "-Command",
+            $"Import-Module -Name '{fixture.ScriptPath.Replace("'", "''", StringComparison.Ordinal)}' -Force; {calls}");
+        var compiled = Run(host, "-NoProfile", "-NonInteractive", "-Command",
+            $"Import-Module -Name '{result.ArtifactPath!.Replace("'", "''", StringComparison.Ordinal)}' -Force; {calls}");
+
+        Assert.Equal(0, original.ExitCode);
+        Assert.True(compiled.ExitCode == 0, compiled.StandardError + Environment.NewLine + compiled.StandardOutput);
+        Assert.Equal(original.StandardOutput.Trim(), compiled.StandardOutput.Trim());
+        Assert.True(string.IsNullOrWhiteSpace(original.StandardError), original.StandardError);
+        Assert.True(string.IsNullOrWhiteSpace(compiled.StandardError), compiled.StandardError);
+    }
+
+    [Theory]
+    [InlineData("net8.0", "pwsh")]
+    [InlineData("net472", "powershell.exe")]
+    public void Build_BinaryModulePreservesShouldProcessAndWhatIfState(string targetFramework, string host)
+    {
+        if (targetFramework == "net472" && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        using var fixture = ArtifactFixture.Create(
+            "function Test-RuntimeApproval { [CmdletBinding(SupportsShouldProcess = $true)] param([string] $Target) return $PSCmdlet.ShouldProcess($Target, 'Change') }; " +
+            "function Set-RuntimeState { [CmdletBinding(SupportsShouldProcess = $true)] param([string] $Target) " +
+            "if ($WhatIfPreference) { return 'whatif' }; if (Test-RuntimeApproval -Target $Target) { return 'changed' }; return 'skipped' }",
+            ".psm1");
+        var typed = new PowerShellTypedCompilationTranspiler().TranspileForBinaryModule(
+            new[] { fixture.ScriptPath },
+            "PowerForge.RuntimeStateModule",
+            "CompiledPowerShell",
+            targetFramework);
+        Assert.Equal(2, typed.Methods.Length);
+        Assert.All(typed.Methods, static method => Assert.True(method.RequiresPowerShellRuntimeState));
+        var result = new PowerShellCompilationArtifactBuilder().Build(new PowerShellCompilationBuildSpec(
+            fixture.ScriptPath,
+            fixture.OutputPath,
+            "PowerForge.RuntimeStateModule",
+            PowerShellCompilationArtifactKind.BinaryModule,
+            PowerShellCompilationMode.Strict)
+        {
+            TargetFramework = targetFramework
+        });
+
+        Assert.True(
+            result.Succeeded,
+            result.Error + Environment.NewLine + result.BuildOutput + Environment.NewLine +
+            string.Join(Environment.NewLine, result.Manifest?.Diagnostics.Select(static diagnostic => diagnostic.Message) ?? Array.Empty<string>()));
+        foreach (var arguments in new[] { "-Confirm:$false", "-WhatIf" })
+        {
+            var original = Run(host, "-NoProfile", "-NonInteractive", "-Command",
+                $"Import-Module -Name '{fixture.ScriptPath.Replace("'", "''", StringComparison.Ordinal)}' -Force; Set-RuntimeState -Target 'item' {arguments}");
+            var compiled = Run(host, "-NoProfile", "-NonInteractive", "-Command",
+                $"Import-Module -Name '{result.ArtifactPath!.Replace("'", "''", StringComparison.Ordinal)}' -Force; Set-RuntimeState -Target 'item' {arguments}");
+
+            Assert.Equal(0, original.ExitCode);
+            Assert.True(compiled.ExitCode == 0, compiled.StandardError + Environment.NewLine + compiled.StandardOutput);
+            Assert.Equal(original.StandardOutput.Trim(), compiled.StandardOutput.Trim());
+            Assert.True(string.IsNullOrWhiteSpace(original.StandardError), original.StandardError);
+            Assert.True(string.IsNullOrWhiteSpace(compiled.StandardError), compiled.StandardError);
+        }
+    }
+
+    [Fact]
+    public void Analyze_StrictExecutableKeepsPSCmdletInteractionOnFallback()
+    {
+        using var fixture = ArtifactFixture.Create(
+            "[CmdletBinding(SupportsShouldProcess = $true)] param([string] $Target) return $PSCmdlet.ShouldProcess($Target)");
+
+        var plan = new PowerShellCompilationAnalyzer().Analyze(new PowerShellCompilationSpec(
+            fixture.ScriptPath,
+            PowerShellCompilationMode.Strict,
+            targetFramework: "net10.0",
+            capabilities: PowerShellCompilationCapabilities.TypedExecutable));
+
+        Assert.False(Assert.Single(Assert.Single(plan.Files).Units).IsCompilable);
+        Assert.Contains(Assert.Single(plan.Files).Units.SelectMany(static unit => unit.Diagnostics), static diagnostic =>
+            diagnostic.FeatureId == PowerShellCompilationFeatureIds.RuntimeScope);
+    }
+
+    [Theory]
+    [InlineData("return $PSVersionTable.GitCommitId")]
+    [InlineData("return $PSCmdlet.ShouldContinue('Continue?', 'Caption')")]
+    public void Analyze_RuntimeStateIntrinsicsRemainBounded(string body)
+    {
+        using var fixture = ArtifactFixture.Create(
+            $"function Get-RuntimeState {{ [CmdletBinding(SupportsShouldProcess = $true)] param() {body} }}",
+            ".psm1");
+
+        var plan = new PowerShellCompilationAnalyzer().Analyze(new PowerShellCompilationSpec(
+            fixture.ScriptPath,
+            targetFramework: "net10.0",
+            capabilities: PowerShellCompilationCapabilities.BinaryModule));
+        var function = Assert.Single(Assert.Single(plan.Files).Units, static unit => unit.Kind == PowerShellCompilationUnitKind.Function);
+
+        Assert.False(function.IsCompilable);
+        Assert.Contains(function.Diagnostics, static diagnostic => diagnostic.FeatureId == PowerShellCompilationFeatureIds.RuntimeScope);
+    }
+}

--- a/PowerForge/Models/PowerShellCompilation/PowerShellCompilationParameterContract.cs
+++ b/PowerForge/Models/PowerShellCompilation/PowerShellCompilationParameterContract.cs
@@ -14,13 +14,15 @@ public static class PowerShellCompilationCapabilities
         PowerShellCompilationCapability.PipelineParameterBinding |
         PowerShellCompilationCapability.PowerShellHostTypes |
         PowerShellCompilationCapability.PowerShellLanguageConversions |
-        PowerShellCompilationCapability.PowerShellLanguageOperators;
+        PowerShellCompilationCapability.PowerShellLanguageOperators |
+        PowerShellCompilationCapability.RuntimeStateIntrinsics;
 
     /// <summary>Capabilities supplied by a runtime-independent typed executable.</summary>
     public const PowerShellCompilationCapability TypedExecutable =
         PowerShellCompilationCapability.LocalFunctionCalls |
         PowerShellCompilationCapability.BoundParameters |
-        PowerShellCompilationCapability.ExecutableParameterBinding;
+        PowerShellCompilationCapability.ExecutableParameterBinding |
+        PowerShellCompilationCapability.RuntimeStateIntrinsics;
 }
 
 /// <summary>Surfaces on which a resolved parameter type can be represented without changing its meaning.</summary>

--- a/PowerForge/Models/PowerShellCompilation/PowerShellCompilationPlan.cs
+++ b/PowerForge/Models/PowerShellCompilation/PowerShellCompilationPlan.cs
@@ -47,7 +47,10 @@ public enum PowerShellCompilationCapability
     PowerShellLanguageConversions = 128,
 
     /// <summary>Generated methods may use public PowerShell comparison, wildcard, and membership primitives.</summary>
-    PowerShellLanguageOperators = 256
+    PowerShellLanguageOperators = 256,
+
+    /// <summary>Generated methods may lower a bounded set of read-only automatic state and host interactions.</summary>
+    RuntimeStateIntrinsics = 512
 }
 
 /// <summary>
@@ -343,7 +346,8 @@ public sealed class PowerShellCompilationSpec
                               PowerShellCompilationCapability.PipelineParameterBinding |
                               PowerShellCompilationCapability.PowerShellHostTypes |
                               PowerShellCompilationCapability.PowerShellLanguageConversions |
-                              PowerShellCompilationCapability.PowerShellLanguageOperators)) != 0)
+                              PowerShellCompilationCapability.PowerShellLanguageOperators |
+                              PowerShellCompilationCapability.RuntimeStateIntrinsics)) != 0)
             throw new ArgumentOutOfRangeException(nameof(capabilities));
         var normalizedTargetFramework = targetFramework?.Trim();
         if (normalizedTargetFramework is not null && normalizedTargetFramework.Length > 0)

--- a/PowerForge/Models/PowerShellCompilation/PowerShellTypedCompilationResult.cs
+++ b/PowerForge/Models/PowerShellCompilation/PowerShellTypedCompilationResult.cs
@@ -32,7 +32,8 @@ public sealed class PowerShellCompiledMethod
         string[]? aliases = null,
         bool requiresPowerShellBoundParameters = false,
         bool isAdvancedFunction = false,
-        PowerShellCompilationCommandBinding? commandBinding = null)
+        PowerShellCompilationCommandBinding? commandBinding = null,
+        bool requiresPowerShellRuntimeState = false)
     {
         SourceName = sourceName ?? string.Empty;
         GeneratedName = generatedName ?? string.Empty;
@@ -46,6 +47,7 @@ public sealed class PowerShellCompiledMethod
         RequiresPowerShellBoundParameters = requiresPowerShellBoundParameters;
         IsAdvancedFunction = isAdvancedFunction;
         CommandBinding = commandBinding ?? new PowerShellCompilationCommandBinding(isAdvancedFunction);
+        RequiresPowerShellRuntimeState = requiresPowerShellRuntimeState;
     }
 
     /// <summary>Original PowerShell function name.</summary>
@@ -71,6 +73,9 @@ public sealed class PowerShellCompiledMethod
 
     /// <summary>Whether adjacent command statements are dispatched as one PowerShell runtime region.</summary>
     public bool RequiresPowerShellCommandRegions { get; }
+
+    /// <summary>Whether the generated method expects bounded PowerShell runtime-state delegates and values.</summary>
+    public bool RequiresPowerShellRuntimeState { get; }
 
     /// <summary>Whether the generated method expects the names of explicitly bound PowerShell parameters.</summary>
     public bool RequiresPowerShellBoundParameters { get; }


### PR DESCRIPTION
## Summary

- lowers target-backed platform facts into runtime-free artifacts
- injects live PowerShell version, WhatIf, and ShouldProcess state into generated binary cmdlets
- propagates supported runtime state through typed local calls while preserving command identity where PowerShell must remain authoritative

Runtime-dependent state is accepted only when the selected artifact host can supply it safely.

## Stack

Builds on #814. Followed by #816.

## Validation

On the complete stack:

- `dotnet build .\PowerForge.PowerShell\PowerForge.PowerShell.csproj -c Release --no-restore` (net472, net8.0, and net10.0; zero warnings/errors)
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~PowerShellCompilation"` (450 passed)