### PR TITLE
Include README in PowerForge packages

### DIFF
--- a/PowerForge.Web/PowerForge.Web.csproj
+++ b/PowerForge.Web/PowerForge.Web.csproj
@@ -15,11 +15,13 @@
     <Copyright>Copyright (c) 2024-2026 Evotec Services sp. z o.o.</Copyright>
     <PackageTags>website;static-site;docs;automation;powerforge</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.MD</PackageReadmeFile>
     <RepositoryUrl>https://github.com/EvotecIT/PSPublishModule</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\README.MD" Pack="true" PackagePath="\" />
     <ProjectReference Include="..\PowerForge\PowerForge.csproj">
       <GlobalPropertiesToRemove>PublishAot;RuntimeIdentifier;SelfContained</GlobalPropertiesToRemove>
     </ProjectReference>

--- a/PowerForge.Web/PowerForge.Web.csproj
+++ b/PowerForge.Web/PowerForge.Web.csproj
@@ -15,13 +15,14 @@
     <Copyright>Copyright (c) 2024-2026 Evotec Services sp. z o.o.</Copyright>
     <PackageTags>website;static-site;docs;automation;powerforge</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReadmeFile>README.MD</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/EvotecIT/PSPublishModule</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\README.MD" Pack="true" PackagePath="\" />
+    <None Remove="README.md" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
     <ProjectReference Include="..\PowerForge\PowerForge.csproj">
       <GlobalPropertiesToRemove>PublishAot;RuntimeIdentifier;SelfContained</GlobalPropertiesToRemove>
     </ProjectReference>

--- a/PowerForge.Web/README.md
+++ b/PowerForge.Web/README.md
@@ -1,0 +1,7 @@
+# PowerForge.Web
+
+PowerForge.Web provides the reusable static-site, documentation, traffic-evidence, and deployment capabilities used by PowerForge-powered websites.
+
+Start with the [PowerForge repository documentation](https://github.com/EvotecIT/PSPublishModule#readme), browse the [PowerForge.Web source](https://github.com/EvotecIT/PSPublishModule/tree/main/PowerForge.Web), or report a problem in the [issue tracker](https://github.com/EvotecIT/PSPublishModule/issues).
+
+The package is licensed under the [MIT License](https://github.com/EvotecIT/PSPublishModule/blob/main/LICENSE).

--- a/PowerForge/PowerForge.csproj
+++ b/PowerForge/PowerForge.csproj
@@ -17,6 +17,7 @@
     <Copyright>Copyright (c) 2024-2026 Evotec Services sp. z o.o.</Copyright>
     <PackageTags>powershell;build;publishing;automation;github</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.MD</PackageReadmeFile>
     <RepositoryUrl>https://github.com/EvotecIT/PSPublishModule</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
@@ -28,6 +29,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0' ">
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.11" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\README.MD" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">

--- a/PowerForge/PowerForge.csproj
+++ b/PowerForge/PowerForge.csproj
@@ -17,7 +17,7 @@
     <Copyright>Copyright (c) 2024-2026 Evotec Services sp. z o.o.</Copyright>
     <PackageTags>powershell;build;publishing;automation;github</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReadmeFile>README.MD</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/EvotecIT/PSPublishModule</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
@@ -32,7 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\README.MD" Pack="true" PackagePath="\" />
+    <None Remove="README.md" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">

--- a/PowerForge/README.md
+++ b/PowerForge/README.md
@@ -1,0 +1,7 @@
+# PowerForge
+
+PowerForge is the reusable .NET build, packaging, signing, and release engine behind PSPublishModule. It provides typed APIs for projects that need the same pipeline behavior without hosting PowerShell.
+
+Start with the [PowerForge repository documentation](https://github.com/EvotecIT/PSPublishModule#readme), browse the [PowerForge source](https://github.com/EvotecIT/PSPublishModule/tree/main/PowerForge), or report a problem in the [issue tracker](https://github.com/EvotecIT/PSPublishModule/issues).
+
+The package is licensed under the [MIT License](https://github.com/EvotecIT/PSPublishModule/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

Includes feed-safe package guidance in the PowerForge and PowerForge.Web NuGet packages.

## What changed

- adds a focused README for each library
- uses absolute documentation and source links that resolve from package feeds
- packs each README at the package root

## Validation

- packed PowerForge 3.0.124 successfully and confirmed root README.md
- packed PowerForge.Web 3.0.124 successfully and confirmed root README.md