### PR TITLE
Fix formatted installer exit launch targets

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -2059,7 +2059,8 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
             authoring.ExitLaunch = new PowerForgeInstallerExitLaunch
             {
                 Text = "Open app",
-                Target = "http://127.0.0.1:9000/"
+                Target = "http://127.0.0.1:9000/",
+                EscapeLiteralBrackets = true
             };
             authoring.LicenseAgreement = new PowerForgeInstallerLicenseAgreement
             {
@@ -2089,7 +2090,8 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
                     {
                         Id = "OpenConfig",
                         Text = "Open config",
-                        Target = "http://127.0.0.1:9000/config"
+                        Target = "http://127.0.0.1:9000/config",
+                        EscapeLiteralBrackets = true
                     }
                 }
             });
@@ -2114,6 +2116,7 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
             Assert.NotNull(installerPlan.Authoring!.ExitLaunch);
             Assert.Equal("Open app", installerPlan.Authoring.ExitLaunch!.Text);
             Assert.Equal("http://127.0.0.1:9000/", installerPlan.Authoring.ExitLaunch.Target);
+            Assert.True(installerPlan.Authoring.ExitLaunch.EscapeLiteralBrackets);
             Assert.NotNull(installerPlan.Authoring.LicenseAgreement);
             Assert.Equal("Installer/App/License.rtf", installerPlan.Authoring.LicenseAgreement!.Path);
             var input = Assert.Single(installerPlan.Authoring!.Inputs);
@@ -2127,6 +2130,7 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
             var action = Assert.Single(dialog.Actions);
             Assert.Equal("OpenConfig", action.Id);
             Assert.Equal("http://127.0.0.1:9000/config", action.Target);
+            Assert.True(action.EscapeLiteralBrackets);
 
             var prepareStep = Assert.Single(plan.Steps, s => s.Kind == DotNetPublishStepKind.MsiPrepare);
             Assert.Equal("ProductFiles", prepareStep.HarvestComponentGroupId);

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -363,13 +363,13 @@ public sealed class PowerForgeInstallerAuthoringTests
     }
 
     [Fact]
-    public void EmitSource_EscapesLiteralUrlQueryBracketsButPreservesInstallerProperties()
+    public void EmitSource_EscapesAllLiteralUrlBrackets()
     {
         var definition = CreateMonitoringInstaller();
         definition.ExitLaunch = new PowerForgeInstallerExitLaunch
         {
             Text = "Open filtered dashboard",
-            Target = "https://example.test/[TENANT]/search?filter[status]=[STATUS]"
+            Target = "https://example.test/search?filter=[status]&items[value]=active"
         };
 
         var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
@@ -378,7 +378,7 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.Contains(doc.Descendants(Wix + "Publish"), element =>
             (string?)element.Attribute("Dialog") == "ExitDialog" &&
             (string?)element.Attribute("Property") == "WixShellExecTarget" &&
-            (string?)element.Attribute("Value") == "https://example.test/[TENANT]/search?filter[\\[]status[\\]]=[STATUS]");
+            (string?)element.Attribute("Value") == "https://example.test/search?filter=[\\[]status[\\]]&items[\\[]value[\\]]=active");
     }
 
     [Fact]
@@ -619,6 +619,36 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.NotNull(action.Elements(Wix + "Publish").SingleOrDefault(e =>
             (string?)e.Attribute("Property") == "WixShellExecTarget" &&
             (string?)e.Attribute("Value") == "http://127.0.0.1:9000/" &&
+            (string?)e.Attribute("Order") == "3"));
+    }
+
+    [Fact]
+    public void EmitSource_EscapesLiteralBracketsForDialogAndRestoredUrlTargets()
+    {
+        var definition = CreateMonitoringInstaller();
+        definition.ExitLaunch = new PowerForgeInstallerExitLaunch
+        {
+            Text = "Open monitoring",
+            Target = "https://example.test/?filter=[status]"
+        };
+        var dialog = definition.Dialogs.Single(dialog => dialog.Id == "ConfigurationDlg");
+        dialog.Actions.Add(new PowerForgeInstallerDialogAction
+        {
+            Id = "OpenStudio",
+            Text = "Open Studio",
+            Target = "https://example.test/studio?items[value]=active"
+        });
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+        var action = doc.Descendants(Wix + "Control").Single(e =>
+            (string?)e.Attribute("Id") == "OpenStudio");
+
+        Assert.NotNull(action.Elements(Wix + "Publish").SingleOrDefault(e =>
+            (string?)e.Attribute("Value") == "https://example.test/studio?items[\\[]value[\\]]=active" &&
+            (string?)e.Attribute("Order") == "1"));
+        Assert.NotNull(action.Elements(Wix + "Publish").SingleOrDefault(e =>
+            (string?)e.Attribute("Value") == "https://example.test/?filter=[\\[]status[\\]]" &&
             (string?)e.Attribute("Order") == "3"));
     }
 

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -363,6 +363,25 @@ public sealed class PowerForgeInstallerAuthoringTests
     }
 
     [Fact]
+    public void EmitSource_EscapesLiteralUrlQueryBracketsButPreservesInstallerProperties()
+    {
+        var definition = CreateMonitoringInstaller();
+        definition.ExitLaunch = new PowerForgeInstallerExitLaunch
+        {
+            Text = "Open filtered dashboard",
+            Target = "https://example.test/[TENANT]/search?filter[status]=[STATUS]"
+        };
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        Assert.Contains(doc.Descendants(Wix + "Publish"), element =>
+            (string?)element.Attribute("Dialog") == "ExitDialog" &&
+            (string?)element.Attribute("Property") == "WixShellExecTarget" &&
+            (string?)element.Attribute("Value") == "https://example.test/[TENANT]/search?filter[\\[]status[\\]]=[STATUS]");
+    }
+
+    [Fact]
     public void EmitSource_ModelsDeferredExecutableActions()
     {
         var definition = CreateMonitoringInstaller();

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -344,6 +344,25 @@ public sealed class PowerForgeInstallerAuthoringTests
     }
 
     [Fact]
+    public void EmitSource_PreservesLiteralIpv6UrlBracketsInFormattedExitTarget()
+    {
+        var definition = CreateMonitoringInstaller();
+        definition.ExitLaunch = new PowerForgeInstallerExitLaunch
+        {
+            Text = "Open local dashboard",
+            Target = "http://[::1]:9000/"
+        };
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        Assert.Contains(doc.Descendants(Wix + "Publish"), element =>
+            (string?)element.Attribute("Dialog") == "ExitDialog" &&
+            (string?)element.Attribute("Property") == "WixShellExecTarget" &&
+            (string?)element.Attribute("Value") == "http://[\\[]::1[\\]]:9000/");
+    }
+
+    [Fact]
     public void EmitSource_ModelsDeferredExecutableActions()
     {
         var definition = CreateMonitoringInstaller();

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -300,7 +300,7 @@ public sealed class PowerForgeInstallerAuthoringTests
             (string?)e.Attribute("Value") == "Open TestimoX Monitoring"));
         Assert.NotNull(doc.Descendants(Wix + "Property").SingleOrDefault(e =>
             (string?)e.Attribute("Id") == "WixShellExecTarget" &&
-            (string?)e.Attribute("Value") == "http://127.0.0.1:9000/"));
+            (string?)e.Attribute("Value") == "about:blank"));
         Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
             (string?)e.Attribute("Id") == "PowerForgeLaunchOnExit" &&
             (string?)e.Attribute("BinaryRef") == "Wix4UtilCA_$(sys.BUILDARCHSHORT)" &&
@@ -308,8 +308,39 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.NotNull(doc.Descendants(Wix + "Publish").SingleOrDefault(e =>
             (string?)e.Attribute("Dialog") == "ExitDialog" &&
             (string?)e.Attribute("Control") == "Finish" &&
+            (string?)e.Attribute("Property") == "WixShellExecTarget" &&
+            (string?)e.Attribute("Value") == "http://127.0.0.1:9000/" &&
+            (string?)e.Attribute("Order") == "1"));
+        Assert.NotNull(doc.Descendants(Wix + "Publish").SingleOrDefault(e =>
+            (string?)e.Attribute("Dialog") == "ExitDialog" &&
+            (string?)e.Attribute("Control") == "Finish" &&
             (string?)e.Attribute("Event") == "DoAction" &&
-            (string?)e.Attribute("Value") == "PowerForgeLaunchOnExit"));
+            (string?)e.Attribute("Value") == "PowerForgeLaunchOnExit" &&
+            (string?)e.Attribute("Order") == "2"));
+    }
+
+    [Fact]
+    public void EmitSource_AssignsFormattedExitTargetFromTheExitDialog()
+    {
+        var definition = CreateMonitoringInstaller();
+        definition.ExitLaunch = new PowerForgeInstallerExitLaunch
+        {
+            Text = "Launch bridge",
+            Target = "[INSTALLFOLDER]Icue.Bridge.exe"
+        };
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        Assert.DoesNotContain(doc.Descendants(Wix + "Property"), element =>
+            (string?)element.Attribute("Id") == "WixShellExecTarget" &&
+            ((string?)element.Attribute("Value"))?.Contains("[INSTALLFOLDER]", StringComparison.Ordinal) == true);
+        Assert.Contains(doc.Descendants(Wix + "Publish"), element =>
+            (string?)element.Attribute("Dialog") == "ExitDialog" &&
+            (string?)element.Attribute("Control") == "Finish" &&
+            (string?)element.Attribute("Property") == "WixShellExecTarget" &&
+            (string?)element.Attribute("Value") == "[INSTALLFOLDER]Icue.Bridge.exe" &&
+            (string?)element.Attribute("Order") == "1");
     }
 
     [Fact]

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -350,7 +350,8 @@ public sealed class PowerForgeInstallerAuthoringTests
         definition.ExitLaunch = new PowerForgeInstallerExitLaunch
         {
             Text = "Open local dashboard",
-            Target = "http://[::1]:9000/"
+            Target = "http://[::1]:9000/",
+            EscapeLiteralBrackets = true
         };
 
         var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
@@ -369,7 +370,8 @@ public sealed class PowerForgeInstallerAuthoringTests
         definition.ExitLaunch = new PowerForgeInstallerExitLaunch
         {
             Text = "Open filtered dashboard",
-            Target = "https://example.test/search?filter=[status]&items[value]=active"
+            Target = "https://example.test/search?filter=[status]&items[value]=active",
+            EscapeLiteralBrackets = true
         };
 
         var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
@@ -379,6 +381,25 @@ public sealed class PowerForgeInstallerAuthoringTests
             (string?)element.Attribute("Dialog") == "ExitDialog" &&
             (string?)element.Attribute("Property") == "WixShellExecTarget" &&
             (string?)element.Attribute("Value") == "https://example.test/search?filter=[\\[]status[\\]]&items[\\[]value[\\]]=active");
+    }
+
+    [Fact]
+    public void EmitSource_PreservesMsiPropertiesInAbsoluteUrlTargetsByDefault()
+    {
+        var definition = CreateMonitoringInstaller();
+        definition.ExitLaunch = new PowerForgeInstallerExitLaunch
+        {
+            Text = "Open instance",
+            Target = "https://example.test/?instance=[INSTANCE]"
+        };
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        Assert.Contains(doc.Descendants(Wix + "Publish"), element =>
+            (string?)element.Attribute("Dialog") == "ExitDialog" &&
+            (string?)element.Attribute("Property") == "WixShellExecTarget" &&
+            (string?)element.Attribute("Value") == "https://example.test/?instance=[INSTANCE]");
     }
 
     [Fact]
@@ -629,14 +650,16 @@ public sealed class PowerForgeInstallerAuthoringTests
         definition.ExitLaunch = new PowerForgeInstallerExitLaunch
         {
             Text = "Open monitoring",
-            Target = "https://example.test/?filter=[status]"
+            Target = "https://example.test/?filter=[status]",
+            EscapeLiteralBrackets = true
         };
         var dialog = definition.Dialogs.Single(dialog => dialog.Id == "ConfigurationDlg");
         dialog.Actions.Add(new PowerForgeInstallerDialogAction
         {
             Id = "OpenStudio",
             Text = "Open Studio",
-            Target = "https://example.test/studio?items[value]=active"
+            Target = "https://example.test/studio?items[value]=active",
+            EscapeLiteralBrackets = true
         });
 
         var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);

--- a/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
+++ b/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
@@ -142,6 +142,11 @@ public sealed class PowerForgeInstallerExitLaunch
     public string Target { get; set; } = string.Empty;
 
     /// <summary>
+    /// Whether square brackets in <see cref="Target"/> are literal URL characters rather than MSI property references.
+    /// </summary>
+    public bool EscapeLiteralBrackets { get; set; }
+
+    /// <summary>
     /// WiX condition controlling the launch action.
     /// </summary>
     public string Condition { get; set; } = "WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 AND NOT Installed";
@@ -461,6 +466,11 @@ public sealed class PowerForgeInstallerDialogAction
     /// Shell target to open, for example an HTTP URL, folder, or executable path.
     /// </summary>
     public string Target { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Whether square brackets in <see cref="Target"/> are literal URL characters rather than MSI property references.
+    /// </summary>
+    public bool EscapeLiteralBrackets { get; set; }
 
     /// <summary>
     /// MSI condition controlling whether the action runs.

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -1073,6 +1073,7 @@ public sealed partial class DotNetPublishPipelineRunner
                     Enabled = definition.ExitLaunch.Enabled,
                     Text = definition.ExitLaunch.Text,
                     Target = definition.ExitLaunch.Target,
+                    EscapeLiteralBrackets = definition.ExitLaunch.EscapeLiteralBrackets,
                     Condition = definition.ExitLaunch.Condition
                 },
             LicenseAgreement = definition.LicenseAgreement is null
@@ -1155,6 +1156,7 @@ public sealed partial class DotNetPublishPipelineRunner
                     Id = action.Id,
                     Text = action.Text,
                     Target = action.Target,
+                    EscapeLiteralBrackets = action.EscapeLiteralBrackets,
                     Condition = action.Condition
                 });
             }

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -349,54 +349,21 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         var formatted = new StringBuilder(target.Length);
         for (var index = 0; index < target.Length; index++)
         {
-            if (target[index] != '[')
+            if (target[index] == '[')
             {
-                formatted.Append(target[index]);
-                continue;
+                formatted.Append("[\\[]");
             }
-
-            var closingBracket = target.IndexOf(']', index + 1);
-            if (closingBracket < 0)
+            else if (target[index] == ']')
             {
-                formatted.Append(target[index]);
-                continue;
-            }
-
-            if (IsInstallerPropertyReference(target, index, closingBracket))
-            {
-                formatted.Append(target, index, closingBracket - index + 1);
+                formatted.Append("[\\]]");
             }
             else
             {
-                formatted.Append("[\\[]");
-                formatted.Append(target, index + 1, closingBracket - index - 1);
-                formatted.Append("[\\]]");
+                formatted.Append(target[index]);
             }
-
-            index = closingBracket;
         }
 
         return formatted.ToString();
-    }
-
-    private static bool IsInstallerPropertyReference(string target, int openingBracket, int closingBracket)
-    {
-        if (closingBracket == openingBracket + 1
-            || (openingBracket > 0 && (char.IsLetterOrDigit(target[openingBracket - 1]) || target[openingBracket - 1] == '_')))
-        {
-            return false;
-        }
-
-        for (var index = openingBracket + 1; index < closingBracket; index++)
-        {
-            var character = target[index];
-            if (!char.IsLetterOrDigit(character) && character != '_' && character != '.')
-            {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     private static string BuildRequiredInputDialogId(int index)
@@ -625,7 +592,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 new XElement(
                     WixNamespace + "Publish",
                     new XAttribute("Property", "WixShellExecTarget"),
-                    new XAttribute("Value", action.Target),
+                    new XAttribute("Value", FormatExitLaunchTarget(action.Target)),
                     new XAttribute("Order", "1"),
                     new XAttribute("Condition", action.Condition)),
                 new XElement(
@@ -651,7 +618,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         return new XElement(
             WixNamespace + "Publish",
             new XAttribute("Property", "WixShellExecTarget"),
-            new XAttribute("Value", exitLaunch.Target),
+            new XAttribute("Value", FormatExitLaunchTarget(exitLaunch.Target)),
             new XAttribute("Order", "3"),
             new XAttribute("Condition", string.IsNullOrWhiteSpace(condition) ? "1" : condition));
     }

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -325,7 +325,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 new XAttribute("Dialog", "ExitDialog"),
                 new XAttribute("Control", "Finish"),
                 new XAttribute("Property", "WixShellExecTarget"),
-                new XAttribute("Value", FormatExitLaunchTarget(exitLaunch.Target)),
+                new XAttribute("Value", FormatShellTarget(exitLaunch.Target, exitLaunch.EscapeLiteralBrackets)),
                 new XAttribute("Order", "1"),
                 new XAttribute("Condition", exitLaunch.Condition)),
             new XElement(
@@ -339,9 +339,9 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         };
     }
 
-    private static string FormatExitLaunchTarget(string target)
+    private static string FormatShellTarget(string target, bool escapeLiteralBrackets)
     {
-        if (!Uri.TryCreate(target, UriKind.Absolute, out _))
+        if (!escapeLiteralBrackets)
         {
             return target;
         }
@@ -592,7 +592,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 new XElement(
                     WixNamespace + "Publish",
                     new XAttribute("Property", "WixShellExecTarget"),
-                    new XAttribute("Value", FormatExitLaunchTarget(action.Target)),
+                    new XAttribute("Value", FormatShellTarget(action.Target, action.EscapeLiteralBrackets)),
                     new XAttribute("Order", "1"),
                     new XAttribute("Condition", action.Condition)),
                 new XElement(
@@ -618,7 +618,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         return new XElement(
             WixNamespace + "Publish",
             new XAttribute("Property", "WixShellExecTarget"),
-            new XAttribute("Value", FormatExitLaunchTarget(exitLaunch.Target)),
+            new XAttribute("Value", FormatShellTarget(exitLaunch.Target, exitLaunch.EscapeLiteralBrackets)),
             new XAttribute("Order", "3"),
             new XAttribute("Condition", string.IsNullOrWhiteSpace(condition) ? "1" : condition));
     }

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -324,7 +324,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 new XAttribute("Dialog", "ExitDialog"),
                 new XAttribute("Control", "Finish"),
                 new XAttribute("Property", "WixShellExecTarget"),
-                new XAttribute("Value", exitLaunch.Target),
+                new XAttribute("Value", FormatExitLaunchTarget(exitLaunch.Target)),
                 new XAttribute("Order", "1"),
                 new XAttribute("Condition", exitLaunch.Condition)),
             new XElement(
@@ -336,6 +336,33 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 new XAttribute("Order", "2"),
                 new XAttribute("Condition", exitLaunch.Condition))
         };
+    }
+
+    private static string FormatExitLaunchTarget(string target)
+    {
+        if (!Uri.TryCreate(target, UriKind.Absolute, out var uri) || uri.HostNameType != UriHostNameType.IPv6)
+        {
+            return target;
+        }
+
+        var openingBracket = target.IndexOf("://[", StringComparison.Ordinal);
+        if (openingBracket < 0)
+        {
+            return target;
+        }
+
+        openingBracket += 3;
+        var closingBracket = target.IndexOf(']', openingBracket + 1);
+        if (closingBracket < 0)
+        {
+            return target;
+        }
+
+        return target[..openingBracket]
+               + "[\\[]"
+               + target[(openingBracket + 1)..closingBracket]
+               + "[\\]]"
+               + target[(closingBracket + 1)..];
     }
 
     private static string BuildRequiredInputDialogId(int index)

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -252,7 +252,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             new XElement(
                 WixNamespace + "Property",
                 new XAttribute("Id", "WixShellExecTarget"),
-                new XAttribute("Value", exitLaunch.Target)),
+                new XAttribute("Value", "about:blank")),
             new XElement(
                 WixNamespace + "CustomAction",
                 new XAttribute("Id", "PowerForgeLaunchOnExit"),
@@ -315,15 +315,27 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         return ui;
     }
 
-    private static XElement EmitExitLaunchPublish(PowerForgeInstallerExitLaunch exitLaunch)
+    private static IEnumerable<XElement> EmitExitLaunchPublish(PowerForgeInstallerExitLaunch exitLaunch)
     {
-        return new XElement(
-            WixNamespace + "Publish",
-            new XAttribute("Dialog", "ExitDialog"),
-            new XAttribute("Control", "Finish"),
-            new XAttribute("Event", "DoAction"),
-            new XAttribute("Value", "PowerForgeLaunchOnExit"),
-            new XAttribute("Condition", exitLaunch.Condition));
+        return new[]
+        {
+            new XElement(
+                WixNamespace + "Publish",
+                new XAttribute("Dialog", "ExitDialog"),
+                new XAttribute("Control", "Finish"),
+                new XAttribute("Property", "WixShellExecTarget"),
+                new XAttribute("Value", exitLaunch.Target),
+                new XAttribute("Order", "1"),
+                new XAttribute("Condition", exitLaunch.Condition)),
+            new XElement(
+                WixNamespace + "Publish",
+                new XAttribute("Dialog", "ExitDialog"),
+                new XAttribute("Control", "Finish"),
+                new XAttribute("Event", "DoAction"),
+                new XAttribute("Value", "PowerForgeLaunchOnExit"),
+                new XAttribute("Order", "2"),
+                new XAttribute("Condition", exitLaunch.Condition))
+        };
     }
 
     private static string BuildRequiredInputDialogId(int index)

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Xml.Linq;
 
 namespace PowerForge;
@@ -340,29 +341,62 @@ public sealed class PowerForgeWixInstallerSourceEmitter
 
     private static string FormatExitLaunchTarget(string target)
     {
-        if (!Uri.TryCreate(target, UriKind.Absolute, out var uri) || uri.HostNameType != UriHostNameType.IPv6)
+        if (!Uri.TryCreate(target, UriKind.Absolute, out _))
         {
             return target;
         }
 
-        var openingBracket = target.IndexOf("://[", StringComparison.Ordinal);
-        if (openingBracket < 0)
+        var formatted = new StringBuilder(target.Length);
+        for (var index = 0; index < target.Length; index++)
         {
-            return target;
+            if (target[index] != '[')
+            {
+                formatted.Append(target[index]);
+                continue;
+            }
+
+            var closingBracket = target.IndexOf(']', index + 1);
+            if (closingBracket < 0)
+            {
+                formatted.Append(target[index]);
+                continue;
+            }
+
+            if (IsInstallerPropertyReference(target, index, closingBracket))
+            {
+                formatted.Append(target, index, closingBracket - index + 1);
+            }
+            else
+            {
+                formatted.Append("[\\[]");
+                formatted.Append(target, index + 1, closingBracket - index - 1);
+                formatted.Append("[\\]]");
+            }
+
+            index = closingBracket;
         }
 
-        openingBracket += 3;
-        var closingBracket = target.IndexOf(']', openingBracket + 1);
-        if (closingBracket < 0)
+        return formatted.ToString();
+    }
+
+    private static bool IsInstallerPropertyReference(string target, int openingBracket, int closingBracket)
+    {
+        if (closingBracket == openingBracket + 1
+            || (openingBracket > 0 && (char.IsLetterOrDigit(target[openingBracket - 1]) || target[openingBracket - 1] == '_')))
         {
-            return target;
+            return false;
         }
 
-        return target[..openingBracket]
-               + "[\\[]"
-               + target[(openingBracket + 1)..closingBracket]
-               + "[\\]]"
-               + target[(closingBracket + 1)..];
+        for (var index = openingBracket + 1; index < closingBracket; index++)
+        {
+            var character = target[index];
+            if (!char.IsLetterOrDigit(character) && character != '_' && character != '.')
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static string BuildRequiredInputDialogId(int index)


### PR DESCRIPTION
## Summary

Corrects WiX exit-dialog and custom-dialog shell launch authoring without conflating literal URL brackets with MSI property references.

## What changed

- preserves formatted MSI properties in executable and absolute URL targets by default
- adds an explicit `EscapeLiteralBrackets` contract for IPv6, path and query brackets that must remain literal
- restores the exit launch target after intermediate dialog actions
- avoids duplicate restore actions when targets already match
- applies the same target contract to exit, dialog-action and restored-target events
- preserves the new authoring option through publish-plan cloning and net472 builds

## Validation

- installer authoring tests: 87 passed
- affected installer and publish-plan tests: 154 passed
- PowerForge net472 Release build passed