### PR TITLE
Fix App Store territory availability updates

### DIFF
--- a/PowerForge.Tests/AppStoreConnectGovernanceTests.cs
+++ b/PowerForge.Tests/AppStoreConnectGovernanceTests.cs
@@ -110,7 +110,7 @@ public sealed partial class AppStoreConnectClientTests
     }
 
     [Fact]
-    public async Task UpdateTerritoryAvailabilityAsync_TargetsTheV2Resource()
+    public async Task UpdateTerritoryAvailabilityAsync_TargetsTheV1Resource()
     {
         var handler = new SequenceHandler(new SequenceResponse(HttpStatusCode.OK,
             """{ "data": { "type": "territoryAvailabilities", "id": "territory-1", "attributes": { "available": false }, "relationships": { "territory": { "data": { "type": "territories", "id": "POL" } } } } }"""));
@@ -123,7 +123,7 @@ public sealed partial class AppStoreConnectClientTests
 
         Assert.Equal(HttpMethod.Patch, Assert.Single(handler.Methods));
         Assert.Equal(
-            "https://api.appstoreconnect.apple.com/v2/territoryAvailabilities/territory-1",
+            "https://api.appstoreconnect.apple.com/v1/territoryAvailabilities/territory-1",
             Assert.Single(handler.RequestUris).ToString());
         using var body = JsonDocument.Parse(Assert.Single(handler.RequestBodies));
         var attributes = body.RootElement.GetProperty("data").GetProperty("attributes");

--- a/PowerForge/Services/AppStoreConnectClient.Governance.cs
+++ b/PowerForge/Services/AppStoreConnectClient.Governance.cs
@@ -199,7 +199,7 @@ public sealed partial class AppStoreConnectClient
             }
         };
         return PatchSingleAsync(
-            $"../v2/territoryAvailabilities/{Uri.EscapeDataString(territoryAvailabilityId.Trim())}",
+            $"territoryAvailabilities/{Uri.EscapeDataString(territoryAvailabilityId.Trim())}",
             body,
             ParseTerritoryAvailability,
             cancellationToken);


### PR DESCRIPTION
## Summary

- send territory availability updates to the supported App Store Connect v1 resource
- keep v2 app-availability reads and creation unchanged
- update the request-contract regression test

## Why

A live CasaRay China availability plan reached the correct territory record but Apple returned 404 for the v2 PATCH path. The current App Store Connect schema exposes territory availability updates only through v1.

## Validation

- focused territory request-contract tests: 2 passed
- broader AppStoreConnectClientTests slice: 152 passed
- independent read-only review: no findings

After merge, CasaRay will pin the exact merge revision and rerun the reviewed China plan through the corrected shared client.