### PR TITLE
Fix Apple monitor native runtime packaging

### DIFF
--- a/.github/actions/build-powerforge/action.yml
+++ b/.github/actions/build-powerforge/action.yml
@@ -1,5 +1,5 @@
 name: Build pinned PowerForge source
-description: Build one immutable standalone PowerForge executable through the repository release pipeline.
+description: Build one immutable self-contained PowerForge payload through the repository release pipeline.
 
 inputs:
   source-root:
@@ -12,7 +12,7 @@ inputs:
 
 outputs:
   tool-path:
-    description: Absolute path to the standalone PowerForge executable.
+    description: Absolute path to the PowerForge executable in the self-contained payload.
     value: ${{ steps.build.outputs.tool-path }}
   runtime:
     description: Validated runtime identifier.
@@ -26,7 +26,7 @@ runs:
       with:
         dotnet-version: 10.0.x
 
-    - name: Build immutable standalone PowerForge
+    - name: Build immutable self-contained PowerForge
       id: build
       shell: pwsh
       env:
@@ -46,7 +46,7 @@ runs:
           '-Target', 'PowerForge',
           '-Runtimes', $env:TOOL_RUNTIME,
           '-Frameworks', 'net10.0',
-          '-Flavors', 'SingleContained',
+          '-Flavors', 'Portable',
           '-Configuration', 'Release'
         )
         $maximumAttempts = 2
@@ -60,7 +60,7 @@ runs:
           Write-Warning "PowerForge source build failed on attempt $attempt of $maximumAttempts with exit code $buildExitCode; retrying in 5 seconds."
           Start-Sleep -Seconds 5
         }
-        $toolPath = Join-Path $sourceRoot "Artifacts/PowerForge/$($env:TOOL_RUNTIME)/net10.0/SingleContained/PowerForge"
+        $toolPath = Join-Path $sourceRoot "Artifacts/PowerForge/$($env:TOOL_RUNTIME)/net10.0/Portable/PowerForge"
         if (-not (Test-Path -LiteralPath $toolPath -PathType Leaf)) { throw "PowerForge executable was not produced: $toolPath" }
         if (-not $IsWindows) { & chmod +x $toolPath }
         "tool-path=$toolPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.MonitorIncidents.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.MonitorIncidents.cs
@@ -173,7 +173,7 @@ public sealed partial class AppleReleaseWorkflowTests
                 if ($attempt -eq 1) { exit 1 }
 
                 $sourceRoot = Split-Path -Parent $PSScriptRoot
-                $toolPath = Join-Path $sourceRoot "Artifacts/PowerForge/$($Runtimes[0])/net10.0/SingleContained/PowerForge"
+                $toolPath = Join-Path $sourceRoot "Artifacts/PowerForge/$($Runtimes[0])/net10.0/$($Flavors[0])/PowerForge"
                 New-Item -ItemType Directory -Force -Path (Split-Path -Parent $toolPath) | Out-Null
                 Set-Content -LiteralPath $toolPath -Value 'recovered-tool' -NoNewline
                 exit 0
@@ -181,7 +181,7 @@ public sealed partial class AppleReleaseWorkflowTests
             var outputPath = Path.Combine(sandbox, "github-output.txt");
             var script = ReadCompositeActionStepScript(
                 Path.Combine(root, ".github", "actions", "build-powerforge", "action.yml"),
-                "Build immutable standalone PowerForge");
+                "Build immutable self-contained PowerForge");
             var environment = new Dictionary<string, string?>
             {
                 ["SOURCE_ROOT"] = sandbox,

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.cs
@@ -539,7 +539,7 @@ public sealed partial class AppleReleaseWorkflowTests
     }
 
     [Fact]
-    public void SourceBuildActionUsesCanonicalReleaseBuilderAndPinnedDotNetSetup()
+    public void SourceBuildActionUsesCompleteSelfContainedPayloadAndPinnedDotNetSetup()
     {
         var root = FindRepoRoot();
         var action = Read(root, ".github", "actions", "build-powerforge", "action.yml");
@@ -547,6 +547,9 @@ public sealed partial class AppleReleaseWorkflowTests
         Assert.Contains("actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7", action, StringComparison.Ordinal);
         Assert.Contains("Build/Build-Project.ps1", action, StringComparison.Ordinal);
         Assert.Contains("'-Target', 'PowerForge'", action, StringComparison.Ordinal);
+        Assert.Contains("'-Flavors', 'Portable'", action, StringComparison.Ordinal);
+        Assert.Contains("/Portable/PowerForge", action, StringComparison.Ordinal);
+        Assert.DoesNotContain("SingleContained", action, StringComparison.Ordinal);
         Assert.Contains("runtime must be osx-arm64 or osx-x64", action, StringComparison.Ordinal);
         Assert.Contains("tool-path=$toolPath", action, StringComparison.Ordinal);
     }


### PR DESCRIPTION
## Summary

- build the pinned PowerForge source as a complete self-contained folder payload for Apple release workflows
- keep the exact-source and retry behavior while returning the executable from that payload
- protect the packaging contract with focused workflow tests

## Why

The macOS single-file payload omitted core native runtime libraries. When Apple release workflows launched PowerForge, .NET could not load `System.Native`, so Doctor failed before it could inspect App Store state. The portable self-contained payload keeps `libSystem.Native.dylib` and the other runtime dependencies beside the executable.

## Validation

- the focused source-build and retry contracts pass
- an `osx-arm64` payload contains `libSystem.Native.dylib` and launches successfully
- a live read-only Doctor run against CasaRay source `216c1d67c4fd1024dded844f5b414c9bc025bc19` completed without any `System.Native` diagnostics

## Release follow-up

This addresses the runtime failure reported in EvotecIT/CasaRay#191. After merge, CasaRay must repin its Apple workflow to the merged PowerForge commit. The live Doctor run then exposes a separate existing China territory governance drift; this PR does not change App Store availability.