### PR TITLE
Honor generated redirects in Apache site scaffolds

### DIFF
--- a/Docs/PowerForge.Web.LinuxDeployment.md
+++ b/Docs/PowerForge.Web.LinuxDeployment.md
@@ -102,12 +102,14 @@ Validate the installed file with `visudo -cf`. Sites upgrading from the earlier
 one-shot action must install these rules before repinning the action; retaining only
 the old promotion rule will reject the deferred verification protocol.
 
-The generated Apache virtual hosts use `AllowOverride FileInfo`. This is the narrow
-override class required for PowerForge's generated `.htaccess` redirects and custom
-error documents while keeping authentication, directory indexing, and unrelated
-server policy under the root-owned virtual host. Existing hosts created with
-`AllowOverride None` must update that one directory policy and reload Apache before
-declared aliases can work in production.
+The generated Apache virtual hosts keep override classes disabled with
+`AllowOverride None` and use `AllowOverrideList` to permit only the directives emitted
+by PowerForge: custom error documents, rewrite rules, response headers, and Markdown
+content types. This avoids granting unrelated `FileInfo` capabilities such as handler
+selection. Generated redirect artifacts also bypass ACME HTTP-01 challenges and the
+PowerForge deployment marker before evaluating site redirects. Existing hosts created
+with only `AllowOverride None` must add the generated `AllowOverrideList` line and
+reload Apache before declared aliases can work in production.
 
 The promoter rejects path traversal, links, special files, checksum mismatches,
 unconfigured site ids, mutable site configuration, and workflow staging files owned

--- a/Docs/PowerForge.Web.LinuxDeployment.md
+++ b/Docs/PowerForge.Web.LinuxDeployment.md
@@ -102,6 +102,13 @@ Validate the installed file with `visudo -cf`. Sites upgrading from the earlier
 one-shot action must install these rules before repinning the action; retaining only
 the old promotion rule will reject the deferred verification protocol.
 
+The generated Apache virtual hosts use `AllowOverride FileInfo`. This is the narrow
+override class required for PowerForge's generated `.htaccess` redirects and custom
+error documents while keeping authentication, directory indexing, and unrelated
+server policy under the root-owned virtual host. Existing hosts created with
+`AllowOverride None` must update that one directory policy and reload Apache before
+declared aliases can work in production.
+
 The promoter rejects path traversal, links, special files, checksum mismatches,
 unconfigured site ids, mutable site configuration, and workflow staging files owned
 by another account. It atomically promotes a timestamped release, purges Cloudflare

--- a/PowerForge.Tests/ServerScaffoldTests.cs
+++ b/PowerForge.Tests/ServerScaffoldTests.cs
@@ -19,6 +19,8 @@ public sealed class ServerScaffoldTests
         var recoveryValidationWorkflow = files[".github/workflows/server-recovery-ci.yml"];
         var manifest = files["deploy/linux/example.serverrecovery.json"];
         var onboarding = files["deploy/linux/ONBOARDING.md"];
+        var apacheHttp = files["Website/deploy/apache.conf"];
+        var apacheHttps = files["Website/deploy/apache-ssl.conf"];
 
         Assert.DoesNotContain("run: |", workflow, StringComparison.Ordinal);
         Assert.Contains("powerforge-website-deploy.yml@" + EngineRef, workflow, StringComparison.Ordinal);
@@ -42,6 +44,10 @@ public sealed class ServerScaffoldTests
         Assert.Contains("CLOUDFLARE_PURGE_ENABLED=0", files["deploy/linux/example.test.env"], StringComparison.Ordinal);
         Assert.DoesNotContain("www.example.test", files["Website/deploy/apache.conf"], StringComparison.Ordinal);
         Assert.DoesNotContain("www.example.test", files["Website/deploy/apache-ssl.conf"], StringComparison.Ordinal);
+        Assert.Contains("AllowOverride FileInfo", apacheHttp, StringComparison.Ordinal);
+        Assert.Contains("AllowOverride FileInfo", apacheHttps, StringComparison.Ordinal);
+        Assert.DoesNotContain("AllowOverride None", apacheHttp, StringComparison.Ordinal);
+        Assert.DoesNotContain("AllowOverride None", apacheHttps, StringComparison.Ordinal);
         Assert.DoesNotContain("www.example.test", manifest, StringComparison.Ordinal);
         Assert.All(files.Where(file => !file.Key.EndsWith(".example", StringComparison.Ordinal)), file =>
         {

--- a/PowerForge.Tests/ServerScaffoldTests.cs
+++ b/PowerForge.Tests/ServerScaffoldTests.cs
@@ -44,10 +44,13 @@ public sealed class ServerScaffoldTests
         Assert.Contains("CLOUDFLARE_PURGE_ENABLED=0", files["deploy/linux/example.test.env"], StringComparison.Ordinal);
         Assert.DoesNotContain("www.example.test", files["Website/deploy/apache.conf"], StringComparison.Ordinal);
         Assert.DoesNotContain("www.example.test", files["Website/deploy/apache-ssl.conf"], StringComparison.Ordinal);
-        Assert.Contains("AllowOverride FileInfo", apacheHttp, StringComparison.Ordinal);
-        Assert.Contains("AllowOverride FileInfo", apacheHttps, StringComparison.Ordinal);
-        Assert.DoesNotContain("AllowOverride None", apacheHttp, StringComparison.Ordinal);
-        Assert.DoesNotContain("AllowOverride None", apacheHttps, StringComparison.Ordinal);
+        const string allowedDirectives = "AllowOverrideList ErrorDocument RewriteEngine RewriteCond RewriteRule Header AddType <IfModule <If";
+        Assert.Contains("AllowOverride None", apacheHttp, StringComparison.Ordinal);
+        Assert.Contains("AllowOverride None", apacheHttps, StringComparison.Ordinal);
+        Assert.Contains(allowedDirectives, apacheHttp, StringComparison.Ordinal);
+        Assert.Contains(allowedDirectives, apacheHttps, StringComparison.Ordinal);
+        Assert.DoesNotContain("AllowOverride FileInfo", apacheHttp, StringComparison.Ordinal);
+        Assert.DoesNotContain("AllowOverride FileInfo", apacheHttps, StringComparison.Ordinal);
         Assert.DoesNotContain("www.example.test", manifest, StringComparison.Ordinal);
         Assert.All(files.Where(file => !file.Key.EndsWith(".example", StringComparison.Ordinal)), file =>
         {

--- a/PowerForge.Tests/WebLinkServiceTests.cs
+++ b/PowerForge.Tests/WebLinkServiceTests.cs
@@ -574,6 +574,11 @@ public sealed class WebLinkServiceTests
             Assert.Equal(3, result.RuleCount);
             var apache = File.ReadAllText(outPath);
             Assert.Contains("ErrorDocument 404 /404.html", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteCond %{REQUEST_URI} !^/(?:\\.well-known/acme-challenge(?:/|$)|_powerforge/deployment\\.json$) [NC]", apache, StringComparison.Ordinal);
+            Assert.DoesNotContain("RewriteRule ^ - [END]", apache, StringComparison.Ordinal);
+            Assert.Equal(
+                apache.Split("RewriteCond %{REQUEST_URI} !", StringSplitOptions.None).Length - 1,
+                apache.Split('\n').Count(static line => line.StartsWith("RewriteRule ", StringComparison.Ordinal)));
             Assert.Contains("RewriteCond %{HTTP_HOST} ^(www\\.)?evotec\\.pl$ [NC]", apache, StringComparison.Ordinal);
             Assert.Contains("RewriteRule ^/?stary/?$ /nowy/ [R=301,L,QSD]", apache, StringComparison.Ordinal);
             Assert.Contains("RewriteCond %{QUERY_STRING} (^|&)p=123(&|$)", apache, StringComparison.Ordinal);

--- a/PowerForge.Tests/WebPipelineRunnerApacheRedirectsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerApacheRedirectsTests.cs
@@ -61,6 +61,11 @@ public class WebPipelineRunnerApacheRedirectsTests
             Assert.True(File.Exists(outputPath));
             var config = File.ReadAllText(outputPath);
             Assert.Contains("RewriteEngine On", config, StringComparison.Ordinal);
+            Assert.Contains("RewriteCond %{REQUEST_URI} !^/(?:\\.well-known/acme-challenge(?:/|$)|_powerforge/deployment\\.json$) [NC]", config, StringComparison.Ordinal);
+            Assert.DoesNotContain("RewriteRule ^ - [END]", config, StringComparison.Ordinal);
+            Assert.Equal(
+                Regex.Matches(config, "^RewriteCond %\\{REQUEST_URI\\} !", RegexOptions.Multiline).Count,
+                Regex.Matches(config, "^RewriteRule .+\\[R=", RegexOptions.Multiline).Count);
             Assert.Contains("RewriteCond %{QUERY_STRING} (^|&)p=15(&|$)", config, StringComparison.Ordinal);
             Assert.Contains("RewriteCond %{QUERY_STRING} (^|&)page_id=40(&|$)", config, StringComparison.Ordinal);
             Assert.Contains("/new-url [R=301,L]", config, StringComparison.Ordinal);

--- a/PowerForge.Tests/WebSiteAuditOptimizeBuildTests.cs
+++ b/PowerForge.Tests/WebSiteAuditOptimizeBuildTests.cs
@@ -371,6 +371,13 @@ public partial class WebSiteAuditOptimizeBuildTests
                         From = "/legacy?id=2",
                         To = "/newer/",
                         Status = 302
+                    },
+                    new RedirectSpec
+                    {
+                        From = "/*",
+                        To = "/archive/{path}",
+                        Status = 301,
+                        MatchType = RedirectMatchType.Wildcard
                     }
                 },
                 Collections = new[]
@@ -393,6 +400,7 @@ public partial class WebSiteAuditOptimizeBuildTests
             var apache = File.ReadAllText(Path.Combine(result.OutputPath, ".htaccess"));
             Assert.Contains("docs/api", apache, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("/api/$1", apache, StringComparison.OrdinalIgnoreCase);
+            AssertOperationalPathsBypassRedirects(apache);
 
             var nginx = File.ReadAllText(Path.Combine(result.OutputPath, "nginx.redirects.conf"));
             Assert.Contains("location ~ ^/docs/api", nginx, StringComparison.OrdinalIgnoreCase);
@@ -414,6 +422,21 @@ public partial class WebSiteAuditOptimizeBuildTests
             if (Directory.Exists(root))
                 Directory.Delete(root, true);
         }
+    }
+
+    private static void AssertOperationalPathsBypassRedirects(string apache)
+    {
+        const string bypass = "RewriteCond %{REQUEST_URI} !^/(?:\\.well-known/acme-challenge(?:/|$)|_powerforge/deployment\\.json$) [NC]";
+        var bypassIndex = apache.IndexOf(bypass, StringComparison.Ordinal);
+        var generatedRedirectIndex = apache.IndexOf("[R=", StringComparison.Ordinal);
+        var bypassCount = apache.Split(bypass, StringSplitOptions.None).Length - 1;
+        var generatedRedirectCount = apache.Split('\n').Count(static line =>
+            line.StartsWith("RewriteRule ", StringComparison.Ordinal) && line.Contains("[R=", StringComparison.Ordinal));
+
+        Assert.True(bypassIndex >= 0, "The Apache artifact must exempt operational endpoints.");
+        Assert.True(generatedRedirectIndex > bypassIndex, "Operational endpoint bypasses must precede every generated redirect, including catch-all rules.");
+        Assert.Equal(generatedRedirectCount, bypassCount);
+        Assert.DoesNotContain("RewriteRule ^ - [END]", apache, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/PowerForge.Web.Cli/Templates/ServerScaffold/apache-http.conf
+++ b/PowerForge.Web.Cli/Templates/ServerScaffold/apache-http.conf
@@ -5,7 +5,8 @@ __SERVER_ALIAS__
 
     <Directory /var/www/__SITE_ID__/site/current>
         Options -Indexes +FollowSymLinks
-        AllowOverride FileInfo
+        AllowOverride None
+        AllowOverrideList ErrorDocument RewriteEngine RewriteCond RewriteRule Header AddType <IfModule <If
         Require all granted
     </Directory>
 

--- a/PowerForge.Web.Cli/Templates/ServerScaffold/apache-http.conf
+++ b/PowerForge.Web.Cli/Templates/ServerScaffold/apache-http.conf
@@ -5,7 +5,7 @@ __SERVER_ALIAS__
 
     <Directory /var/www/__SITE_ID__/site/current>
         Options -Indexes +FollowSymLinks
-        AllowOverride None
+        AllowOverride FileInfo
         Require all granted
     </Directory>
 

--- a/PowerForge.Web.Cli/Templates/ServerScaffold/apache-https.conf
+++ b/PowerForge.Web.Cli/Templates/ServerScaffold/apache-https.conf
@@ -6,7 +6,7 @@ __SERVER_ALIAS__
 
     <Directory /var/www/__SITE_ID__/site/current>
         Options -Indexes +FollowSymLinks
-        AllowOverride None
+        AllowOverride FileInfo
         Require all granted
     </Directory>
 

--- a/PowerForge.Web.Cli/Templates/ServerScaffold/apache-https.conf
+++ b/PowerForge.Web.Cli/Templates/ServerScaffold/apache-https.conf
@@ -6,7 +6,8 @@ __SERVER_ALIAS__
 
     <Directory /var/www/__SITE_ID__/site/current>
         Options -Indexes +FollowSymLinks
-        AllowOverride FileInfo
+        AllowOverride None
+        AllowOverrideList ErrorDocument RewriteEngine RewriteCond RewriteRule Header AddType <IfModule <If
         Require all granted
     </Directory>
 

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ApacheRedirects.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ApacheRedirects.cs
@@ -111,6 +111,7 @@ internal static partial class WebPipelineRunner
                 if (!string.IsNullOrWhiteSpace(hostCondition))
                     lines.Add($"RewriteCond %{{HTTP_HOST}} {hostCondition} [NC]");
                 lines.Add($"RewriteCond %{{QUERY_STRING}} (^|&)p={id}(&|$)");
+                WebApacheRewriteSafety.AppendOperationalPathCondition(lines);
                 lines.Add($"RewriteRule ^/?$ {row.TargetUrl} [R={row.Status},L,QSD]");
                 lines.Add(string.Empty);
                 continue;
@@ -123,6 +124,7 @@ internal static partial class WebPipelineRunner
                 if (!string.IsNullOrWhiteSpace(hostCondition))
                     lines.Add($"RewriteCond %{{HTTP_HOST}} {hostCondition} [NC]");
                 lines.Add($"RewriteCond %{{QUERY_STRING}} (^|&)page_id={id}(&|$)");
+                WebApacheRewriteSafety.AppendOperationalPathCondition(lines);
                 lines.Add($"RewriteRule ^/?$ {row.TargetUrl} [R={row.Status},L,QSD]");
                 lines.Add(string.Empty);
                 continue;
@@ -139,6 +141,7 @@ internal static partial class WebPipelineRunner
                 if (!string.IsNullOrWhiteSpace(hostCondition))
                     lines.Add($"RewriteCond %{{HTTP_HOST}} {hostCondition} [NC]");
                 AppendApacheLegacyQueryCondition(lines, source.SourceQuery);
+                WebApacheRewriteSafety.AppendOperationalPathCondition(lines);
                 lines.Add($"RewriteRule ^/?$ {row.TargetUrl} [R={row.Status},L{(string.IsNullOrWhiteSpace(source.SourceQuery) ? string.Empty : ",QSD")}]");
                 lines.Add(string.Empty);
                 continue;
@@ -148,6 +151,7 @@ internal static partial class WebPipelineRunner
             if (!string.IsNullOrWhiteSpace(hostCondition))
                 lines.Add($"RewriteCond %{{HTTP_HOST}} {hostCondition} [NC]");
             AppendApacheLegacyQueryCondition(lines, source.SourceQuery);
+            WebApacheRewriteSafety.AppendOperationalPathCondition(lines);
             lines.Add($"RewriteRule ^{escapedPath}/?$ {row.TargetUrl} [R={row.Status},L{(string.IsNullOrWhiteSpace(source.SourceQuery) ? string.Empty : ",QSD")}]");
             lines.Add(string.Empty);
         }

--- a/PowerForge.Web/Services/WebApacheRewriteSafety.cs
+++ b/PowerForge.Web/Services/WebApacheRewriteSafety.cs
@@ -1,0 +1,18 @@
+namespace PowerForge.Web;
+
+/// <summary>Provides shared safety rules for generated Apache rewrite artifacts.</summary>
+public static class WebApacheRewriteSafety
+{
+    /// <summary>
+    /// Appends a condition that keeps certificate issuance and PowerForge deployment
+    /// verification outside the next generated redirect rule without terminating
+    /// unrelated rules in a containing virtual host.
+    /// </summary>
+    /// <param name="lines">The Apache configuration lines to append to.</param>
+    public static void AppendOperationalPathCondition(ICollection<string> lines)
+    {
+        ArgumentNullException.ThrowIfNull(lines);
+
+        lines.Add("RewriteCond %{REQUEST_URI} !^/(?:\\.well-known/acme-challenge(?:/|$)|_powerforge/deployment\\.json$) [NC]");
+    }
+}

--- a/PowerForge.Web/Services/WebLinkService.ExportApache.cs
+++ b/PowerForge.Web/Services/WebLinkService.ExportApache.cs
@@ -110,6 +110,7 @@ public static partial class WebLinkService
 
             AppendHostCondition(lines, rule.SourceHost);
             AppendQueryCondition(lines, rule.SourceQuery, rule.SourceQueryParameter);
+            WebApacheRewriteSafety.AppendOperationalPathCondition(lines);
             lines.Add($"RewriteRule {gonePattern} - [G,L]");
             lines.Add(string.Empty);
             return true;
@@ -124,6 +125,7 @@ public static partial class WebLinkService
 
         AppendHostCondition(lines, rule.SourceHost);
         AppendQueryCondition(lines, rule.SourceQuery, rule.SourceQueryParameter);
+        WebApacheRewriteSafety.AppendOperationalPathCondition(lines);
 
         var hasSourceQuery = HasSourceQuerySelector(rule);
         var flags = new List<string>

--- a/PowerForge.Web/Services/WebSiteBuilder.Redirects.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.Redirects.cs
@@ -333,6 +333,7 @@ public static partial class WebSiteBuilder
             var hasSourceQuery = TryGetRedirectSourceQuery(redirect.From, out var sourceQuery);
             if (hasSourceQuery)
                 lines.Add($"RewriteCond %{{QUERY_STRING}} ^{Regex.Escape(sourceQuery)}$");
+            WebApacheRewriteSafety.AppendOperationalPathCondition(lines);
 
             var flags = new List<string>
             {


### PR DESCRIPTION
## What changed

- Generate Apache HTTP and HTTPS site configurations with `AllowOverride None` plus an exact `AllowOverrideList` for PowerForge-emitted directives.
- Protect ACME HTTP-01 challenges and `/_powerforge/deployment.json` by attaching an exclusion condition to every generated Apache redirect, including catch-all and Gone rules.
- Share that protection across site builds, link exports, and the legacy Apache redirect pipeline.
- Add scaffold and artifact contracts for permission scope, guard ordering/count, and vhost-safe behavior; document the existing-host upgrade.

## Why

PowerForge.Web emits redirect rules in `.htaccess`, but the Linux Apache scaffold disabled every override. A deployed alias could therefore return 404 even though build and deployment checks passed. Broadly enabling the `FileInfo` class would also grant unrelated handler directives, while catch-all redirects could intercept certificate renewal and deployment verification paths.

## Validation

- 38 focused scaffold, site-builder, link-export, and Apache pipeline tests pass.
- Apache 2.4.58 accepts the generated allow-list. A live temporary combined `.htaccess` using `<IfModule>`, `<If>`, `Header`, and `AddType` returned HTTPS 200 with both conditional headers and `text/markdown`.
- CasaRay production remains healthy with the narrowed policy: the deployment marker returns 200 and all 40 legacy slash/no-slash variants retain permanent redirects.
- Independent closure review found two remediation issues before publication; both were fixed, and targeted confirmation found no remaining actionable issue in those defect classes.