### PR TITLE
Fix App Store territory preorder payloads

### DIFF
--- a/PowerForge.Tests/AppStoreConnectGovernanceTests.cs
+++ b/PowerForge.Tests/AppStoreConnectGovernanceTests.cs
@@ -83,9 +83,59 @@ public sealed partial class AppStoreConnectClientTests
         var territory = Assert.Single(body.RootElement.GetProperty("included").EnumerateArray());
         var attributes = territory.GetProperty("attributes");
         Assert.True(attributes.GetProperty("available").GetBoolean());
-        Assert.Equal(JsonValueKind.Null, attributes.GetProperty("releaseDate").ValueKind);
+        Assert.False(attributes.TryGetProperty("releaseDate", out _));
         Assert.False(attributes.TryGetProperty("preOrderEnabled", out _));
         Assert.Equal("POL", territory.GetProperty("relationships").GetProperty("territory").GetProperty("data").GetProperty("id").GetString());
+    }
+
+    [Fact]
+    public async Task CreateAppAvailabilityAsync_IncludesReviewedPreorderDate()
+    {
+        var handler = new SequenceHandler(new SequenceResponse(HttpStatusCode.Created,
+            """{ "data": { "type": "appAvailabilities", "id": "availability-1", "attributes": { "availableInNewTerritories": false } } }"""));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        _ = await client.CreateAppAvailabilityAsync("app-1", new AppStoreConnectAppAvailabilitySpec
+        {
+            AvailableInNewTerritories = false,
+            Territories =
+            [
+                new AppStoreConnectTerritoryAvailabilitySpec
+                {
+                    TerritoryId = "POL",
+                    Available = true,
+                    ReleaseDate = "2026-09-15",
+                    PreOrderEnabled = true
+                }
+            ]
+        });
+
+        using var body = JsonDocument.Parse(Assert.Single(handler.RequestBodies));
+        var attributes = Assert.Single(body.RootElement.GetProperty("included").EnumerateArray()).GetProperty("attributes");
+        Assert.True(attributes.GetProperty("preOrderEnabled").GetBoolean());
+        Assert.Equal("2026-09-15", attributes.GetProperty("releaseDate").GetString());
+    }
+
+    [Fact]
+    public async Task TerritoryAvailabilityMutations_RejectPreorderWithoutReleaseDate()
+    {
+        var handler = new SequenceHandler();
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var territory = new AppStoreConnectTerritoryAvailabilitySpec
+        {
+            TerritoryId = "POL",
+            Available = true,
+            PreOrderEnabled = true
+        };
+
+        await Assert.ThrowsAsync<ArgumentException>(() => client.CreateAppAvailabilityAsync("app-1", new AppStoreConnectAppAvailabilitySpec
+        {
+            Territories = [territory]
+        }));
+        await Assert.ThrowsAsync<ArgumentException>(() => client.UpdateTerritoryAvailabilityAsync("territory-1", territory));
+        Assert.Empty(handler.RequestUris);
     }
 
     [Fact]
@@ -128,7 +178,7 @@ public sealed partial class AppStoreConnectClientTests
         using var body = JsonDocument.Parse(Assert.Single(handler.RequestBodies));
         var attributes = body.RootElement.GetProperty("data").GetProperty("attributes");
         Assert.False(attributes.GetProperty("available").GetBoolean());
-        Assert.Equal(JsonValueKind.Null, attributes.GetProperty("releaseDate").ValueKind);
+        Assert.False(attributes.TryGetProperty("releaseDate", out _));
         Assert.False(attributes.TryGetProperty("preOrderEnabled", out _));
     }
 
@@ -146,11 +196,107 @@ public sealed partial class AppStoreConnectClientTests
             {
                 TerritoryId = "POL",
                 Available = true,
+                ReleaseDate = "2026-07-03",
                 PreOrderEnabled = false
             });
 
         using var body = JsonDocument.Parse(Assert.Single(handler.RequestBodies));
-        Assert.False(body.RootElement.GetProperty("data").GetProperty("attributes").GetProperty("preOrderEnabled").GetBoolean());
+        var attributes = body.RootElement.GetProperty("data").GetProperty("attributes");
+        Assert.False(attributes.GetProperty("preOrderEnabled").GetBoolean());
+        Assert.False(attributes.TryGetProperty("releaseDate", out _));
+    }
+
+    [Fact]
+    public async Task UpdateTerritoryAvailabilityAsync_IncludesReleaseDateForPreorder()
+    {
+        var handler = new SequenceHandler(new SequenceResponse(HttpStatusCode.OK,
+            """{ "data": { "type": "territoryAvailabilities", "id": "territory-1", "attributes": { "available": true, "releaseDate": "2026-09-15", "preOrderEnabled": true }, "relationships": { "territory": { "data": { "type": "territories", "id": "POL" } } } } }"""));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        _ = await client.UpdateTerritoryAvailabilityAsync(
+            "territory-1",
+            new AppStoreConnectTerritoryAvailabilitySpec
+            {
+                TerritoryId = "POL",
+                Available = true,
+                ReleaseDate = "2026-09-15",
+                PreOrderEnabled = true
+            });
+
+        using var body = JsonDocument.Parse(Assert.Single(handler.RequestBodies));
+        var attributes = body.RootElement.GetProperty("data").GetProperty("attributes");
+        Assert.True(attributes.GetProperty("preOrderEnabled").GetBoolean());
+        Assert.Equal("2026-09-15", attributes.GetProperty("releaseDate").GetString());
+    }
+
+    [Fact]
+    public async Task GovernancePlan_IgnoresHistoricalReleaseDateOutsidePreorder()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """{ "data": { "type": "appAvailabilities", "id": "availability-1", "attributes": { "availableInNewTerritories": true } } }"""),
+            new SequenceResponse(HttpStatusCode.OK,
+                """{ "data": [ { "type": "territoryAvailabilities", "id": "territory-1", "attributes": { "available": true, "releaseDate": "2026-01-01", "preOrderEnabled": false }, "relationships": { "territory": { "data": { "type": "territories", "id": "POL" } } } } ] }"""));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var plan = await new AppStoreConnectGovernanceService(client).PlanAsync(new AppStoreConnectGovernanceSpec
+        {
+            AppId = "app-1",
+            Availability = new AppStoreConnectAppAvailabilitySpec
+            {
+                AvailableInNewTerritories = true,
+                Territories =
+                [
+                    new AppStoreConnectTerritoryAvailabilitySpec
+                    {
+                        TerritoryId = "POL",
+                        Available = true,
+                        ReleaseDate = "2026-02-01",
+                        PreOrderEnabled = false
+                    }
+                ]
+            }
+        });
+
+        Assert.True(plan.IsConverged);
+        Assert.Empty(plan.Changes);
+    }
+
+    [Fact]
+    public async Task GovernancePlan_DetectsReleaseDateDriftDuringPreorder()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """{ "data": { "type": "appAvailabilities", "id": "availability-1", "attributes": { "availableInNewTerritories": true } } }"""),
+            new SequenceResponse(HttpStatusCode.OK,
+                """{ "data": [ { "type": "territoryAvailabilities", "id": "territory-1", "attributes": { "available": true, "releaseDate": "2026-09-15", "preOrderEnabled": true }, "relationships": { "territory": { "data": { "type": "territories", "id": "POL" } } } } ] }"""));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var plan = await new AppStoreConnectGovernanceService(client).PlanAsync(new AppStoreConnectGovernanceSpec
+        {
+            AppId = "app-1",
+            Availability = new AppStoreConnectAppAvailabilitySpec
+            {
+                AvailableInNewTerritories = true,
+                Territories =
+                [
+                    new AppStoreConnectTerritoryAvailabilitySpec
+                    {
+                        TerritoryId = "POL",
+                        Available = true,
+                        ReleaseDate = "2026-09-22",
+                        PreOrderEnabled = true
+                    }
+                ]
+            }
+        });
+
+        var change = Assert.Single(plan.Changes);
+        Assert.Equal(AppStoreConnectGovernanceChangeAction.Update, change.Action);
+        Assert.Equal("TerritoryAvailability", change.ResourceType);
     }
 
     [Fact]
@@ -278,6 +424,18 @@ public sealed partial class AppStoreConnectClientTests
         var findings = new AppStoreConnectGovernanceConfiguration().Validate(new AppStoreConnectGovernanceSpec
         {
             AppId = "app-1",
+            Availability = new AppStoreConnectAppAvailabilitySpec
+            {
+                Territories =
+                [
+                    new AppStoreConnectTerritoryAvailabilitySpec
+                    {
+                        TerritoryId = "POL",
+                        Available = true,
+                        PreOrderEnabled = true
+                    }
+                ]
+            },
             Accessibility =
             [
                 new AppStoreConnectAccessibilityDeclarationSpec { DeviceFamily = "CARPLAY" }
@@ -297,6 +455,7 @@ public sealed partial class AppStoreConnectClientTests
 
         Assert.Contains(findings, finding => finding.Code == "Governance.Accessibility.DeviceFamily");
         Assert.Contains(findings, finding => finding.Code == "Governance.Accessibility.Empty");
+        Assert.Contains(findings, finding => finding.Code == "Governance.Availability.PreOrderReleaseDate");
         Assert.Contains(findings, finding => finding.Code == "Governance.Subscriptions.Period");
     }
 

--- a/PowerForge.Tests/PowerForgeReleaseSchemaTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseSchemaTests.cs
@@ -67,11 +67,20 @@ public sealed class PowerForgeReleaseSchemaTests
     [Theory]
     [InlineData("""{ "schemaVersion": 1, "appId": "123", "accessibility": [ { "deviceFamily": "IPHONE", "supportsVoiceover": true } ] }""", true)]
     [InlineData("""{ "schemaVersion": 1, "appId": "123", "accessibility": [ { "deviceFamily": "CARPLAY" } ] }""", false)]
+    [InlineData("""{ "schemaVersion": 1, "appId": "123", "availability": { "availableInNewTerritories": false, "territories": [ { "territoryId": "POL", "available": true, "preOrderEnabled": false, "releaseDate": "2026-07-03" } ] } }""", true)]
+    [InlineData("""{ "schemaVersion": 1, "appId": "123", "availability": { "availableInNewTerritories": false, "territories": [ { "territoryId": "POL", "available": true, "preOrderEnabled": true, "releaseDate": "2026-09-15" } ] } }""", true)]
+    [InlineData("""{ "schemaVersion": 1, "appId": "123", "availability": { "availableInNewTerritories": false, "territories": [ { "territoryId": "POL", "available": true, "preOrderEnabled": true, "releaseDate": "2026-02-31" } ] } }""", false)]
+    [InlineData("""{ "schemaVersion": 1, "appId": "123", "availability": { "availableInNewTerritories": false, "territories": [ { "territoryId": "POL", "available": true, "preOrderEnabled": true } ] } }""", false)]
+    [InlineData("""{ "schemaVersion": 1, "appId": "123", "availability": { "availableInNewTerritories": false, "territories": [ { "territoryId": "POL", "available": true, "preOrderEnabled": true, "releaseDate": null } ] } }""", false)]
     [InlineData("""{ "schemaVersion": 1, "appId": "123", "inventedLegalAnswer": true }""", false)]
     public void Apple_governance_schema_rejects_unknown_or_unsupported_contracts(string json, bool expectedValid)
     {
         var schema = JsonSchema.FromText(File.ReadAllText(GetSchemaPath("appstore-connect-governance.schema.json")));
-        var result = schema.Evaluate(JsonNode.Parse(json)!, new EvaluationOptions { OutputFormat = OutputFormat.List });
+        var result = schema.Evaluate(JsonNode.Parse(json)!, new EvaluationOptions
+        {
+            OutputFormat = OutputFormat.List,
+            RequireFormatValidation = true
+        });
         Assert.Equal(expectedValid, result.IsValid);
     }
 

--- a/PowerForge/Services/AppStoreConnectClient.Governance.cs
+++ b/PowerForge/Services/AppStoreConnectClient.Governance.cs
@@ -189,6 +189,8 @@ public sealed partial class AppStoreConnectClient
             throw new ArgumentNullException(nameof(spec));
         RequireValue(spec.TerritoryId, nameof(spec), "TerritoryId");
         ValidateDate(spec.ReleaseDate, nameof(spec.ReleaseDate));
+        if (spec.PreOrderEnabled == true && string.IsNullOrWhiteSpace(spec.ReleaseDate))
+            throw new ArgumentException("ReleaseDate is required when PreOrderEnabled is true.", nameof(spec));
         var body = new
         {
             data = new
@@ -209,11 +211,12 @@ public sealed partial class AppStoreConnectClient
     {
         var attributes = new Dictionary<string, object?>
         {
-            ["available"] = spec.Available,
-            ["releaseDate"] = Normalize(spec.ReleaseDate)
+            ["available"] = spec.Available
         };
         if (spec.PreOrderEnabled.HasValue)
             attributes["preOrderEnabled"] = spec.PreOrderEnabled.Value;
+        if (spec.PreOrderEnabled == true && Normalize(spec.ReleaseDate) is { } releaseDate)
+            attributes["releaseDate"] = releaseDate;
         return attributes;
     }
 
@@ -445,6 +448,8 @@ public sealed partial class AppStoreConnectClient
                 throw new ArgumentException("Territory entries must not be null.", nameof(territories));
             RequireValue(territory.TerritoryId, nameof(territories), "TerritoryId");
             ValidateDate(territory.ReleaseDate, nameof(territory.ReleaseDate));
+            if (territory.PreOrderEnabled == true && string.IsNullOrWhiteSpace(territory.ReleaseDate))
+                throw new ArgumentException("ReleaseDate is required when PreOrderEnabled is true.", nameof(territories));
         }
     }
 

--- a/PowerForge/Services/AppStoreConnectGovernanceConfiguration.cs
+++ b/PowerForge/Services/AppStoreConnectGovernanceConfiguration.cs
@@ -121,6 +121,8 @@ public sealed class AppStoreConnectGovernanceConfiguration
             if (item is null) { Error(findings, "Governance.Availability.Null", path, "Territory entry must not be null."); continue; }
             Required(findings, item.TerritoryId, path + ".territoryId", "Governance.Availability.Territory", "Territory id is required.");
             Date(findings, item.ReleaseDate, path + ".releaseDate");
+            if (item.PreOrderEnabled == true && string.IsNullOrWhiteSpace(item.ReleaseDate))
+                Error(findings, "Governance.Availability.PreOrderReleaseDate", path + ".releaseDate", "Preorder availability requires a release date.");
         }
     }
 

--- a/PowerForge/Services/AppStoreConnectGovernanceService.cs
+++ b/PowerForge/Services/AppStoreConnectGovernanceService.cs
@@ -368,7 +368,7 @@ public sealed partial class AppStoreConnectGovernanceService
                     $"Territory '{territory.TerritoryId}' is not present in Apple's availability relationship and cannot be added independently by the published API.", current.Id);
             }
             else if (existing.Available != territory.Available ||
-                     !SameDate(existing.ReleaseDate, territory.ReleaseDate) ||
+                     (territory.PreOrderEnabled == true && !SameDate(existing.ReleaseDate, territory.ReleaseDate)) ||
                      (territory.PreOrderEnabled.HasValue && existing.PreOrderEnabled != territory.PreOrderEnabled))
             {
                 Add(changes, "Availability", "TerritoryAvailability", territory.TerritoryId, AppStoreConnectGovernanceChangeAction.Update,

--- a/Schemas/appstore-connect-governance.schema.json
+++ b/Schemas/appstore-connect-governance.schema.json
@@ -24,7 +24,8 @@
     }
   },
   "definitions": {
-    "date": { "type": [ "string", "null" ], "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" },
+    "date": { "type": [ "string", "null" ], "format": "date", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" },
+    "requiredDate": { "type": "string", "format": "date", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" },
     "pricing": {
       "type": "object",
       "additionalProperties": false,
@@ -59,6 +60,18 @@
             "type": "object",
             "additionalProperties": false,
             "required": [ "territoryId", "available" ],
+            "allOf": [
+              {
+                "if": {
+                  "properties": { "preOrderEnabled": { "const": true } },
+                  "required": [ "preOrderEnabled" ]
+                },
+                "then": {
+                  "required": [ "releaseDate" ],
+                  "properties": { "releaseDate": { "$ref": "#/definitions/requiredDate" } }
+                }
+              }
+            ],
             "properties": {
               "territoryId": { "type": "string", "minLength": 1 },
               "available": { "type": "boolean" },


### PR DESCRIPTION
## Summary

- omit historical release dates from non-preorder territory mutations
- serialize release dates only for active preorder availability
- reject preorder declarations that do not provide a valid release date
- align the published governance schema with runtime preorder and calendar-date validation
- ignore immutable historical release-date differences outside preorder

## Why

A live CasaRay China availability update reached Apple on the supported v1 endpoint but Apple rejected the payload because it included a historical release date while preorder was disabled. The rejected request changed no Store state.

## Validation

- live one-territory CasaRay apply succeeded after the fix, followed by a zero-drift read-back plan
- focused preorder and availability contract tests: 9 passed
- broader AppStoreConnectClientTests slice: 157 passed
- governance schema contract matrix: 8 passed
- independent review found one preorder validation P2; fixed and confirmed
- hosted review found one schema-parity P2; fixed, tested, and its thread resolved
- owner-level closure audit found no P0-P2; its adjacent invalid-calendar P3 was also fixed

No preorder state was changed during live validation.