### PR TITLE
Add a generic PowerShell compiler corpus

### DIFF
--- a/Benchmarks/PowerShellCompilation/Corpus/HybridModule/Generic.Compiler.Corpus.psd1
+++ b/Benchmarks/PowerShellCompilation/Corpus/HybridModule/Generic.Compiler.Corpus.psd1
@@ -1,0 +1,19 @@
+@{
+    RootModule = 'Generic.Compiler.Corpus.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = '6a56ec5b-3484-41a6-b768-43f34e2b3105'
+    Author = 'PowerForge'
+    Description = 'Portable contract corpus for generic PowerShell typed compilation.'
+    PowerShellVersion = '5.1'
+    FunctionsToExport = @(
+        'Measure-TextScore'
+        'Get-CountdownValue'
+        'Get-RuntimeState'
+        'Get-CommandText'
+        'Test-TokenPattern'
+        'Get-EnvironmentBoundary'
+    )
+    CmdletsToExport = @()
+    VariablesToExport = @()
+    AliasesToExport = @()
+}

--- a/Benchmarks/PowerShellCompilation/Corpus/HybridModule/Generic.Compiler.Corpus.psm1
+++ b/Benchmarks/PowerShellCompilation/Corpus/HybridModule/Generic.Compiler.Corpus.psm1
@@ -1,0 +1,93 @@
+function Measure-TextScore {
+    [CmdletBinding()]
+    [OutputType([int])]
+    param(
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Alias('InputText')]
+        [ValidateNotNullOrEmpty()]
+        [string] $Text,
+
+        [int] $Offset = 2
+    )
+
+    [int] $length = $Text.Length
+    [int] $score = ($length -shl 1)
+    $score += $Offset
+    return $score
+}
+
+function Get-CountdownValue {
+    [OutputType([long])]
+    param(
+        [long] $Number
+    )
+
+    if ($Number -le [long] 0) {
+        return $Number
+    }
+
+    $Number -= [long] 1
+    return Get-CountdownValue -Number $Number
+}
+
+function Get-RuntimeState {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    [OutputType([string])]
+    param(
+        [string] $Target = 'sample'
+    )
+
+    if ($WhatIfPreference) {
+        return 'whatif'
+    }
+    if ($PSCmdlet.ShouldProcess($Target, 'Inspect')) {
+        return $PSVersionTable.PSVersion.ToString()
+    }
+    return $PSEdition
+}
+
+function Get-CommandText {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Text
+    )
+
+    [string] $captured = Write-Output $Text
+    return $captured.ToUpperInvariant()
+}
+
+function Test-TokenPattern {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [string] $Token,
+        [string[]] $Allowed = @('alpha', 'beta')
+    )
+
+    [int] $mask = (3 -shl 2)
+    return (($Token -match '^[a-z]+$') -and ($Token -in $Allowed) -and (($mask -band 12) -eq 12))
+}
+
+function Get-EnvironmentBoundary {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [string] $Fallback = 'unset'
+    )
+
+    if ($env:POWERFORGE_COMPILER_CORPUS) {
+        return $env:POWERFORGE_COMPILER_CORPUS
+    }
+    return $Fallback
+}
+
+Export-ModuleMember -Function @(
+    'Measure-TextScore'
+    'Get-CountdownValue'
+    'Get-RuntimeState'
+    'Get-CommandText'
+    'Test-TokenPattern'
+    'Get-EnvironmentBoundary'
+)

--- a/Benchmarks/PowerShellCompilation/Corpus/README.md
+++ b/Benchmarks/PowerShellCompilation/Corpus/README.md
@@ -1,0 +1,18 @@
+# Generic compiler corpus
+
+This checked-in corpus is the portable, product-neutral acceptance surface for PowerForge PowerShell compilation. It does not encode module names, command names, paths, or special cases from an external repository.
+
+- `HybridModule` exercises parameter metadata and literal defaults, typed operators, direct self-recursion, safe runtime-state intrinsics, command-result capture, and one intentional runtime-scope fallback.
+- `StrictProgram` is a multi-file script graph that must build as a PowerShell-free typed executable.
+- `census-baseline.net10.json` records post-emission module coverage and a source fingerprint. Its relative product path remains comparable from another checkout root.
+
+Run the portable coverage gate from the repository root:
+
+```powershell
+powerforge powershell census `
+    .\Benchmarks\PowerShellCompilation\Corpus\HybridModule\Generic.Compiler.Corpus.psd1 `
+    --framework net10.0 `
+    --baseline .\Benchmarks\PowerShellCompilation\Corpus\census-baseline.net10.json
+```
+
+The wider external-repository census remains useful scale evidence, but every external root is optional and replaceable. Compiler eligibility is based only on generic syntax, type, binding, host-capability, and artifact contracts.

--- a/Benchmarks/PowerShellCompilation/Corpus/StrictProgram/Main.ps1
+++ b/Benchmarks/PowerShellCompilation/Corpus/StrictProgram/Main.ps1
@@ -1,0 +1,14 @@
+[CmdletBinding()]
+param(
+    [Alias('n')]
+    [ValidateRange(0, 32)]
+    [int] $Number = 4,
+
+    [ValidateNotNullOrEmpty()]
+    [string] $Label = 'item'
+)
+
+. "$PSScriptRoot/Operations.ps1"
+
+[int] $score = Get-PortableScore -Number $Number -Label $Label
+return $score

--- a/Benchmarks/PowerShellCompilation/Corpus/StrictProgram/Operations.ps1
+++ b/Benchmarks/PowerShellCompilation/Corpus/StrictProgram/Operations.ps1
@@ -1,0 +1,27 @@
+function Get-PortableScore {
+    [OutputType([int])]
+    param(
+        [int] $Number,
+        [string] $Label
+    )
+
+    [int] $countdown = Get-PortableCountdown -Number $Number
+    [int] $length = $Label.Length
+    [int] $score = ($length -shl 1)
+    $score += $countdown
+    return $score
+}
+
+function Get-PortableCountdown {
+    [OutputType([int])]
+    param(
+        [int] $Number
+    )
+
+    if ($Number -le 0) {
+        return $Number
+    }
+
+    $Number -= 1
+    return Get-PortableCountdown -Number $Number
+}

--- a/Benchmarks/PowerShellCompilation/Corpus/census-baseline.net10.json
+++ b/Benchmarks/PowerShellCompilation/Corpus/census-baseline.net10.json
@@ -1,0 +1,145 @@
+{
+  "targetFramework": "net10.0",
+  "products": [
+    {
+      "name": "Generic.Compiler.Corpus",
+      "path": "HybridModule/Generic.Compiler.Corpus.psd1",
+      "sourceFiles": 1,
+      "totalUnits": 6,
+      "compilableUnits": 5,
+      "runtimeFallbackUnits": 1,
+      "parseErrorFiles": 0,
+      "compilationCoveragePercentage": 83.33333333333333,
+      "analysisMilliseconds": 0,
+      "blockers": [
+        {
+          "code": "RuntimeScope",
+          "message": "Variable '$env:POWERFORGE_COMPILER_CORPUS' depends on PowerShell runtime scope.",
+          "occurrences": 2
+        }
+      ],
+      "featureImpacts": [
+        {
+          "featureId": "runtime.scope",
+          "title": "PowerShell runtime scope",
+          "recommendation": "Model a safe automatic-state intrinsic or keep this unit in Package/Hybrid mode.",
+          "occurrences": 2,
+          "affectedUnits": 1,
+          "visibleSoleBlockerUnits": 1,
+          "affectedProducts": 1,
+          "candidateCompleteProductsUnlocked": 1,
+          "currentCompilableUnits": 5,
+          "totalUnits": 6,
+          "candidateCompilableUnits": 6,
+          "candidateCoveragePercentage": 100
+        }
+      ],
+      "dependencySummary": [
+        {
+          "kind": "PowerShellSource",
+          "disposition": "PreservedScript",
+          "files": 1,
+          "missing": 0,
+          "sizeBytes": 1971
+        },
+        {
+          "kind": "ModuleManifest",
+          "disposition": "CopiedAdjacent",
+          "files": 1,
+          "missing": 0,
+          "sizeBytes": 559
+        }
+      ],
+      "resourceSummary": {
+        "includedFiles": 0,
+        "includedBytes": 0,
+        "requiredFiles": 0,
+        "requiredBytes": 0,
+        "inferredFiles": 0,
+        "inferredBytes": 0,
+        "excludedFiles": 0,
+        "excludedBytes": 0,
+        "unclassifiedFiles": 0,
+        "unclassifiedBytes": 0
+      },
+      "coverage": {
+        "postEmissionEvaluated": true,
+        "totalFunctions": 6,
+        "analyzerEligibleFunctions": 5,
+        "emittedFunctions": 5,
+        "droppedEligibleFunctions": 0,
+        "fallbackFunctions": 1,
+        "totalScriptUnits": 0,
+        "structurallyEligibleScriptUnits": 0,
+        "fallbackScriptUnits": 0,
+        "runtimeOnlyFunctions": 0,
+        "runtimeOnlyScriptUnits": 0,
+        "emittedFunctionCoveragePercentage": 83.33333333333333
+      },
+      "sourceFingerprint": "022da69139b945896c133d1755f92ae979c1496d12a7b62d35dd06ed2291c9a8",
+      "functionImpacts": [
+        {
+          "featureId": "runtime.scope",
+          "title": "PowerShell runtime scope",
+          "recommendation": "Model a safe automatic-state intrinsic or keep this unit in Package/Hybrid mode.",
+          "occurrences": 2,
+          "affectedUnits": 1,
+          "visibleSoleBlockerUnits": 1,
+          "affectedProducts": 1,
+          "candidateCompleteProductsUnlocked": 1,
+          "currentCompilableUnits": 5,
+          "totalUnits": 6,
+          "candidateCompilableUnits": 6,
+          "candidateCoveragePercentage": 100
+        }
+      ]
+    }
+  ],
+  "regressions": [],
+  "frontier": [
+    {
+      "featureId": "runtime.scope",
+      "title": "PowerShell runtime scope",
+      "recommendation": "Model a safe automatic-state intrinsic or keep this unit in Package/Hybrid mode.",
+      "occurrences": 2,
+      "affectedUnits": 1,
+      "visibleSoleBlockerUnits": 1,
+      "affectedProducts": 1,
+      "candidateCompleteProductsUnlocked": 1,
+      "currentCompilableUnits": 5,
+      "totalUnits": 6,
+      "candidateCompilableUnits": 6,
+      "candidateCoveragePercentage": 100
+    }
+  ],
+  "coBlockers": [],
+  "sourceDrifts": [],
+  "functionFrontier": [
+    {
+      "featureId": "runtime.scope",
+      "title": "PowerShell runtime scope",
+      "recommendation": "Model a safe automatic-state intrinsic or keep this unit in Package/Hybrid mode.",
+      "occurrences": 2,
+      "affectedUnits": 1,
+      "visibleSoleBlockerUnits": 1,
+      "affectedProducts": 1,
+      "candidateCompleteProductsUnlocked": 1,
+      "currentCompilableUnits": 5,
+      "totalUnits": 6,
+      "candidateCompilableUnits": 6,
+      "candidateCoveragePercentage": 100
+    }
+  ],
+  "functionCoBlockers": [],
+  "sourceFiles": 1,
+  "postEmissionEvaluated": true,
+  "totalUnits": 6,
+  "compilableUnits": 5,
+  "runtimeFallbackUnits": 1,
+  "parseErrorFiles": 0,
+  "totalFunctions": 6,
+  "emittedFunctions": 5,
+  "droppedEligibleFunctions": 0,
+  "emittedFunctionCoveragePercentage": 83.33333333333333,
+  "passed": true
+}

--- a/Benchmarks/PowerShellCompilation/README.md
+++ b/Benchmarks/PowerShellCompilation/README.md
@@ -10,6 +10,8 @@ This benchmark matrix separates three different claims:
 
 The real-source workloads are a production threshold calculation and PowerInfoBlox's `Convert-IpAddressToPtrString`. The triangular-number and indexed-array loops are intentionally synthetic and expose hot-loop and typed-indexing behavior without command, provider, or I/O noise. Every measured lane validates its result outside the timed operation. Artifact generation, assembly loading, module import, and workload setup are also outside the timed block.
 
+The adjacent `Corpus` directory is the compiler's product-neutral correctness and coverage gate, not a performance workload. It contains a portable Hybrid module, a multi-file Strict program, and a committed post-emission census baseline. External module workloads remain optional and replaceable scale evidence.
+
 See [PowerShell Compilation](../../Docs/PowerForge.PowerShellCompilation.md#measured-performance) for the clean-candidate tables, environment, run IDs, interpretation, and eligibility limits. Quick runs are smoke evidence only and record `gitWorktreeClean: false` when the candidate is still changing.
 
 Build or import the current PSPublishModule binary, then run:

--- a/Docs/PowerForge.PowerShellCompilation.md
+++ b/Docs/PowerForge.PowerShellCompilation.md
@@ -430,9 +430,24 @@ Invoke-BenchmarkSuite `
 
 See [the benchmark README](../Benchmarks/PowerShellCompilation/README.md) for the quick smoke command and lane definitions.
 
+## Portable generic acceptance corpus
+
+PowerForge carries a self-contained, product-neutral compiler corpus under `Benchmarks/PowerShellCompilation/Corpus`. The Hybrid module exercises parameter metadata and defaults, operators, typed recursion, runtime-state injection, command-result capture, and an intentional environment-scope fallback. Its committed net10 census baseline records a portable source fingerprint and 5/6 post-emission functions (83.33%) with no eligible function lost during graph or binary-cmdlet shaping. The multi-file Strict program is separately required to analyze 3/3 units, build as a runtime-free net8 executable, and match direct PowerShell execution.
+
+This is the stable acceptance surface for generic compiler contracts. It runs from any checkout without neighboring repositories:
+
+```powershell
+powerforge powershell census `
+    .\Benchmarks\PowerShellCompilation\Corpus\HybridModule\Generic.Compiler.Corpus.psd1 `
+    --framework net10.0 `
+    --baseline .\Benchmarks\PowerShellCompilation\Corpus\census-baseline.net10.json
+```
+
+See [the corpus README](../Benchmarks/PowerShellCompilation/Corpus/README.md) for the contract split. External repositories can be added, replaced, or removed as scale workloads without changing the compiler design.
+
 ## Real-source eligibility
 
-The canonical census uses exact committed source from six PowerShell-first products. It scans only authored module trees (`Public`, `Private`, and PSSharedGoods `Enums`), not dirty working-tree changes, generated modules, examples, tests, build scripts, or website assets. The pinned inputs are PowerInfoBlox `9de3730afbfd61ed6bec59bc78e9e7a8d91b6233`, PSSharedGoods `12e9c2520d347df2988286ea1ba3e81e011ef0de`, PSWriteHTML `fa88b1bbecc539b59c9a82cd4b95efc6cc951244`, O365Essentials `fad82882ff116c262ffd3c2c3fdb2781a8ddf0f3`, ADEssentials `b2b1f760853becb773841f744bea196d02aa6c2b`, and PSWriteWord `1fdee837c3fcbc1fdb5c67a9843526bd532c2728`.
+The wider example census uses exact committed source from six replaceable PowerShell-first products. It scans only authored module trees (`Public`, `Private`, and PSSharedGoods `Enums`), not dirty working-tree changes, generated modules, examples, tests, build scripts, or website assets. The pinned inputs are PowerInfoBlox `9de3730afbfd61ed6bec59bc78e9e7a8d91b6233`, PSSharedGoods `12e9c2520d347df2988286ea1ba3e81e011ef0de`, PSWriteHTML `fa88b1bbecc539b59c9a82cd4b95efc6cc951244`, O365Essentials `fad82882ff116c262ffd3c2c3fdb2781a8ddf0f3`, ADEssentials `b2b1f760853becb773841f744bea196d02aa6c2b`, and PSWriteWord `1fdee837c3fcbc1fdb5c67a9843526bd532c2728`.
 
 The current six-product lane contains 1,263 authored files and 1,353 whole script/function units with no parse-error files. The PowerInfoBlox helper is also built and invoked as a strict generated binary cmdlet with mandatory parameter metadata, while PSSharedGoods `ConvertFrom-OperationType` is differentially checked for known, case-insensitive, and missing dictionary keys. O365 enum-name overload binding was verified against the original private function.
 

--- a/PowerForge.Tests/PowerShellCompilationGenericCorpusTests.cs
+++ b/PowerForge.Tests/PowerShellCompilationGenericCorpusTests.cs
@@ -1,0 +1,158 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using PowerForge;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class PowerShellCompilationArtifactHardeningTests
+{
+    [Fact]
+    public void Corpus_CensusMatchesPortablePostEmissionBaseline()
+    {
+        var corpusRoot = FindGenericCorpusRoot();
+        var manifest = Path.Combine(corpusRoot, "HybridModule", "Generic.Compiler.Corpus.psd1");
+        var baselinePath = Path.Combine(corpusRoot, "census-baseline.net10.json");
+        var baseline = JsonSerializer.Deserialize<PowerShellCompilationCensusResult>(
+            File.ReadAllText(baselinePath),
+            new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                Converters = { new JsonStringEnumConverter() }
+            });
+
+        Assert.NotNull(baseline);
+        var result = new PowerShellCompilationCensusRunner().Run(new[] { manifest }, "net10.0", baseline);
+
+        Assert.True(result.Passed, string.Join(Environment.NewLine, result.Regressions.Select(static regression =>
+            $"{regression.Product}: {regression.Metric} {regression.Baseline} -> {regression.Current}")));
+        Assert.Empty(result.SourceDrifts);
+        Assert.True(result.PostEmissionEvaluated);
+        Assert.Equal(6, result.TotalFunctions);
+        Assert.Equal(5, result.EmittedFunctions);
+        Assert.Equal(0, result.DroppedEligibleFunctions);
+        Assert.Equal(1, result.RuntimeFallbackUnits);
+        Assert.Contains(result.FunctionFrontier, static impact => impact.FeatureId == PowerShellCompilationFeatureIds.RuntimeScope);
+    }
+
+    [Fact]
+    public void Corpus_HybridModulePreservesTypedAndFallbackContracts()
+    {
+        var corpusRoot = FindGenericCorpusRoot();
+        var manifest = Path.Combine(corpusRoot, "HybridModule", "Generic.Compiler.Corpus.psd1");
+        var output = CreateGenericCorpusOutput();
+        try
+        {
+            var resolved = new PowerShellCompilationInputResolver().Resolve(
+                manifest,
+                PowerShellCompilationArtifactKind.BinaryModule,
+                PowerShellCompilationMode.Hybrid);
+            var result = new PowerShellCompilationArtifactBuilder().Build(new PowerShellCompilationBuildSpec(
+                resolved.SourcePath,
+                output,
+                "GenericCompilerCorpus",
+                resolved.Kind,
+                resolved.Mode)
+            {
+                ModuleManifestPath = resolved.ModuleManifestPath,
+                CompilationSourcePaths = resolved.CompilationSourceFiles,
+                RuntimeSourcePaths = resolved.SourceFiles,
+                TargetFramework = "net8.0",
+                EmitSource = true
+            });
+
+            Assert.True(result.Succeeded, result.Error + Environment.NewLine + result.BuildOutput);
+            Assert.Equal(5, result.Manifest!.CompiledMethods);
+            Assert.Equal(1, result.Manifest.RuntimeFallbackUnits);
+            Assert.True(result.Manifest.UsesPowerShellRuntimeFallback);
+            const string proof =
+                "$env:POWERFORGE_COMPILER_CORPUS = 'runtime'; " +
+                "Measure-TextScore -Text Ada; Get-CountdownValue -Number 4; Get-RuntimeState -WhatIf; " +
+                "Get-CommandText -Text Ada; Test-TokenPattern -Token alpha; Get-EnvironmentBoundary";
+            var original = RunCorpusModule(manifest, proof);
+            var compiled = RunCorpusModule(result.ArtifactPath!, proof);
+
+            Assert.Equal((0, string.Empty), (original.ExitCode, original.StandardError.Trim()));
+            Assert.Equal((0, string.Empty), (compiled.ExitCode, compiled.StandardError.Trim()));
+            Assert.Equal(original.StandardOutput.Trim(), compiled.StandardOutput.Trim());
+            Assert.Equal(
+                new[] { "8", "0", "whatif", "ADA", "True", "runtime" },
+                compiled.StandardOutput.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries));
+            var generated = File.ReadAllText(Path.Combine(result.GeneratedSourcePath!, "CompiledPowerShell.cs"));
+            Assert.Contains("__invokePowerShellCapture", generated, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { Directory.Delete(output, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Corpus_StrictProgramBuildsAndRunsWithoutPowerShellRuntime()
+    {
+        var corpusRoot = FindGenericCorpusRoot();
+        var entryPoint = Path.Combine(corpusRoot, "StrictProgram", "Main.ps1");
+        var output = CreateGenericCorpusOutput();
+        try
+        {
+            var resolved = new PowerShellCompilationInputResolver().Resolve(
+                entryPoint,
+                PowerShellCompilationArtifactKind.Executable,
+                PowerShellCompilationMode.Strict);
+            var result = new PowerShellCompilationArtifactBuilder().Build(new PowerShellCompilationBuildSpec(
+                resolved.SourcePath,
+                output,
+                "GenericCompilerProgram",
+                resolved.Kind,
+                resolved.Mode)
+            {
+                CompilationSourcePaths = resolved.CompilationSourceFiles,
+                RuntimeSourcePaths = resolved.SourceFiles,
+                TargetFramework = "net8.0",
+                EmitSource = true
+            });
+
+            Assert.True(result.Succeeded, result.Error + Environment.NewLine + result.BuildOutput);
+            Assert.False(result.Manifest!.RequiresPowerShellRuntime);
+            Assert.False(result.Manifest.UsesPowerShellRuntimeFallback);
+            Assert.Equal(3, result.Manifest.CompiledMethods);
+            var original = Run("pwsh", "-NoProfile", "-NonInteractive", "-File", entryPoint, "-Number", "4", "-Label", "item");
+            var compiled = Run(result.ArtifactPath!, "--Number", "4", "--Label", "item");
+
+            Assert.Equal((0, "8", string.Empty), (original.ExitCode, original.StandardOutput.Trim(), original.StandardError.Trim()));
+            Assert.Equal((0, "8", string.Empty), (compiled.ExitCode, compiled.StandardOutput.Trim(), compiled.StandardError.Trim()));
+        }
+        finally
+        {
+            try { Directory.Delete(output, recursive: true); } catch { }
+        }
+    }
+
+    private static string FindGenericCorpusRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, "Benchmarks", "PowerShellCompilation", "Corpus");
+            if (File.Exists(Path.Combine(candidate, "census-baseline.net10.json")))
+                return candidate;
+            current = current.Parent;
+        }
+        throw new DirectoryNotFoundException("Unable to locate the generic PowerShell compilation corpus.");
+    }
+
+    private static string CreateGenericCorpusOutput()
+    {
+        var output = Path.Combine(Path.GetTempPath(), "PowerForge Generic Compiler Corpus", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(output);
+        return output;
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) RunCorpusModule(string modulePath, string proof)
+        => Run(
+            "pwsh",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            $"Import-Module -Name '{modulePath.Replace("'", "''", StringComparison.Ordinal)}' -Force; {proof}");
+}


### PR DESCRIPTION
## Summary

- adds a neutral module corpus for Hybrid compilation and a runtime-free Strict program corpus
- commits a portable census baseline and differential execution coverage
- makes the generic corpus the canonical acceptance contract; replaceable external sources remain secondary scale evidence

The corpus is intentionally product-neutral and exercises language, binding, type-system, host, and artifact behavior.

## Stack

Builds on #816. Followed by #818.

## Validation

On the complete stack:

- `dotnet build .\PowerForge.PowerShell\PowerForge.PowerShell.csproj -c Release --no-restore` (net472, net8.0, and net10.0; zero warnings/errors)
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~PowerShellCompilation"` (450 passed)