### PR TITLE
Preserve mixed parameter-set requiredness in generated help

### DIFF
--- a/PowerForge.Tests/DocumentationGenerationTests.cs
+++ b/PowerForge.Tests/DocumentationGenerationTests.cs
@@ -306,6 +306,18 @@ EXAMPLES
             Assert.Equal("true", apiFilePath.Attribute("required")?.Value);
             Assert.Equal("false", jfrogFilePath.Attribute("required")?.Value);
             Assert.Equal("true", jfrogBaseUri.Attribute("required")?.Value);
+
+            var aggregateFilePath = doc.Descendants(commandNs + "parameters")
+                .Elements(commandNs + "parameter")
+                .Single(element => string.Equals(element.Element(mamlNs + "name")?.Value, "FilePath", StringComparison.Ordinal));
+            Assert.Equal("false", aggregateFilePath.Attribute("required")?.Value);
+
+            var markdownRoot = Path.Combine(root, "Docs");
+            new MarkdownHelpWriter().WriteCommandHelpFiles(payload, "TestModule", markdownRoot);
+            var markdown = File.ReadAllText(Path.Combine(markdownRoot, "New-Thing.md"));
+            var filePathSection = markdown.Substring(markdown.IndexOf("### -FilePath", StringComparison.Ordinal));
+            filePathSection = filePathSection.Substring(0, filePathSection.IndexOf("### -JFrogBaseUri", StringComparison.Ordinal));
+            Assert.Contains("Required: False", filePathSection, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/DocumentationGenerationTests.cs
+++ b/PowerForge.Tests/DocumentationGenerationTests.cs
@@ -326,6 +326,29 @@ EXAMPLES
         }
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("(All)")]
+    [InlineData("__AllParameterSets")]
+    public void ParameterRequiredResolver_PreservesExplicitOptionalSetsWhenMembershipIsUnavailable(string? membership)
+    {
+        var parameter = new DocumentationParameterHelp
+        {
+            Name = "FilePath",
+            Type = "String",
+            Required = true,
+            ParameterSetRequired =
+            {
+                ["ApiFromFile"] = true,
+                ["JFrog"] = false
+            }
+        };
+        if (membership is not null)
+            parameter.ParameterSets.Add(membership);
+
+        Assert.False(DocumentationParameterRequiredResolver.IsAlwaysRequired(parameter));
+    }
+
     [Fact]
     public void MamlHelpWriter_TreatsAllParameterSetsRequiredMetadataAsShared()
     {

--- a/PowerForge/Services/Documentation/DocumentationParameterRequiredResolver.cs
+++ b/PowerForge/Services/Documentation/DocumentationParameterRequiredResolver.cs
@@ -16,6 +16,12 @@ internal static class DocumentationParameterRequiredResolver
         if (requiredBySet is null || requiredBySet.Count == 0)
             return parameter.Required;
 
+        // The extractor can preserve per-set requiredness even when it cannot
+        // recover concrete command-level membership and reports only (All).
+        // An explicit optional set is authoritative for aggregate help.
+        if (requiredBySet.Values.Any(required => !required))
+            return false;
+
         var parameterSets = (parameter.ParameterSets ?? new List<string>())
             .Where(name => !string.IsNullOrEmpty(name))
             .Distinct(StringComparer.OrdinalIgnoreCase)

--- a/PowerForge/Services/Documentation/DocumentationParameterRequiredResolver.cs
+++ b/PowerForge/Services/Documentation/DocumentationParameterRequiredResolver.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PowerForge;
+
+/// <summary>Resolves aggregate requiredness without losing parameter-set-specific optionality.</summary>
+internal static class DocumentationParameterRequiredResolver
+{
+    /// <summary>Returns true only when the parameter is required in every parameter set where it appears.</summary>
+    public static bool IsAlwaysRequired(DocumentationParameterHelp parameter)
+    {
+        if (parameter is null) throw new ArgumentNullException(nameof(parameter));
+
+        var requiredBySet = parameter.ParameterSetRequired;
+        if (requiredBySet is null || requiredBySet.Count == 0)
+            return parameter.Required;
+
+        var parameterSets = (parameter.ParameterSets ?? new List<string>())
+            .Where(name => !string.IsNullOrEmpty(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (parameterSets.Length == 0)
+            return parameter.Required;
+
+        foreach (var parameterSet in parameterSets)
+        {
+            if (TryGetRequired(requiredBySet, parameterSet, out var required))
+            {
+                if (!required) return false;
+                continue;
+            }
+
+            if (!parameter.Required) return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryGetRequired(
+        IReadOnlyDictionary<string, bool> requiredBySet,
+        string parameterSet,
+        out bool required)
+    {
+        foreach (var entry in requiredBySet)
+        {
+            if (string.Equals(entry.Key, parameterSet, StringComparison.OrdinalIgnoreCase))
+            {
+                required = entry.Value;
+                return true;
+            }
+        }
+
+        foreach (var entry in requiredBySet)
+        {
+            if (string.Equals(entry.Key, "(All)", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(entry.Key, "__AllParameterSets", StringComparison.OrdinalIgnoreCase))
+            {
+                required = entry.Value;
+                return true;
+            }
+        }
+
+        required = false;
+        return false;
+    }
+}

--- a/PowerForge/Services/Documentation/MamlHelpWriter.cs
+++ b/PowerForge/Services/Documentation/MamlHelpWriter.cs
@@ -475,7 +475,7 @@ internal sealed class MamlHelpWriter
     private static bool ParameterRequiredInSet(DocumentationParameterHelp p, string? setName, string? syntaxText)
     {
         if (p is null) return false;
-        if (string.IsNullOrEmpty(setName)) return p.Required;
+        if (string.IsNullOrEmpty(setName)) return DocumentationParameterRequiredResolver.IsAlwaysRequired(p);
 
         var setRequired = p.ParameterSetRequired;
         if (setRequired is null || setRequired.Count == 0)

--- a/PowerForge/Services/Documentation/MarkdownHelpWriter.cs
+++ b/PowerForge/Services/Documentation/MarkdownHelpWriter.cs
@@ -218,7 +218,7 @@ internal sealed class MarkdownHelpWriter
                 $"Aliases: {FormatAliases(p)}",
                 $"Possible values: {FormatPossibleValues(p)}",
                 string.Empty,
-                $"Required: {Bool(p.Required)}",
+                $"Required: {Bool(DocumentationParameterRequiredResolver.IsAlwaysRequired(p))}",
                 $"Position: {p.Position}",
                 $"Default value: {DefaultValue(p.DefaultValue)}",
                 $"Accept pipeline input: {PipelineInput(p.PipelineInput)}",


### PR DESCRIPTION
## Summary

- derive aggregate parameter requiredness across all applicable parameter sets
- keep per-syntax MAML requiredness exact for each parameter set
- share the requiredness rule between Markdown and MAML generation
- cover mixed mandatory/optional parameter-set behavior with focused tests

This keeps generated help truthful for commands where a parameter is mandatory in action sets but optional in an information-only set.

## Validation

- focused documentation generation tests: 2 passed
- broader documentation tests: 56 passed
- local PowerForge module build completed successfully
- regenerated HomeAssistantX Markdown and MAML preserve optional aggregate metadata and exact per-syntax requirements