### PR TITLE
Add Cloudflare operational analytics pulse

### DIFF
--- a/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Fixtures.cs
+++ b/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Fixtures.cs
@@ -11,6 +11,9 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
     private static CloudflareAnalyticsCollector CreateCollector(HttpClient client) =>
         new(client, new FakeTokenProvider(), timeProvider: new FixedTimeProvider(CompletionTime));
 
+    private static CloudflareAnalyticsCollector CreateCollector(HttpClient client, TimeProvider timeProvider) =>
+        new(client, new FakeTokenProvider(), timeProvider: timeProvider);
+
     private static CloudflareAnalyticsCollectionOptions CreateOptions() => new()
     {
         ProviderId = "cloudflare",
@@ -106,11 +109,7 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
     private static HttpResponseMessage CapabilityResponse(
         int maxPageSize = 1000,
         int? maxDuration = 86_400,
-        int? notOlderThan = 2_678_400,
-        bool firewallEnabled = true,
-        int? firewallMaxPageSize = null,
-        int? firewallMaxDuration = null,
-        int? firewallNotOlderThan = null) => JsonResponse(new
+        int? notOlderThan = 2_678_400) => JsonResponse(new
     {
         errors = (object?)null,
         data = new
@@ -123,14 +122,32 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
                     {
                         settings = new
                         {
-                            httpRequestsAdaptiveGroups = new { enabled = true, maxPageSize, maxDuration, notOlderThan },
-                            firewallEventsAdaptiveGroups = new
-                            {
-                                enabled = firewallEnabled,
-                                maxPageSize = firewallMaxPageSize ?? maxPageSize,
-                                maxDuration = firewallMaxDuration ?? maxDuration,
-                                notOlderThan = firewallNotOlderThan ?? notOlderThan
-                            }
+                            httpRequestsAdaptiveGroups = new { enabled = true, maxPageSize, maxDuration, notOlderThan }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    private static HttpResponseMessage FirewallCapabilityResponse(
+        bool enabled = true,
+        int maxPageSize = 1000,
+        int? maxDuration = 86_400,
+        int? notOlderThan = 2_678_400) => JsonResponse(new
+    {
+        errors = (object?)null,
+        data = new
+        {
+            viewer = new
+            {
+                zones = new[]
+                {
+                    new
+                    {
+                        settings = new
+                        {
+                            firewallEventsAdaptiveGroups = new { enabled, maxPageSize, maxDuration, notOlderThan }
                         }
                     }
                 }
@@ -204,6 +221,12 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
     private sealed class FixedTimeProvider(DateTimeOffset value) : TimeProvider
     {
         public override DateTimeOffset GetUtcNow() => value;
+    }
+
+    private sealed class AdvancingTimeProvider(DateTimeOffset value, TimeSpan step) : TimeProvider
+    {
+        private int _calls;
+        public override DateTimeOffset GetUtcNow() => value.AddTicks(step.Ticks * _calls++);
     }
 
     private sealed class ScriptedHandler(Func<HttpRequestMessage, int, HttpResponseMessage> responder) : HttpMessageHandler

--- a/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Fixtures.cs
+++ b/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Fixtures.cs
@@ -106,7 +106,11 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
     private static HttpResponseMessage CapabilityResponse(
         int maxPageSize = 1000,
         int? maxDuration = 86_400,
-        int? notOlderThan = 2_678_400) => JsonResponse(new
+        int? notOlderThan = 2_678_400,
+        bool firewallEnabled = true,
+        int? firewallMaxPageSize = null,
+        int? firewallMaxDuration = null,
+        int? firewallNotOlderThan = null) => JsonResponse(new
     {
         errors = (object?)null,
         data = new
@@ -119,7 +123,14 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
                     {
                         settings = new
                         {
-                            httpRequestsAdaptiveGroups = new { enabled = true, maxPageSize, maxDuration, notOlderThan }
+                            httpRequestsAdaptiveGroups = new { enabled = true, maxPageSize, maxDuration, notOlderThan },
+                            firewallEventsAdaptiveGroups = new
+                            {
+                                enabled = firewallEnabled,
+                                maxPageSize = firewallMaxPageSize ?? maxPageSize,
+                                maxDuration = firewallMaxDuration ?? maxDuration,
+                                notOlderThan = firewallNotOlderThan ?? notOlderThan
+                            }
                         }
                     }
                 }
@@ -133,11 +144,11 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         data = new { viewer = new { zones = new object?[] { null } } }
     });
 
-    private static HttpResponseMessage ZoneResponse(string name) => JsonResponse(new
+    private static HttpResponseMessage ZoneResponse(string name, string? accountId = TestAccountId) => JsonResponse(new
     {
         success = true,
         errors = Array.Empty<object>(),
-        result = new { id = ZoneId, name }
+        result = new { id = ZoneId, name, account = accountId is null ? null : new { id = accountId } }
     });
 
     private static object TrafficRow(

--- a/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Fixtures.cs
+++ b/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Fixtures.cs
@@ -107,6 +107,7 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
     };
 
     private static HttpResponseMessage CapabilityResponse(
+        bool enabled = true,
         int maxPageSize = 1000,
         int? maxDuration = 86_400,
         int? notOlderThan = 2_678_400) => JsonResponse(new
@@ -122,7 +123,7 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
                     {
                         settings = new
                         {
-                            httpRequestsAdaptiveGroups = new { enabled = true, maxPageSize, maxDuration, notOlderThan }
+                            httpRequestsAdaptiveGroups = new { enabled, maxPageSize, maxDuration, notOlderThan }
                         }
                     }
                 }
@@ -216,6 +217,19 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
     private sealed class FakeTokenProvider : ICloudflareAnalyticsTokenProvider
     {
         public Task<string> GetTokenAsync(CancellationToken cancellationToken = default) => Task.FromResult("test-token");
+    }
+
+    private sealed class SingleUseTokenProvider : ICloudflareAnalyticsTokenProvider
+    {
+        public int CallCount { get; private set; }
+
+        public Task<string> GetTokenAsync(CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            if (CallCount > 1)
+                throw new InvalidOperationException("The credential must be resolved only once per collection.");
+            return Task.FromResult("test-token");
+        }
     }
 
     private sealed class FixedTimeProvider(DateTimeOffset value) : TimeProvider

--- a/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Operations.cs
+++ b/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Operations.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using PowerForge.Web;
+
+namespace PowerForge.Tests;
+
+public sealed partial class WebCloudflareAnalyticsCollectorTests
+{
+    [Fact]
+    public async Task CollectOperations_MapsHourlyCacheErrorsFirewallAndRumState()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(),
+            2 => OperationalHttpResponse(
+                HttpOperationRow("2026-08-10T09:00:00Z", "hit", 200, 10, 1000, 2),
+                HttpOperationRow("2026-08-10T09:00:00Z", "miss", 404, 3, 300, 1),
+                HttpOperationRow("2026-08-10T10:00:00Z", "dynamic", 503, 2, 200, 1)),
+            3 => OperationalFirewallResponse(
+                FirewallOperationRow("2026-08-10T09:00:00Z", "block", 4, 2),
+                FirewallOperationRow("2026-08-10T09:00:00Z", "log", 1, 1)),
+            4 => RumSitesResponse(enabled: true, autoInstall: true),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: true));
+
+        Assert.True(result.Success);
+        Assert.True(result.Http.Success);
+        Assert.True(result.Firewall.Success);
+        Assert.Equal(5, result.RequestCount);
+        Assert.True(result.Rum.Requested);
+        Assert.True(result.Rum.Configured);
+        Assert.True(result.Rum.Enabled);
+        Assert.True(result.Rum.AutoInstall);
+        Assert.Equal(2, result.Hours.Length);
+        var first = result.Hours[0];
+        Assert.Equal(23, first.Requests);
+        Assert.Equal(20, first.CachedRequests);
+        Assert.Equal(3, first.ClientErrors);
+        Assert.Equal(9, first.FirewallEvents);
+        Assert.Equal(8, first.FirewallMitigated);
+        Assert.Equal(2, first.MaximumSampleInterval);
+        Assert.Equal(20d * 100d / 23d, first.CacheHitPercent, precision: 6);
+        Assert.Contains("clientRequestHTTPHost", handler.Requests[2].Body, StringComparison.Ordinal);
+        Assert.Contains("firewallEventsAdaptiveGroups", handler.Requests[3].Body, StringComparison.Ordinal);
+        Assert.Equal(HttpMethod.Get, handler.Requests[4].Method);
+        Assert.Contains("/rum/site_info/list", handler.Requests[4].Uri.AbsoluteUri, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CollectOperations_PreservesHttpEvidenceWhenFirewallDatasetIsUnavailable()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(),
+            2 => OperationalHttpResponse(HttpOperationRow("2026-08-10T09:00:00Z", "hit", 200, 10, 1000, 1)),
+            3 => new HttpResponseMessage(HttpStatusCode.Forbidden),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: false));
+
+        Assert.True(result.Success);
+        Assert.True(result.Http.Success);
+        Assert.False(result.Firewall.Success);
+        Assert.Equal("authentication-rejected", result.Firewall.ErrorCode);
+        Assert.Single(result.Hours);
+        Assert.False(result.Rum.Requested);
+    }
+
+    private static CloudflareOperationalCollectionOptions CreateOperationalOptions(bool includeAccount) => new()
+    {
+        SiteId = "officeimo",
+        ZoneId = ZoneId,
+        SiteBaseUrl = "https://officeimo.com/",
+        FromUtc = new DateTimeOffset(2026, 8, 10, 9, 0, 0, TimeSpan.Zero),
+        ThroughUtc = new DateTimeOffset(2026, 8, 10, 11, 0, 0, TimeSpan.Zero),
+        AccountId = includeAccount ? "0123456789abcdef0123456789abcdef" : null
+    };
+
+    private static object HttpOperationRow(string hour, string cacheStatus, int status, ulong count, ulong bytes, double sampleInterval) => new
+    {
+        count,
+        avg = new { sampleInterval },
+        sum = new { edgeResponseBytes = bytes },
+        dimensions = new { datetimeHour = hour, cacheStatus, edgeResponseStatus = status }
+    };
+
+    private static object FirewallOperationRow(string hour, string action, ulong count, double sampleInterval) => new
+    {
+        count,
+        avg = new { sampleInterval },
+        dimensions = new { datetimeHour = hour, action }
+    };
+
+    private static HttpResponseMessage OperationalHttpResponse(params object[] rows) => JsonResponse(new
+    {
+        errors = (object?)null,
+        data = new { viewer = new { zones = new[] { new { http = rows } } } }
+    });
+
+    private static HttpResponseMessage OperationalFirewallResponse(params object[] rows) => JsonResponse(new
+    {
+        errors = (object?)null,
+        data = new { viewer = new { zones = new[] { new { firewall = rows } } } }
+    });
+
+    private static HttpResponseMessage RumSitesResponse(bool enabled, bool autoInstall) => JsonResponse(new
+    {
+        success = true,
+        errors = Array.Empty<object>(),
+        result = new[] { new { auto_install = autoInstall, ruleset = new { enabled, zone_tag = ZoneId } } }
+    });
+}

--- a/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Operations.cs
+++ b/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Operations.cs
@@ -99,6 +99,45 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
     }
 
     [Fact]
+    public async Task CollectOperations_RejectsRangesOutsideProviderRetention()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(notOlderThan: 3600),
+            _ => throw new InvalidOperationException("Operational queries must not run outside provider retention.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: true));
+
+        Assert.False(result.Success);
+        Assert.Equal("retention-boundary", result.Http.ErrorCode);
+        Assert.Equal("not-attempted", result.Firewall.ErrorCode);
+        Assert.Equal("not-attempted", result.Rum.ErrorCode);
+        Assert.Equal(2, result.RequestCount);
+    }
+
+    [Fact]
+    public async Task CollectOperations_UsesBoundedFallbackWhenProbeOmitsMaximumDuration()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(maxDuration: null),
+            2 => OperationalHttpResponse(),
+            3 => OperationalFirewallResponse(),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: false));
+
+        Assert.True(result.Success);
+        Assert.Equal(4, result.RequestCount);
+    }
+
+    [Fact]
     public async Task CollectOperations_FailsClosedWhenProviderPageLimitIsReached()
     {
         var handler = new ScriptedHandler((_, index) => index switch
@@ -140,6 +179,27 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         Assert.Equal(6, result.RequestCount);
         Assert.Contains("page=1", handler.Requests[4].Uri.Query, StringComparison.Ordinal);
         Assert.Contains("page=2", handler.Requests[5].Uri.Query, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CollectOperations_MatchesRumSiteByZoneAndHost()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(),
+            2 => OperationalHttpResponse(),
+            3 => OperationalFirewallResponse(),
+            4 => RumSitesForHostsResponse(),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: true));
+
+        Assert.True(result.Rum.Configured);
+        Assert.True(result.Rum.Enabled);
+        Assert.True(result.Rum.AutoInstall);
     }
 
     [Fact]
@@ -255,7 +315,18 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
     {
         success = true,
         errors = Array.Empty<object>(),
-        result = new[] { new { auto_install = autoInstall, ruleset = new { enabled, zone_tag = ZoneId } } }
+        result = new[] { new { host = "officeimo.com", auto_install = autoInstall, ruleset = new { enabled, zone_tag = ZoneId } } }
+    });
+
+    private static HttpResponseMessage RumSitesForHostsResponse() => JsonResponse(new
+    {
+        success = true,
+        errors = Array.Empty<object>(),
+        result = new[]
+        {
+            new { host = "other.officeimo.com", auto_install = false, ruleset = new { enabled = false, zone_tag = ZoneId } },
+            new { host = "officeimo.com", auto_install = true, ruleset = new { enabled = true, zone_tag = ZoneId } }
+        }
     });
 
     private static HttpResponseMessage RumSitesPageResponse(bool includeMatch, int totalPages, int itemCount)
@@ -264,6 +335,7 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
             .Select(index => new
             {
                 auto_install = includeMatch && index == 0,
+                host = includeMatch && index == 0 ? "officeimo.com" : $"other-{index}.officeimo.com",
                 ruleset = new
                 {
                     enabled = includeMatch && index == 0,

--- a/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Operations.cs
+++ b/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Operations.cs
@@ -84,6 +84,52 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
     }
 
     [Fact]
+    public async Task CollectOperations_PreservesFirewallAndRumWhenHttpDatasetIsUnavailable()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(enabled: false),
+            2 => FirewallCapabilityResponse(),
+            3 => OperationalFirewallResponse(FirewallOperationRow("2026-08-10T09:00:00Z", "block", 2, 1)),
+            4 => RumSitesResponse(enabled: true, autoInstall: true),
+            _ => throw new InvalidOperationException("HTTP collection must not run for an unavailable dataset.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: true));
+
+        Assert.False(result.Success);
+        Assert.Equal("dataset-unavailable", result.Http.ErrorCode);
+        Assert.True(result.Firewall.Success);
+        Assert.True(result.Rum.Configured);
+        Assert.Equal(2, Assert.Single(result.Hours).FirewallEvents);
+        Assert.Equal(5, result.RequestCount);
+    }
+
+    [Fact]
+    public async Task CollectOperations_ResolvesOneCredentialForProbeAndCollection()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(),
+            2 => FirewallCapabilityResponse(),
+            3 => OperationalHttpResponse(),
+            4 => OperationalFirewallResponse(),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+        var tokenProvider = new SingleUseTokenProvider();
+        var collector = new CloudflareAnalyticsCollector(client, tokenProvider, timeProvider: new FixedTimeProvider(CompletionTime));
+
+        var result = await collector.CollectOperationsAsync(CreateOperationalOptions(includeAccount: false));
+
+        Assert.True(result.Success);
+        Assert.Equal(1, tokenProvider.CallCount);
+    }
+
+    [Fact]
     public async Task CollectOperations_PartitionsByProbeDurationAndUsesPageLimit()
     {
         var handler = new ScriptedHandler((_, index) => index switch

--- a/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Operations.cs
+++ b/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Operations.cs
@@ -29,6 +29,7 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: true));
 
         Assert.True(result.Success);
+        Assert.Equal("officeimo", result.SiteId);
         Assert.True(result.Http.Success);
         Assert.True(result.Firewall.Success);
         Assert.Equal(5, result.RequestCount);
@@ -47,6 +48,7 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         Assert.Equal(22d * 100d / 25d, first.CacheHitPercent, precision: 6);
         Assert.Contains("clientRequestHTTPHost", handler.Requests[2].Body, StringComparison.Ordinal);
         Assert.Contains("firewallEventsAdaptiveGroups", handler.Requests[3].Body, StringComparison.Ordinal);
+        Assert.Contains("clientRequestScheme", handler.Requests[3].Body, StringComparison.Ordinal);
         Assert.Equal(HttpMethod.Get, handler.Requests[4].Method);
         Assert.Contains("/rum/site_info/list", handler.Requests[4].Uri.AbsoluteUri, StringComparison.Ordinal);
     }
@@ -115,9 +117,19 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
 
         Assert.False(result.Success);
         Assert.Equal("retention-boundary", result.Http.ErrorCode);
-        Assert.Equal("not-attempted", result.Firewall.ErrorCode);
+        Assert.Equal("retention-boundary", result.Firewall.ErrorCode);
         Assert.Equal("not-attempted", result.Rum.ErrorCode);
         Assert.Equal(2, result.RequestCount);
+    }
+
+    [Fact]
+    public async Task CollectOperations_RequiresAnHourAlignedUtcWindow()
+    {
+        using var client = new HttpClient(new ScriptedHandler((_, _) => throw new InvalidOperationException("No request expected.")));
+        var options = CreateOperationalOptions(includeAccount: false);
+        options.FromUtc = options.FromUtc.AddMinutes(15);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => CreateCollector(client).CollectOperationsAsync(options));
     }
 
     [Fact]
@@ -225,6 +237,114 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
     }
 
     [Fact]
+    public async Task CollectOperations_UsesFirewallSpecificCapabilityLimits()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(maxPageSize: 1000, firewallMaxPageSize: 25),
+            2 => OperationalHttpResponse(),
+            3 => OperationalFirewallResponse(),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: false));
+
+        Assert.True(result.Firewall.Success);
+        Assert.Contains("\"limit\":25", handler.Requests[3].Body, StringComparison.Ordinal);
+        Assert.Contains("\"limit\":1000", handler.Requests[2].Body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CollectOperations_RejectsIncompleteRumConfiguration()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(),
+            2 => OperationalHttpResponse(),
+            3 => OperationalFirewallResponse(),
+            4 => JsonResponse(new
+            {
+                success = true,
+                errors = Array.Empty<object>(),
+                result = new[] { new { host = "officeimo.com", auto_install = (bool?)null, ruleset = new { enabled = (bool?)null, zone_tag = ZoneId } } }
+            }),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: true));
+
+        Assert.Equal("invalid-response", result.Rum.ErrorCode);
+        Assert.False(result.Rum.Configured);
+    }
+
+    [Fact]
+    public async Task CollectOperations_RejectsRumAccountThatDoesNotOwnTheZone()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com", "ffffffffffffffffffffffffffffffff"),
+            1 => CapabilityResponse(),
+            2 => OperationalHttpResponse(),
+            3 => OperationalFirewallResponse(),
+            _ => throw new InvalidOperationException("RUM lookup must not run for a mismatched account.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: true));
+
+        Assert.Equal("account-zone-mismatch", result.Rum.ErrorCode);
+        Assert.Equal(4, result.RequestCount);
+    }
+
+    [Theory]
+    [InlineData("2026-08-10T08:00:00Z")]
+    [InlineData("2026-08-10T09:15:00Z")]
+    public async Task CollectOperations_RejectsInvalidHttpHourDimensions(string hour)
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(),
+            2 => OperationalHttpResponse(HttpOperationRow(hour, "hit", 200, 1, 100, 1)),
+            3 => OperationalFirewallResponse(),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: false));
+
+        Assert.False(result.Http.Success);
+        Assert.Equal("invalid-response", result.Http.ErrorCode);
+        Assert.Empty(result.Hours);
+    }
+
+    [Theory]
+    [InlineData("2026-08-10T11:00:00Z")]
+    [InlineData("2026-08-10T10:00:30Z")]
+    public async Task CollectOperations_RejectsInvalidFirewallHourDimensions(string hour)
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(),
+            2 => OperationalHttpResponse(),
+            3 => OperationalFirewallResponse(FirewallOperationRow(hour, "block", 1, 1)),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: false));
+
+        Assert.False(result.Firewall.Success);
+        Assert.Equal("invalid-response", result.Firewall.ErrorCode);
+        Assert.Empty(result.Hours);
+    }
+
+    [Fact]
     public async Task CollectOperations_DiscardsPartialFirewallRowsWhenDatasetIsInvalid()
     {
         var invalidRow = new
@@ -303,7 +423,7 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         SiteBaseUrl = "https://officeimo.com/",
         FromUtc = new DateTimeOffset(2026, 8, 10, 9, 0, 0, TimeSpan.Zero),
         ThroughUtc = new DateTimeOffset(2026, 8, 10, 11, 0, 0, TimeSpan.Zero),
-        AccountId = includeAccount ? "0123456789abcdef0123456789abcdef" : null
+        AccountId = includeAccount ? TestAccountId : null
     };
 
     private static object HttpOperationRow(string hour, string cacheStatus, int status, ulong count, ulong bytes, double sampleInterval) => new

--- a/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Operations.cs
+++ b/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Operations.cs
@@ -46,6 +46,7 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         Assert.Equal(25, first.Requests);
         Assert.Equal(22, first.CachedRequests);
         Assert.Equal(3, first.ClientErrors);
+        Assert.Equal(2_500, first.EdgeResponseBytes);
         Assert.Equal(12, first.FirewallEvents);
         Assert.Equal(11, first.FirewallMitigated);
         Assert.Equal(2, first.MaximumSampleInterval);
@@ -162,6 +163,7 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
             0 => ZoneResponse("officeimo.com"),
             1 => CapabilityResponse(notOlderThan: 3600),
             2 => FirewallCapabilityResponse(notOlderThan: 3600),
+            3 => RumSitesResponse(enabled: true, autoInstall: true),
             _ => throw new InvalidOperationException("Operational queries must not run outside provider retention.")
         });
         using var client = new HttpClient(handler);
@@ -171,8 +173,10 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         Assert.False(result.Success);
         Assert.Equal("retention-boundary", result.Http.ErrorCode);
         Assert.Equal("retention-boundary", result.Firewall.ErrorCode);
-        Assert.Equal("not-attempted", result.Rum.ErrorCode);
-        Assert.Equal(3, result.RequestCount);
+        Assert.True(result.Rum.Configured);
+        Assert.True(result.Rum.Enabled);
+        Assert.True(result.Rum.AutoInstall);
+        Assert.Equal(4, result.RequestCount);
     }
 
     [Fact]

--- a/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Operations.cs
+++ b/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Operations.cs
@@ -14,10 +14,12 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
             1 => CapabilityResponse(),
             2 => OperationalHttpResponse(
                 HttpOperationRow("2026-08-10T09:00:00Z", "hit", 200, 10, 1000, 2),
+                HttpOperationRow("2026-08-10T09:00:00Z", "stale", 200, 2, 200, 1),
                 HttpOperationRow("2026-08-10T09:00:00Z", "miss", 404, 3, 300, 1),
                 HttpOperationRow("2026-08-10T10:00:00Z", "dynamic", 503, 2, 200, 1)),
             3 => OperationalFirewallResponse(
                 FirewallOperationRow("2026-08-10T09:00:00Z", "block", 4, 2),
+                FirewallOperationRow("2026-08-10T09:00:00Z", "managedChallenge", 3, 1),
                 FirewallOperationRow("2026-08-10T09:00:00Z", "log", 1, 1)),
             4 => RumSitesResponse(enabled: true, autoInstall: true),
             _ => throw new InvalidOperationException("Unexpected request.")
@@ -36,13 +38,13 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         Assert.True(result.Rum.AutoInstall);
         Assert.Equal(2, result.Hours.Length);
         var first = result.Hours[0];
-        Assert.Equal(23, first.Requests);
-        Assert.Equal(20, first.CachedRequests);
+        Assert.Equal(25, first.Requests);
+        Assert.Equal(22, first.CachedRequests);
         Assert.Equal(3, first.ClientErrors);
-        Assert.Equal(9, first.FirewallEvents);
-        Assert.Equal(8, first.FirewallMitigated);
+        Assert.Equal(12, first.FirewallEvents);
+        Assert.Equal(11, first.FirewallMitigated);
         Assert.Equal(2, first.MaximumSampleInterval);
-        Assert.Equal(20d * 100d / 23d, first.CacheHitPercent, precision: 6);
+        Assert.Equal(22d * 100d / 25d, first.CacheHitPercent, precision: 6);
         Assert.Contains("clientRequestHTTPHost", handler.Requests[2].Body, StringComparison.Ordinal);
         Assert.Contains("firewallEventsAdaptiveGroups", handler.Requests[3].Body, StringComparison.Ordinal);
         Assert.Equal(HttpMethod.Get, handler.Requests[4].Method);
@@ -200,6 +202,26 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         Assert.True(result.Rum.Configured);
         Assert.True(result.Rum.Enabled);
         Assert.True(result.Rum.AutoInstall);
+    }
+
+    [Fact]
+    public async Task CollectOperations_CountsFailedRumTransportAttempt()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(),
+            2 => OperationalHttpResponse(),
+            3 => OperationalFirewallResponse(),
+            4 => throw new HttpRequestException("Synthetic RUM transport failure."),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: true));
+
+        Assert.Equal("request-failed", result.Rum.ErrorCode);
+        Assert.Equal(5, result.RequestCount);
     }
 
     [Fact]

--- a/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Operations.cs
+++ b/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Operations.cs
@@ -12,16 +12,17 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         {
             0 => ZoneResponse("officeimo.com"),
             1 => CapabilityResponse(),
-            2 => OperationalHttpResponse(
+            2 => FirewallCapabilityResponse(),
+            3 => OperationalHttpResponse(
                 HttpOperationRow("2026-08-10T09:00:00Z", "hit", 200, 10, 1000, 2),
                 HttpOperationRow("2026-08-10T09:00:00Z", "stale", 200, 2, 200, 1),
                 HttpOperationRow("2026-08-10T09:00:00Z", "miss", 404, 3, 300, 1),
                 HttpOperationRow("2026-08-10T10:00:00Z", "dynamic", 503, 2, 200, 1)),
-            3 => OperationalFirewallResponse(
+            4 => OperationalFirewallResponse(
                 FirewallOperationRow("2026-08-10T09:00:00Z", "block", 4, 2),
                 FirewallOperationRow("2026-08-10T09:00:00Z", "managedChallenge", 3, 1),
                 FirewallOperationRow("2026-08-10T09:00:00Z", "log", 1, 1)),
-            4 => RumSitesResponse(enabled: true, autoInstall: true),
+            5 => RumSitesResponse(enabled: true, autoInstall: true),
             _ => throw new InvalidOperationException("Unexpected request.")
         });
         using var client = new HttpClient(handler);
@@ -32,7 +33,10 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         Assert.Equal("officeimo", result.SiteId);
         Assert.True(result.Http.Success);
         Assert.True(result.Firewall.Success);
-        Assert.Equal(5, result.RequestCount);
+        Assert.Equal(6, result.RequestCount);
+        Assert.Equal(new DateTimeOffset(2026, 8, 10, 9, 0, 0, TimeSpan.Zero), result.FromUtc);
+        Assert.Equal(new DateTimeOffset(2026, 8, 10, 11, 0, 0, TimeSpan.Zero), result.ThroughUtc);
+        Assert.Equal(CompletionTime, result.CollectedAtUtc);
         Assert.True(result.Rum.Requested);
         Assert.True(result.Rum.Configured);
         Assert.True(result.Rum.Enabled);
@@ -46,11 +50,13 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         Assert.Equal(11, first.FirewallMitigated);
         Assert.Equal(2, first.MaximumSampleInterval);
         Assert.Equal(22d * 100d / 25d, first.CacheHitPercent, precision: 6);
-        Assert.Contains("clientRequestHTTPHost", handler.Requests[2].Body, StringComparison.Ordinal);
-        Assert.Contains("firewallEventsAdaptiveGroups", handler.Requests[3].Body, StringComparison.Ordinal);
-        Assert.Contains("clientRequestScheme", handler.Requests[3].Body, StringComparison.Ordinal);
-        Assert.Equal(HttpMethod.Get, handler.Requests[4].Method);
-        Assert.Contains("/rum/site_info/list", handler.Requests[4].Uri.AbsoluteUri, StringComparison.Ordinal);
+        Assert.DoesNotContain("firewallEventsAdaptiveGroups", handler.Requests[1].Body, StringComparison.Ordinal);
+        Assert.Contains("firewallEventsAdaptiveGroups", handler.Requests[2].Body, StringComparison.Ordinal);
+        Assert.Contains("clientRequestHTTPHost", handler.Requests[3].Body, StringComparison.Ordinal);
+        Assert.Contains("firewallEventsAdaptiveGroups", handler.Requests[4].Body, StringComparison.Ordinal);
+        Assert.Contains("clientRequestScheme", handler.Requests[4].Body, StringComparison.Ordinal);
+        Assert.Equal(HttpMethod.Get, handler.Requests[5].Method);
+        Assert.Contains("/rum/site_info/list", handler.Requests[5].Uri.AbsoluteUri, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -60,8 +66,8 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         {
             0 => ZoneResponse("officeimo.com"),
             1 => CapabilityResponse(),
-            2 => OperationalHttpResponse(HttpOperationRow("2026-08-10T09:00:00Z", "hit", 200, 10, 1000, 1)),
-            3 => new HttpResponseMessage(HttpStatusCode.Forbidden),
+            2 => new HttpResponseMessage(HttpStatusCode.Forbidden),
+            3 => OperationalHttpResponse(HttpOperationRow("2026-08-10T09:00:00Z", "hit", 200, 10, 1000, 1)),
             _ => throw new InvalidOperationException("Unexpected request.")
         });
         using var client = new HttpClient(handler);
@@ -83,8 +89,9 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         {
             0 => ZoneResponse("officeimo.com"),
             1 => CapabilityResponse(maxPageSize: 7, maxDuration: 3600),
-            2 or 3 => OperationalHttpResponse(),
-            4 or 5 => OperationalFirewallResponse(),
+            2 => FirewallCapabilityResponse(maxDuration: 3600),
+            3 or 4 => OperationalHttpResponse(),
+            5 or 6 => OperationalFirewallResponse(),
             _ => throw new InvalidOperationException("Unexpected request.")
         });
         using var client = new HttpClient(handler);
@@ -94,12 +101,57 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         var result = await CreateCollector(client).CollectOperationsAsync(options);
 
         Assert.True(result.Success);
-        Assert.Equal(6, result.RequestCount);
-        Assert.Contains("\"limit\":7", handler.Requests[2].Body, StringComparison.Ordinal);
-        Assert.Contains("2026-08-10T09:00:00Z", handler.Requests[2].Body, StringComparison.Ordinal);
-        Assert.Contains("2026-08-10T10:00:00Z", handler.Requests[3].Body, StringComparison.Ordinal);
-        Assert.Contains("clientRequestPath", handler.Requests[4].Body, StringComparison.Ordinal);
-        Assert.Contains("/products/powerforge", handler.Requests[4].Body, StringComparison.Ordinal);
+        Assert.Equal(7, result.RequestCount);
+        Assert.Contains("\"limit\":7", handler.Requests[3].Body, StringComparison.Ordinal);
+        Assert.Contains("2026-08-10T09:00:00Z", handler.Requests[3].Body, StringComparison.Ordinal);
+        Assert.Contains("2026-08-10T10:00:00Z", handler.Requests[4].Body, StringComparison.Ordinal);
+        Assert.Contains("clientRequestPath", handler.Requests[5].Body, StringComparison.Ordinal);
+        Assert.Contains("/products/powerforge", handler.Requests[5].Body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CollectOperations_AlignsNonIntegralProviderDurationsToCompleteUtcHours()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(maxDuration: 5_400),
+            2 => FirewallCapabilityResponse(maxDuration: 5_400),
+            3 => OperationalHttpResponse(HttpOperationRow("2026-08-10T09:00:00Z", "hit", 200, 1, 100, 1)),
+            4 => OperationalHttpResponse(HttpOperationRow("2026-08-10T10:00:00Z", "hit", 200, 1, 100, 1)),
+            5 => OperationalFirewallResponse(FirewallOperationRow("2026-08-10T09:00:00Z", "block", 1, 1)),
+            6 => OperationalFirewallResponse(FirewallOperationRow("2026-08-10T10:00:00Z", "block", 1, 1)),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: false));
+
+        Assert.True(result.Success);
+        Assert.True(result.Firewall.Success);
+        Assert.Equal(2, result.Hours.Length);
+        Assert.Contains("2026-08-10T10:00:00Z", handler.Requests[4].Body, StringComparison.Ordinal);
+        Assert.Contains("2026-08-10T10:00:00Z", handler.Requests[6].Body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CollectOperations_FailsClosedWhenProviderDurationCannotCoverAnHour()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(maxDuration: 1_800),
+            2 => FirewallCapabilityResponse(maxDuration: 1_800),
+            _ => throw new InvalidOperationException("Operational queries must not run for sub-hour capability limits.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: false));
+
+        Assert.False(result.Success);
+        Assert.Equal("duration-boundary", result.Http.ErrorCode);
+        Assert.Equal("duration-boundary", result.Firewall.ErrorCode);
+        Assert.Equal(3, result.RequestCount);
     }
 
     [Fact]
@@ -109,6 +161,7 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         {
             0 => ZoneResponse("officeimo.com"),
             1 => CapabilityResponse(notOlderThan: 3600),
+            2 => FirewallCapabilityResponse(notOlderThan: 3600),
             _ => throw new InvalidOperationException("Operational queries must not run outside provider retention.")
         });
         using var client = new HttpClient(handler);
@@ -119,7 +172,7 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         Assert.Equal("retention-boundary", result.Http.ErrorCode);
         Assert.Equal("retention-boundary", result.Firewall.ErrorCode);
         Assert.Equal("not-attempted", result.Rum.ErrorCode);
-        Assert.Equal(2, result.RequestCount);
+        Assert.Equal(3, result.RequestCount);
     }
 
     [Fact]
@@ -139,8 +192,9 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         {
             0 => ZoneResponse("officeimo.com"),
             1 => CapabilityResponse(maxDuration: null),
-            2 => OperationalHttpResponse(),
-            3 => OperationalFirewallResponse(),
+            2 => FirewallCapabilityResponse(maxDuration: null),
+            3 => OperationalHttpResponse(),
+            4 => OperationalFirewallResponse(),
             _ => throw new InvalidOperationException("Unexpected request.")
         });
         using var client = new HttpClient(handler);
@@ -148,7 +202,7 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: false));
 
         Assert.True(result.Success);
-        Assert.Equal(4, result.RequestCount);
+        Assert.Equal(5, result.RequestCount);
     }
 
     [Fact]
@@ -158,8 +212,9 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         {
             0 => ZoneResponse("officeimo.com"),
             1 => CapabilityResponse(maxPageSize: 1),
-            2 => OperationalHttpResponse(HttpOperationRow("2026-08-10T09:00:00Z", "hit", 200, 10, 1000, 1)),
-            3 => OperationalFirewallResponse(),
+            2 => FirewallCapabilityResponse(),
+            3 => OperationalHttpResponse(HttpOperationRow("2026-08-10T09:00:00Z", "hit", 200, 10, 1000, 1)),
+            4 => OperationalFirewallResponse(),
             _ => throw new InvalidOperationException("Unexpected request.")
         });
         using var client = new HttpClient(handler);
@@ -169,7 +224,7 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         Assert.False(result.Success);
         Assert.Equal("row-limit-reached", result.Http.ErrorCode);
         Assert.Empty(result.Hours);
-        Assert.Contains("\"limit\":1", handler.Requests[2].Body, StringComparison.Ordinal);
+        Assert.Contains("\"limit\":1", handler.Requests[3].Body, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -179,10 +234,11 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         {
             0 => ZoneResponse("officeimo.com"),
             1 => CapabilityResponse(),
-            2 => OperationalHttpResponse(),
-            3 => OperationalFirewallResponse(),
-            4 => RumSitesPageResponse(includeMatch: false, totalPages: 2, itemCount: 50),
-            5 => RumSitesPageResponse(includeMatch: true, totalPages: 2, itemCount: 1),
+            2 => FirewallCapabilityResponse(),
+            3 => OperationalHttpResponse(),
+            4 => OperationalFirewallResponse(),
+            5 => RumSitesPageResponse(includeMatch: false, totalPages: 2, itemCount: 50),
+            6 => RumSitesPageResponse(includeMatch: true, totalPages: 2, itemCount: 1),
             _ => throw new InvalidOperationException("Unexpected request.")
         });
         using var client = new HttpClient(handler);
@@ -190,9 +246,9 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: true));
 
         Assert.True(result.Rum.Configured);
-        Assert.Equal(6, result.RequestCount);
-        Assert.Contains("page=1", handler.Requests[4].Uri.Query, StringComparison.Ordinal);
-        Assert.Contains("page=2", handler.Requests[5].Uri.Query, StringComparison.Ordinal);
+        Assert.Equal(7, result.RequestCount);
+        Assert.Contains("page=1", handler.Requests[5].Uri.Query, StringComparison.Ordinal);
+        Assert.Contains("page=2", handler.Requests[6].Uri.Query, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -202,9 +258,10 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         {
             0 => ZoneResponse("officeimo.com"),
             1 => CapabilityResponse(),
-            2 => OperationalHttpResponse(),
-            3 => OperationalFirewallResponse(),
-            4 => RumSitesForHostsResponse(),
+            2 => FirewallCapabilityResponse(),
+            3 => OperationalHttpResponse(),
+            4 => OperationalFirewallResponse(),
+            5 => RumSitesForHostsResponse(),
             _ => throw new InvalidOperationException("Unexpected request.")
         });
         using var client = new HttpClient(handler);
@@ -223,9 +280,10 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         {
             0 => ZoneResponse("officeimo.com"),
             1 => CapabilityResponse(),
-            2 => OperationalHttpResponse(),
-            3 => OperationalFirewallResponse(),
-            4 => throw new HttpRequestException("Synthetic RUM transport failure."),
+            2 => FirewallCapabilityResponse(),
+            3 => OperationalHttpResponse(),
+            4 => OperationalFirewallResponse(),
+            5 => throw new HttpRequestException("Synthetic RUM transport failure."),
             _ => throw new InvalidOperationException("Unexpected request.")
         });
         using var client = new HttpClient(handler);
@@ -233,7 +291,7 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: true));
 
         Assert.Equal("request-failed", result.Rum.ErrorCode);
-        Assert.Equal(5, result.RequestCount);
+        Assert.Equal(6, result.RequestCount);
     }
 
     [Fact]
@@ -242,9 +300,10 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         var handler = new ScriptedHandler((_, index) => index switch
         {
             0 => ZoneResponse("officeimo.com"),
-            1 => CapabilityResponse(maxPageSize: 1000, firewallMaxPageSize: 25),
-            2 => OperationalHttpResponse(),
-            3 => OperationalFirewallResponse(),
+            1 => CapabilityResponse(maxPageSize: 1000),
+            2 => FirewallCapabilityResponse(maxPageSize: 25),
+            3 => OperationalHttpResponse(),
+            4 => OperationalFirewallResponse(),
             _ => throw new InvalidOperationException("Unexpected request.")
         });
         using var client = new HttpClient(handler);
@@ -252,8 +311,8 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: false));
 
         Assert.True(result.Firewall.Success);
-        Assert.Contains("\"limit\":25", handler.Requests[3].Body, StringComparison.Ordinal);
-        Assert.Contains("\"limit\":1000", handler.Requests[2].Body, StringComparison.Ordinal);
+        Assert.Contains("\"limit\":25", handler.Requests[4].Body, StringComparison.Ordinal);
+        Assert.Contains("\"limit\":1000", handler.Requests[3].Body, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -263,9 +322,10 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         {
             0 => ZoneResponse("officeimo.com"),
             1 => CapabilityResponse(),
-            2 => OperationalHttpResponse(),
-            3 => OperationalFirewallResponse(),
-            4 => JsonResponse(new
+            2 => FirewallCapabilityResponse(),
+            3 => OperationalHttpResponse(),
+            4 => OperationalFirewallResponse(),
+            5 => JsonResponse(new
             {
                 success = true,
                 errors = Array.Empty<object>(),
@@ -288,8 +348,9 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         {
             0 => ZoneResponse("officeimo.com", "ffffffffffffffffffffffffffffffff"),
             1 => CapabilityResponse(),
-            2 => OperationalHttpResponse(),
-            3 => OperationalFirewallResponse(),
+            2 => FirewallCapabilityResponse(),
+            3 => OperationalHttpResponse(),
+            4 => OperationalFirewallResponse(),
             _ => throw new InvalidOperationException("RUM lookup must not run for a mismatched account.")
         });
         using var client = new HttpClient(handler);
@@ -297,7 +358,7 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: true));
 
         Assert.Equal("account-zone-mismatch", result.Rum.ErrorCode);
-        Assert.Equal(4, result.RequestCount);
+        Assert.Equal(5, result.RequestCount);
     }
 
     [Theory]
@@ -309,8 +370,9 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         {
             0 => ZoneResponse("officeimo.com"),
             1 => CapabilityResponse(),
-            2 => OperationalHttpResponse(HttpOperationRow(hour, "hit", 200, 1, 100, 1)),
-            3 => OperationalFirewallResponse(),
+            2 => FirewallCapabilityResponse(),
+            3 => OperationalHttpResponse(HttpOperationRow(hour, "hit", 200, 1, 100, 1)),
+            4 => OperationalFirewallResponse(),
             _ => throw new InvalidOperationException("Unexpected request.")
         });
         using var client = new HttpClient(handler);
@@ -331,8 +393,9 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         {
             0 => ZoneResponse("officeimo.com"),
             1 => CapabilityResponse(),
-            2 => OperationalHttpResponse(),
-            3 => OperationalFirewallResponse(FirewallOperationRow(hour, "block", 1, 1)),
+            2 => FirewallCapabilityResponse(),
+            3 => OperationalHttpResponse(),
+            4 => OperationalFirewallResponse(FirewallOperationRow(hour, "block", 1, 1)),
             _ => throw new InvalidOperationException("Unexpected request.")
         });
         using var client = new HttpClient(handler);
@@ -357,8 +420,9 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         {
             0 => ZoneResponse("officeimo.com"),
             1 => CapabilityResponse(),
-            2 => OperationalHttpResponse(HttpOperationRow("2026-08-10T09:00:00Z", "hit", 200, 10, 1000, 1)),
-            3 => OperationalFirewallResponse(FirewallOperationRow("2026-08-10T09:00:00Z", "block", 4, 1), invalidRow),
+            2 => FirewallCapabilityResponse(),
+            3 => OperationalHttpResponse(HttpOperationRow("2026-08-10T09:00:00Z", "hit", 200, 10, 1000, 1)),
+            4 => OperationalFirewallResponse(FirewallOperationRow("2026-08-10T09:00:00Z", "block", 4, 1), invalidRow),
             _ => throw new InvalidOperationException("Unexpected request.")
         });
         using var client = new HttpClient(handler);
@@ -386,8 +450,9 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         {
             0 => ZoneResponse("officeimo.com"),
             1 => CapabilityResponse(),
-            2 => OperationalHttpResponse(missingCacheStatus),
-            3 => OperationalFirewallResponse(),
+            2 => FirewallCapabilityResponse(),
+            3 => OperationalHttpResponse(missingCacheStatus),
+            4 => OperationalFirewallResponse(),
             _ => throw new InvalidOperationException("Unexpected request.")
         });
         using var client = new HttpClient(handler);
@@ -397,6 +462,72 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         Assert.False(result.Success);
         Assert.Equal("invalid-response", result.Http.ErrorCode);
         Assert.Empty(result.Hours);
+    }
+
+    [Fact]
+    public async Task CollectOperations_RejectsDuplicateHttpDimensionsWithoutPartialEvidence()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(),
+            2 => FirewallCapabilityResponse(),
+            3 => OperationalHttpResponse(
+                HttpOperationRow("2026-08-10T09:00:00Z", "hit", 200, 1, 100, 1),
+                HttpOperationRow("2026-08-10T09:00:00Z", " HIT ", 200, 2, 200, 1)),
+            4 => OperationalFirewallResponse(),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: false));
+
+        Assert.False(result.Http.Success);
+        Assert.Equal("invalid-response", result.Http.ErrorCode);
+        Assert.Empty(result.Hours);
+    }
+
+    [Fact]
+    public async Task CollectOperations_RejectsDuplicateFirewallDimensionsWithoutPartialEvidence()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(),
+            2 => FirewallCapabilityResponse(),
+            3 => OperationalHttpResponse(),
+            4 => OperationalFirewallResponse(
+                FirewallOperationRow("2026-08-10T09:00:00Z", "block", 1, 1),
+                FirewallOperationRow("2026-08-10T09:00:00Z", " BLOCK ", 2, 1)),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: false));
+
+        Assert.False(result.Firewall.Success);
+        Assert.Equal("invalid-response", result.Firewall.ErrorCode);
+        Assert.Empty(result.Hours);
+    }
+
+    [Fact]
+    public async Task CollectOperations_RecordsCompletionTimeAfterProviderWork()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(),
+            2 => FirewallCapabilityResponse(),
+            3 => OperationalHttpResponse(),
+            4 => OperationalFirewallResponse(),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+        var clock = new AdvancingTimeProvider(CompletionTime, TimeSpan.FromMinutes(1));
+
+        var result = await CreateCollector(client, clock).CollectOperationsAsync(CreateOperationalOptions(includeAccount: false));
+
+        Assert.Equal(CompletionTime.AddMinutes(2), result.CollectedAtUtc);
     }
 
     [Fact]

--- a/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Operations.cs
+++ b/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.Operations.cs
@@ -72,6 +72,148 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         Assert.False(result.Rum.Requested);
     }
 
+    [Fact]
+    public async Task CollectOperations_PartitionsByProbeDurationAndUsesPageLimit()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(maxPageSize: 7, maxDuration: 3600),
+            2 or 3 => OperationalHttpResponse(),
+            4 or 5 => OperationalFirewallResponse(),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+        var options = CreateOperationalOptions(includeAccount: false);
+        options.SiteBaseUrl = "https://officeimo.com/products/powerforge/";
+
+        var result = await CreateCollector(client).CollectOperationsAsync(options);
+
+        Assert.True(result.Success);
+        Assert.Equal(6, result.RequestCount);
+        Assert.Contains("\"limit\":7", handler.Requests[2].Body, StringComparison.Ordinal);
+        Assert.Contains("2026-08-10T09:00:00Z", handler.Requests[2].Body, StringComparison.Ordinal);
+        Assert.Contains("2026-08-10T10:00:00Z", handler.Requests[3].Body, StringComparison.Ordinal);
+        Assert.Contains("clientRequestPath", handler.Requests[4].Body, StringComparison.Ordinal);
+        Assert.Contains("/products/powerforge", handler.Requests[4].Body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CollectOperations_FailsClosedWhenProviderPageLimitIsReached()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(maxPageSize: 1),
+            2 => OperationalHttpResponse(HttpOperationRow("2026-08-10T09:00:00Z", "hit", 200, 10, 1000, 1)),
+            3 => OperationalFirewallResponse(),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: false));
+
+        Assert.False(result.Success);
+        Assert.Equal("row-limit-reached", result.Http.ErrorCode);
+        Assert.Empty(result.Hours);
+        Assert.Contains("\"limit\":1", handler.Requests[2].Body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CollectOperations_TraversesRumPagesUntilZoneIsFound()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(),
+            2 => OperationalHttpResponse(),
+            3 => OperationalFirewallResponse(),
+            4 => RumSitesPageResponse(includeMatch: false, totalPages: 2, itemCount: 50),
+            5 => RumSitesPageResponse(includeMatch: true, totalPages: 2, itemCount: 1),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: true));
+
+        Assert.True(result.Rum.Configured);
+        Assert.Equal(6, result.RequestCount);
+        Assert.Contains("page=1", handler.Requests[4].Uri.Query, StringComparison.Ordinal);
+        Assert.Contains("page=2", handler.Requests[5].Uri.Query, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CollectOperations_DiscardsPartialFirewallRowsWhenDatasetIsInvalid()
+    {
+        var invalidRow = new
+        {
+            count = 1UL,
+            avg = new { sampleInterval = 1d },
+            dimensions = new { datetimeHour = "2026-08-10T09:00:00Z", action = (string?)null }
+        };
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(),
+            2 => OperationalHttpResponse(HttpOperationRow("2026-08-10T09:00:00Z", "hit", 200, 10, 1000, 1)),
+            3 => OperationalFirewallResponse(FirewallOperationRow("2026-08-10T09:00:00Z", "block", 4, 1), invalidRow),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: false));
+
+        Assert.True(result.Success);
+        Assert.False(result.Firewall.Success);
+        Assert.Single(result.Hours);
+        Assert.Equal(0, result.Hours[0].FirewallEvents);
+        Assert.Equal(0, result.Hours[0].FirewallMitigated);
+    }
+
+    [Fact]
+    public async Task CollectOperations_RejectsRowsMissingRequestedCategoryDimensions()
+    {
+        var missingCacheStatus = new
+        {
+            count = 1UL,
+            avg = new { sampleInterval = 1d },
+            sum = new { edgeResponseBytes = 100UL },
+            dimensions = new { datetimeHour = "2026-08-10T09:00:00Z", cacheStatus = (string?)null, edgeResponseStatus = 200 }
+        };
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(),
+            2 => OperationalHttpResponse(missingCacheStatus),
+            3 => OperationalFirewallResponse(),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: false));
+
+        Assert.False(result.Success);
+        Assert.Equal("invalid-response", result.Http.ErrorCode);
+        Assert.Empty(result.Hours);
+    }
+
+    [Fact]
+    public async Task CollectOperations_MarksRumNotAttemptedWhenProbeFails()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => new HttpResponseMessage(HttpStatusCode.Forbidden),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+
+        var result = await CreateCollector(client).CollectOperationsAsync(CreateOperationalOptions(includeAccount: true));
+
+        Assert.False(result.Success);
+        Assert.True(result.Rum.Requested);
+        Assert.Equal("not-attempted", result.Rum.ErrorCode);
+    }
+
     private static CloudflareOperationalCollectionOptions CreateOperationalOptions(bool includeAccount) => new()
     {
         SiteId = "officeimo",
@@ -115,4 +257,26 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         errors = Array.Empty<object>(),
         result = new[] { new { auto_install = autoInstall, ruleset = new { enabled, zone_tag = ZoneId } } }
     });
+
+    private static HttpResponseMessage RumSitesPageResponse(bool includeMatch, int totalPages, int itemCount)
+    {
+        var rows = Enumerable.Range(0, itemCount)
+            .Select(index => new
+            {
+                auto_install = includeMatch && index == 0,
+                ruleset = new
+                {
+                    enabled = includeMatch && index == 0,
+                    zone_tag = includeMatch && index == 0 ? ZoneId : index.ToString("x32")
+                }
+            })
+            .ToArray();
+        return JsonResponse(new
+        {
+            success = true,
+            errors = Array.Empty<object>(),
+            result = rows,
+            result_info = new { total_pages = totalPages }
+        });
+    }
 }

--- a/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.cs
+++ b/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.cs
@@ -100,6 +100,26 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
     }
 
     [Fact]
+    public async Task Collect_ResolvesOneCredentialForProbeAndPartitions()
+    {
+        var handler = new ScriptedHandler((_, index) => index switch
+        {
+            0 => ZoneResponse("officeimo.com"),
+            1 => CapabilityResponse(),
+            2 => TrafficResponse(),
+            _ => throw new InvalidOperationException("Unexpected request.")
+        });
+        using var client = new HttpClient(handler);
+        var tokenProvider = new SingleUseTokenProvider();
+        var collector = new CloudflareAnalyticsCollector(client, tokenProvider, timeProvider: new FixedTimeProvider(CompletionTime));
+
+        var result = await collector.CollectAsync(CreateOptions());
+
+        Assert.True(result.Success);
+        Assert.Equal(1, tokenProvider.CallCount);
+    }
+
+    [Fact]
     public async Task Collect_RejectsRowsFromAnotherUrlScheme()
     {
         var handler = new ScriptedHandler((_, index) => index switch

--- a/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.cs
+++ b/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.cs
@@ -11,6 +11,7 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
 {
     private static readonly DateTimeOffset CompletionTime = new(2026, 8, 10, 12, 34, 56, TimeSpan.Zero);
     private const string ZoneId = "abcdef0123456789abcdef0123456789";
+    private const string TestAccountId = "0123456789abcdef0123456789abcdef";
 
     [Fact]
     public async Task Probe_DiscoversPlanSpecificDatasetLimitsWithoutExposingTheToken()

--- a/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.cs
+++ b/PowerForge.Tests/WebCloudflareAnalyticsCollectorTests.cs
@@ -86,6 +86,9 @@ public sealed partial class WebCloudflareAnalyticsCollectorTests
         Assert.Equal([new DateOnly(2026, 8, 1), new DateOnly(2026, 8, 2)], normalized.CollectionCoverage.CompletedDates);
         var sampled = Assert.Single(normalized.Observations, value => value.Date == new DateOnly(2026, 8, 1));
         Assert.Equal("officeimo.com", sampled.Host);
+        Assert.Equal(200, sampled.Requests);
+        Assert.Equal(50, sampled.Visits);
+        Assert.Equal(10_000, sampled.EdgeResponseBytes);
         Assert.Equal(2d, sampled.SampleInterval);
         Assert.All(handler.Requests.Skip(2), request =>
         {

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.Operations.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.Operations.cs
@@ -155,8 +155,8 @@ public sealed partial class CloudflareAnalyticsCollector
                 using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
                 request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 requestCount++;
+                using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 if (!response.IsSuccessStatusCode)
                     return (FailedRum(MapStatus(response.StatusCode), $"Cloudflare RUM site lookup returned HTTP {(int)response.StatusCode}."), requestCount);
                 var envelope = await response.Content.ReadFromJsonAsync<CloudflareRumSitesEnvelope>(JsonOptions, cancellationToken).ConfigureAwait(false);
@@ -329,8 +329,8 @@ public sealed partial class CloudflareAnalyticsCollector
         return bucket;
     }
 
-    private static bool IsCached(string? status) => status?.Trim().ToLowerInvariant() is "hit" or "revalidated" or "updating";
-    private static bool IsMitigated(string? action) => action?.Trim().ToLowerInvariant() is "block" or "challenge" or "jschallenge" or "managed_challenge";
+    private static bool IsCached(string? status) => status?.Trim().ToLowerInvariant() is "hit" or "revalidated" or "stale" or "updating";
+    private static bool IsMitigated(string? action) => action?.Trim().ToLowerInvariant() is "block" or "challenge" or "jschallenge" or "managedchallenge" or "managed_challenge";
     private static bool IsValidSampleInterval(double value) => double.IsFinite(value) && value >= 1d;
     private static DateTimeOffset NormalizeHour(DateTimeOffset value) => new(value.UtcDateTime.Year, value.UtcDateTime.Month, value.UtcDateTime.Day, value.UtcDateTime.Hour, 0, 0, TimeSpan.Zero);
     private static string FormatUtc(DateTimeOffset value) => value.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.Operations.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.Operations.cs
@@ -29,6 +29,16 @@ public sealed partial class CloudflareAnalyticsCollector
             return result;
         }
 
+        if (probe.NotOlderThanSeconds is > 0 &&
+            options.FromUtc < _timeProvider.GetUtcNow().Subtract(TimeSpan.FromSeconds(probe.NotOlderThanSeconds.Value)))
+        {
+            result.Http = FailedCapability("retention-boundary", "The requested Cloudflare operational range starts before the provider-reported retention boundary.");
+            result.Firewall = FailedCapability("not-attempted", "Firewall collection was not attempted because the requested range is outside provider retention.");
+            if (result.Rum.Requested)
+                result.Rum = FailedRum("not-attempted", "RUM inspection was not attempted because the requested range is outside provider retention.");
+            return result;
+        }
+
         string token;
         try { token = await _tokenProvider.GetTokenAsync(cancellationToken).ConfigureAwait(false); }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
@@ -53,7 +63,12 @@ public sealed partial class CloudflareAnalyticsCollector
 
         if (!string.IsNullOrWhiteSpace(options.AccountId))
         {
-            var rum = await InspectRumSiteAsync(options.AccountId!, options.ZoneId, token, cancellationToken).ConfigureAwait(false);
+            var rum = await InspectRumSiteAsync(
+                options.AccountId!,
+                options.ZoneId,
+                NormalizeSiteHost(options.SiteBaseUrl),
+                token,
+                cancellationToken).ConfigureAwait(false);
             result.Rum = rum.State;
             result.RequestCount += rum.RequestCount;
         }
@@ -124,7 +139,12 @@ public sealed partial class CloudflareAnalyticsCollector
         return OperationalPartitionResult.Succeeded(buckets, requestCount);
     }
 
-    private async Task<(CloudflareRumSiteState State, int RequestCount)> InspectRumSiteAsync(string accountId, string zoneId, string token, CancellationToken cancellationToken)
+    private async Task<(CloudflareRumSiteState State, int RequestCount)> InspectRumSiteAsync(
+        string accountId,
+        string zoneId,
+        string siteHost,
+        string token,
+        CancellationToken cancellationToken)
     {
         var requestCount = 0;
         try
@@ -142,7 +162,11 @@ public sealed partial class CloudflareAnalyticsCollector
                 var envelope = await response.Content.ReadFromJsonAsync<CloudflareRumSitesEnvelope>(JsonOptions, cancellationToken).ConfigureAwait(false);
                 if (envelope?.Success != true || envelope.Errors.Length > 0)
                     return (FailedRum("rum-lookup-error", "Cloudflare RUM site lookup returned errors."), requestCount);
-                var site = envelope.Result.FirstOrDefault(value => string.Equals(value.Ruleset?.ZoneTag, zoneId, StringComparison.OrdinalIgnoreCase));
+                var site = envelope.Result.FirstOrDefault(value =>
+                    string.Equals(value.Ruleset?.ZoneTag, zoneId, StringComparison.OrdinalIgnoreCase) &&
+                    value.Host is not null &&
+                    TryNormalizeHostDimension(value.Host, out var rumHost) &&
+                    string.Equals(rumHost, siteHost, StringComparison.Ordinal));
                 if (site is not null)
                     return (new CloudflareRumSiteState { Requested = true, Configured = true, Enabled = site.Ruleset?.Enabled == true, AutoInstall = site.AutoInstall == true }, requestCount);
 
@@ -225,7 +249,9 @@ public sealed partial class CloudflareAnalyticsCollector
         CloudflareOperationalCollectionOptions options,
         CloudflareAnalyticsCapabilityProbeResult probe)
     {
-        var duration = TimeSpan.FromSeconds(probe.MaxDurationSeconds ?? throw new InvalidOperationException("Cloudflare capability probe omitted the maximum duration."));
+        var duration = probe.MaxDurationSeconds is > 0
+            ? TimeSpan.FromSeconds(probe.MaxDurationSeconds.Value)
+            : TimeSpan.FromDays(1);
         for (var start = options.FromUtc; start < options.ThroughUtc;)
         {
             var candidateEnd = start + duration;

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.Operations.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.Operations.cs
@@ -17,7 +17,8 @@ public sealed partial class CloudflareAnalyticsCollector
         var result = new CloudflareOperationalCollectionResult
         {
             SiteId = options.SiteId,
-            CollectedAtUtc = _timeProvider.GetUtcNow(),
+            FromUtc = options.FromUtc,
+            ThroughUtc = options.ThroughUtc,
             RequestCount = probe.RequestCount,
             Rum = new CloudflareRumSiteState { Requested = !string.IsNullOrWhiteSpace(options.AccountId) }
         };
@@ -27,7 +28,7 @@ public sealed partial class CloudflareAnalyticsCollector
             result.Firewall = FailedCapability("not-attempted", "Firewall collection was not attempted because zone validation failed.");
             if (result.Rum.Requested)
                 result.Rum = FailedRum("not-attempted", "RUM inspection was not attempted because zone validation failed.");
-            return result;
+            return CompleteOperationalResult(result);
         }
 
         string token;
@@ -39,10 +40,12 @@ public sealed partial class CloudflareAnalyticsCollector
             result.Firewall = FailedCapability("credential-unavailable", "Cloudflare analytics credential resolution failed.");
             if (result.Rum.Requested)
                 result.Rum = FailedRum("credential-unavailable", "Cloudflare RUM credential resolution failed.");
-            return result;
+            return CompleteOperationalResult(result);
         }
 
         var now = _timeProvider.GetUtcNow();
+        var firewallProbe = await ProbeFirewallCapabilityAsync(options.ZoneId, token, cancellationToken).ConfigureAwait(false);
+        result.RequestCount += firewallProbe.RequestCount;
         var http = IsOutsideRetention(options.FromUtc, now, probe.NotOlderThanSeconds)
             ? OperationalPartitionResult.Failed("retention-boundary", "The requested Cloudflare HTTP operational range starts before the provider-reported retention boundary.", 0)
             : await CollectHttpOperationsAsync(options, probe, token, cancellationToken).ConfigureAwait(false);
@@ -50,16 +53,12 @@ public sealed partial class CloudflareAnalyticsCollector
         result.Http = http.State;
 
         OperationalPartitionResult firewall;
-        if (!probe.FirewallDatasetEnabled)
-            firewall = OperationalPartitionResult.Failed("dataset-unavailable", "Cloudflare firewallEventsAdaptiveGroups is not enabled for this zone.", 0);
-        else if (probe.FirewallMaxPageSize <= 0)
-            firewall = OperationalPartitionResult.Failed("invalid-response", "Cloudflare did not report a usable firewall analytics page size.", 0);
-        else if (probe.FirewallMaxDurationSeconds is <= 0 || probe.FirewallNotOlderThanSeconds is <= 0)
-            firewall = OperationalPartitionResult.Failed("invalid-response", "Cloudflare reported an invalid firewall duration or retention boundary.", 0);
-        else if (IsOutsideRetention(options.FromUtc, now, probe.FirewallNotOlderThanSeconds))
+        if (!firewallProbe.Success)
+            firewall = OperationalPartitionResult.Failed(firewallProbe.ErrorCode!, firewallProbe.ErrorMessage!, 0);
+        else if (IsOutsideRetention(options.FromUtc, now, firewallProbe.NotOlderThanSeconds))
             firewall = OperationalPartitionResult.Failed("retention-boundary", "The requested Cloudflare firewall operational range starts before the provider-reported retention boundary.", 0);
         else
-            firewall = await CollectFirewallOperationsAsync(options, probe, token, cancellationToken).ConfigureAwait(false);
+            firewall = await CollectFirewallOperationsAsync(options, firewallProbe, token, cancellationToken).ConfigureAwait(false);
         result.RequestCount += firewall.RequestCount;
         result.Firewall = firewall.State;
         result.Hours = CombineBuckets(http.Buckets, firewall.Buckets);
@@ -70,7 +69,7 @@ public sealed partial class CloudflareAnalyticsCollector
         {
             if (result.Rum.Requested)
                 result.Rum = FailedRum("not-attempted", "RUM inspection was not attempted because the requested operational range is outside provider retention.");
-            return result;
+            return CompleteOperationalResult(result);
         }
 
         if (!string.IsNullOrWhiteSpace(options.AccountId))
@@ -95,7 +94,40 @@ public sealed partial class CloudflareAnalyticsCollector
                 result.RequestCount += rum.RequestCount;
             }
         }
+        return CompleteOperationalResult(result);
+    }
+
+    private CloudflareOperationalCollectionResult CompleteOperationalResult(CloudflareOperationalCollectionResult result)
+    {
+        result.CollectedAtUtc = _timeProvider.GetUtcNow();
         return result;
+    }
+
+    private async Task<FirewallCapabilityProbeResult> ProbeFirewallCapabilityAsync(
+        string zoneId,
+        string token,
+        CancellationToken cancellationToken)
+    {
+        var response = await SendAsync<CloudflareCapabilityData>(FirewallCapabilityQuery, new { zoneTag = zoneId.ToLowerInvariant() }, token, cancellationToken)
+            .ConfigureAwait(false);
+        if (!response.Success)
+            return FirewallCapabilityProbeResult.Failed(response.ErrorCode!, response.ErrorMessage!);
+        var zones = response.Value?.Viewer?.Zones ?? Array.Empty<CloudflareCapabilityZone>();
+        if (zones.Length != 1)
+            return FirewallCapabilityProbeResult.Failed("zone-not-visible", "The configured Cloudflare zone is not visible to this credential.");
+        if (zones[0] is null)
+            return FirewallCapabilityProbeResult.Failed("invalid-response", "Cloudflare returned an invalid firewall capability response.");
+        var settings = zones[0].Settings?.FirewallEventsAdaptiveGroups;
+        if (settings?.Enabled != true)
+            return FirewallCapabilityProbeResult.Failed("dataset-unavailable", "Cloudflare firewallEventsAdaptiveGroups is not enabled for this zone.");
+        if (settings.MaxPageSize is null or <= 0)
+            return FirewallCapabilityProbeResult.Failed("invalid-response", "Cloudflare did not report a usable firewall analytics page size.");
+        if (settings.MaxDuration is <= 0 || settings.NotOlderThan is <= 0)
+            return FirewallCapabilityProbeResult.Failed("invalid-response", "Cloudflare reported an invalid firewall duration or retention boundary.");
+        return FirewallCapabilityProbeResult.Succeeded(
+            Math.Min(settings.MaxPageSize.Value, ClientMaximumRowsPerDay),
+            settings.MaxDuration,
+            settings.NotOlderThan);
     }
 
     private async Task<OperationalPartitionResult> CollectHttpOperationsAsync(
@@ -104,9 +136,11 @@ public sealed partial class CloudflareAnalyticsCollector
         string token,
         CancellationToken cancellationToken)
     {
+        if (!TryGetOperationalPartitionDuration(probe.MaxDurationSeconds, out var duration))
+            return OperationalPartitionResult.Failed("duration-boundary", "The provider-reported HTTP query duration cannot cover a complete UTC hourly partition.", 0);
         var buckets = new Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation>();
         var requestCount = 0;
-        foreach (var partition in BuildOperationalPartitions(options, probe.MaxDurationSeconds))
+        foreach (var partition in BuildOperationalPartitions(options, duration))
         {
             var response = await SendAsync<CloudflareOperationalData>(HttpOperationalQuery, new
             {
@@ -132,18 +166,20 @@ public sealed partial class CloudflareAnalyticsCollector
 
     private async Task<OperationalPartitionResult> CollectFirewallOperationsAsync(
         CloudflareOperationalCollectionOptions options,
-        CloudflareAnalyticsCapabilityProbeResult probe,
+        FirewallCapabilityProbeResult probe,
         string token,
         CancellationToken cancellationToken)
     {
+        if (!TryGetOperationalPartitionDuration(probe.MaxDurationSeconds, out var duration))
+            return OperationalPartitionResult.Failed("duration-boundary", "The provider-reported firewall query duration cannot cover a complete UTC hourly partition.", 0);
         var buckets = new Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation>();
         var requestCount = 0;
-        foreach (var partition in BuildOperationalPartitions(options, probe.FirewallMaxDurationSeconds))
+        foreach (var partition in BuildOperationalPartitions(options, duration))
         {
             var response = await SendAsync<CloudflareOperationalData>(FirewallOperationalQuery, new
             {
                 zoneTag = options.ZoneId.ToLowerInvariant(),
-                limit = probe.FirewallMaxPageSize,
+                limit = probe.MaxPageSize,
                 filter = BuildFirewallFilter(options.SiteBaseUrl, partition.FromUtc, partition.ThroughUtc)
             }, token, cancellationToken).ConfigureAwait(false);
             requestCount++;
@@ -151,7 +187,7 @@ public sealed partial class CloudflareAnalyticsCollector
                 return OperationalPartitionResult.Failed(code!, message!, requestCount);
             if (zone!.Firewall is not { } rows)
                 return OperationalPartitionResult.Failed("invalid-response", "Cloudflare returned no firewall dataset.", requestCount);
-            if (rows.Length >= probe.FirewallMaxPageSize)
+            if (rows.Length >= probe.MaxPageSize)
                 return OperationalPartitionResult.Failed("row-limit-reached", "Cloudflare reached the firewall operational row limit, so the requested range cannot be marked complete.", requestCount);
             var partitionBuckets = new Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation>();
             if (!TryMapFirewall(rows, partition.FromUtc, partition.ThroughUtc, partitionBuckets, out var error))
@@ -223,6 +259,7 @@ public sealed partial class CloudflareAnalyticsCollector
     {
         error = null;
         if (rows is null) { error = "Cloudflare returned no HTTP operational dataset."; return false; }
+        var dimensions = new HashSet<(DateTimeOffset Hour, string CacheStatus, int EdgeResponseStatus)>();
         foreach (var row in rows)
         {
             if (row?.Count is null || row.Average?.SampleInterval is null || row.Sum?.EdgeResponseBytes is null ||
@@ -233,6 +270,9 @@ public sealed partial class CloudflareAnalyticsCollector
             { error = "Cloudflare returned an invalid HTTP operational row."; return false; }
             if (!TryValidateOperationalHour(row.Dimensions.HourUtc.Value, fromUtc, throughUtc, out var hour))
             { error = "Cloudflare returned an HTTP operational row outside the requested hourly window."; return false; }
+            var dimension = (hour, row.Dimensions.CacheStatus.Trim().ToLowerInvariant(), row.Dimensions.EdgeResponseStatus.Value);
+            if (!dimensions.Add(dimension))
+            { error = "Cloudflare returned duplicate HTTP operational dimensions."; return false; }
             var bucket = GetBucket(buckets, hour);
             try
             {
@@ -261,6 +301,7 @@ public sealed partial class CloudflareAnalyticsCollector
     {
         error = null;
         if (rows is null) { error = "Cloudflare returned no firewall dataset."; return false; }
+        var dimensions = new HashSet<(DateTimeOffset Hour, string Action)>();
         foreach (var row in rows)
         {
             if (row?.Count is null || row.Average?.SampleInterval is null || row.Dimensions?.HourUtc is null || string.IsNullOrWhiteSpace(row.Dimensions.Action) ||
@@ -269,6 +310,9 @@ public sealed partial class CloudflareAnalyticsCollector
             { error = "Cloudflare returned an invalid firewall row."; return false; }
             if (!TryValidateOperationalHour(row.Dimensions.HourUtc.Value, fromUtc, throughUtc, out var hour))
             { error = "Cloudflare returned a firewall row outside the requested hourly window."; return false; }
+            var dimension = (hour, row.Dimensions.Action.Trim().ToLowerInvariant());
+            if (!dimensions.Add(dimension))
+            { error = "Cloudflare returned duplicate firewall operational dimensions."; return false; }
             var bucket = GetBucket(buckets, hour);
             try
             {
@@ -287,11 +331,8 @@ public sealed partial class CloudflareAnalyticsCollector
 
     private static IEnumerable<(DateTimeOffset FromUtc, DateTimeOffset ThroughUtc)> BuildOperationalPartitions(
         CloudflareOperationalCollectionOptions options,
-        int? maxDurationSeconds)
+        TimeSpan duration)
     {
-        var duration = maxDurationSeconds is > 0
-            ? TimeSpan.FromSeconds(maxDurationSeconds.Value)
-            : TimeSpan.FromDays(1);
         for (var start = options.FromUtc; start < options.ThroughUtc;)
         {
             var candidateEnd = start + duration;
@@ -299,6 +340,19 @@ public sealed partial class CloudflareAnalyticsCollector
             yield return (start, end);
             start = end;
         }
+    }
+
+    private static bool TryGetOperationalPartitionDuration(int? maxDurationSeconds, out TimeSpan duration)
+    {
+        if (maxDurationSeconds is > 0 and < 3_600)
+        {
+            duration = default;
+            return false;
+        }
+        duration = maxDurationSeconds is > 0
+            ? TimeSpan.FromHours(Math.Floor(maxDurationSeconds.Value / 3_600d))
+            : TimeSpan.FromDays(1);
+        return true;
     }
 
     private static Dictionary<string, object?> BuildFirewallFilter(string siteBaseUrl, DateTimeOffset fromUtc, DateTimeOffset throughUtc)
@@ -444,6 +498,31 @@ public sealed partial class CloudflareAnalyticsCollector
           } }
         }
         """;
+
+    private const string FirewallCapabilityQuery = """
+        query PowerForgeCloudflareFirewallCapabilities($zoneTag: string) {
+          viewer { zones(filter: { zoneTag: $zoneTag }) {
+            settings { firewallEventsAdaptiveGroups { enabled maxPageSize maxDuration notOlderThan } }
+          } }
+        }
+        """;
+
+    private sealed record FirewallCapabilityProbeResult(
+        bool Success,
+        int MaxPageSize,
+        int? MaxDurationSeconds,
+        int? NotOlderThanSeconds,
+        string? ErrorCode,
+        string? ErrorMessage)
+    {
+        public int RequestCount => 1;
+
+        public static FirewallCapabilityProbeResult Succeeded(int maxPageSize, int? maxDurationSeconds, int? notOlderThanSeconds) =>
+            new(true, maxPageSize, maxDurationSeconds, notOlderThanSeconds, null, null);
+
+        public static FirewallCapabilityProbeResult Failed(string code, string message) =>
+            new(false, 0, null, null, code, message);
+    }
 
     private sealed class OperationalPartitionResult
     {

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.Operations.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.Operations.cs
@@ -64,14 +64,6 @@ public sealed partial class CloudflareAnalyticsCollector
         result.Hours = CombineBuckets(http.Buckets, firewall.Buckets);
         result.Success = result.Http.Success;
 
-        if (string.Equals(result.Http.ErrorCode, "retention-boundary", StringComparison.Ordinal) &&
-            string.Equals(result.Firewall.ErrorCode, "retention-boundary", StringComparison.Ordinal))
-        {
-            if (result.Rum.Requested)
-                result.Rum = FailedRum("not-attempted", "RUM inspection was not attempted because the requested operational range is outside provider retention.");
-            return CompleteOperationalResult(result);
-        }
-
         if (!string.IsNullOrWhiteSpace(options.AccountId))
         {
             if (string.IsNullOrWhiteSpace(probe.ZoneAccountId))
@@ -266,7 +258,8 @@ public sealed partial class CloudflareAnalyticsCollector
                 row.Sum.EdgeResponseBytes.Value > long.MaxValue || row.Dimensions?.HourUtc is null ||
                 row.Dimensions.EdgeResponseStatus is null || string.IsNullOrWhiteSpace(row.Dimensions.CacheStatus) ||
                 !IsValidSampleInterval(row.Average.SampleInterval.Value) ||
-                !TryScaleSampledCount(row.Count.Value, row.Average.SampleInterval.Value, out var count))
+                !TryScaleSampledCount(row.Count.Value, row.Average.SampleInterval.Value, out var count) ||
+                !TryScaleSampledCount(row.Sum.EdgeResponseBytes.Value, row.Average.SampleInterval.Value, out var edgeResponseBytes))
             { error = "Cloudflare returned an invalid HTTP operational row."; return false; }
             if (!TryValidateOperationalHour(row.Dimensions.HourUtc.Value, fromUtc, throughUtc, out var hour))
             { error = "Cloudflare returned an HTTP operational row outside the requested hourly window."; return false; }
@@ -277,7 +270,7 @@ public sealed partial class CloudflareAnalyticsCollector
             try
             {
                 bucket.Requests = checked(bucket.Requests + count);
-                bucket.EdgeResponseBytes = checked(bucket.EdgeResponseBytes + (long)row.Sum.EdgeResponseBytes.Value);
+                bucket.EdgeResponseBytes = checked(bucket.EdgeResponseBytes + edgeResponseBytes);
                 bucket.MaximumSampleInterval = Math.Max(bucket.MaximumSampleInterval, row.Average.SampleInterval.Value);
                 if (IsCached(row.Dimensions.CacheStatus)) bucket.CachedRequests = checked(bucket.CachedRequests + count);
                 if (row.Dimensions.EdgeResponseStatus is >= 400 and <= 499) bucket.ClientErrors = checked(bucket.ClientErrors + count);

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.Operations.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.Operations.cs
@@ -24,6 +24,8 @@ public sealed partial class CloudflareAnalyticsCollector
         {
             result.Http = FailedCapability(probe.ErrorCode!, probe.ErrorMessage!);
             result.Firewall = FailedCapability("not-attempted", "Firewall collection was not attempted because zone validation failed.");
+            if (result.Rum.Requested)
+                result.Rum = FailedRum("not-attempted", "RUM inspection was not attempted because zone validation failed.");
             return result;
         }
 
@@ -34,77 +36,131 @@ public sealed partial class CloudflareAnalyticsCollector
         {
             result.Http = FailedCapability("credential-unavailable", "Cloudflare analytics credential resolution failed.");
             result.Firewall = FailedCapability("credential-unavailable", "Cloudflare analytics credential resolution failed.");
+            if (result.Rum.Requested)
+                result.Rum = FailedRum("credential-unavailable", "Cloudflare RUM credential resolution failed.");
             return result;
         }
 
-        var buckets = new Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation>();
-        var httpResponse = await SendAsync<CloudflareOperationalData>(HttpOperationalQuery, new
-        {
-            zoneTag = options.ZoneId.ToLowerInvariant(),
-            filter = BuildTrafficFilter(options.SiteBaseUrl, options.FromUtc.UtcDateTime, options.ThroughUtc.UtcDateTime)
-        }, token, cancellationToken).ConfigureAwait(false);
-        result.RequestCount++;
-        if (!TryGetOperationalZone(httpResponse, out var httpZone, out var httpCode, out var httpMessage))
-            result.Http = FailedCapability(httpCode!, httpMessage!);
-        else
-            result.Http = TryMapHttp(httpZone!.Http, buckets, out var httpError)
-                ? new CloudflareOperationalCapabilityState { Success = true }
-                : FailedCapability("invalid-response", httpError!);
+        var http = await CollectHttpOperationsAsync(options, probe, token, cancellationToken).ConfigureAwait(false);
+        result.RequestCount += http.RequestCount;
+        result.Http = http.State;
 
-        var firewallResponse = await SendAsync<CloudflareOperationalData>(FirewallOperationalQuery, new
-        {
-            zoneTag = options.ZoneId.ToLowerInvariant(),
-            filter = new Dictionary<string, object?>
-            {
-                ["datetime_geq"] = FormatUtc(options.FromUtc),
-                ["datetime_lt"] = FormatUtc(options.ThroughUtc),
-                ["clientRequestHTTPHost"] = new Uri(options.SiteBaseUrl).IdnHost.TrimEnd('.').ToLowerInvariant()
-            }
-        }, token, cancellationToken).ConfigureAwait(false);
-        result.RequestCount++;
-        if (!TryGetOperationalZone(firewallResponse, out var firewallZone, out var firewallCode, out var firewallMessage))
-            result.Firewall = FailedCapability(firewallCode!, firewallMessage!);
-        else
-            result.Firewall = TryMapFirewall(firewallZone!.Firewall, buckets, out var firewallError)
-                ? new CloudflareOperationalCapabilityState { Success = true }
-                : FailedCapability("invalid-response", firewallError!);
-        result.Hours = buckets.Values.OrderBy(value => value.HourUtc).ToArray();
+        var firewall = await CollectFirewallOperationsAsync(options, probe, token, cancellationToken).ConfigureAwait(false);
+        result.RequestCount += firewall.RequestCount;
+        result.Firewall = firewall.State;
+        result.Hours = CombineBuckets(http.Buckets, firewall.Buckets);
         result.Success = result.Http.Success;
 
         if (!string.IsNullOrWhiteSpace(options.AccountId))
         {
-            result.Rum = await InspectRumSiteAsync(options.AccountId!, options.ZoneId, token, cancellationToken).ConfigureAwait(false);
-            result.RequestCount++;
+            var rum = await InspectRumSiteAsync(options.AccountId!, options.ZoneId, token, cancellationToken).ConfigureAwait(false);
+            result.Rum = rum.State;
+            result.RequestCount += rum.RequestCount;
         }
         return result;
     }
 
-    private async Task<CloudflareRumSiteState> InspectRumSiteAsync(string accountId, string zoneId, string token, CancellationToken cancellationToken)
+    private async Task<OperationalPartitionResult> CollectHttpOperationsAsync(
+        CloudflareOperationalCollectionOptions options,
+        CloudflareAnalyticsCapabilityProbeResult probe,
+        string token,
+        CancellationToken cancellationToken)
     {
+        var buckets = new Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation>();
+        var requestCount = 0;
+        foreach (var partition in BuildOperationalPartitions(options, probe))
+        {
+            var response = await SendAsync<CloudflareOperationalData>(HttpOperationalQuery, new
+            {
+                zoneTag = options.ZoneId.ToLowerInvariant(),
+                limit = probe.MaxPageSize,
+                filter = BuildTrafficFilter(options.SiteBaseUrl, partition.FromUtc.UtcDateTime, partition.ThroughUtc.UtcDateTime)
+            }, token, cancellationToken).ConfigureAwait(false);
+            requestCount++;
+            if (!TryGetOperationalZone(response, out var zone, out var code, out var message))
+                return OperationalPartitionResult.Failed(code!, message!, requestCount);
+            if (zone!.Http is not { } rows)
+                return OperationalPartitionResult.Failed("invalid-response", "Cloudflare returned no HTTP operational dataset.", requestCount);
+            if (rows.Length >= probe.MaxPageSize)
+                return OperationalPartitionResult.Failed("row-limit-reached", "Cloudflare reached the HTTP operational row limit, so the requested range cannot be marked complete.", requestCount);
+            var partitionBuckets = new Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation>();
+            if (!TryMapHttp(rows, partitionBuckets, out var error))
+                return OperationalPartitionResult.Failed("invalid-response", error!, requestCount);
+            if (!TryMergeBuckets(buckets, partitionBuckets, out error))
+                return OperationalPartitionResult.Failed("invalid-response", error!, requestCount);
+        }
+        return OperationalPartitionResult.Succeeded(buckets, requestCount);
+    }
+
+    private async Task<OperationalPartitionResult> CollectFirewallOperationsAsync(
+        CloudflareOperationalCollectionOptions options,
+        CloudflareAnalyticsCapabilityProbeResult probe,
+        string token,
+        CancellationToken cancellationToken)
+    {
+        var buckets = new Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation>();
+        var requestCount = 0;
+        foreach (var partition in BuildOperationalPartitions(options, probe))
+        {
+            var response = await SendAsync<CloudflareOperationalData>(FirewallOperationalQuery, new
+            {
+                zoneTag = options.ZoneId.ToLowerInvariant(),
+                limit = probe.MaxPageSize,
+                filter = BuildFirewallFilter(options.SiteBaseUrl, partition.FromUtc, partition.ThroughUtc)
+            }, token, cancellationToken).ConfigureAwait(false);
+            requestCount++;
+            if (!TryGetOperationalZone(response, out var zone, out var code, out var message))
+                return OperationalPartitionResult.Failed(code!, message!, requestCount);
+            if (zone!.Firewall is not { } rows)
+                return OperationalPartitionResult.Failed("invalid-response", "Cloudflare returned no firewall dataset.", requestCount);
+            if (rows.Length >= probe.MaxPageSize)
+                return OperationalPartitionResult.Failed("row-limit-reached", "Cloudflare reached the firewall operational row limit, so the requested range cannot be marked complete.", requestCount);
+            var partitionBuckets = new Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation>();
+            if (!TryMapFirewall(rows, partitionBuckets, out var error))
+                return OperationalPartitionResult.Failed("invalid-response", error!, requestCount);
+            if (!TryMergeBuckets(buckets, partitionBuckets, out error))
+                return OperationalPartitionResult.Failed("invalid-response", error!, requestCount);
+        }
+        return OperationalPartitionResult.Succeeded(buckets, requestCount);
+    }
+
+    private async Task<(CloudflareRumSiteState State, int RequestCount)> InspectRumSiteAsync(string accountId, string zoneId, string token, CancellationToken cancellationToken)
+    {
+        var requestCount = 0;
         try
         {
-            var endpoint = new Uri(_endpoint, $"accounts/{accountId.ToLowerInvariant()}/rum/site_info/list?per_page=50");
-            using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-            if (!response.IsSuccessStatusCode)
-                return FailedRum(MapStatus(response.StatusCode), $"Cloudflare RUM site lookup returned HTTP {(int)response.StatusCode}.");
-            var envelope = await response.Content.ReadFromJsonAsync<CloudflareRumSitesEnvelope>(JsonOptions, cancellationToken).ConfigureAwait(false);
-            if (envelope?.Success != true || envelope.Errors.Length > 0)
-                return FailedRum("rum-lookup-error", "Cloudflare RUM site lookup returned errors.");
-            var site = envelope.Result.FirstOrDefault(value => string.Equals(value.Ruleset?.ZoneTag, zoneId, StringComparison.OrdinalIgnoreCase));
-            return new CloudflareRumSiteState
+            for (var page = 1;; page++)
             {
-                Requested = true,
-                Configured = site is not null,
-                Enabled = site?.Ruleset?.Enabled == true,
-                AutoInstall = site?.AutoInstall == true
-            };
+                var endpoint = new Uri(_endpoint, $"accounts/{accountId.ToLowerInvariant()}/rum/site_info/list?per_page=50&page={page.ToString(CultureInfo.InvariantCulture)}");
+                using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                requestCount++;
+                if (!response.IsSuccessStatusCode)
+                    return (FailedRum(MapStatus(response.StatusCode), $"Cloudflare RUM site lookup returned HTTP {(int)response.StatusCode}."), requestCount);
+                var envelope = await response.Content.ReadFromJsonAsync<CloudflareRumSitesEnvelope>(JsonOptions, cancellationToken).ConfigureAwait(false);
+                if (envelope?.Success != true || envelope.Errors.Length > 0)
+                    return (FailedRum("rum-lookup-error", "Cloudflare RUM site lookup returned errors."), requestCount);
+                var site = envelope.Result.FirstOrDefault(value => string.Equals(value.Ruleset?.ZoneTag, zoneId, StringComparison.OrdinalIgnoreCase));
+                if (site is not null)
+                    return (new CloudflareRumSiteState { Requested = true, Configured = true, Enabled = site.Ruleset?.Enabled == true, AutoInstall = site.AutoInstall == true }, requestCount);
+
+                var totalPages = envelope.ResultInfo?.TotalPages;
+                if (totalPages is > 0)
+                {
+                    if (page >= totalPages.Value)
+                        return (new CloudflareRumSiteState { Requested = true }, requestCount);
+                    continue;
+                }
+                if (envelope.Result.Length < 50)
+                    return (new CloudflareRumSiteState { Requested = true }, requestCount);
+                return (FailedRum("invalid-response", "Cloudflare RUM site lookup omitted pagination metadata for a full page."), requestCount);
+            }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
-        catch (JsonException) { return FailedRum("invalid-response", "Cloudflare RUM site lookup returned invalid JSON."); }
-        catch { return FailedRum("request-failed", "Cloudflare RUM site lookup failed."); }
+        catch (JsonException) { return (FailedRum("invalid-response", "Cloudflare RUM site lookup returned invalid JSON."), requestCount); }
+        catch { return (FailedRum("request-failed", "Cloudflare RUM site lookup failed."), requestCount); }
     }
 
     private static bool TryMapHttp(IEnumerable<CloudflareHttpOperationalGroup?>? rows, IDictionary<DateTimeOffset, CloudflareHourlyOperationalObservation> buckets, out string? error)
@@ -115,7 +171,8 @@ public sealed partial class CloudflareAnalyticsCollector
         {
             if (row?.Count is null || row.Average?.SampleInterval is null || row.Sum?.EdgeResponseBytes is null ||
                 row.Sum.EdgeResponseBytes.Value > long.MaxValue || row.Dimensions?.HourUtc is null ||
-                row.Dimensions.EdgeResponseStatus is null || !IsValidSampleInterval(row.Average.SampleInterval.Value) ||
+                row.Dimensions.EdgeResponseStatus is null || string.IsNullOrWhiteSpace(row.Dimensions.CacheStatus) ||
+                !IsValidSampleInterval(row.Average.SampleInterval.Value) ||
                 !TryScaleSampledCount(row.Count.Value, row.Average.SampleInterval.Value, out var count))
             { error = "Cloudflare returned an invalid HTTP operational row."; return false; }
             var hour = NormalizeHour(row.Dimensions.HourUtc.Value);
@@ -144,7 +201,7 @@ public sealed partial class CloudflareAnalyticsCollector
         if (rows is null) { error = "Cloudflare returned no firewall dataset."; return false; }
         foreach (var row in rows)
         {
-            if (row?.Count is null || row.Average?.SampleInterval is null || row.Dimensions?.HourUtc is null ||
+            if (row?.Count is null || row.Average?.SampleInterval is null || row.Dimensions?.HourUtc is null || string.IsNullOrWhiteSpace(row.Dimensions.Action) ||
                 !IsValidSampleInterval(row.Average.SampleInterval.Value) ||
                 !TryScaleSampledCount(row.Count.Value, row.Average.SampleInterval.Value, out var count))
             { error = "Cloudflare returned an invalid firewall row."; return false; }
@@ -162,6 +219,82 @@ public sealed partial class CloudflareAnalyticsCollector
             }
         }
         return true;
+    }
+
+    private static IEnumerable<(DateTimeOffset FromUtc, DateTimeOffset ThroughUtc)> BuildOperationalPartitions(
+        CloudflareOperationalCollectionOptions options,
+        CloudflareAnalyticsCapabilityProbeResult probe)
+    {
+        var duration = TimeSpan.FromSeconds(probe.MaxDurationSeconds ?? throw new InvalidOperationException("Cloudflare capability probe omitted the maximum duration."));
+        for (var start = options.FromUtc; start < options.ThroughUtc;)
+        {
+            var candidateEnd = start + duration;
+            var end = candidateEnd < options.ThroughUtc ? candidateEnd : options.ThroughUtc;
+            yield return (start, end);
+            start = end;
+        }
+    }
+
+    private static Dictionary<string, object?> BuildFirewallFilter(string siteBaseUrl, DateTimeOffset fromUtc, DateTimeOffset throughUtc)
+    {
+        var siteUri = new Uri(siteBaseUrl, UriKind.Absolute);
+        var sitePath = NormalizeSitePath(siteUri.AbsolutePath);
+        var filter = new Dictionary<string, object?>
+        {
+            ["datetime_geq"] = FormatUtc(fromUtc),
+            ["datetime_lt"] = FormatUtc(throughUtc),
+            ["clientRequestHTTPHost"] = siteUri.IdnHost.TrimEnd('.').ToLowerInvariant()
+        };
+        if (sitePath != "/")
+        {
+            var exactPath = sitePath.TrimEnd('/');
+            filter["OR"] = new object[]
+            {
+                new Dictionary<string, string> { ["clientRequestPath"] = exactPath },
+                new Dictionary<string, string> { ["clientRequestPath_like"] = exactPath + "/%" }
+            };
+        }
+        return filter;
+    }
+
+    private static bool TryMergeBuckets(
+        IDictionary<DateTimeOffset, CloudflareHourlyOperationalObservation> destination,
+        IReadOnlyDictionary<DateTimeOffset, CloudflareHourlyOperationalObservation> source,
+        out string? error)
+    {
+        error = null;
+        try
+        {
+            foreach (var pair in source)
+            {
+                var target = GetBucket(destination, pair.Key);
+                var value = pair.Value;
+                target.Requests = checked(target.Requests + value.Requests);
+                target.CachedRequests = checked(target.CachedRequests + value.CachedRequests);
+                target.ClientErrors = checked(target.ClientErrors + value.ClientErrors);
+                target.ServerErrors = checked(target.ServerErrors + value.ServerErrors);
+                target.EdgeResponseBytes = checked(target.EdgeResponseBytes + value.EdgeResponseBytes);
+                target.FirewallEvents = checked(target.FirewallEvents + value.FirewallEvents);
+                target.FirewallMitigated = checked(target.FirewallMitigated + value.FirewallMitigated);
+                target.MaximumSampleInterval = Math.Max(target.MaximumSampleInterval, value.MaximumSampleInterval);
+            }
+            return true;
+        }
+        catch (OverflowException)
+        {
+            error = "Cloudflare returned operational values outside the supported range.";
+            return false;
+        }
+    }
+
+    private static CloudflareHourlyOperationalObservation[] CombineBuckets(
+        IReadOnlyDictionary<DateTimeOffset, CloudflareHourlyOperationalObservation> http,
+        IReadOnlyDictionary<DateTimeOffset, CloudflareHourlyOperationalObservation> firewall)
+    {
+        var combined = new Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation>();
+        _ = TryMergeBuckets(combined, http, out _);
+        _ = TryMergeBuckets(combined, firewall, out _);
+        return combined.Values.OrderBy(value => value.HourUtc).ToArray();
     }
 
     private static CloudflareHourlyOperationalObservation GetBucket(IDictionary<DateTimeOffset, CloudflareHourlyOperationalObservation> buckets, DateTimeOffset hour)
@@ -211,9 +344,9 @@ public sealed partial class CloudflareAnalyticsCollector
     }
 
     private const string HttpOperationalQuery = """
-        query PowerForgeCloudflareHttpOperations($zoneTag: string, $filter: ZoneHttpRequestsAdaptiveGroupsFilter_InputObject) {
+        query PowerForgeCloudflareHttpOperations($zoneTag: string, $filter: ZoneHttpRequestsAdaptiveGroupsFilter_InputObject, $limit: Int) {
           viewer { zones(filter: { zoneTag: $zoneTag }) {
-            http: httpRequestsAdaptiveGroups(filter: $filter, limit: 10000) {
+            http: httpRequestsAdaptiveGroups(filter: $filter, limit: $limit) {
               count avg { sampleInterval } sum { edgeResponseBytes } dimensions { datetimeHour cacheStatus edgeResponseStatus }
             }
           } }
@@ -221,12 +354,35 @@ public sealed partial class CloudflareAnalyticsCollector
         """;
 
     private const string FirewallOperationalQuery = """
-        query PowerForgeCloudflareFirewallOperations($zoneTag: string, $filter: ZoneFirewallEventsAdaptiveGroupsFilter_InputObject) {
+        query PowerForgeCloudflareFirewallOperations($zoneTag: string, $filter: ZoneFirewallEventsAdaptiveGroupsFilter_InputObject, $limit: Int) {
           viewer { zones(filter: { zoneTag: $zoneTag }) {
-            firewall: firewallEventsAdaptiveGroups(filter: $filter, limit: 10000) {
+            firewall: firewallEventsAdaptiveGroups(filter: $filter, limit: $limit) {
               count avg { sampleInterval } dimensions { datetimeHour action }
             }
           } }
         }
         """;
+
+    private sealed class OperationalPartitionResult
+    {
+        private OperationalPartitionResult(
+            CloudflareOperationalCapabilityState state,
+            Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation> buckets,
+            int requestCount)
+        {
+            State = state;
+            Buckets = buckets;
+            RequestCount = requestCount;
+        }
+
+        public CloudflareOperationalCapabilityState State { get; }
+        public Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation> Buckets { get; }
+        public int RequestCount { get; }
+
+        public static OperationalPartitionResult Succeeded(Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation> buckets, int requestCount) =>
+            new(new CloudflareOperationalCapabilityState { Success = true }, buckets, requestCount);
+
+        public static OperationalPartitionResult Failed(string code, string message, int requestCount) =>
+            new(FailedCapability(code, message), new Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation>(), requestCount);
+    }
 }

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.Operations.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.Operations.cs
@@ -1,0 +1,232 @@
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace PowerForge.Web;
+
+public sealed partial class CloudflareAnalyticsCollector
+{
+    /// <summary>Collects hourly requests, cache/status, WAF mitigation and RUM installation state.</summary>
+    public async Task<CloudflareOperationalCollectionResult> CollectOperationsAsync(
+        CloudflareOperationalCollectionOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateOperationalOptions(options);
+        var probe = await ProbeAsync(options.ZoneId, options.SiteBaseUrl, cancellationToken).ConfigureAwait(false);
+        var result = new CloudflareOperationalCollectionResult
+        {
+            CollectedAtUtc = _timeProvider.GetUtcNow(),
+            RequestCount = probe.RequestCount,
+            Rum = new CloudflareRumSiteState { Requested = !string.IsNullOrWhiteSpace(options.AccountId) }
+        };
+        if (!probe.Success)
+        {
+            result.Http = FailedCapability(probe.ErrorCode!, probe.ErrorMessage!);
+            result.Firewall = FailedCapability("not-attempted", "Firewall collection was not attempted because zone validation failed.");
+            return result;
+        }
+
+        string token;
+        try { token = await _tokenProvider.GetTokenAsync(cancellationToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+        catch
+        {
+            result.Http = FailedCapability("credential-unavailable", "Cloudflare analytics credential resolution failed.");
+            result.Firewall = FailedCapability("credential-unavailable", "Cloudflare analytics credential resolution failed.");
+            return result;
+        }
+
+        var buckets = new Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation>();
+        var httpResponse = await SendAsync<CloudflareOperationalData>(HttpOperationalQuery, new
+        {
+            zoneTag = options.ZoneId.ToLowerInvariant(),
+            filter = BuildTrafficFilter(options.SiteBaseUrl, options.FromUtc.UtcDateTime, options.ThroughUtc.UtcDateTime)
+        }, token, cancellationToken).ConfigureAwait(false);
+        result.RequestCount++;
+        if (!TryGetOperationalZone(httpResponse, out var httpZone, out var httpCode, out var httpMessage))
+            result.Http = FailedCapability(httpCode!, httpMessage!);
+        else
+            result.Http = TryMapHttp(httpZone!.Http, buckets, out var httpError)
+                ? new CloudflareOperationalCapabilityState { Success = true }
+                : FailedCapability("invalid-response", httpError!);
+
+        var firewallResponse = await SendAsync<CloudflareOperationalData>(FirewallOperationalQuery, new
+        {
+            zoneTag = options.ZoneId.ToLowerInvariant(),
+            filter = new Dictionary<string, object?>
+            {
+                ["datetime_geq"] = FormatUtc(options.FromUtc),
+                ["datetime_lt"] = FormatUtc(options.ThroughUtc),
+                ["clientRequestHTTPHost"] = new Uri(options.SiteBaseUrl).IdnHost.TrimEnd('.').ToLowerInvariant()
+            }
+        }, token, cancellationToken).ConfigureAwait(false);
+        result.RequestCount++;
+        if (!TryGetOperationalZone(firewallResponse, out var firewallZone, out var firewallCode, out var firewallMessage))
+            result.Firewall = FailedCapability(firewallCode!, firewallMessage!);
+        else
+            result.Firewall = TryMapFirewall(firewallZone!.Firewall, buckets, out var firewallError)
+                ? new CloudflareOperationalCapabilityState { Success = true }
+                : FailedCapability("invalid-response", firewallError!);
+        result.Hours = buckets.Values.OrderBy(value => value.HourUtc).ToArray();
+        result.Success = result.Http.Success;
+
+        if (!string.IsNullOrWhiteSpace(options.AccountId))
+        {
+            result.Rum = await InspectRumSiteAsync(options.AccountId!, options.ZoneId, token, cancellationToken).ConfigureAwait(false);
+            result.RequestCount++;
+        }
+        return result;
+    }
+
+    private async Task<CloudflareRumSiteState> InspectRumSiteAsync(string accountId, string zoneId, string token, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var endpoint = new Uri(_endpoint, $"accounts/{accountId.ToLowerInvariant()}/rum/site_info/list?per_page=50");
+            using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+                return FailedRum(MapStatus(response.StatusCode), $"Cloudflare RUM site lookup returned HTTP {(int)response.StatusCode}.");
+            var envelope = await response.Content.ReadFromJsonAsync<CloudflareRumSitesEnvelope>(JsonOptions, cancellationToken).ConfigureAwait(false);
+            if (envelope?.Success != true || envelope.Errors.Length > 0)
+                return FailedRum("rum-lookup-error", "Cloudflare RUM site lookup returned errors.");
+            var site = envelope.Result.FirstOrDefault(value => string.Equals(value.Ruleset?.ZoneTag, zoneId, StringComparison.OrdinalIgnoreCase));
+            return new CloudflareRumSiteState
+            {
+                Requested = true,
+                Configured = site is not null,
+                Enabled = site?.Ruleset?.Enabled == true,
+                AutoInstall = site?.AutoInstall == true
+            };
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+        catch (JsonException) { return FailedRum("invalid-response", "Cloudflare RUM site lookup returned invalid JSON."); }
+        catch { return FailedRum("request-failed", "Cloudflare RUM site lookup failed."); }
+    }
+
+    private static bool TryMapHttp(IEnumerable<CloudflareHttpOperationalGroup?>? rows, IDictionary<DateTimeOffset, CloudflareHourlyOperationalObservation> buckets, out string? error)
+    {
+        error = null;
+        if (rows is null) { error = "Cloudflare returned no HTTP operational dataset."; return false; }
+        foreach (var row in rows)
+        {
+            if (row?.Count is null || row.Average?.SampleInterval is null || row.Sum?.EdgeResponseBytes is null ||
+                row.Sum.EdgeResponseBytes.Value > long.MaxValue || row.Dimensions?.HourUtc is null ||
+                row.Dimensions.EdgeResponseStatus is null || !IsValidSampleInterval(row.Average.SampleInterval.Value) ||
+                !TryScaleSampledCount(row.Count.Value, row.Average.SampleInterval.Value, out var count))
+            { error = "Cloudflare returned an invalid HTTP operational row."; return false; }
+            var hour = NormalizeHour(row.Dimensions.HourUtc.Value);
+            var bucket = GetBucket(buckets, hour);
+            try
+            {
+                bucket.Requests = checked(bucket.Requests + count);
+                bucket.EdgeResponseBytes = checked(bucket.EdgeResponseBytes + (long)row.Sum.EdgeResponseBytes.Value);
+                bucket.MaximumSampleInterval = Math.Max(bucket.MaximumSampleInterval, row.Average.SampleInterval.Value);
+                if (IsCached(row.Dimensions.CacheStatus)) bucket.CachedRequests = checked(bucket.CachedRequests + count);
+                if (row.Dimensions.EdgeResponseStatus is >= 400 and <= 499) bucket.ClientErrors = checked(bucket.ClientErrors + count);
+                if (row.Dimensions.EdgeResponseStatus is >= 500 and <= 599) bucket.ServerErrors = checked(bucket.ServerErrors + count);
+            }
+            catch (OverflowException)
+            {
+                error = "Cloudflare returned HTTP operational values outside the supported range.";
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static bool TryMapFirewall(IEnumerable<CloudflareFirewallOperationalGroup?>? rows, IDictionary<DateTimeOffset, CloudflareHourlyOperationalObservation> buckets, out string? error)
+    {
+        error = null;
+        if (rows is null) { error = "Cloudflare returned no firewall dataset."; return false; }
+        foreach (var row in rows)
+        {
+            if (row?.Count is null || row.Average?.SampleInterval is null || row.Dimensions?.HourUtc is null ||
+                !IsValidSampleInterval(row.Average.SampleInterval.Value) ||
+                !TryScaleSampledCount(row.Count.Value, row.Average.SampleInterval.Value, out var count))
+            { error = "Cloudflare returned an invalid firewall row."; return false; }
+            var bucket = GetBucket(buckets, NormalizeHour(row.Dimensions.HourUtc.Value));
+            try
+            {
+                bucket.FirewallEvents = checked(bucket.FirewallEvents + count);
+                bucket.MaximumSampleInterval = Math.Max(bucket.MaximumSampleInterval, row.Average.SampleInterval.Value);
+                if (IsMitigated(row.Dimensions.Action)) bucket.FirewallMitigated = checked(bucket.FirewallMitigated + count);
+            }
+            catch (OverflowException)
+            {
+                error = "Cloudflare returned firewall values outside the supported range.";
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static CloudflareHourlyOperationalObservation GetBucket(IDictionary<DateTimeOffset, CloudflareHourlyOperationalObservation> buckets, DateTimeOffset hour)
+    {
+        if (!buckets.TryGetValue(hour, out var bucket)) { bucket = new CloudflareHourlyOperationalObservation { HourUtc = hour }; buckets.Add(hour, bucket); }
+        return bucket;
+    }
+
+    private static bool IsCached(string? status) => status?.Trim().ToLowerInvariant() is "hit" or "revalidated" or "updating";
+    private static bool IsMitigated(string? action) => action?.Trim().ToLowerInvariant() is "block" or "challenge" or "jschallenge" or "managed_challenge";
+    private static bool IsValidSampleInterval(double value) => double.IsFinite(value) && value >= 1d;
+    private static DateTimeOffset NormalizeHour(DateTimeOffset value) => new(value.UtcDateTime.Year, value.UtcDateTime.Month, value.UtcDateTime.Day, value.UtcDateTime.Hour, 0, 0, TimeSpan.Zero);
+    private static string FormatUtc(DateTimeOffset value) => value.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
+    private static CloudflareOperationalCapabilityState FailedCapability(string code, string message) => new() { ErrorCode = code, ErrorMessage = message };
+    private static CloudflareRumSiteState FailedRum(string code, string message) => new() { Requested = true, ErrorCode = code, ErrorMessage = message };
+
+    private void ValidateOperationalOptions(CloudflareOperationalCollectionOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (string.IsNullOrWhiteSpace(options.SiteId)) throw new ArgumentException("Cloudflare operational collection requires a site identifier.", nameof(options));
+        ValidateZoneId(options.ZoneId); _ = NormalizeSiteHost(options.SiteBaseUrl);
+        if (options.FromUtc == default || options.ThroughUtc == default || options.FromUtc >= options.ThroughUtc || options.ThroughUtc > _timeProvider.GetUtcNow() || options.ThroughUtc - options.FromUtc > TimeSpan.FromDays(7))
+            throw new ArgumentException("Cloudflare operational window must be a closed UTC range no longer than seven days.", nameof(options));
+        if (!string.IsNullOrWhiteSpace(options.AccountId) && (options.AccountId.Length != 32 || !options.AccountId.All(Uri.IsHexDigit)))
+            throw new ArgumentException("Cloudflare accountId must be a 32-character hexadecimal identifier.", nameof(options));
+    }
+
+    private static bool TryGetOperationalZone(
+        ApiResult<CloudflareOperationalData> response,
+        out CloudflareOperationalZone? zone,
+        out string? errorCode,
+        out string? errorMessage)
+    {
+        zone = null;
+        errorCode = response.ErrorCode;
+        errorMessage = response.ErrorMessage;
+        if (!response.Success)
+            return false;
+        if (response.Value?.Viewer?.Zones is not { Length: 1 } zones || zones[0] is not { } value)
+        {
+            errorCode = "invalid-response";
+            errorMessage = "Cloudflare returned invalid operational analytics data.";
+            return false;
+        }
+        zone = value;
+        return true;
+    }
+
+    private const string HttpOperationalQuery = """
+        query PowerForgeCloudflareHttpOperations($zoneTag: string, $filter: ZoneHttpRequestsAdaptiveGroupsFilter_InputObject) {
+          viewer { zones(filter: { zoneTag: $zoneTag }) {
+            http: httpRequestsAdaptiveGroups(filter: $filter, limit: 10000) {
+              count avg { sampleInterval } sum { edgeResponseBytes } dimensions { datetimeHour cacheStatus edgeResponseStatus }
+            }
+          } }
+        }
+        """;
+
+    private const string FirewallOperationalQuery = """
+        query PowerForgeCloudflareFirewallOperations($zoneTag: string, $filter: ZoneFirewallEventsAdaptiveGroupsFilter_InputObject) {
+          viewer { zones(filter: { zoneTag: $zoneTag }) {
+            firewall: firewallEventsAdaptiveGroups(filter: $filter, limit: 10000) {
+              count avg { sampleInterval } dimensions { datetimeHour action }
+            }
+          } }
+        }
+        """;
+}

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.Operations.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.Operations.cs
@@ -13,23 +13,13 @@ public sealed partial class CloudflareAnalyticsCollector
         CancellationToken cancellationToken = default)
     {
         ValidateOperationalOptions(options);
-        var probe = await ProbeAsync(options.ZoneId, options.SiteBaseUrl, cancellationToken).ConfigureAwait(false);
         var result = new CloudflareOperationalCollectionResult
         {
             SiteId = options.SiteId,
             FromUtc = options.FromUtc,
             ThroughUtc = options.ThroughUtc,
-            RequestCount = probe.RequestCount,
             Rum = new CloudflareRumSiteState { Requested = !string.IsNullOrWhiteSpace(options.AccountId) }
         };
-        if (!probe.Success)
-        {
-            result.Http = FailedCapability(probe.ErrorCode!, probe.ErrorMessage!);
-            result.Firewall = FailedCapability("not-attempted", "Firewall collection was not attempted because zone validation failed.");
-            if (result.Rum.Requested)
-                result.Rum = FailedRum("not-attempted", "RUM inspection was not attempted because zone validation failed.");
-            return CompleteOperationalResult(result);
-        }
 
         string token;
         try { token = await _tokenProvider.GetTokenAsync(cancellationToken).ConfigureAwait(false); }
@@ -43,10 +33,27 @@ public sealed partial class CloudflareAnalyticsCollector
             return CompleteOperationalResult(result);
         }
 
+        var probe = await ProbeWithTokenAsync(
+            options.ZoneId,
+            NormalizeSiteHost(options.SiteBaseUrl),
+            token,
+            cancellationToken).ConfigureAwait(false);
+        result.RequestCount = probe.RequestCount;
+        if (!probe.Success && string.IsNullOrWhiteSpace(probe.ZoneName))
+        {
+            result.Http = FailedCapability(probe.ErrorCode!, probe.ErrorMessage!);
+            result.Firewall = FailedCapability("not-attempted", "Firewall collection was not attempted because zone validation failed.");
+            if (result.Rum.Requested)
+                result.Rum = FailedRum("not-attempted", "RUM inspection was not attempted because zone validation failed.");
+            return CompleteOperationalResult(result);
+        }
+
         var now = _timeProvider.GetUtcNow();
         var firewallProbe = await ProbeFirewallCapabilityAsync(options.ZoneId, token, cancellationToken).ConfigureAwait(false);
         result.RequestCount += firewallProbe.RequestCount;
-        var http = IsOutsideRetention(options.FromUtc, now, probe.NotOlderThanSeconds)
+        var http = !probe.Success
+            ? OperationalPartitionResult.Failed(probe.ErrorCode!, probe.ErrorMessage!, 0)
+            : IsOutsideRetention(options.FromUtc, now, probe.NotOlderThanSeconds)
             ? OperationalPartitionResult.Failed("retention-boundary", "The requested Cloudflare HTTP operational range starts before the provider-reported retention boundary.", 0)
             : await CollectHttpOperationsAsync(options, probe, token, cancellationToken).ConfigureAwait(false);
         result.RequestCount += http.RequestCount;

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.Operations.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.Operations.cs
@@ -16,6 +16,7 @@ public sealed partial class CloudflareAnalyticsCollector
         var probe = await ProbeAsync(options.ZoneId, options.SiteBaseUrl, cancellationToken).ConfigureAwait(false);
         var result = new CloudflareOperationalCollectionResult
         {
+            SiteId = options.SiteId,
             CollectedAtUtc = _timeProvider.GetUtcNow(),
             RequestCount = probe.RequestCount,
             Rum = new CloudflareRumSiteState { Requested = !string.IsNullOrWhiteSpace(options.AccountId) }
@@ -26,16 +27,6 @@ public sealed partial class CloudflareAnalyticsCollector
             result.Firewall = FailedCapability("not-attempted", "Firewall collection was not attempted because zone validation failed.");
             if (result.Rum.Requested)
                 result.Rum = FailedRum("not-attempted", "RUM inspection was not attempted because zone validation failed.");
-            return result;
-        }
-
-        if (probe.NotOlderThanSeconds is > 0 &&
-            options.FromUtc < _timeProvider.GetUtcNow().Subtract(TimeSpan.FromSeconds(probe.NotOlderThanSeconds.Value)))
-        {
-            result.Http = FailedCapability("retention-boundary", "The requested Cloudflare operational range starts before the provider-reported retention boundary.");
-            result.Firewall = FailedCapability("not-attempted", "Firewall collection was not attempted because the requested range is outside provider retention.");
-            if (result.Rum.Requested)
-                result.Rum = FailedRum("not-attempted", "RUM inspection was not attempted because the requested range is outside provider retention.");
             return result;
         }
 
@@ -51,26 +42,58 @@ public sealed partial class CloudflareAnalyticsCollector
             return result;
         }
 
-        var http = await CollectHttpOperationsAsync(options, probe, token, cancellationToken).ConfigureAwait(false);
+        var now = _timeProvider.GetUtcNow();
+        var http = IsOutsideRetention(options.FromUtc, now, probe.NotOlderThanSeconds)
+            ? OperationalPartitionResult.Failed("retention-boundary", "The requested Cloudflare HTTP operational range starts before the provider-reported retention boundary.", 0)
+            : await CollectHttpOperationsAsync(options, probe, token, cancellationToken).ConfigureAwait(false);
         result.RequestCount += http.RequestCount;
         result.Http = http.State;
 
-        var firewall = await CollectFirewallOperationsAsync(options, probe, token, cancellationToken).ConfigureAwait(false);
+        OperationalPartitionResult firewall;
+        if (!probe.FirewallDatasetEnabled)
+            firewall = OperationalPartitionResult.Failed("dataset-unavailable", "Cloudflare firewallEventsAdaptiveGroups is not enabled for this zone.", 0);
+        else if (probe.FirewallMaxPageSize <= 0)
+            firewall = OperationalPartitionResult.Failed("invalid-response", "Cloudflare did not report a usable firewall analytics page size.", 0);
+        else if (probe.FirewallMaxDurationSeconds is <= 0 || probe.FirewallNotOlderThanSeconds is <= 0)
+            firewall = OperationalPartitionResult.Failed("invalid-response", "Cloudflare reported an invalid firewall duration or retention boundary.", 0);
+        else if (IsOutsideRetention(options.FromUtc, now, probe.FirewallNotOlderThanSeconds))
+            firewall = OperationalPartitionResult.Failed("retention-boundary", "The requested Cloudflare firewall operational range starts before the provider-reported retention boundary.", 0);
+        else
+            firewall = await CollectFirewallOperationsAsync(options, probe, token, cancellationToken).ConfigureAwait(false);
         result.RequestCount += firewall.RequestCount;
         result.Firewall = firewall.State;
         result.Hours = CombineBuckets(http.Buckets, firewall.Buckets);
         result.Success = result.Http.Success;
 
+        if (string.Equals(result.Http.ErrorCode, "retention-boundary", StringComparison.Ordinal) &&
+            string.Equals(result.Firewall.ErrorCode, "retention-boundary", StringComparison.Ordinal))
+        {
+            if (result.Rum.Requested)
+                result.Rum = FailedRum("not-attempted", "RUM inspection was not attempted because the requested operational range is outside provider retention.");
+            return result;
+        }
+
         if (!string.IsNullOrWhiteSpace(options.AccountId))
         {
-            var rum = await InspectRumSiteAsync(
-                options.AccountId!,
-                options.ZoneId,
-                NormalizeSiteHost(options.SiteBaseUrl),
-                token,
-                cancellationToken).ConfigureAwait(false);
-            result.Rum = rum.State;
-            result.RequestCount += rum.RequestCount;
+            if (string.IsNullOrWhiteSpace(probe.ZoneAccountId))
+            {
+                result.Rum = FailedRum("invalid-response", "Cloudflare zone lookup omitted the owning account identifier.");
+            }
+            else if (!string.Equals(probe.ZoneAccountId, options.AccountId, StringComparison.OrdinalIgnoreCase))
+            {
+                result.Rum = FailedRum("account-zone-mismatch", "The configured Cloudflare account does not own the selected zone.");
+            }
+            else
+            {
+                var rum = await InspectRumSiteAsync(
+                    options.AccountId!,
+                    options.ZoneId,
+                    NormalizeSiteHost(options.SiteBaseUrl),
+                    token,
+                    cancellationToken).ConfigureAwait(false);
+                result.Rum = rum.State;
+                result.RequestCount += rum.RequestCount;
+            }
         }
         return result;
     }
@@ -83,7 +106,7 @@ public sealed partial class CloudflareAnalyticsCollector
     {
         var buckets = new Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation>();
         var requestCount = 0;
-        foreach (var partition in BuildOperationalPartitions(options, probe))
+        foreach (var partition in BuildOperationalPartitions(options, probe.MaxDurationSeconds))
         {
             var response = await SendAsync<CloudflareOperationalData>(HttpOperationalQuery, new
             {
@@ -99,7 +122,7 @@ public sealed partial class CloudflareAnalyticsCollector
             if (rows.Length >= probe.MaxPageSize)
                 return OperationalPartitionResult.Failed("row-limit-reached", "Cloudflare reached the HTTP operational row limit, so the requested range cannot be marked complete.", requestCount);
             var partitionBuckets = new Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation>();
-            if (!TryMapHttp(rows, partitionBuckets, out var error))
+            if (!TryMapHttp(rows, partition.FromUtc, partition.ThroughUtc, partitionBuckets, out var error))
                 return OperationalPartitionResult.Failed("invalid-response", error!, requestCount);
             if (!TryMergeBuckets(buckets, partitionBuckets, out error))
                 return OperationalPartitionResult.Failed("invalid-response", error!, requestCount);
@@ -115,12 +138,12 @@ public sealed partial class CloudflareAnalyticsCollector
     {
         var buckets = new Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation>();
         var requestCount = 0;
-        foreach (var partition in BuildOperationalPartitions(options, probe))
+        foreach (var partition in BuildOperationalPartitions(options, probe.FirewallMaxDurationSeconds))
         {
             var response = await SendAsync<CloudflareOperationalData>(FirewallOperationalQuery, new
             {
                 zoneTag = options.ZoneId.ToLowerInvariant(),
-                limit = probe.MaxPageSize,
+                limit = probe.FirewallMaxPageSize,
                 filter = BuildFirewallFilter(options.SiteBaseUrl, partition.FromUtc, partition.ThroughUtc)
             }, token, cancellationToken).ConfigureAwait(false);
             requestCount++;
@@ -128,10 +151,10 @@ public sealed partial class CloudflareAnalyticsCollector
                 return OperationalPartitionResult.Failed(code!, message!, requestCount);
             if (zone!.Firewall is not { } rows)
                 return OperationalPartitionResult.Failed("invalid-response", "Cloudflare returned no firewall dataset.", requestCount);
-            if (rows.Length >= probe.MaxPageSize)
+            if (rows.Length >= probe.FirewallMaxPageSize)
                 return OperationalPartitionResult.Failed("row-limit-reached", "Cloudflare reached the firewall operational row limit, so the requested range cannot be marked complete.", requestCount);
             var partitionBuckets = new Dictionary<DateTimeOffset, CloudflareHourlyOperationalObservation>();
-            if (!TryMapFirewall(rows, partitionBuckets, out var error))
+            if (!TryMapFirewall(rows, partition.FromUtc, partition.ThroughUtc, partitionBuckets, out var error))
                 return OperationalPartitionResult.Failed("invalid-response", error!, requestCount);
             if (!TryMergeBuckets(buckets, partitionBuckets, out error))
                 return OperationalPartitionResult.Failed("invalid-response", error!, requestCount);
@@ -160,15 +183,19 @@ public sealed partial class CloudflareAnalyticsCollector
                 if (!response.IsSuccessStatusCode)
                     return (FailedRum(MapStatus(response.StatusCode), $"Cloudflare RUM site lookup returned HTTP {(int)response.StatusCode}."), requestCount);
                 var envelope = await response.Content.ReadFromJsonAsync<CloudflareRumSitesEnvelope>(JsonOptions, cancellationToken).ConfigureAwait(false);
-                if (envelope?.Success != true || envelope.Errors.Length > 0)
+                if (envelope?.Success != true || envelope.Errors is { Length: > 0 } || envelope.Result is null || envelope.Result.Any(value => value is null))
                     return (FailedRum("rum-lookup-error", "Cloudflare RUM site lookup returned errors."), requestCount);
                 var site = envelope.Result.FirstOrDefault(value =>
-                    string.Equals(value.Ruleset?.ZoneTag, zoneId, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(value!.Ruleset?.ZoneTag, zoneId, StringComparison.OrdinalIgnoreCase) &&
                     value.Host is not null &&
                     TryNormalizeHostDimension(value.Host, out var rumHost) &&
                     string.Equals(rumHost, siteHost, StringComparison.Ordinal));
                 if (site is not null)
-                    return (new CloudflareRumSiteState { Requested = true, Configured = true, Enabled = site.Ruleset?.Enabled == true, AutoInstall = site.AutoInstall == true }, requestCount);
+                {
+                    if (site.Ruleset?.Enabled is null || site.AutoInstall is null)
+                        return (FailedRum("invalid-response", "Cloudflare RUM site lookup returned incomplete configuration state."), requestCount);
+                    return (new CloudflareRumSiteState { Requested = true, Configured = true, Enabled = site.Ruleset.Enabled.Value, AutoInstall = site.AutoInstall.Value }, requestCount);
+                }
 
                 var totalPages = envelope.ResultInfo?.TotalPages;
                 if (totalPages is > 0)
@@ -187,7 +214,12 @@ public sealed partial class CloudflareAnalyticsCollector
         catch { return (FailedRum("request-failed", "Cloudflare RUM site lookup failed."), requestCount); }
     }
 
-    private static bool TryMapHttp(IEnumerable<CloudflareHttpOperationalGroup?>? rows, IDictionary<DateTimeOffset, CloudflareHourlyOperationalObservation> buckets, out string? error)
+    private static bool TryMapHttp(
+        IEnumerable<CloudflareHttpOperationalGroup?>? rows,
+        DateTimeOffset fromUtc,
+        DateTimeOffset throughUtc,
+        IDictionary<DateTimeOffset, CloudflareHourlyOperationalObservation> buckets,
+        out string? error)
     {
         error = null;
         if (rows is null) { error = "Cloudflare returned no HTTP operational dataset."; return false; }
@@ -199,7 +231,8 @@ public sealed partial class CloudflareAnalyticsCollector
                 !IsValidSampleInterval(row.Average.SampleInterval.Value) ||
                 !TryScaleSampledCount(row.Count.Value, row.Average.SampleInterval.Value, out var count))
             { error = "Cloudflare returned an invalid HTTP operational row."; return false; }
-            var hour = NormalizeHour(row.Dimensions.HourUtc.Value);
+            if (!TryValidateOperationalHour(row.Dimensions.HourUtc.Value, fromUtc, throughUtc, out var hour))
+            { error = "Cloudflare returned an HTTP operational row outside the requested hourly window."; return false; }
             var bucket = GetBucket(buckets, hour);
             try
             {
@@ -219,7 +252,12 @@ public sealed partial class CloudflareAnalyticsCollector
         return true;
     }
 
-    private static bool TryMapFirewall(IEnumerable<CloudflareFirewallOperationalGroup?>? rows, IDictionary<DateTimeOffset, CloudflareHourlyOperationalObservation> buckets, out string? error)
+    private static bool TryMapFirewall(
+        IEnumerable<CloudflareFirewallOperationalGroup?>? rows,
+        DateTimeOffset fromUtc,
+        DateTimeOffset throughUtc,
+        IDictionary<DateTimeOffset, CloudflareHourlyOperationalObservation> buckets,
+        out string? error)
     {
         error = null;
         if (rows is null) { error = "Cloudflare returned no firewall dataset."; return false; }
@@ -229,7 +267,9 @@ public sealed partial class CloudflareAnalyticsCollector
                 !IsValidSampleInterval(row.Average.SampleInterval.Value) ||
                 !TryScaleSampledCount(row.Count.Value, row.Average.SampleInterval.Value, out var count))
             { error = "Cloudflare returned an invalid firewall row."; return false; }
-            var bucket = GetBucket(buckets, NormalizeHour(row.Dimensions.HourUtc.Value));
+            if (!TryValidateOperationalHour(row.Dimensions.HourUtc.Value, fromUtc, throughUtc, out var hour))
+            { error = "Cloudflare returned a firewall row outside the requested hourly window."; return false; }
+            var bucket = GetBucket(buckets, hour);
             try
             {
                 bucket.FirewallEvents = checked(bucket.FirewallEvents + count);
@@ -247,10 +287,10 @@ public sealed partial class CloudflareAnalyticsCollector
 
     private static IEnumerable<(DateTimeOffset FromUtc, DateTimeOffset ThroughUtc)> BuildOperationalPartitions(
         CloudflareOperationalCollectionOptions options,
-        CloudflareAnalyticsCapabilityProbeResult probe)
+        int? maxDurationSeconds)
     {
-        var duration = probe.MaxDurationSeconds is > 0
-            ? TimeSpan.FromSeconds(probe.MaxDurationSeconds.Value)
+        var duration = maxDurationSeconds is > 0
+            ? TimeSpan.FromSeconds(maxDurationSeconds.Value)
             : TimeSpan.FromDays(1);
         for (var start = options.FromUtc; start < options.ThroughUtc;)
         {
@@ -269,7 +309,8 @@ public sealed partial class CloudflareAnalyticsCollector
         {
             ["datetime_geq"] = FormatUtc(fromUtc),
             ["datetime_lt"] = FormatUtc(throughUtc),
-            ["clientRequestHTTPHost"] = siteUri.IdnHost.TrimEnd('.').ToLowerInvariant()
+            ["clientRequestHTTPHost"] = siteUri.IdnHost.TrimEnd('.').ToLowerInvariant(),
+            ["clientRequestScheme"] = siteUri.Scheme.ToLowerInvariant()
         };
         if (sitePath != "/")
         {
@@ -332,7 +373,20 @@ public sealed partial class CloudflareAnalyticsCollector
     private static bool IsCached(string? status) => status?.Trim().ToLowerInvariant() is "hit" or "revalidated" or "stale" or "updating";
     private static bool IsMitigated(string? action) => action?.Trim().ToLowerInvariant() is "block" or "challenge" or "jschallenge" or "managedchallenge" or "managed_challenge";
     private static bool IsValidSampleInterval(double value) => double.IsFinite(value) && value >= 1d;
-    private static DateTimeOffset NormalizeHour(DateTimeOffset value) => new(value.UtcDateTime.Year, value.UtcDateTime.Month, value.UtcDateTime.Day, value.UtcDateTime.Hour, 0, 0, TimeSpan.Zero);
+    private static bool IsOutsideRetention(DateTimeOffset fromUtc, DateTimeOffset now, int? notOlderThanSeconds) =>
+        notOlderThanSeconds is > 0 && fromUtc < now.Subtract(TimeSpan.FromSeconds(notOlderThanSeconds.Value));
+
+    private static bool TryValidateOperationalHour(
+        DateTimeOffset value,
+        DateTimeOffset fromUtc,
+        DateTimeOffset throughUtc,
+        out DateTimeOffset hourUtc)
+    {
+        hourUtc = value.ToUniversalTime();
+        if (hourUtc.Minute != 0 || hourUtc.Second != 0 || hourUtc.Millisecond != 0 || hourUtc.Ticks % TimeSpan.TicksPerSecond != 0)
+            return false;
+        return hourUtc >= fromUtc && hourUtc < throughUtc;
+    }
     private static string FormatUtc(DateTimeOffset value) => value.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
     private static CloudflareOperationalCapabilityState FailedCapability(string code, string message) => new() { ErrorCode = code, ErrorMessage = message };
     private static CloudflareRumSiteState FailedRum(string code, string message) => new() { Requested = true, ErrorCode = code, ErrorMessage = message };
@@ -342,7 +396,9 @@ public sealed partial class CloudflareAnalyticsCollector
         ArgumentNullException.ThrowIfNull(options);
         if (string.IsNullOrWhiteSpace(options.SiteId)) throw new ArgumentException("Cloudflare operational collection requires a site identifier.", nameof(options));
         ValidateZoneId(options.ZoneId); _ = NormalizeSiteHost(options.SiteBaseUrl);
-        if (options.FromUtc == default || options.ThroughUtc == default || options.FromUtc >= options.ThroughUtc || options.ThroughUtc > _timeProvider.GetUtcNow() || options.ThroughUtc - options.FromUtc > TimeSpan.FromDays(7))
+        if (options.FromUtc == default || options.ThroughUtc == default || options.FromUtc >= options.ThroughUtc || options.ThroughUtc > _timeProvider.GetUtcNow() || options.ThroughUtc - options.FromUtc > TimeSpan.FromDays(7) ||
+            options.FromUtc.Offset != TimeSpan.Zero || options.ThroughUtc.Offset != TimeSpan.Zero ||
+            options.FromUtc.Ticks % TimeSpan.TicksPerHour != 0 || options.ThroughUtc.Ticks % TimeSpan.TicksPerHour != 0)
             throw new ArgumentException("Cloudflare operational window must be a closed UTC range no longer than seven days.", nameof(options));
         if (!string.IsNullOrWhiteSpace(options.AccountId) && (options.AccountId.Length != 32 || !options.AccountId.All(Uri.IsHexDigit)))
             throw new ArgumentException("Cloudflare accountId must be a 32-character hexadecimal identifier.", nameof(options));

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.cs
@@ -87,10 +87,15 @@ public sealed partial class CloudflareAnalyticsCollector
             Success = true,
             DatasetEnabled = true,
             ZoneName = zoneName,
+            ZoneAccountId = zoneResponse.Value.Account?.Id,
             RequestCount = 2,
             MaxPageSize = Math.Min(settings.MaxPageSize.Value, ClientMaximumRowsPerDay),
             MaxDurationSeconds = settings.MaxDuration,
-            NotOlderThanSeconds = settings.NotOlderThan
+            NotOlderThanSeconds = settings.NotOlderThan,
+            FirewallDatasetEnabled = zones[0].Settings?.FirewallEventsAdaptiveGroups?.Enabled == true,
+            FirewallMaxPageSize = Math.Min(zones[0].Settings?.FirewallEventsAdaptiveGroups?.MaxPageSize ?? 0, ClientMaximumRowsPerDay),
+            FirewallMaxDurationSeconds = zones[0].Settings?.FirewallEventsAdaptiveGroups?.MaxDuration,
+            FirewallNotOlderThanSeconds = zones[0].Settings?.FirewallEventsAdaptiveGroups?.NotOlderThan
         };
     }
 
@@ -531,6 +536,12 @@ public sealed partial class CloudflareAnalyticsCollector
             zones(filter: { zoneTag: $zoneTag }) {
               settings {
                 httpRequestsAdaptiveGroups {
+                  enabled
+                  maxPageSize
+                  maxDuration
+                  notOlderThan
+                }
+                firewallEventsAdaptiveGroups {
                   enabled
                   maxPageSize
                   maxDuration

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.cs
@@ -56,6 +56,15 @@ public sealed partial class CloudflareAnalyticsCollector
             return ProbeFailure(0, "credential-unavailable", "Cloudflare analytics credential resolution failed.");
         }
 
+        return await ProbeWithTokenAsync(zoneId, siteHost, token, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<CloudflareAnalyticsCapabilityProbeResult> ProbeWithTokenAsync(
+        string zoneId,
+        string siteHost,
+        string token,
+        CancellationToken cancellationToken)
+    {
         var zoneResponse = await GetZoneAsync(zoneId, token, cancellationToken).ConfigureAwait(false);
         if (!zoneResponse.Success)
             return ProbeFailure(1, zoneResponse.ErrorCode!, zoneResponse.ErrorMessage!);
@@ -68,19 +77,19 @@ public sealed partial class CloudflareAnalyticsCollector
         var response = await SendAsync<CloudflareCapabilityData>(CapabilityQuery, new { zoneTag = zoneId.ToLowerInvariant() }, token, cancellationToken)
             .ConfigureAwait(false);
         if (!response.Success)
-            return ProbeFailure(2, response.ErrorCode!, response.ErrorMessage!);
+            return ProbeFailure(2, response.ErrorCode!, response.ErrorMessage!, zoneName, zoneResponse.Value.Account?.Id);
         var zones = response.Value?.Viewer?.Zones ?? Array.Empty<CloudflareCapabilityZone>();
         if (zones.Length != 1)
-            return ProbeFailure(2, "zone-not-visible", "The configured Cloudflare zone is not visible to this credential.");
+            return ProbeFailure(2, "zone-not-visible", "The configured Cloudflare zone is not visible to this credential.", zoneName, zoneResponse.Value.Account?.Id);
         if (zones[0] is null)
-            return ProbeFailure(2, "invalid-response", "Cloudflare returned an invalid analytics capability response.");
+            return ProbeFailure(2, "invalid-response", "Cloudflare returned an invalid analytics capability response.", zoneName, zoneResponse.Value.Account?.Id);
         var settings = zones[0].Settings?.HttpRequestsAdaptiveGroups;
         if (settings?.Enabled != true)
-            return ProbeFailure(2, "dataset-unavailable", "Cloudflare httpRequestsAdaptiveGroups is not enabled for this zone.");
+            return ProbeFailure(2, "dataset-unavailable", "Cloudflare httpRequestsAdaptiveGroups is not enabled for this zone.", zoneName, zoneResponse.Value.Account?.Id);
         if (settings.MaxPageSize is null or <= 0)
-            return ProbeFailure(2, "invalid-response", "Cloudflare did not report a usable analytics page size.");
+            return ProbeFailure(2, "invalid-response", "Cloudflare did not report a usable analytics page size.", zoneName, zoneResponse.Value.Account?.Id);
         if (settings.MaxDuration is <= 0 || settings.NotOlderThan is <= 0)
-            return ProbeFailure(2, "invalid-response", "Cloudflare reported an invalid analytics duration or retention boundary.");
+            return ProbeFailure(2, "invalid-response", "Cloudflare reported an invalid analytics duration or retention boundary.", zoneName, zoneResponse.Value.Account?.Id);
 
         return new CloudflareAnalyticsCapabilityProbeResult
         {
@@ -101,7 +110,22 @@ public sealed partial class CloudflareAnalyticsCollector
         CancellationToken cancellationToken = default)
     {
         ValidateOptions(options);
-        var probe = await ProbeAsync(options.ZoneId, options.SiteBaseUrl, cancellationToken).ConfigureAwait(false);
+        string token;
+        try
+        {
+            token = await _tokenProvider.GetTokenAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            var credentialFailure = ProbeFailure(0, "credential-unavailable", "Cloudflare analytics credential resolution failed.");
+            return Failure(options, credentialFailure, 0, Array.Empty<WebTrafficObservation>(), Array.Empty<DateOnly>(), options.FromDate, credentialFailure.ErrorCode!, credentialFailure.ErrorMessage!);
+        }
+
+        var probe = await ProbeWithTokenAsync(options.ZoneId, NormalizeSiteHost(options.SiteBaseUrl), token, cancellationToken).ConfigureAwait(false);
         if (!probe.Success)
             return Failure(options, probe, probe.RequestCount, Array.Empty<WebTrafficObservation>(), Array.Empty<DateOnly>(), options.FromDate, probe.ErrorCode!, probe.ErrorMessage!);
 
@@ -116,20 +140,6 @@ public sealed partial class CloudflareAnalyticsCollector
         {
             return Failure(options, probe, probe.RequestCount, Array.Empty<WebTrafficObservation>(), Array.Empty<DateOnly>(), options.FromDate,
                 "duration-boundary", "The provider-reported query duration cannot cover a complete UTC traffic partition.");
-        }
-
-        string token;
-        try
-        {
-            token = await _tokenProvider.GetTokenAsync(cancellationToken).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch
-        {
-            return Failure(options, probe, probe.RequestCount, Array.Empty<WebTrafficObservation>(), Array.Empty<DateOnly>(), options.FromDate, "credential-unavailable", "Cloudflare analytics credential resolution failed.");
         }
 
         var observations = new List<WebTrafficObservation>();
@@ -507,8 +517,15 @@ public sealed partial class CloudflareAnalyticsCollector
         string.Equals(host, zoneName, StringComparison.Ordinal) ||
         host.EndsWith("." + zoneName, StringComparison.Ordinal);
 
-    private static CloudflareAnalyticsCapabilityProbeResult ProbeFailure(int requestCount, string code, string message) => new()
+    private static CloudflareAnalyticsCapabilityProbeResult ProbeFailure(
+        int requestCount,
+        string code,
+        string message,
+        string? zoneName = null,
+        string? zoneAccountId = null) => new()
     {
+        ZoneName = zoneName,
+        ZoneAccountId = zoneAccountId,
         RequestCount = requestCount,
         ErrorCode = code,
         ErrorMessage = message

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.cs
@@ -91,11 +91,7 @@ public sealed partial class CloudflareAnalyticsCollector
             RequestCount = 2,
             MaxPageSize = Math.Min(settings.MaxPageSize.Value, ClientMaximumRowsPerDay),
             MaxDurationSeconds = settings.MaxDuration,
-            NotOlderThanSeconds = settings.NotOlderThan,
-            FirewallDatasetEnabled = zones[0].Settings?.FirewallEventsAdaptiveGroups?.Enabled == true,
-            FirewallMaxPageSize = Math.Min(zones[0].Settings?.FirewallEventsAdaptiveGroups?.MaxPageSize ?? 0, ClientMaximumRowsPerDay),
-            FirewallMaxDurationSeconds = zones[0].Settings?.FirewallEventsAdaptiveGroups?.MaxDuration,
-            FirewallNotOlderThanSeconds = zones[0].Settings?.FirewallEventsAdaptiveGroups?.NotOlderThan
+            NotOlderThanSeconds = settings.NotOlderThan
         };
     }
 
@@ -536,12 +532,6 @@ public sealed partial class CloudflareAnalyticsCollector
             zones(filter: { zoneTag: $zoneTag }) {
               settings {
                 httpRequestsAdaptiveGroups {
-                  enabled
-                  maxPageSize
-                  maxDuration
-                  notOlderThan
-                }
-                firewallEventsAdaptiveGroups {
                   enabled
                   maxPageSize
                   maxDuration

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.cs
@@ -224,7 +224,9 @@ public sealed partial class CloudflareAnalyticsCollector
                 observations = Array.Empty<WebTrafficObservation>();
                 return false;
             }
-            if (!TryScaleSampledCount(row.Count.Value, row.Average.SampleInterval.Value, out var requests))
+            if (!TryScaleSampledCount(row.Count.Value, row.Average.SampleInterval.Value, out var requests) ||
+                !TryScaleSampledCount(row.Sum.Visits.Value, row.Average.SampleInterval.Value, out var visits) ||
+                !TryScaleSampledCount(row.Sum.EdgeResponseBytes.Value, row.Average.SampleInterval.Value, out var edgeResponseBytes))
             {
                 observations = Array.Empty<WebTrafficObservation>();
                 return false;
@@ -247,8 +249,8 @@ public sealed partial class CloudflareAnalyticsCollector
                 Host = rowHost,
                 Path = dimensions.Path,
                 Requests = requests,
-                Visits = (long)row.Sum.Visits.Value,
-                EdgeResponseBytes = (long)row.Sum.EdgeResponseBytes.Value,
+                Visits = visits,
+                EdgeResponseBytes = edgeResponseBytes,
                 SampleInterval = row.Average.SampleInterval.Value,
                 EvidenceReference = options.EvidenceReference
             });

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsCollector.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 namespace PowerForge.Web;
 
 /// <summary>Collects bounded daily end-user HTTP traffic from Cloudflare GraphQL Analytics.</summary>
-public sealed class CloudflareAnalyticsCollector
+public sealed partial class CloudflareAnalyticsCollector
 {
     /// <summary>Fleet provider kind handled by this collector.</summary>
     public const string ProviderKind = "cloudflare-analytics";

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsModels.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsModels.cs
@@ -39,6 +39,8 @@ public sealed class CloudflareAnalyticsCapabilityProbeResult
     public bool DatasetEnabled { get; set; }
     /// <summary>Canonical zone name verified against the owning fleet site.</summary>
     public string? ZoneName { get; set; }
+    /// <summary>Owning account identifier returned by the zone lookup, when available.</summary>
+    public string? ZoneAccountId { get; set; }
     /// <summary>Number of Cloudflare HTTP requests attempted by the probe.</summary>
     public int RequestCount { get; set; }
     /// <summary>Effective maximum rows requested by the collector.</summary>
@@ -47,6 +49,14 @@ public sealed class CloudflareAnalyticsCapabilityProbeResult
     public int? MaxDurationSeconds { get; set; }
     /// <summary>Provider-reported retention boundary, when available.</summary>
     public int? NotOlderThanSeconds { get; set; }
+    /// <summary>Whether the firewall events adaptive group dataset is enabled.</summary>
+    public bool FirewallDatasetEnabled { get; set; }
+    /// <summary>Provider-reported maximum firewall rows.</summary>
+    public int FirewallMaxPageSize { get; set; }
+    /// <summary>Provider-reported maximum firewall query duration, when available.</summary>
+    public int? FirewallMaxDurationSeconds { get; set; }
+    /// <summary>Provider-reported firewall retention boundary, when available.</summary>
+    public int? FirewallNotOlderThanSeconds { get; set; }
     /// <summary>Stable failure category.</summary>
     public string? ErrorCode { get; set; }
     /// <summary>Sanitized failure description.</summary>
@@ -112,6 +122,15 @@ internal sealed class CloudflareZoneDetails
 
     [JsonPropertyName("name")]
     public string? Name { get; set; }
+
+    [JsonPropertyName("account")]
+    public CloudflareZoneAccount? Account { get; set; }
+}
+
+internal sealed class CloudflareZoneAccount
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
 }
 
 internal sealed class CloudflareCapabilityData
@@ -136,6 +155,9 @@ internal sealed class CloudflareAnalyticsSettings
 {
     [JsonPropertyName("httpRequestsAdaptiveGroups")]
     public CloudflareDatasetSettings? HttpRequestsAdaptiveGroups { get; set; }
+
+    [JsonPropertyName("firewallEventsAdaptiveGroups")]
+    public CloudflareDatasetSettings? FirewallEventsAdaptiveGroups { get; set; }
 }
 
 internal sealed class CloudflareDatasetSettings

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsModels.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareAnalyticsModels.cs
@@ -49,14 +49,6 @@ public sealed class CloudflareAnalyticsCapabilityProbeResult
     public int? MaxDurationSeconds { get; set; }
     /// <summary>Provider-reported retention boundary, when available.</summary>
     public int? NotOlderThanSeconds { get; set; }
-    /// <summary>Whether the firewall events adaptive group dataset is enabled.</summary>
-    public bool FirewallDatasetEnabled { get; set; }
-    /// <summary>Provider-reported maximum firewall rows.</summary>
-    public int FirewallMaxPageSize { get; set; }
-    /// <summary>Provider-reported maximum firewall query duration, when available.</summary>
-    public int? FirewallMaxDurationSeconds { get; set; }
-    /// <summary>Provider-reported firewall retention boundary, when available.</summary>
-    public int? FirewallNotOlderThanSeconds { get; set; }
     /// <summary>Stable failure category.</summary>
     public string? ErrorCode { get; set; }
     /// <summary>Sanitized failure description.</summary>

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareOperationalModels.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareOperationalModels.cs
@@ -77,6 +77,8 @@ public sealed class CloudflareOperationalCollectionResult
 {
     /// <summary>Whether zone traffic completed. Optional WAF/RUM gaps do not erase traffic evidence.</summary>
     public bool Success { get; set; }
+    /// <summary>Stable fleet site identifier for this pulse.</summary>
+    public string SiteId { get; set; } = string.Empty;
     /// <summary>Capture time.</summary>
     public DateTimeOffset CollectedAtUtc { get; set; }
     /// <summary>Number of provider requests attempted.</summary>
@@ -125,8 +127,8 @@ internal sealed class CloudflareFirewallOperationalDimensions
 internal sealed class CloudflareRumSitesEnvelope
 {
     [JsonPropertyName("success")] public bool? Success { get; set; }
-    [JsonPropertyName("result")] public CloudflareRumSiteInfo[] Result { get; set; } = Array.Empty<CloudflareRumSiteInfo>();
-    [JsonPropertyName("errors")] public CloudflareApiError[] Errors { get; set; } = Array.Empty<CloudflareApiError>();
+    [JsonPropertyName("result")] public CloudflareRumSiteInfo?[]? Result { get; set; } = Array.Empty<CloudflareRumSiteInfo?>();
+    [JsonPropertyName("errors")] public CloudflareApiError[]? Errors { get; set; } = Array.Empty<CloudflareApiError>();
     [JsonPropertyName("result_info")] public CloudflareRumResultInfo? ResultInfo { get; set; }
 }
 internal sealed class CloudflareRumResultInfo

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareOperationalModels.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareOperationalModels.cs
@@ -1,0 +1,140 @@
+using System.Text.Json.Serialization;
+
+namespace PowerForge.Web;
+
+/// <summary>Options for a bounded Cloudflare operational pulse.</summary>
+public sealed class CloudflareOperationalCollectionOptions
+{
+    /// <summary>Stable fleet site identifier.</summary>
+    public string SiteId { get; set; } = string.Empty;
+    /// <summary>Owning Cloudflare zone identifier.</summary>
+    public string ZoneId { get; set; } = string.Empty;
+    /// <summary>Owning site URL used to constrain HTTP and WAF observations.</summary>
+    public string SiteBaseUrl { get; set; } = string.Empty;
+    /// <summary>Inclusive UTC beginning of the operational window.</summary>
+    public DateTimeOffset FromUtc { get; set; }
+    /// <summary>Exclusive UTC end of the operational window.</summary>
+    public DateTimeOffset ThroughUtc { get; set; }
+    /// <summary>Optional Cloudflare account identifier used to inspect RUM configuration.</summary>
+    public string? AccountId { get; set; }
+}
+
+/// <summary>One normalized hourly Cloudflare operational observation.</summary>
+public sealed class CloudflareHourlyOperationalObservation
+{
+    /// <summary>Beginning of the UTC hour.</summary>
+    public DateTimeOffset HourUtc { get; set; }
+    /// <summary>Estimated end-user request count.</summary>
+    public long Requests { get; set; }
+    /// <summary>Estimated cache-hit request count.</summary>
+    public long CachedRequests { get; set; }
+    /// <summary>Estimated 4xx response count.</summary>
+    public long ClientErrors { get; set; }
+    /// <summary>Estimated 5xx response count.</summary>
+    public long ServerErrors { get; set; }
+    /// <summary>Estimated edge response bytes.</summary>
+    public long EdgeResponseBytes { get; set; }
+    /// <summary>Estimated WAF/security event count.</summary>
+    public long FirewallEvents { get; set; }
+    /// <summary>Estimated blocked/challenged WAF event count.</summary>
+    public long FirewallMitigated { get; set; }
+    /// <summary>Largest adaptive sample interval contributing to the hour.</summary>
+    public double MaximumSampleInterval { get; set; } = 1d;
+    /// <summary>Cache-hit percentage when request evidence is available.</summary>
+    public double CacheHitPercent => Requests <= 0 ? 0d : CachedRequests * 100d / Requests;
+}
+
+/// <summary>Cloudflare Web Analytics/RUM installation state for the owning zone.</summary>
+public sealed class CloudflareRumSiteState
+{
+    /// <summary>Whether account-scoped RUM inspection was requested.</summary>
+    public bool Requested { get; set; }
+    /// <summary>Whether a matching Web Analytics site was found.</summary>
+    public bool Configured { get; set; }
+    /// <summary>Whether the matching ruleset is enabled.</summary>
+    public bool Enabled { get; set; }
+    /// <summary>Whether Cloudflare automatically injects the RUM beacon.</summary>
+    public bool AutoInstall { get; set; }
+    /// <summary>Stable failure category when inspection was unavailable.</summary>
+    public string? ErrorCode { get; set; }
+    /// <summary>Sanitized failure description.</summary>
+    public string? ErrorMessage { get; set; }
+}
+
+/// <summary>Independent capability state within a Cloudflare operational pulse.</summary>
+public sealed class CloudflareOperationalCapabilityState
+{
+    /// <summary>Whether the capability returned complete evidence.</summary>
+    public bool Success { get; set; }
+    /// <summary>Stable failure category.</summary>
+    public string? ErrorCode { get; set; }
+    /// <summary>Sanitized failure description.</summary>
+    public string? ErrorMessage { get; set; }
+}
+
+/// <summary>Cloudflare operational pulse with independently degradable datasets.</summary>
+public sealed class CloudflareOperationalCollectionResult
+{
+    /// <summary>Whether zone traffic completed. Optional WAF/RUM gaps do not erase traffic evidence.</summary>
+    public bool Success { get; set; }
+    /// <summary>Capture time.</summary>
+    public DateTimeOffset CollectedAtUtc { get; set; }
+    /// <summary>Number of provider requests attempted.</summary>
+    public int RequestCount { get; set; }
+    /// <summary>HTTP/cache/status dataset state.</summary>
+    public CloudflareOperationalCapabilityState Http { get; set; } = new();
+    /// <summary>WAF/security dataset state.</summary>
+    public CloudflareOperationalCapabilityState Firewall { get; set; } = new();
+    /// <summary>RUM configuration state.</summary>
+    public CloudflareRumSiteState Rum { get; set; } = new();
+    /// <summary>Normalized hourly observations.</summary>
+    public CloudflareHourlyOperationalObservation[] Hours { get; set; } = Array.Empty<CloudflareHourlyOperationalObservation>();
+}
+
+internal sealed class CloudflareOperationalData { [JsonPropertyName("viewer")] public CloudflareOperationalViewer? Viewer { get; set; } }
+internal sealed class CloudflareOperationalViewer { [JsonPropertyName("zones")] public CloudflareOperationalZone?[] Zones { get; set; } = Array.Empty<CloudflareOperationalZone?>(); }
+internal sealed class CloudflareOperationalZone
+{
+    [JsonPropertyName("http")] public CloudflareHttpOperationalGroup?[]? Http { get; set; }
+    [JsonPropertyName("firewall")] public CloudflareFirewallOperationalGroup?[]? Firewall { get; set; }
+}
+internal sealed class CloudflareHttpOperationalGroup
+{
+    [JsonPropertyName("count")] public ulong? Count { get; set; }
+    [JsonPropertyName("avg")] public CloudflareTrafficAverage? Average { get; set; }
+    [JsonPropertyName("sum")] public CloudflareTrafficSum? Sum { get; set; }
+    [JsonPropertyName("dimensions")] public CloudflareHttpOperationalDimensions? Dimensions { get; set; }
+}
+internal sealed class CloudflareHttpOperationalDimensions
+{
+    [JsonPropertyName("datetimeHour")] public DateTimeOffset? HourUtc { get; set; }
+    [JsonPropertyName("cacheStatus")] public string? CacheStatus { get; set; }
+    [JsonPropertyName("edgeResponseStatus")] public int? EdgeResponseStatus { get; set; }
+}
+internal sealed class CloudflareFirewallOperationalGroup
+{
+    [JsonPropertyName("count")] public ulong? Count { get; set; }
+    [JsonPropertyName("avg")] public CloudflareTrafficAverage? Average { get; set; }
+    [JsonPropertyName("dimensions")] public CloudflareFirewallOperationalDimensions? Dimensions { get; set; }
+}
+internal sealed class CloudflareFirewallOperationalDimensions
+{
+    [JsonPropertyName("datetimeHour")] public DateTimeOffset? HourUtc { get; set; }
+    [JsonPropertyName("action")] public string? Action { get; set; }
+}
+internal sealed class CloudflareRumSitesEnvelope
+{
+    [JsonPropertyName("success")] public bool? Success { get; set; }
+    [JsonPropertyName("result")] public CloudflareRumSiteInfo[] Result { get; set; } = Array.Empty<CloudflareRumSiteInfo>();
+    [JsonPropertyName("errors")] public CloudflareApiError[] Errors { get; set; } = Array.Empty<CloudflareApiError>();
+}
+internal sealed class CloudflareRumSiteInfo
+{
+    [JsonPropertyName("auto_install")] public bool? AutoInstall { get; set; }
+    [JsonPropertyName("ruleset")] public CloudflareRumRuleset? Ruleset { get; set; }
+}
+internal sealed class CloudflareRumRuleset
+{
+    [JsonPropertyName("enabled")] public bool? Enabled { get; set; }
+    [JsonPropertyName("zone_tag")] public string? ZoneTag { get; set; }
+}

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareOperationalModels.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareOperationalModels.cs
@@ -135,6 +135,7 @@ internal sealed class CloudflareRumResultInfo
 }
 internal sealed class CloudflareRumSiteInfo
 {
+    [JsonPropertyName("host")] public string? Host { get; set; }
     [JsonPropertyName("auto_install")] public bool? AutoInstall { get; set; }
     [JsonPropertyName("ruleset")] public CloudflareRumRuleset? Ruleset { get; set; }
 }

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareOperationalModels.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareOperationalModels.cs
@@ -79,7 +79,11 @@ public sealed class CloudflareOperationalCollectionResult
     public bool Success { get; set; }
     /// <summary>Stable fleet site identifier for this pulse.</summary>
     public string SiteId { get; set; } = string.Empty;
-    /// <summary>Capture time.</summary>
+    /// <summary>Inclusive start of the requested UTC window.</summary>
+    public DateTimeOffset FromUtc { get; set; }
+    /// <summary>Exclusive end of the requested UTC window.</summary>
+    public DateTimeOffset ThroughUtc { get; set; }
+    /// <summary>Time when collection completed.</summary>
     public DateTimeOffset CollectedAtUtc { get; set; }
     /// <summary>Number of provider requests attempted.</summary>
     public int RequestCount { get; set; }

--- a/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareOperationalModels.cs
+++ b/PowerForge.Web/Traffic/Providers/Cloudflare/CloudflareOperationalModels.cs
@@ -127,6 +127,11 @@ internal sealed class CloudflareRumSitesEnvelope
     [JsonPropertyName("success")] public bool? Success { get; set; }
     [JsonPropertyName("result")] public CloudflareRumSiteInfo[] Result { get; set; } = Array.Empty<CloudflareRumSiteInfo>();
     [JsonPropertyName("errors")] public CloudflareApiError[] Errors { get; set; } = Array.Empty<CloudflareApiError>();
+    [JsonPropertyName("result_info")] public CloudflareRumResultInfo? ResultInfo { get; set; }
+}
+internal sealed class CloudflareRumResultInfo
+{
+    [JsonPropertyName("total_pages")] public int? TotalPages { get; set; }
 }
 internal sealed class CloudflareRumSiteInfo
 {


### PR DESCRIPTION
## Summary

Adds reusable Cloudflare operational analytics to PowerForge.Web for website monitoring surfaces.

## What changed

- collects hourly cache, origin error and firewall activity with independently degradable HTTP, firewall and RUM capability states
- resolves one credential per collection so ownership, capabilities and evidence use a consistent authorization context
- keeps firewall and RUM evidence available when the HTTP analytics dataset is unavailable after zone ownership succeeds
- scopes firewall evidence to the configured scheme, host and path
- reports the requested UTC window and records the pulse timestamp only after collection completes
- partitions long query windows on complete UTC hours, handles optional duration metadata and fails closed when an hour cannot fit
- rejects out-of-window, non-hour-aligned and duplicate provider dimensions without leaking partial evidence
- scales sampled request, visit and byte aggregates consistently with Cloudflare sampling intervals
- fails closed on page-size truncation while preserving valid HTTP evidence when optional firewall capability is unavailable
- keeps RUM inspection available even when historical analytics falls outside retention
- classifies stale cache responses and managed-challenge mitigations accurately
- verifies the configured RUM account owns the zone, paginates site discovery and rejects incomplete configuration records
- preserves provider request-attempt counts across successful and failed transports
- exposes typed operational models for thin dashboard consumers

## Validation

- Cloudflare analytics test surface: 83 passed
- PowerForge.Web Release builds passed for net8.0 and net10.0