### PR TITLE
Bind reviewed screenshot subsets to exact Apple release targets

### DIFF
--- a/Docs/PSPublishModule.AppleRelease.md
+++ b/Docs/PSPublishModule.AppleRelease.md
@@ -849,6 +849,11 @@ height inventory exactly. Explicit `--version`, `--source-commit`, or
 capture-metadata options may still be supplied for recovery, but they must match
 the provenance document exactly.
 
+When the pinned local helper runs `apple-release Screenshots` or a screenshot-enabled
+`apple-release Advance`, pass the retained screenshot directory as `--allowed-root`.
+The helper consumes this local-only option to bind each approved relative path to one
+explicit root; the provenance JSON may remain in its separate downloaded artifact.
+
 The capture workflow therefore requires the exact two- or three-part marketing version;
 blank or branch-relative capture evidence cannot be approved. The pinned helper
 also requires the retained provenance for every local `Screenshots` action, for

--- a/PowerForge.Cli/Program.Command.AppleRelease.cs
+++ b/PowerForge.Cli/Program.Command.AppleRelease.cs
@@ -81,6 +81,7 @@ internal static partial class Program
             "--apple-wait",
             "--no-apple-wait",
             "--summary",
+            "--apple-resolve-target-identities",
             "--apple-sync-screenshots"
         };
         var options = new HashSet<string>(StringComparer.OrdinalIgnoreCase)

--- a/PowerForge.Cli/Program.Command.Release.cs
+++ b/PowerForge.Cli/Program.Command.Release.cs
@@ -394,6 +394,8 @@ internal static partial class Program
         request.AppleResume = ResolveBooleanOverride(argv, "--apple-resume", "--no-apple-resume", request.AppleResume);
         request.AppleWaitForProcessing = ResolveBooleanOverride(argv, "--apple-wait", "--no-apple-wait", request.AppleWaitForProcessing);
         request.AppleSummaryOnly = argv.Any(a => a.Equals("--summary", StringComparison.OrdinalIgnoreCase));
+        request.AppleResolveTargetIdentities = argv.Any(a =>
+            a.Equals("--apple-resolve-target-identities", StringComparison.OrdinalIgnoreCase));
         if (TryParsePositiveInt(TryGetOptionValue(argv, "--apple-timeout-seconds"), out var appleTimeoutSeconds))
             request.AppleProcessingTimeoutSeconds = appleTimeoutSeconds;
         if (TryParsePositiveInt(TryGetOptionValue(argv, "--apple-poll-seconds"), out var applePollSeconds))

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
@@ -31,7 +31,7 @@ public sealed partial class AppleReleaseWorkflowTests
                 }
                 . $Support
 
-                $ArgumentList = @('apple-release', 'Status', '--config', 'powerforge.release.json', '--capture-provenance', 'capture.json')
+                $ArgumentList = @('apple-release', 'Status', '--config', 'powerforge.release.json', '--capture-provenance', 'capture.json', '--allowed-root', 'capture')
                 $forwarded = @(Get-ForwardedArgumentList -SourceCommit '{{commit}}')
                 if (($forwarded -join '|') -ne 'apple-release|Status|--config|powerforge.release.json|--apple-source-commit|{{commit}}') {
                     throw "Verified source commit was not injected: $($forwarded -join '|')"
@@ -43,14 +43,21 @@ public sealed partial class AppleReleaseWorkflowTests
                     throw "Explicit source commit was not normalized: $($forwarded -join '|')"
                 }
 
-                $ArgumentList = @('apple-release', 'Status', '--config', 'powerforge.release.json', '--capture-provenance', '--apple-source-commit={{commit}}')
+                $ArgumentList = @('apple-release', 'Status', '--config', 'powerforge.release.json', '--allowed-root=capture')
                 $forwarded = @(Get-ForwardedArgumentList -SourceCommit '{{commit}}')
                 if (($forwarded -join '|') -ne 'apple-release|Status|--config|powerforge.release.json|--apple-source-commit|{{commit}}') {
-                    throw "A capture path was mistaken for a source option: $($forwarded -join '|')"
+                    throw "The local retained root was forwarded to the release engine: $($forwarded -join '|')"
                 }
 
                 foreach ($invalidArguments in @(
                     @('apple-release', 'Status', '--config', 'powerforge.release.json', '--apple-source-commit', ''),
+                    @('apple-release', 'Status', '--config', 'powerforge.release.json', '--allowed-root'),
+                    @('apple-release', 'Status', '--config', 'powerforge.release.json', '--allowed-root='),
+                    @('apple-release', 'Status', '--config', 'powerforge.release.json', '--allowed-root=-capture'),
+                    @('apple-release', 'Status', '--config', 'powerforge.release.json', '--capture-provenance=-capture.json'),
+                    @('apple-release', 'Status', '--config', 'powerforge.release.json', '--allowed-root', '--plan'),
+                    @('apple-release', 'Status', '--config', 'powerforge.release.json', '--allowed-root', 'capture', '--allowed-root=other'),
+                    @('apple-release', 'Status', '--config', 'powerforge.release.json', '--capture-provenance', 'capture.json', '--capture-provenance=other.json'),
                     @('apple-release', 'Status', '--config', 'powerforge.release.json', '--apple-source-commit', '{{commit}}', '--apple-source-commit={{commit}}'),
                     @('apple-release', 'Status', '--config', 'powerforge.release.json', '--apple-source-commit', '89abcdef0123456789abcdef0123456789abcdef'))) {
                     $ArgumentList = $invalidArguments
@@ -193,9 +200,15 @@ public sealed partial class AppleReleaseWorkflowTests
             var nestedHash = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(nested))).ToLowerInvariant();
             const string commit = "0123456789abcdef0123456789abcdef01234567";
             File.WriteAllText(Path.Combine(sandbox, "powerforge.release.json"),
-                """{ "AppleApps": { "ProjectRoot": ".", "ScreenshotConfigPaths": [ "screenshots.json" ], "Apps": [ { "Name": "App", "Platform": "IOS", "AppStoreConnectAppId": "123" } ] } }""");
+                """{ "AppleApps": { "ProjectRoot": ".", "SyncScreenshots": true, "ScreenshotConfigPaths": [ "screenshots.json", "other-screenshots.json", "beta-screenshots.json", "historical-screenshots.json" ], "Apps": [ { "Name": " App ", "BundleId": "com.example.app", "Platform": "IOS" }, { "Name": "Other", "BundleId": "com.example.other", "Platform": "IOS", "AppStoreConnectAppId": "888" }, { "Name": "Beta", "BundleId": "com.example.beta", "Platform": "IOS", "DistributionRoute": "TestFlightOnly", "AppStoreConnectAppId": "999" }, { "Name": "Direct", "BundleId": "com.example.direct", "Platform": "macOS", "DistributionRoute": "DirectNotarized", "AppStoreConnectAppId": "777" } ] } }""");
             File.WriteAllText(Path.Combine(sandbox, "screenshots.json"),
-                """{ "AppId": "123", "Platform": "IOS", "Quality": { "ApprovalManifestPath": "screenshots.approval.json" } }""");
+                """{ "AppId": "123", "Platform": "IOS", "UseReleaseVersion": true, "Quality": { "ApprovalManifestPath": "screenshots.approval.json" } }""");
+            File.WriteAllText(Path.Combine(sandbox, "other-screenshots.json"),
+                """{ "AppId": "888", "Platform": "IOS", "UseReleaseVersion": true, "Quality": { "ApprovalManifestPath": "missing-other.approval.json" } }""");
+            File.WriteAllText(Path.Combine(sandbox, "beta-screenshots.json"),
+                """{ "AppId": "999", "Platform": "IOS", "UseReleaseVersion": true, "Quality": { "ApprovalManifestPath": "missing-beta.approval.json" } }""");
+            File.WriteAllText(Path.Combine(sandbox, "historical-screenshots.json"),
+                """{ "AppId": "123", "Platform": "IOS", "VersionString": "1.1.0", "Quality": { "ApprovalManifestPath": "missing-historical.approval.json" } }""");
             File.WriteAllText(Path.Combine(sandbox, "screenshots.approval.json"), JsonSerializer.Serialize(new
             {
                 CaptureRunId = "42",
@@ -210,7 +223,7 @@ public sealed partial class AppleReleaseWorkflowTests
             }));
             File.WriteAllText(Path.Combine(sandbox, ".gitignore"), "capture/\n*.approval.json\n");
             Run("git", sandbox, "init", "--quiet").EnsureSuccess();
-            Run("git", sandbox, "add", "powerforge.release.json", "screenshots.json", ".gitignore").EnsureSuccess();
+            Run("git", sandbox, "add", "powerforge.release.json", "screenshots.json", "other-screenshots.json", "beta-screenshots.json", "historical-screenshots.json", ".gitignore").EnsureSuccess();
             CommitTrackedReleaseSandbox(sandbox, "Tracked screenshot configuration");
 
             var harness = Path.Combine(parent, "evidence-harness.ps1");
@@ -229,15 +242,57 @@ public sealed partial class AppleReleaseWorkflowTests
                         [pscustomobject]@{ path='website-candidate/home.png'; sha256='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'; width=1200; height=800 })
                 }
                 $consumer = [IO.Path]::GetFullPath($Consumer)
-                $script:validatedCaptureProvenancePath = Join-Path $consumer 'capture/powerforge-apple-screenshot-provenance.json'
-                $ArgumentList = @('apple-release','Screenshots','--config','powerforge.release.json')
+                $ArgumentList = @('apple-release','Screenshots','--config','powerforge.release.json','--target','App','--allowed-root','capture')
                 function Invoke-GitText { param([string]$Root,[string[]]$Arguments); $o=@(& $script:gitPath -c core.quotePath=false -C $Root @Arguments 2>&1); if($LASTEXITCODE -ne 0){throw 'git failed'}; return ($o -join [Environment]::NewLine).Trim() }
                 function Get-OptionValue { param([string]$Option); $i=[Array]::IndexOf($ArgumentList,$Option); if($i -ge 0 -and $i+1 -lt $ArgumentList.Count){return $ArgumentList[$i+1]}; return $null }
                 function Resolve-OptionPath { param([string]$Value); if([IO.Path]::IsPathRooted($Value)){return [IO.Path]::GetFullPath($Value)}; return [IO.Path]::GetFullPath((Join-Path $consumer $Value)) }
                 function Resolve-PathFromBase { param([string]$BasePath,[string]$Value); if([IO.Path]::IsPathRooted($Value)){return [IO.Path]::GetFullPath($Value)}; return [IO.Path]::GetFullPath((Join-Path $BasePath $Value)) }
                 function Assert-UnlinkedPath { param([string]$Path,[string]$Name,[switch]$AllowMissingLeaf) }
+                function Assert-UnlinkedDirectory { param([string]$Path,[string]$Name) }
                 . $Support
                 Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'
+                $originalArguments = @($ArgumentList)
+                $ArgumentList = @('apple-release','Screenshots','--config','powerforge.release.json','--target','App,Missing','--allowed-root','capture')
+                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'; throw 'A mixed unknown target list was accepted.' }
+                catch { if ($_.Exception.Message -notlike '*Unknown Apple app target(s): Missing*') { throw } }
+                $releasePath = Join-Path $consumer 'powerforge.release.json'
+                $originalRelease = Get-Content -LiteralPath $releasePath -Raw
+                $releaseWithoutScreenshots = $originalRelease | ConvertFrom-Json
+                $releaseWithoutScreenshots.AppleApps.ScreenshotConfigPaths = @('', '   ')
+                $releaseWithoutScreenshots | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $releasePath
+                $originalProvenance = $script:validatedCaptureProvenance
+                $script:validatedCaptureProvenance = $null
+                $ArgumentList = @('apple-release','Advance','--config','powerforge.release.json','--target','App')
+                Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'
+                Set-Content -LiteralPath $releasePath -Value $originalRelease -NoNewline
+                foreach ($routeTarget in @('Beta', 'Direct')) {
+                    $ArgumentList = @('apple-release','Advance','--config','powerforge.release.json','--target',$routeTarget)
+                    Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'
+                }
+                $script:validatedCaptureProvenance = $originalProvenance
+                $ArgumentList = @('apple-release','Screenshots','--config','powerforge.release.json','--target','App')
+                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'; throw 'Missing retained root was accepted.' }
+                catch { if ($_.Exception.Message -notlike '*requires --allowed-root*') { throw } }
+                $ArgumentList = $originalArguments
+                $approvalPath = Join-Path $consumer 'screenshots.approval.json'
+                $originalApproval = Get-Content -LiteralPath $approvalPath -Raw
+                $caseVariantApproval = $originalApproval | ConvertFrom-Json
+                $caseVariantApproval.Screenshots[0].File = 'capture/phone/Home.png'
+                $caseVariantPath = Join-Path $consumer 'capture/phone/Home.png'
+                $caseVariantCreated = $false
+                if (-not (Test-Path -LiteralPath $caseVariantPath -PathType Leaf)) {
+                    Copy-Item -LiteralPath (Join-Path $consumer 'capture/phone/home.png') -Destination $caseVariantPath
+                    $caseVariantCreated = $true
+                }
+                $caseVariantApproval | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $approvalPath
+                if ($IsWindows) {
+                    Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'
+                } else {
+                    try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'; throw 'Case-variant inventory path was accepted.' }
+                    catch { if ($_.Exception.Message -notlike '*approved inventory*') { throw } }
+                }
+                Set-Content -LiteralPath $approvalPath -Value $originalApproval -NoNewline
+                if ($caseVariantCreated) { Remove-Item -LiteralPath $caseVariantPath }
                 $originalProvenanceScreenshots = @($script:validatedCaptureProvenance.screenshots)
                 $script:validatedCaptureProvenance.screenshots += [pscustomobject]@{
                     path = 'home.png';
@@ -248,8 +303,6 @@ public sealed partial class AppleReleaseWorkflowTests
                 try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'; throw 'Conflicting provenance path was accepted.' }
                 catch { if ($_.Exception.Message -notlike '*duplicate screenshot path*') { throw } }
                 $script:validatedCaptureProvenance.screenshots = $originalProvenanceScreenshots
-                $approvalPath = Join-Path $consumer 'screenshots.approval.json'
-                $originalApproval = Get-Content -LiteralPath $approvalPath -Raw
                 $duplicateApproval = $originalApproval | ConvertFrom-Json
                 $duplicateApproval.Screenshots += $duplicateApproval.Screenshots[0]
                 $duplicateApproval | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $approvalPath

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
@@ -118,6 +118,39 @@ public sealed partial class AppleReleaseWorkflowTests
                     throw "Unexpected target-resolution arguments: $($resolvedArguments -join '|')"
                 }
 
+                $consumer = Join-Path (Split-Path -Parent $Output) 'consumer'
+                $snapshot = Join-Path (Split-Path -Parent $Output) 'snapshot'
+                New-Item -ItemType Directory -Path $consumer, $snapshot -Force | Out-Null
+                $releaseConfig = Join-Path $consumer 'powerforge.release.json'
+                '{ "AppleApps": { "ProjectRoot": ".", "Apps": [ { "Name": "App", "ProjectPath": "App.xcodeproj" } ] } }' |
+                    Set-Content -LiteralPath $releaseConfig
+                Copy-Item -LiteralPath $releaseConfig -Destination (Join-Path $snapshot 'powerforge.release.json')
+                $snapshotArguments = @(Get-AppleTargetResolutionSnapshotArgumentList `
+                    -Arguments @('apple-release', 'Screenshots', '--config', $releaseConfig, '--target', 'App') `
+                    -ConsumerRoot $consumer `
+                    -SnapshotRoot $snapshot)
+                $snapshotConfig = $snapshotArguments[[Array]::IndexOf($snapshotArguments, '--config') + 1]
+                if ($snapshotConfig -ne (Join-Path $snapshot 'powerforge.release.json')) {
+                    throw "Target-resolution config was not rebound to the exact consumer snapshot: $snapshotConfig"
+                }
+                $caseSensitivePaths = @(Get-UniquePlatformPaths -Paths @('screenshots.json', 'Screenshots.json') -Comparer ([StringComparer]::Ordinal))
+                $caseInsensitivePaths = @(Get-UniquePlatformPaths -Paths @('screenshots.json', 'Screenshots.json') -Comparer ([StringComparer]::OrdinalIgnoreCase))
+                if ($caseSensitivePaths.Count -ne 2 -or $caseInsensitivePaths.Count -ne 1) {
+                    throw 'Screenshot path uniqueness does not honor the supplied file-system comparer.'
+                }
+
+                '{ "AppleApps": { "ProjectRoot": "ABSOLUTE_ROOT", "Apps": [ { "Name": "App", "ProjectPath": "App.xcodeproj" } ] } }'.Replace('ABSOLUTE_ROOT', $consumer.Replace('\', '\\')) |
+                    Set-Content -LiteralPath $releaseConfig
+                try {
+                    Get-AppleTargetResolutionSnapshotArgumentList `
+                        -Arguments @('apple-release', 'Screenshots', '--config', $releaseConfig) `
+                        -ConsumerRoot $consumer `
+                        -SnapshotRoot $snapshot | Out-Null
+                    throw 'An absolute AppleApps.ProjectRoot escaped snapshot target resolution.'
+                } catch {
+                    if ($_.Exception.Message -notlike '*consumer-relative AppleApps.ProjectRoot*') { throw }
+                }
+
                 [pscustomobject]@{
                     command = 'apple-release'
                     success = $true
@@ -307,12 +340,24 @@ public sealed partial class AppleReleaseWorkflowTests
             File.WriteAllText(Path.Combine(sandbox, "screenshots.json"),
                 """{ "AppId": "123", "Platform": "IOS", "UseReleaseVersion": true, "Quality": { "ApprovalManifestPath": "screenshots.approval.json" } }""");
             File.WriteAllText(Path.Combine(sandbox, "other-screenshots.json"),
-                """{ "AppId": "888", "Platform": "IOS", "UseReleaseVersion": true, "Quality": { "ApprovalManifestPath": "missing-other.approval.json" } }""");
+                """{ "AppId": "888", "Platform": "IOS", "UseReleaseVersion": true, "Quality": { "ApprovalManifestPath": "other-screenshots.approval.json" } }""");
             File.WriteAllText(Path.Combine(sandbox, "beta-screenshots.json"),
                 """{ "AppId": "999", "Platform": "IOS", "UseReleaseVersion": true, "Quality": { "ApprovalManifestPath": "missing-beta.approval.json" } }""");
             File.WriteAllText(Path.Combine(sandbox, "historical-screenshots.json"),
                 """{ "AppId": "123", "Platform": "IOS", "VersionString": "1.1.0", "Quality": { "ApprovalManifestPath": "missing-historical.approval.json" } }""");
             File.WriteAllText(Path.Combine(sandbox, "screenshots.approval.json"), JsonSerializer.Serialize(new
+            {
+                CaptureRunId = "42",
+                CaptureRepository = "EvotecIT/TestApp",
+                CaptureWorkflowRef = "EvotecIT/TestApp/.github/workflows/capture.yml@refs/heads/main",
+                SourceCommit = commit,
+                VersionString = "1.2.3",
+                Screenshots = new object[]
+                {
+                    new { File = "capture/phone/home.png", Sha256 = nestedHash, Width = 100, Height = 200 }
+                }
+            }));
+            File.WriteAllText(Path.Combine(sandbox, "other-screenshots.approval.json"), JsonSerializer.Serialize(new
             {
                 CaptureRunId = "42",
                 CaptureRepository = "EvotecIT/TestApp",
@@ -355,6 +400,10 @@ public sealed partial class AppleReleaseWorkflowTests
                 . $Support
                 $appTargets = @([pscustomobject]@{ name='App'; platform='iOS'; distributionRoute='AppStore'; appId='123'; marketingVersion='1.2.3' })
                 Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $appTargets
+                $sharedPixelTargets = @(
+                    $appTargets[0],
+                    [pscustomobject]@{ name='Other'; platform='iOS'; distributionRoute='AppStore'; appId='888'; marketingVersion='1.2.3' })
+                Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $sharedPixelTargets
                 $mismatchedVersionTargets = @([pscustomobject]@{ name='App'; platform='iOS'; distributionRoute='AppStore'; appId='123'; marketingVersion='1.2.4' })
                 try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $mismatchedVersionTargets; throw 'A mismatched target marketing version was accepted.' }
                 catch { if ($_.Exception.Message -notlike '*does not match selected Apple app*version*') { throw } }
@@ -392,7 +441,7 @@ public sealed partial class AppleReleaseWorkflowTests
                     $caseVariantCreated = $true
                 }
                 $caseVariantApproval | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $approvalPath
-                if ($IsWindows) {
+                if ((Get-ConsumerPathComparer).Compare('a', 'A') -eq 0) {
                     Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $appTargets
                 } else {
                     try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $appTargets; throw 'Case-variant inventory path was accepted.' }

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
@@ -189,11 +189,8 @@ public sealed partial class AppleReleaseWorkflowTests
         {
             Directory.CreateDirectory(Path.Combine(sandbox, "capture", "phone"));
             var nested = Path.Combine(sandbox, "capture", "phone", "home.png");
-            var rootImage = Path.Combine(sandbox, "capture", "home.png");
             File.WriteAllText(nested, "nested screenshot bytes");
-            File.WriteAllText(rootImage, "root screenshot bytes");
             var nestedHash = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(nested))).ToLowerInvariant();
-            var rootHash = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(rootImage))).ToLowerInvariant();
             const string commit = "0123456789abcdef0123456789abcdef01234567";
             File.WriteAllText(Path.Combine(sandbox, "powerforge.release.json"),
                 """{ "AppleApps": { "ProjectRoot": ".", "ScreenshotConfigPaths": [ "screenshots.json" ], "Apps": [ { "Name": "App", "Platform": "IOS", "AppStoreConnectAppId": "123" } ] } }""");
@@ -208,8 +205,7 @@ public sealed partial class AppleReleaseWorkflowTests
                 VersionString = "1.2.3",
                 Screenshots = new object[]
                 {
-                    new { File = "capture/phone/home.png", Sha256 = nestedHash, Width = 100, Height = 200 },
-                    new { File = "capture/home.png", Sha256 = rootHash, Width = 100, Height = 200 }
+                    new { File = "capture/phone/home.png", Sha256 = nestedHash, Width = 100, Height = 200 }
                 }
             }));
             File.WriteAllText(Path.Combine(sandbox, ".gitignore"), "capture/\n*.approval.json\n");
@@ -229,10 +225,11 @@ public sealed partial class AppleReleaseWorkflowTests
                     workflowRef = 'EvotecIT/TestApp/.github/workflows/capture.yml@refs/heads/main';
                     marketingVersion = '1.2.3'; screenshots = @(
                         [pscustomobject]@{ path='phone/home.png'; sha256='NESTED_HASH'; width=100; height=200 },
-                        [pscustomobject]@{ path='home.png'; sha256='ROOT_HASH'; width=100; height=200 },
+                        [pscustomobject]@{ path='home.png'; sha256='NESTED_HASH'; width=100; height=200 },
                         [pscustomobject]@{ path='website-candidate/home.png'; sha256='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'; width=1200; height=800 })
                 }
                 $consumer = [IO.Path]::GetFullPath($Consumer)
+                $script:validatedCaptureProvenancePath = Join-Path $consumer 'capture/powerforge-apple-screenshot-provenance.json'
                 $ArgumentList = @('apple-release','Screenshots','--config','powerforge.release.json')
                 function Invoke-GitText { param([string]$Root,[string[]]$Arguments); $o=@(& $script:gitPath -c core.quotePath=false -C $Root @Arguments 2>&1); if($LASTEXITCODE -ne 0){throw 'git failed'}; return ($o -join [Environment]::NewLine).Trim() }
                 function Get-OptionValue { param([string]$Option); $i=[Array]::IndexOf($ArgumentList,$Option); if($i -ge 0 -and $i+1 -lt $ArgumentList.Count){return $ArgumentList[$i+1]}; return $null }
@@ -278,8 +275,7 @@ public sealed partial class AppleReleaseWorkflowTests
                 try { Assert-ConsumerRepositoryContent; throw 'Unreviewed file was accepted.' }
                 catch { if ($_.Exception.Message -notlike '*non-reviewed content*') { throw }; 'PASS' }
                 """
-                .Replace("NESTED_HASH", nestedHash, StringComparison.Ordinal)
-                .Replace("ROOT_HASH", rootHash, StringComparison.Ordinal));
+                .Replace("NESTED_HASH", nestedHash, StringComparison.Ordinal));
 
             var result = Run(
                 "pwsh",

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
@@ -92,6 +92,109 @@ public sealed partial class AppleReleaseWorkflowTests
     }
 
     [Fact]
+    public void PinnedAppleReleaseResolvesExactTargetsWithAValidationOnlySummary()
+    {
+        var root = FindRepoRoot();
+        var parent = Path.Combine(root, ".test-temp", $"powerforge-target-resolution-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(parent);
+            var harness = Path.Combine(parent, "target-resolution-harness.ps1");
+            File.WriteAllText(harness,
+                """
+                param([string] $Support, [string] $Output)
+                $ErrorActionPreference = 'Stop'
+                . $Support
+
+                $arguments = @(
+                    'apple-release', 'Screenshots', '--config', 'powerforge.release.json',
+                    '--target', 'App', '--plan', '--confirm-apple-action',
+                    '--apple-expected-plan-sha256', ('a' * 64), '--output=text')
+                $resolvedArguments = @(Get-AppleTargetResolutionArgumentList -Arguments $arguments)
+                $expected = @(
+                    'apple-release', 'Screenshots', '--config', 'powerforge.release.json',
+                    '--target', 'App', '--validate', '--summary', '--output', 'json')
+                if (($resolvedArguments -join '|') -ne ($expected -join '|')) {
+                    throw "Unexpected target-resolution arguments: $($resolvedArguments -join '|')"
+                }
+
+                [pscustomobject]@{
+                    command = 'apple-release'
+                    success = $true
+                    result = [pscustomobject]@{
+                        validateOnly = $true
+                        planOnly = $false
+                        targets = @(
+                            [pscustomobject]@{
+                                name = 'App'
+                                platform = 'iOS'
+                                distributionRoute = 'AppStore'
+                                appId = '123'
+                                marketingVersion = '1.2.3'
+                            })
+                    }
+                } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $Output
+                $targets = @(Read-ResolvedAppleTargets -Path $Output)
+                if ($targets.Count -ne 1 -or $targets[0].appId -ne '123') {
+                    throw 'The exact resolved target identity was not returned.'
+                }
+
+                [pscustomobject]@{
+                    command = 'apple-release'
+                    success = $true
+                    result = [pscustomobject]@{
+                        validateOnly = $true
+                        planOnly = $false
+                        targets = @(
+                            [pscustomobject]@{
+                                name = 'App'
+                                platform = 'iOS'
+                                distributionRoute = 'AppStore'
+                                appId = '123'
+                            })
+                    }
+                } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $Output
+                try {
+                    Read-ResolvedAppleTargets -Path $Output | Out-Null
+                    throw 'An App Store target without a marketing version was accepted.'
+                } catch {
+                    if ($_.Exception.Message -like 'An App Store target without a marketing version was accepted.*') { throw }
+                }
+
+                [pscustomobject]@{
+                    command = 'apple-release'
+                    success = $true
+                    result = [pscustomobject]@{
+                        validateOnly = $false
+                        planOnly = $true
+                        targets = @()
+                    }
+                } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $Output
+                try {
+                    Read-ResolvedAppleTargets -Path $Output | Out-Null
+                    throw 'A non-validation target summary was accepted.'
+                } catch {
+                    if ($_.Exception.Message -like 'A non-validation target summary was accepted.*') { throw }
+                }
+                'PASS'
+                """);
+
+            var result = Run(
+                "pwsh",
+                parent,
+                "-NoLogo", "-NoProfile", "-File", harness,
+                "-Support", Path.Combine(root, "scripts", "Invoke-PinnedPowerForge.Evidence.ps1"),
+                "-Output", Path.Combine(parent, "summary.json"));
+            result.EnsureSuccess();
+            Assert.Contains("PASS", result.StandardOutput, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(parent)) Directory.Delete(parent, recursive: true);
+        }
+    }
+
+    [Fact]
     public void TrackedSourceLinksMustRemainInsideTheExactConsumerCheckout()
     {
         if (OperatingSystem.IsWindows()) return;
@@ -200,7 +303,7 @@ public sealed partial class AppleReleaseWorkflowTests
             var nestedHash = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(nested))).ToLowerInvariant();
             const string commit = "0123456789abcdef0123456789abcdef01234567";
             File.WriteAllText(Path.Combine(sandbox, "powerforge.release.json"),
-                """{ "AppleApps": { "ProjectRoot": ".", "SyncScreenshots": true, "ScreenshotConfigPaths": [ "screenshots.json", "other-screenshots.json", "beta-screenshots.json", "historical-screenshots.json" ], "Apps": [ { "Name": " App ", "BundleId": "com.example.app", "Platform": "IOS" }, { "Name": "Other", "BundleId": "com.example.other", "Platform": "IOS", "AppStoreConnectAppId": "888" }, { "Name": "Beta", "BundleId": "com.example.beta", "Platform": "IOS", "DistributionRoute": "TestFlightOnly", "AppStoreConnectAppId": "999" }, { "Name": "Direct", "BundleId": "com.example.direct", "Platform": "macOS", "DistributionRoute": "DirectNotarized", "AppStoreConnectAppId": "777" } ] } }""");
+                """{ "AppleApps": { "ProjectRoot": ".", "SyncScreenshots": true, "ScreenshotConfigPaths": [ "screenshots.json", "other-screenshots.json", "beta-screenshots.json", "historical-screenshots.json" ], "Apps": [ { "Name": " App ", "BundleId": "com.example.app", "Platform": "IOS" }, { "Name": "Other", "BundleId": "com.example.other", "Platform": "IOS" }, { "Name": "Beta", "BundleId": "com.example.beta", "Platform": "IOS", "DistributionRoute": "TestFlightOnly", "AppStoreConnectAppId": "999" }, { "Name": "Direct", "BundleId": "com.example.direct", "Platform": "macOS", "DistributionRoute": "DirectNotarized", "AppStoreConnectAppId": "777" } ] } }""");
             File.WriteAllText(Path.Combine(sandbox, "screenshots.json"),
                 """{ "AppId": "123", "Platform": "IOS", "UseReleaseVersion": true, "Quality": { "ApprovalManifestPath": "screenshots.approval.json" } }""");
             File.WriteAllText(Path.Combine(sandbox, "other-screenshots.json"),
@@ -250,11 +353,12 @@ public sealed partial class AppleReleaseWorkflowTests
                 function Assert-UnlinkedPath { param([string]$Path,[string]$Name,[switch]$AllowMissingLeaf) }
                 function Assert-UnlinkedDirectory { param([string]$Path,[string]$Name) }
                 . $Support
-                Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'
+                $appTargets = @([pscustomobject]@{ name='App'; platform='iOS'; distributionRoute='AppStore'; appId='123'; marketingVersion='1.2.3' })
+                Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $appTargets
+                $mismatchedVersionTargets = @([pscustomobject]@{ name='App'; platform='iOS'; distributionRoute='AppStore'; appId='123'; marketingVersion='1.2.4' })
+                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $mismatchedVersionTargets; throw 'A mismatched target marketing version was accepted.' }
+                catch { if ($_.Exception.Message -notlike '*does not match selected Apple app*version*') { throw } }
                 $originalArguments = @($ArgumentList)
-                $ArgumentList = @('apple-release','Screenshots','--config','powerforge.release.json','--target','App,Missing','--allowed-root','capture')
-                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'; throw 'A mixed unknown target list was accepted.' }
-                catch { if ($_.Exception.Message -notlike '*Unknown Apple app target(s): Missing*') { throw } }
                 $releasePath = Join-Path $consumer 'powerforge.release.json'
                 $originalRelease = Get-Content -LiteralPath $releasePath -Raw
                 $releaseWithoutScreenshots = $originalRelease | ConvertFrom-Json
@@ -263,15 +367,18 @@ public sealed partial class AppleReleaseWorkflowTests
                 $originalProvenance = $script:validatedCaptureProvenance
                 $script:validatedCaptureProvenance = $null
                 $ArgumentList = @('apple-release','Advance','--config','powerforge.release.json','--target','App')
-                Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'
+                Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $appTargets
                 Set-Content -LiteralPath $releasePath -Value $originalRelease -NoNewline
-                foreach ($routeTarget in @('Beta', 'Direct')) {
-                    $ArgumentList = @('apple-release','Advance','--config','powerforge.release.json','--target',$routeTarget)
-                    Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'
+                foreach ($route in @(
+                    [pscustomobject]@{ Target='Beta'; Platform='iOS'; DistributionRoute='TestFlightOnly'; AppId='999' },
+                    [pscustomobject]@{ Target='Direct'; Platform='macOS'; DistributionRoute='DirectNotarized'; AppId='777' })) {
+                    $ArgumentList = @('apple-release','Advance','--config','powerforge.release.json','--target',$route.Target)
+                    $routeTargets = @([pscustomobject]@{ name=$route.Target; platform=$route.Platform; distributionRoute=$route.DistributionRoute; appId=$route.AppId })
+                    Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $routeTargets
                 }
                 $script:validatedCaptureProvenance = $originalProvenance
                 $ArgumentList = @('apple-release','Screenshots','--config','powerforge.release.json','--target','App')
-                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'; throw 'Missing retained root was accepted.' }
+                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $appTargets; throw 'Missing retained root was accepted.' }
                 catch { if ($_.Exception.Message -notlike '*requires --allowed-root*') { throw } }
                 $ArgumentList = $originalArguments
                 $approvalPath = Join-Path $consumer 'screenshots.approval.json'
@@ -286,9 +393,9 @@ public sealed partial class AppleReleaseWorkflowTests
                 }
                 $caseVariantApproval | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $approvalPath
                 if ($IsWindows) {
-                    Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'
+                    Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $appTargets
                 } else {
-                    try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'; throw 'Case-variant inventory path was accepted.' }
+                    try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $appTargets; throw 'Case-variant inventory path was accepted.' }
                     catch { if ($_.Exception.Message -notlike '*approved inventory*') { throw } }
                 }
                 Set-Content -LiteralPath $approvalPath -Value $originalApproval -NoNewline
@@ -300,13 +407,13 @@ public sealed partial class AppleReleaseWorkflowTests
                     width = 101;
                     height = 200
                 }
-                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'; throw 'Conflicting provenance path was accepted.' }
+                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $appTargets; throw 'Conflicting provenance path was accepted.' }
                 catch { if ($_.Exception.Message -notlike '*duplicate screenshot path*') { throw } }
                 $script:validatedCaptureProvenance.screenshots = $originalProvenanceScreenshots
                 $duplicateApproval = $originalApproval | ConvertFrom-Json
                 $duplicateApproval.Screenshots += $duplicateApproval.Screenshots[0]
                 $duplicateApproval | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $approvalPath
-                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'; throw 'Duplicate approved screenshot was accepted.' }
+                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $appTargets; throw 'Duplicate approved screenshot was accepted.' }
                 catch { if ($_.Exception.Message -notlike '*duplicate approved screenshot path*') { throw } }
                 Set-Content -LiteralPath $approvalPath -Value $originalApproval -NoNewline
                 $unretainedPath = Join-Path $consumer 'capture/unretained.png'
@@ -319,7 +426,7 @@ public sealed partial class AppleReleaseWorkflowTests
                     Height = 200
                 }
                 $approval | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $approvalPath
-                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'; throw 'Unretained screenshot was accepted.' }
+                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $appTargets; throw 'Unretained screenshot was accepted.' }
                 catch { if ($_.Exception.Message -notlike '*approved inventory*') { throw } }
                 Set-Content -LiteralPath $approvalPath -Value $originalApproval -NoNewline
                 Remove-Item -LiteralPath $unretainedPath
@@ -374,7 +481,8 @@ public sealed partial class AppleReleaseWorkflowTests
                 Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'
                 'SUBMIT_PASS'
                 $ArgumentList = @('apple-release','Screenshots','--config','powerforge.release.json')
-                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'; throw 'Screenshots accepted missing capture provenance.' }
+                $appTargets = @([pscustomobject]@{ name='App'; platform='iOS'; distributionRoute='AppStore'; appId='123'; marketingVersion='1.2.3' })
+                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $appTargets; throw 'Screenshots accepted missing capture provenance.' }
                 catch { if ($_.Exception.Message -notlike '*requires --capture-provenance*') { throw }; 'SCREENSHOTS_BLOCKED' }
                 """);
 

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
@@ -109,11 +109,12 @@ public sealed partial class AppleReleaseWorkflowTests
                 $arguments = @(
                     'apple-release', 'Screenshots', '--config', 'powerforge.release.json',
                     '--target', 'App', '--plan', '--confirm-apple-action',
+                    '--apple-resolve-target-identities',
                     '--apple-expected-plan-sha256', ('a' * 64), '--output=text')
                 $resolvedArguments = @(Get-AppleTargetResolutionArgumentList -Arguments $arguments)
                 $expected = @(
                     'apple-release', 'Screenshots', '--config', 'powerforge.release.json',
-                    '--target', 'App', '--validate', '--summary', '--output', 'json')
+                    '--target', 'App', '--validate', '--summary', '--apple-resolve-target-identities', '--output', 'json')
                 if (($resolvedArguments -join '|') -ne ($expected -join '|')) {
                     throw "Unexpected target-resolution arguments: $($resolvedArguments -join '|')"
                 }
@@ -400,6 +401,11 @@ public sealed partial class AppleReleaseWorkflowTests
                 . $Support
                 $appTargets = @([pscustomobject]@{ name='App'; platform='iOS'; distributionRoute='AppStore'; appId='123'; marketingVersion='1.2.3' })
                 Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $appTargets
+                if ((Get-ConsumerPathComparer).Compare('a', 'A') -eq 0) {
+                    $ArgumentList = @('apple-release','Screenshots','--config','powerforge.release.json','--target','App','--allowed-root','Capture')
+                    Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567' -ResolvedTargets $appTargets
+                    $ArgumentList = @('apple-release','Screenshots','--config','powerforge.release.json','--target','App','--allowed-root','capture')
+                }
                 $sharedPixelTargets = @(
                     $appTargets[0],
                     [pscustomobject]@{ name='Other'; platform='iOS'; distributionRoute='AppStore'; appId='888'; marketingVersion='1.2.3' })

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.PinnedEvidence.cs
@@ -180,7 +180,7 @@ public sealed partial class AppleReleaseWorkflowTests
     }
 
     [Fact]
-    public void ScreenshotEvidenceUsesOneExactInventoryRootAndRejectsEveryOtherIgnoredFile()
+    public void ScreenshotEvidenceAllowsAnApprovedSubsetWithinOneExactInventoryRootAndRejectsEveryOtherIgnoredFile()
     {
         var root = FindRepoRoot();
         var parent = Path.Combine(root, ".test-temp", $"powerforge-evidence-{Guid.NewGuid():N}");
@@ -229,7 +229,8 @@ public sealed partial class AppleReleaseWorkflowTests
                     workflowRef = 'EvotecIT/TestApp/.github/workflows/capture.yml@refs/heads/main';
                     marketingVersion = '1.2.3'; screenshots = @(
                         [pscustomobject]@{ path='phone/home.png'; sha256='NESTED_HASH'; width=100; height=200 },
-                        [pscustomobject]@{ path='home.png'; sha256='ROOT_HASH'; width=100; height=200 })
+                        [pscustomobject]@{ path='home.png'; sha256='ROOT_HASH'; width=100; height=200 },
+                        [pscustomobject]@{ path='website-candidate/home.png'; sha256='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'; width=1200; height=800 })
                 }
                 $consumer = [IO.Path]::GetFullPath($Consumer)
                 $ArgumentList = @('apple-release','Screenshots','--config','powerforge.release.json')
@@ -240,6 +241,38 @@ public sealed partial class AppleReleaseWorkflowTests
                 function Assert-UnlinkedPath { param([string]$Path,[string]$Name,[switch]$AllowMissingLeaf) }
                 . $Support
                 Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'
+                $originalProvenanceScreenshots = @($script:validatedCaptureProvenance.screenshots)
+                $script:validatedCaptureProvenance.screenshots += [pscustomobject]@{
+                    path = 'home.png';
+                    sha256 = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+                    width = 101;
+                    height = 200
+                }
+                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'; throw 'Conflicting provenance path was accepted.' }
+                catch { if ($_.Exception.Message -notlike '*duplicate screenshot path*') { throw } }
+                $script:validatedCaptureProvenance.screenshots = $originalProvenanceScreenshots
+                $approvalPath = Join-Path $consumer 'screenshots.approval.json'
+                $originalApproval = Get-Content -LiteralPath $approvalPath -Raw
+                $duplicateApproval = $originalApproval | ConvertFrom-Json
+                $duplicateApproval.Screenshots += $duplicateApproval.Screenshots[0]
+                $duplicateApproval | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $approvalPath
+                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'; throw 'Duplicate approved screenshot was accepted.' }
+                catch { if ($_.Exception.Message -notlike '*duplicate approved screenshot path*') { throw } }
+                Set-Content -LiteralPath $approvalPath -Value $originalApproval -NoNewline
+                $unretainedPath = Join-Path $consumer 'capture/unretained.png'
+                Set-Content -LiteralPath $unretainedPath -Value 'unretained screenshot bytes'
+                $approval = $originalApproval | ConvertFrom-Json
+                $approval.Screenshots += [pscustomobject]@{
+                    File = 'capture/unretained.png';
+                    Sha256 = (Get-FileHash -LiteralPath $unretainedPath -Algorithm SHA256).Hash;
+                    Width = 100;
+                    Height = 200
+                }
+                $approval | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $approvalPath
+                try { Assert-ScreenshotPublicationBinding -SourceCommit '0123456789abcdef0123456789abcdef01234567'; throw 'Unretained screenshot was accepted.' }
+                catch { if ($_.Exception.Message -notlike '*approved inventory*') { throw } }
+                Set-Content -LiteralPath $approvalPath -Value $originalApproval -NoNewline
+                Remove-Item -LiteralPath $unretainedPath
                 Assert-ConsumerRepositoryContent
                 Set-Content -LiteralPath (Join-Path $consumer 'capture/injected.bin') -Value 'not reviewed'
                 try { Assert-ConsumerRepositoryContent; throw 'Unreviewed file was accepted.' }

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.RunnerLocalCredentials.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.RunnerLocalCredentials.cs
@@ -55,12 +55,14 @@ public sealed partial class AppleReleaseWorkflowTests
         Assert.Contains("UploadExisting is forbidden at the pinned local operator boundary", script, StringComparison.Ordinal);
         Assert.Contains("if ($null -ne (Get-OptionValue -Option '--capture-provenance'))", script, StringComparison.Ordinal);
         Assert.Contains("Capture provenance source commit", script, StringComparison.Ordinal);
+        Assert.Contains("$script:validatedCaptureProvenancePath = $path", script, StringComparison.Ordinal);
         Assert.Contains("--apple-source-commit must match the exact consumer HEAD", evidence, StringComparison.Ordinal);
         Assert.Contains("Assert-ScreenshotPublicationBinding -SourceCommit $consumerHead", script, StringComparison.Ordinal);
         Assert.Contains("if ($ArgumentList[0] -ne 'apple-release' -or", evidence, StringComparison.Ordinal);
         Assert.Contains("$argument -eq '--capture-provenance'", evidence, StringComparison.Ordinal);
         Assert.Contains("$forwardedArgumentList = Get-ForwardedArgumentList -SourceCommit $consumerHead", script, StringComparison.Ordinal);
         Assert.Contains("Screenshot approval manifests do not identify one exact retained capture root and approved inventory", evidence, StringComparison.Ordinal);
+        Assert.Contains("Split-Path -Parent $script:validatedCaptureProvenancePath", evidence, StringComparison.Ordinal);
         Assert.Contains("Resolve-PathFromBase -BasePath", evidence, StringComparison.Ordinal);
         Assert.Contains("No screenshot configuration matches the selected release targets", evidence, StringComparison.Ordinal);
         Assert.Contains("permissions must not grant group or other access", script, StringComparison.Ordinal);

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.RunnerLocalCredentials.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.RunnerLocalCredentials.cs
@@ -55,14 +55,13 @@ public sealed partial class AppleReleaseWorkflowTests
         Assert.Contains("UploadExisting is forbidden at the pinned local operator boundary", script, StringComparison.Ordinal);
         Assert.Contains("if ($null -ne (Get-OptionValue -Option '--capture-provenance'))", script, StringComparison.Ordinal);
         Assert.Contains("Capture provenance source commit", script, StringComparison.Ordinal);
-        Assert.Contains("$script:validatedCaptureProvenancePath = $path", script, StringComparison.Ordinal);
         Assert.Contains("--apple-source-commit must match the exact consumer HEAD", evidence, StringComparison.Ordinal);
         Assert.Contains("Assert-ScreenshotPublicationBinding -SourceCommit $consumerHead", script, StringComparison.Ordinal);
         Assert.Contains("if ($ArgumentList[0] -ne 'apple-release' -or", evidence, StringComparison.Ordinal);
-        Assert.Contains("$argument -eq '--capture-provenance'", evidence, StringComparison.Ordinal);
+        Assert.Contains("@('--capture-provenance', '--allowed-root')", evidence, StringComparison.Ordinal);
         Assert.Contains("$forwardedArgumentList = Get-ForwardedArgumentList -SourceCommit $consumerHead", script, StringComparison.Ordinal);
         Assert.Contains("Screenshot approval manifests do not identify one exact retained capture root and approved inventory", evidence, StringComparison.Ordinal);
-        Assert.Contains("Split-Path -Parent $script:validatedCaptureProvenancePath", evidence, StringComparison.Ordinal);
+        Assert.Contains("requires --allowed-root to bind screenshots", evidence, StringComparison.Ordinal);
         Assert.Contains("Resolve-PathFromBase -BasePath", evidence, StringComparison.Ordinal);
         Assert.Contains("No screenshot configuration matches the selected release targets", evidence, StringComparison.Ordinal);
         Assert.Contains("permissions must not grant group or other access", script, StringComparison.Ordinal);

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.RunnerLocalCredentials.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.RunnerLocalCredentials.cs
@@ -60,7 +60,7 @@ public sealed partial class AppleReleaseWorkflowTests
         Assert.Contains("if ($ArgumentList[0] -ne 'apple-release' -or", evidence, StringComparison.Ordinal);
         Assert.Contains("$argument -eq '--capture-provenance'", evidence, StringComparison.Ordinal);
         Assert.Contains("$forwardedArgumentList = Get-ForwardedArgumentList -SourceCommit $consumerHead", script, StringComparison.Ordinal);
-        Assert.Contains("Screenshot approval manifests do not identify one exact retained capture root and inventory", evidence, StringComparison.Ordinal);
+        Assert.Contains("Screenshot approval manifests do not identify one exact retained capture root and approved inventory", evidence, StringComparison.Ordinal);
         Assert.Contains("Resolve-PathFromBase -BasePath", evidence, StringComparison.Ordinal);
         Assert.Contains("No screenshot configuration matches the selected release targets", evidence, StringComparison.Ordinal);
         Assert.Contains("permissions must not grant group or other access", script, StringComparison.Ordinal);

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.RunnerLocalCredentials.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.RunnerLocalCredentials.cs
@@ -57,13 +57,20 @@ public sealed partial class AppleReleaseWorkflowTests
         Assert.Contains("Capture provenance source commit", script, StringComparison.Ordinal);
         Assert.Contains("--apple-source-commit must match the exact consumer HEAD", evidence, StringComparison.Ordinal);
         Assert.Contains("Assert-ScreenshotPublicationBinding -SourceCommit $consumerHead", script, StringComparison.Ordinal);
+        Assert.Contains("Get-AppleTargetResolutionArgumentList -Arguments $forwardedArgumentList", script, StringComparison.Ordinal);
+        Assert.Contains("Read-ResolvedAppleTargets -Path $resolutionOutput", script, StringComparison.Ordinal);
+        Assert.Contains("-CaptureStandardOutputPath $resolutionOutput", script, StringComparison.Ordinal);
+        Assert.True(
+            script.IndexOf("Read-ResolvedAppleTargets -Path $resolutionOutput", StringComparison.Ordinal) <
+            script.IndexOf("Assert-ScreenshotPublicationBinding -SourceCommit $consumerHead", StringComparison.Ordinal));
         Assert.Contains("if ($ArgumentList[0] -ne 'apple-release' -or", evidence, StringComparison.Ordinal);
         Assert.Contains("@('--capture-provenance', '--allowed-root')", evidence, StringComparison.Ordinal);
         Assert.Contains("$forwardedArgumentList = Get-ForwardedArgumentList -SourceCommit $consumerHead", script, StringComparison.Ordinal);
         Assert.Contains("Screenshot approval manifests do not identify one exact retained capture root and approved inventory", evidence, StringComparison.Ordinal);
         Assert.Contains("requires --allowed-root to bind screenshots", evidence, StringComparison.Ordinal);
         Assert.Contains("Resolve-PathFromBase -BasePath", evidence, StringComparison.Ordinal);
-        Assert.Contains("No screenshot configuration matches the selected release targets", evidence, StringComparison.Ordinal);
+        Assert.Contains("screenshot configurations match selected Apple app", evidence, StringComparison.Ordinal);
+        Assert.Contains("does not match selected Apple app", evidence, StringComparison.Ordinal);
         Assert.Contains("permissions must not grant group or other access", script, StringComparison.Ordinal);
         Assert.Contains("must not grant access through a POSIX ACL", script, StringComparison.Ordinal);
         Assert.Contains("must not have hard links", script, StringComparison.Ordinal);

--- a/PowerForge.Tests/PowerForgeCliAppleReleaseTests.cs
+++ b/PowerForge.Tests/PowerForgeCliAppleReleaseTests.cs
@@ -50,6 +50,23 @@ public sealed class PowerForgeCliAppleReleaseTests
     }
 
     [Fact]
+    public void AppleRelease_CliMapsExplicitIsolatedTargetResolution()
+    {
+        var request = BuildReleaseRequest(
+            ["--apple-action", "Screenshots", "--apple-resolve-target-identities", "--summary"],
+            "/tmp/powerforge.release.json",
+            planOnly: false,
+            validateOnly: true,
+            packagesOnly: false,
+            moduleOnly: false,
+            toolsOnly: false);
+
+        Assert.True(request.AppleResolveTargetIdentities);
+        Assert.True(request.ValidateOnly);
+        Assert.True(request.AppleSummaryOnly);
+    }
+
+    [Fact]
     public async Task AppleRelease_JsonRedactionPreservesPropertyNames()
     {
         var repoRoot = FindRepositoryRoot();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleHostedReviewRegressions.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleHostedReviewRegressions.cs
@@ -3,6 +3,97 @@ namespace PowerForge.Tests;
 public sealed partial class PowerForgeReleaseServiceTests
 {
     [Fact]
+    public void Execute_TargetedAppleScreenshotPlan_BindsOnlyTheDiscoveredSelectedAppInputs()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.2.0", "9");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var selectedShots = Directory.CreateDirectory(Path.Combine(root, "selected-shots"));
+            File.WriteAllText(Path.Combine(selectedShots.FullName, "home.png"), "selected pixels");
+            WriteScreenshotConfig(
+                root,
+                "selected-screenshots.json",
+                "111",
+                "1.2.0",
+                "iOS",
+                "selected-shots",
+                qualityEnabled: false);
+            WriteScreenshotConfig(
+                root,
+                "unrelated-screenshots.json",
+                "222",
+                "1.2.0",
+                "iOS",
+                "missing-unrelated-shots",
+                qualityEnabled: false);
+
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            var selected = Assert.Single(spec.AppleApps!.Apps);
+            selected.AppStoreConnectAppId = null;
+            spec.AppleApps.ScreenshotConfigPath = null;
+            spec.AppleApps.ScreenshotConfigPaths =
+            [
+                "selected-screenshots.json",
+                "unrelated-screenshots.json"
+            ];
+            spec.AppleApps.SyncScreenshots = true;
+            spec.AppleApps.Apps =
+            [
+                selected,
+                new AppleAppConfiguration
+                {
+                    Name = "Other iOS",
+                    BundleId = "com.evotecit.other",
+                    Platform = ApplePlatform.iOS,
+                    ProjectPath = "CasaRay.xcodeproj",
+                    Scheme = "Other",
+                    AppStoreConnectAppId = null
+                }
+            ];
+
+            var result = CreateAppleAutomationService(
+                    _ => throw new InvalidOperationException("A non-replacing screenshot plan must not query release state."),
+                    findAppleApps: (_, bundleId) =>
+                    [
+                        new AppStoreConnectAppInfo
+                        {
+                            Id = bundleId == "com.evotecit.casaray" ? "111" : "222",
+                            BundleId = bundleId,
+                            Name = bundleId == "com.evotecit.casaray" ? "CasaRay" : "Other"
+                        }
+                    ],
+                    checkAppleReleaseReadiness: (_, request) => CreateReadyReleaseReadiness(request))
+                .Execute(
+                    spec,
+                    new PowerForgeReleaseRequest
+                    {
+                        ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                        AppleAction = PowerForgeAppleReleaseAction.Screenshots,
+                        PlanOnly = true,
+                        Targets = ["CasaRay iOS"]
+                    });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            var target = Assert.Single(result.AppleReceipt!.Targets);
+            Assert.Equal("111", target.AppId);
+            Assert.True(target.AppIdDiscovered);
+            Assert.Contains("selected-screenshots.json", result.AppleReceipt.MutationInputFiles.Keys);
+            Assert.Contains("selected-shots/home.png", result.AppleReceipt.MutationInputFiles.Keys);
+            Assert.DoesNotContain("unrelated-screenshots.json", result.AppleReceipt.MutationInputFiles.Keys);
+            Assert.DoesNotContain(
+                result.AppleReceipt.MutationInputFiles.Keys,
+                path => path.Contains("missing-unrelated-shots", StringComparison.Ordinal));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_ApplePlan_BindsEffectiveAutomationPolicy()
     {
         var root = CreateSandbox();
@@ -170,6 +261,45 @@ public sealed partial class PowerForgeReleaseServiceTests
         finally
         {
             TryDelete(plan.ProjectRoot);
+        }
+    }
+
+    [Fact]
+    public void ApprovedAppleMutationConfig_IgnoresUnselectedScreenshotConfigs()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var selectedPath = Path.Combine(root, "selected-screenshots.json");
+            File.WriteAllText(selectedPath, "{ \"appId\": \"111\" }");
+            var approvedHash = Convert.ToHexString(
+                    System.Security.Cryptography.SHA256.HashData(File.ReadAllBytes(selectedPath)))
+                .ToLowerInvariant();
+            var plan = new PowerForgeAppleReleasePlan
+            {
+                ProjectRoot = root,
+                SyncScreenshots = true,
+                ScreenshotConfigPaths =
+                [
+                    selectedPath,
+                    Path.Combine(root, "missing-unselected-screenshots.json")
+                ],
+                ApprovedMutationInputFilesSha256 = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["selected-screenshots.json"] = approvedHash
+                }
+            };
+
+            PowerForgeReleaseService.CaptureApprovedMutationInputContents(plan);
+
+            Assert.Single(plan.ApprovedMutationInputContents);
+            Assert.Equal(
+                "{ \"appId\": \"111\" }",
+                PowerForgeReleaseService.ReadApprovedMutationInputText(plan, selectedPath));
+        }
+        finally
+        {
+            TryDelete(root);
         }
     }
 

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleHostedReviewRegressions.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleHostedReviewRegressions.cs
@@ -3,6 +3,72 @@ namespace PowerForge.Tests;
 public sealed partial class PowerForgeReleaseServiceTests
 {
     [Fact]
+    public void Execute_AppleScreenshotPlan_PreservesCaseDistinctConfigsOnCaseSensitiveFileSystems()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var lowerPath = Path.Combine(root, "screenshots.json");
+            File.WriteAllText(lowerPath, "lower");
+            var upperPath = Path.Combine(root, "Screenshots.json");
+            if (File.Exists(upperPath))
+                return;
+
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.2.0", "9");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var firstShots = Directory.CreateDirectory(Path.Combine(root, "first-shots"));
+            var secondShots = Directory.CreateDirectory(Path.Combine(root, "second-shots"));
+            File.WriteAllText(Path.Combine(firstShots.FullName, "home.png"), "first pixels");
+            File.WriteAllText(Path.Combine(secondShots.FullName, "home.png"), "second pixels");
+            WriteScreenshotConfig(root, "screenshots.json", "111", "1.2.0", "iOS", "first-shots", qualityEnabled: false);
+            WriteScreenshotConfig(root, "Screenshots.json", "222", "1.2.0", "iOS", "second-shots", qualityEnabled: false);
+
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            var first = Assert.Single(spec.AppleApps!.Apps);
+            first.AppStoreConnectAppId = "111";
+            spec.AppleApps.ScreenshotConfigPath = null;
+            spec.AppleApps.ScreenshotConfigPaths = ["screenshots.json", "Screenshots.json"];
+            spec.AppleApps.SyncScreenshots = true;
+            spec.AppleApps.Apps =
+            [
+                first,
+                new AppleAppConfiguration
+                {
+                    Name = "Other iOS",
+                    BundleId = "com.evotecit.other",
+                    Platform = ApplePlatform.iOS,
+                    ProjectPath = "CasaRay.xcodeproj",
+                    Scheme = "Other",
+                    AppStoreConnectAppId = "222"
+                }
+            ];
+
+            var result = CreateAppleAutomationService(
+                    _ => throw new InvalidOperationException("A non-replacing screenshot plan must not query release state."),
+                    checkAppleReleaseReadiness: (_, request) => CreateReadyReleaseReadiness(request))
+                .Execute(
+                    spec,
+                    new PowerForgeReleaseRequest
+                    {
+                        ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                        AppleAction = PowerForgeAppleReleaseAction.Screenshots,
+                        PlanOnly = true
+                    });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Contains("screenshots.json", result.AppleReceipt!.MutationInputFiles.Keys);
+            Assert.Contains("Screenshots.json", result.AppleReceipt.MutationInputFiles.Keys);
+            Assert.Contains("first-shots/home.png", result.AppleReceipt.MutationInputFiles.Keys);
+            Assert.Contains("second-shots/home.png", result.AppleReceipt.MutationInputFiles.Keys);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_TargetedAppleScreenshotPlan_BindsOnlyTheDiscoveredSelectedAppInputs()
     {
         var root = CreateSandbox();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleProjectGeneration.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleProjectGeneration.cs
@@ -2,6 +2,27 @@ namespace PowerForge.Tests;
 
 public sealed partial class PowerForgeReleaseServiceTests
 {
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void Execute_AppleTargetResolution_RequiresValidationOnlySummary(
+        bool validateOnly,
+        bool summaryOnly)
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeReleaseService(new NullLogger()).Execute(
+                new PowerForgeReleaseSpec(),
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = "powerforge.release.json",
+                    ValidateOnly = validateOnly,
+                    AppleSummaryOnly = summaryOnly,
+                    AppleResolveTargetIdentities = true
+                }));
+
+        Assert.Contains("validation-only summary", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void Execute_AppleArchivePlan_AcceptsMissingXcodeGenProject()
     {
@@ -204,7 +225,7 @@ public sealed partial class PowerForgeReleaseServiceTests
     [Theory]
     [InlineData(PowerForgeAppleReleaseAction.Screenshots)]
     [InlineData(PowerForgeAppleReleaseAction.Advance)]
-    public void Execute_AppleValidation_GeneratesMissingProjectBeforeSummarizingIdentity(
+    public void Execute_IsolatedAppleTargetResolution_GeneratesMissingProjectBeforeSummarizingIdentity(
         PowerForgeAppleReleaseAction action)
     {
         var root = CreateSandbox();
@@ -243,6 +264,8 @@ public sealed partial class PowerForgeReleaseServiceTests
                 {
                     ConfigPath = Path.Combine(root, "powerforge.release.json"),
                     ValidateOnly = true,
+                    AppleSummaryOnly = true,
+                    AppleResolveTargetIdentities = true,
                     AppleAction = action
                 });
 
@@ -259,8 +282,51 @@ public sealed partial class PowerForgeReleaseServiceTests
         }
     }
 
+    [Theory]
+    [InlineData(PowerForgeAppleReleaseAction.Screenshots)]
+    [InlineData(PowerForgeAppleReleaseAction.Advance)]
+    public void Execute_OrdinaryAppleValidation_DoesNotGenerateProjects(
+        PowerForgeAppleReleaseAction action)
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var generatedRoot = Path.Combine(root, "Generated");
+            Directory.CreateDirectory(generatedRoot);
+            File.WriteAllText(Path.Combine(generatedRoot, "project.yml"), "name: Generated");
+            File.WriteAllText(Path.Combine(root, "screenshots.json"), "{}");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.ScreenshotConfigPath = "screenshots.json";
+            var app = Assert.Single(spec.AppleApps.Apps);
+            app.ProjectPath = "Generated/Generated.xcodeproj";
+            app.GenerateProjectIfMissing = true;
+
+            var result = CreateAppleAutomationService(
+                    _ => throw new InvalidOperationException("Validation must not query App Store Connect."),
+                    generateAppleProject: _ => throw new InvalidOperationException("Ordinary validation must not run XcodeGen."))
+                .Execute(
+                    spec,
+                    new PowerForgeReleaseRequest
+                    {
+                        ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                        ValidateOnly = true,
+                        AppleSummaryOnly = true,
+                        AppleAction = action
+                    });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.False(Directory.Exists(Path.Combine(generatedRoot, "Generated.xcodeproj")));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
     [Fact]
-    public void Execute_AppleValidation_MatchesGeneratedIncrementExistingExecutionIdentity()
+    public void Execute_IsolatedAppleTargetResolution_MatchesGeneratedIncrementExistingExecutionIdentity()
     {
         var root = CreateSandbox();
         try
@@ -296,6 +362,8 @@ public sealed partial class PowerForgeReleaseServiceTests
                 {
                     ConfigPath = Path.Combine(root, "powerforge.release.json"),
                     ValidateOnly = true,
+                    AppleSummaryOnly = true,
+                    AppleResolveTargetIdentities = true,
                     AppleAction = PowerForgeAppleReleaseAction.Screenshots
                 });
 
@@ -303,6 +371,79 @@ public sealed partial class PowerForgeReleaseServiceTests
             var target = Assert.Single(result.AppleAppPlan!.Apps);
             Assert.Equal("2.0", target.MarketingVersion);
             Assert.Equal("19", target.BuildNumber);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleScreenshots_GeneratesIdentityBeforeBindingExactMutationInputs()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var generatedRoot = Path.Combine(root, "Generated");
+            Directory.CreateDirectory(generatedRoot);
+            File.WriteAllText(Path.Combine(generatedRoot, "project.yml"), "name: Generated");
+            var screenshotRoot = Directory.CreateDirectory(Path.Combine(root, "screenshots"));
+            File.WriteAllText(Path.Combine(screenshotRoot.FullName, "home.png"), "reviewed pixels");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            var app = Assert.Single(spec.AppleApps!.Apps);
+            app.Name = "Generated iOS";
+            app.ProjectPath = "Generated/Generated.xcodeproj";
+            app.Scheme = "Generated";
+            app.GenerateProjectIfMissing = true;
+            spec.AppleApps.SyncScreenshots = true;
+            spec.AppleApps.ScreenshotConfigPath = "screenshots.json";
+            WriteScreenshotConfig(
+                root,
+                "screenshots.json",
+                app.AppStoreConnectAppId!,
+                "2.0",
+                "iOS",
+                "screenshots",
+                qualityEnabled: false);
+            var sourceCommit = CommitAppleShipSource(root);
+            var generationCalls = 0;
+            AppStoreConnectReleasePreparationRequest? observed = null;
+            var service = CreateAppleAutomationService(
+                request => CreateReleaseState(request, "VALID"),
+                generateAppleProject: plan =>
+                {
+                    generationCalls++;
+                    CreateXcodeProject(
+                        Path.GetDirectoryName(plan.ProjectPath)!,
+                        Path.GetFileName(plan.ProjectPath),
+                        "2.0",
+                        "18");
+                    return true;
+                },
+                prepareAppleDistribution: request =>
+                {
+                    observed = request;
+                    return new AppStoreConnectReleasePreparationResult();
+                });
+
+            var result = service.Execute(
+                spec,
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    AppleAction = PowerForgeAppleReleaseAction.Screenshots,
+                    AppleSourceCommit = sourceCommit
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(1, generationCalls);
+            Assert.NotNull(observed);
+            Assert.Equal("2.0", observed!.VersionString);
+            Assert.Equal("18", observed.BuildNumber);
+            Assert.Contains("screenshots.json", result.AppleAppPlan!.ApprovedMutationInputFilesSha256.Keys);
+            Assert.Contains("screenshots/home.png", result.AppleAppPlan.ApprovedMutationInputFilesSha256.Keys);
         }
         finally
         {

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleProjectGeneration.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleProjectGeneration.cs
@@ -201,6 +201,153 @@ public sealed partial class PowerForgeReleaseServiceTests
         }
     }
 
+    [Theory]
+    [InlineData(PowerForgeAppleReleaseAction.Screenshots)]
+    [InlineData(PowerForgeAppleReleaseAction.Advance)]
+    public void Execute_AppleValidation_GeneratesMissingProjectBeforeSummarizingIdentity(
+        PowerForgeAppleReleaseAction action)
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var generatedRoot = Path.Combine(root, "Generated");
+            Directory.CreateDirectory(generatedRoot);
+            File.WriteAllText(Path.Combine(generatedRoot, "project.yml"), "name: Generated");
+            File.WriteAllText(Path.Combine(root, "screenshots.json"), "{}");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.ScreenshotConfigPath = "screenshots.json";
+            var app = Assert.Single(spec.AppleApps.Apps);
+            app.Name = "Generated iOS";
+            app.ProjectPath = "Generated/Generated.xcodeproj";
+            app.Scheme = "Generated";
+            app.GenerateProjectIfMissing = true;
+            var generationCalls = 0;
+            var service = CreateAppleAutomationService(
+                _ => throw new InvalidOperationException("Validation must not query App Store Connect."),
+                generateAppleProject: plan =>
+                {
+                    generationCalls++;
+                    CreateXcodeProject(
+                        Path.GetDirectoryName(plan.ProjectPath)!,
+                        Path.GetFileName(plan.ProjectPath),
+                        "2.0",
+                        "18");
+                    return true;
+                });
+
+            var result = service.Execute(
+                spec,
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    ValidateOnly = true,
+                    AppleAction = action
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(1, generationCalls);
+            var target = Assert.Single(result.AppleAppPlan!.Apps);
+            Assert.Equal("2.0", target.MarketingVersion);
+            Assert.Equal("18", target.BuildNumber);
+            Assert.Null(result.AppleReceipt);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleValidation_MatchesGeneratedIncrementExistingExecutionIdentity()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var generatedRoot = Path.Combine(root, "Generated");
+            Directory.CreateDirectory(generatedRoot);
+            File.WriteAllText(Path.Combine(generatedRoot, "project.yml"), "name: Generated");
+            File.WriteAllText(Path.Combine(root, "screenshots.json"), "{}");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.ScreenshotConfigPath = "screenshots.json";
+            var app = Assert.Single(spec.AppleApps.Apps);
+            app.ProjectPath = "Generated/Generated.xcodeproj";
+            app.GenerateProjectIfMissing = true;
+            app.MarketingVersion = "2.0";
+            app.BuildNumberPolicy = AppleBuildNumberPolicy.IncrementExisting;
+            var service = CreateAppleAutomationService(
+                _ => throw new InvalidOperationException("Validation must not query App Store Connect."),
+                generateAppleProject: plan =>
+                {
+                    CreateXcodeProject(
+                        Path.GetDirectoryName(plan.ProjectPath)!,
+                        Path.GetFileName(plan.ProjectPath),
+                        "2.0",
+                        "18");
+                    return true;
+                });
+
+            var result = service.Execute(
+                spec,
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    ValidateOnly = true,
+                    AppleAction = PowerForgeAppleReleaseAction.Screenshots
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            var target = Assert.Single(result.AppleAppPlan!.Apps);
+            Assert.Equal("2.0", target.MarketingVersion);
+            Assert.Equal("19", target.BuildNumber);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Theory]
+    [InlineData(PowerForgeAppleReleaseAction.Archive)]
+    [InlineData(PowerForgeAppleReleaseAction.Rehearse)]
+    [InlineData(PowerForgeAppleReleaseAction.Version)]
+    public void Execute_AppleValidation_DoesNotGenerateForActionsWithoutReleaseIdentity(
+        PowerForgeAppleReleaseAction action)
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "2.0", "18");
+            WriteXcodeGenVersionSource(root, "2.0", "18");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+            Assert.Single(spec.AppleApps.Apps).RegenerateProject = true;
+            var result = CreateAppleAutomationService(
+                    _ => throw new InvalidOperationException("Validation must not query App Store Connect."),
+                    generateAppleProject: _ => throw new InvalidOperationException("This validation action must not run XcodeGen."))
+                .Execute(
+                    spec,
+                    new PowerForgeReleaseRequest
+                    {
+                        ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                        ValidateOnly = true,
+                        AppleAction = action,
+                        AppleMarketingVersion = action == PowerForgeAppleReleaseAction.Version ? "2.1" : null
+                    });
+
+            Assert.True(result.Success, result.ErrorMessage);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
     [Fact]
     public void Execute_AppleStatus_GeneratesBeforeResolvingIncrementExistingBuild()
     {

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleShip.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleShip.cs
@@ -14,8 +14,12 @@ public sealed partial class PowerForgeReleaseServiceTests
             WriteXcodeGenVersionSource(root, "1.6.0", "14");
             var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
             File.WriteAllText(keyPath, "private-key");
+            var screenshots = Directory.CreateDirectory(Path.Combine(root, "screenshots"));
+            File.WriteAllText(Path.Combine(screenshots.FullName, "home.png"), "planned pixels");
+            WriteScreenshotConfig(root, "screenshots.json", "6778025328", "1.6.0", "iOS", "screenshots", qualityEnabled: false);
             var spec = CreateAppleAutomationSpec(root, keyPath);
             spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+            spec.AppleApps.ScreenshotConfigPath = "screenshots.json";
             EnableInternalAppleShipTargets(spec);
 
             var exception = Assert.Throws<InvalidOperationException>(() =>
@@ -181,8 +185,11 @@ public sealed partial class PowerForgeReleaseServiceTests
             });
 
             Assert.True(result.Success, result.ErrorMessage);
+            Assert.True(appStorePlan.Success, appStorePlan.ErrorMessage);
             Assert.Equal(PowerForgeAppleShipPhase.VersionCheckpoint, result.AppleReceipt!.ShipPhase);
             Assert.Equal(0, stateQueries);
+            Assert.DoesNotContain("screenshots.json", appStorePlan.AppleReceipt!.MutationInputFiles.Keys);
+            Assert.DoesNotContain("screenshots/home.png", appStorePlan.AppleReceipt.MutationInputFiles.Keys);
             Assert.Matches("^[0-9A-F]{64}$", result.AppleReceipt.PlanSha256!);
             Assert.NotEqual(result.AppleReceipt.PlanSha256, appStorePlan.AppleReceipt!.PlanSha256);
             var target = Assert.Single(result.AppleReceipt.Targets);

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -69,6 +69,12 @@ internal sealed class PowerForgeReleaseRequest
 
     public bool ValidateOnly { get; set; }
 
+    /// <summary>
+    /// Allows an explicitly isolated validation run to materialize Apple projects and resolve
+    /// the exact target identity used by screenshot evidence admission.
+    /// </summary>
+    internal bool AppleResolveTargetIdentities { get; set; }
+
     public bool PackagesOnly { get; set; }
 
     public bool ModuleOnly { get; set; }

--- a/PowerForge/Services/PowerForgeReleaseService.AppleIdentity.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleIdentity.cs
@@ -1,0 +1,43 @@
+namespace PowerForge;
+
+internal sealed partial class PowerForgeReleaseService
+{
+    private bool PrepareAppleProjectAndReleaseIdentity(
+        PowerForgeAppleReleasePlan plan,
+        PowerForgeAppleAppReleaseTargetPlan app)
+    {
+        if (plan.Action == PowerForgeAppleReleaseAction.Cleanup)
+            return false;
+
+        var generated = _generateAppleProject(app);
+        if (app.VersionUpdateRequested &&
+            app.BuildNumberPolicy == AppleBuildNumberPolicy.IncrementExisting &&
+            string.IsNullOrWhiteSpace(app.BuildNumber))
+        {
+            app.BuildNumber = ResolveAppleBuildNumber(
+                new AppleAppConfiguration
+                {
+                    BuildNumberPolicy = app.BuildNumberPolicy
+                },
+                app.ProjectPath,
+                new XcodeProjectVersionEditor());
+        }
+
+        if (RequiresAppleReleaseIdentity(plan))
+        {
+            var values = ResolveAppleDistributionValues(app, versionUpdate: null);
+            app.MarketingVersion = values.MarketingVersion;
+            app.BuildNumber = values.BuildNumber;
+        }
+        return generated;
+    }
+
+    private void ResolveAppleValidationTargetIdentities(PowerForgeAppleReleasePlan plan)
+    {
+        if (!RequiresAppleReleaseIdentity(plan))
+            return;
+
+        foreach (var app in plan.Apps.Where(app => ShouldExecuteAppleTarget(plan.Action, app)))
+            _ = PrepareAppleProjectAndReleaseIdentity(plan, app);
+    }
+}

--- a/PowerForge/Services/PowerForgeReleaseService.AppleScreenshotInputs.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleScreenshotInputs.cs
@@ -15,6 +15,9 @@ internal sealed partial class PowerForgeReleaseService
             return Array.Empty<(AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)>();
 
         configured ??= LoadAppleScreenshotSpecs(plan);
+        if (configured.Length == 0)
+            return Array.Empty<(AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)>();
+
         var selected = new List<(AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)>();
         foreach (var app in plan.Apps.Where(app =>
                      app.DistributionRoute == AppleDistributionRoute.AppStore &&

--- a/PowerForge/Services/PowerForgeReleaseService.AppleScreenshotInputs.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleScreenshotInputs.cs
@@ -6,6 +6,10 @@ internal sealed partial class PowerForgeReleaseService
         PowerForgeAppleReleasePlan plan,
         (AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)[]? configured = null)
     {
+        if (plan.Action == PowerForgeAppleReleaseAction.Ship &&
+            plan.ShipPhase == PowerForgeAppleShipPhase.VersionCheckpoint)
+            return Array.Empty<(AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)>();
+
         if (!plan.SyncScreenshots && !plan.CheckReleaseReadiness &&
             (!plan.SubmitForReview || plan.SkipReviewReadinessCheck))
             return Array.Empty<(AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)>();
@@ -26,7 +30,7 @@ internal sealed partial class PowerForgeReleaseService
                 selected.Add(match.Value);
         }
 
-        var comparer = Path.DirectorySeparatorChar == '\\'
+        var comparer = FrameworkCompatibility.GetPathStringComparisonForPath(plan.ProjectRoot) == StringComparison.OrdinalIgnoreCase
             ? StringComparer.OrdinalIgnoreCase
             : StringComparer.Ordinal;
         return selected
@@ -34,4 +38,5 @@ internal sealed partial class PowerForgeReleaseService
             .Select(static group => group.First())
             .ToArray();
     }
+
 }

--- a/PowerForge/Services/PowerForgeReleaseService.AppleScreenshotInputs.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleScreenshotInputs.cs
@@ -1,0 +1,37 @@
+namespace PowerForge;
+
+internal sealed partial class PowerForgeReleaseService
+{
+    private (AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)[] ResolveSelectedAppleScreenshotSpecs(
+        PowerForgeAppleReleasePlan plan,
+        (AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)[]? configured = null)
+    {
+        if (!plan.SyncScreenshots && !plan.CheckReleaseReadiness &&
+            (!plan.SubmitForReview || plan.SkipReviewReadinessCheck))
+            return Array.Empty<(AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)>();
+
+        configured ??= LoadAppleScreenshotSpecs(plan);
+        var selected = new List<(AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)>();
+        foreach (var app in plan.Apps.Where(app =>
+                     app.DistributionRoute == AppleDistributionRoute.AppStore &&
+                     ShouldRunAppleShipAppStoreStep(plan, app)))
+        {
+            var version = ResolveAppleDistributionValues(app, versionUpdate: null).MarketingVersion;
+            var match = ResolveMatchingScreenshotSpec(
+                configured,
+                app,
+                version,
+                required: plan.SyncScreenshots || configured.Length > 0);
+            if (match is not null)
+                selected.Add(match.Value);
+        }
+
+        var comparer = Path.DirectorySeparatorChar == '\\'
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+        return selected
+            .GroupBy(static value => value.ConfigPath, comparer)
+            .Select(static group => group.First())
+            .ToArray();
+    }
+}

--- a/PowerForge/Services/PowerForgeReleaseService.AppleVersioning.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleVersioning.cs
@@ -26,7 +26,7 @@ internal sealed partial class PowerForgeReleaseService
         {
             if (!string.IsNullOrWhiteSpace(plan.SourceCommit) && HasAppleExecutionMutation(plan))
             {
-                _ = CreateAppleMutationInputEvidence(plan);
+                _ = CreateAppleMutationInputEvidence(plan, ResolveSelectedAppleScreenshotSpecs(plan));
                 CaptureApprovedMutationInputContents(plan);
             }
             return null;
@@ -88,12 +88,13 @@ internal sealed partial class PowerForgeReleaseService
         foreach (var path in paths.Where(static value => !string.IsNullOrWhiteSpace(value)).Distinct(pathComparer))
         {
             var fullPath = Path.GetFullPath(path);
+            var relative = FrameworkCompatibility.GetRelativePath(plan.ProjectRoot, fullPath).Replace('\\', '/');
+            if (!plan.ApprovedMutationInputFilesSha256.TryGetValue(relative, out var expected))
+                continue;
             var bytes = File.ReadAllBytes(fullPath);
             using var sha256 = SHA256.Create();
             var actual = BitConverter.ToString(sha256.ComputeHash(bytes)).Replace("-", string.Empty).ToLowerInvariant();
-            var relative = FrameworkCompatibility.GetRelativePath(plan.ProjectRoot, fullPath).Replace('\\', '/');
-            if (!plan.ApprovedMutationInputFilesSha256.TryGetValue(relative, out var expected) ||
-                !actual.Equals(expected, StringComparison.OrdinalIgnoreCase))
+            if (!actual.Equals(expected, StringComparison.OrdinalIgnoreCase))
             {
                 throw new InvalidOperationException(
                     $"Approved Apple mutation input changed before execution: {relative}");
@@ -137,7 +138,7 @@ internal sealed partial class PowerForgeReleaseService
                 : PowerForgeAppleShipPhase.Release;
         }
 
-        var screenshotSpecs = ((plan.SyncScreenshots && plan.ReplaceScreenshots) ||
+        var screenshotSpecs = (plan.SyncScreenshots ||
                                plan.CheckReleaseReadiness ||
                                (plan.SubmitForReview && !plan.SkipReviewReadinessCheck))
             ? LoadAppleScreenshotSpecs(plan)
@@ -145,7 +146,8 @@ internal sealed partial class PowerForgeReleaseService
         var targets = plan.Apps
             .Select(app => CreateApplePlanTarget(plan, app, versioning, screenshotSpecs))
             .ToArray();
-        var mutationInputs = CreateAppleMutationInputEvidence(plan);
+        var selectedScreenshotSpecs = ResolveSelectedAppleScreenshotSpecs(plan, screenshotSpecs);
+        var mutationInputs = CreateAppleMutationInputEvidence(plan, selectedScreenshotSpecs);
         var receipt = new PowerForgeAppleReleaseReceipt
         {
             Action = plan.Action,
@@ -353,16 +355,15 @@ internal sealed partial class PowerForgeReleaseService
     }
 
     private (Dictionary<string, string> Files, string Sha256) CreateAppleMutationInputEvidence(
-        PowerForgeAppleReleasePlan plan)
+        PowerForgeAppleReleasePlan plan,
+        IReadOnlyCollection<(AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)> screenshotSpecs)
     {
         var files = new Dictionary<string, string>(StringComparer.Ordinal);
         var configuredInputs = new List<string>();
         if (plan.SyncScreenshots || plan.CheckReleaseReadiness ||
             (plan.SubmitForReview && !plan.SkipReviewReadinessCheck))
         {
-            if (!string.IsNullOrWhiteSpace(plan.ScreenshotConfigPath))
-                configuredInputs.Add(plan.ScreenshotConfigPath!);
-            configuredInputs.AddRange(plan.ScreenshotConfigPaths);
+            configuredInputs.AddRange(screenshotSpecs.Select(static configured => configured.ConfigPath));
         }
         if (plan.SyncMetadata)
         {
@@ -395,7 +396,7 @@ internal sealed partial class PowerForgeReleaseService
 
         if (plan.SyncScreenshots)
         {
-            foreach (var configured in LoadAppleScreenshotSpecs(plan))
+            foreach (var configured in screenshotSpecs)
             {
                 var baseDirectory = Path.GetDirectoryName(configured.ConfigPath) ?? plan.ProjectRoot;
                 if (configured.Spec.Quality?.RequireApprovalManifest == true &&

--- a/PowerForge/Services/PowerForgeReleaseService.AppleVersioning.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleVersioning.cs
@@ -24,11 +24,6 @@ internal sealed partial class PowerForgeReleaseService
         if (string.IsNullOrWhiteSpace(expectedPlanSha256) &&
             plan.Action != PowerForgeAppleReleaseAction.Version)
         {
-            if (!string.IsNullOrWhiteSpace(plan.SourceCommit) && HasAppleExecutionMutation(plan))
-            {
-                _ = CreateAppleMutationInputEvidence(plan, ResolveSelectedAppleScreenshotSpecs(plan));
-                CaptureApprovedMutationInputContents(plan);
-            }
             return null;
         }
 

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -255,6 +255,11 @@ internal sealed partial class PowerForgeReleaseService
             throw new ArgumentNullException(nameof(spec));
         if (request is null)
             throw new ArgumentNullException(nameof(request));
+        if (request.AppleResolveTargetIdentities && (!request.ValidateOnly || !request.AppleSummaryOnly))
+        {
+            throw new InvalidOperationException(
+                "Apple target identity resolution requires an explicit validation-only summary run.");
+        }
 
         using var deferredModuleStaging = new DeferredModuleStagingDirectory(_logger);
         request.CancellationToken.ThrowIfCancellationRequested();
@@ -651,7 +656,7 @@ internal sealed partial class PowerForgeReleaseService
                 appleReleaseVersion,
                 request.SkipBuild,
                 selectedAppleTargets);
-            if (request.ValidateOnly)
+            if (request.AppleResolveTargetIdentities)
                 ResolveAppleValidationTargetIdentities(applePlan);
             result.AppleAppPlan = applePlan;
             if (request.PlanOnly)
@@ -2271,18 +2276,84 @@ internal sealed partial class PowerForgeReleaseService
         var resumedByApp = new Dictionary<PowerForgeAppleAppReleaseTargetPlan, bool>();
         var governancePlansByAppId = new Dictionary<string, AppStoreConnectGovernancePlan>(StringComparer.OrdinalIgnoreCase);
         var preflightAttempted = new HashSet<PowerForgeAppleAppReleaseTargetPlan>();
+        var screenshotIdentityPrepared = new HashSet<PowerForgeAppleAppReleaseTargetPlan>();
 
-        foreach (var app in releaseApps)
+        foreach (var app in releaseApps.Where(app =>
+                     screenshotSpecs.Length > 0 &&
+                     app.DistributionRoute == AppleDistributionRoute.AppStore &&
+                     ShouldRunAppleShipAppStoreStep(plan, app)))
         {
             var result = resultsByApp[app];
             preflightAttempted.Add(app);
             try
             {
                 result.ProjectGenerated = PrepareAppleProjectAndReleaseIdentity(plan, app);
-                var needsReleaseIdentity = RequiresAppleReleaseIdentity(plan);
-                if (needsReleaseIdentity)
-                {
+                if (RequiresAppleReleaseIdentity(plan))
                     valuesByApp[app] = (app.MarketingVersion!, app.BuildNumber!);
+                screenshotIdentityPrepared.Add(app);
+            }
+            catch (Exception exception)
+            {
+                foreach (var target in plan.Apps)
+                {
+                    var targetResult = resultsByApp[target];
+                    targetResult.Success = false;
+                    targetResult.SkippedSteps = MergeAppleSkippedSteps(
+                        targetResult.SkippedSteps,
+                        ReferenceEquals(target, app) || preflightAttempted.Contains(target)
+                            ? new[] { "remoteActions" }
+                            : new[] { "preflight", "remoteActions" });
+                    if (ReferenceEquals(target, app))
+                        targetResult.ErrorMessage = exception.Message;
+                }
+
+                return plan.Apps.Select(target => resultsByApp[target]).ToArray();
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(plan.ApprovedPlanSha256) &&
+            !string.IsNullOrWhiteSpace(plan.SourceCommit) &&
+            HasAppleExecutionMutation(plan))
+        {
+            _ = CreateAppleMutationInputEvidence(
+                plan,
+                ResolveSelectedAppleScreenshotSpecs(plan, screenshotSpecs));
+            CaptureApprovedMutationInputContents(plan);
+            screenshotSpecs = needsScreenshotSpecs
+                ? LoadAppleScreenshotSpecs(plan)
+                : Array.Empty<(AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)>();
+            metadataSpecs = plan.SyncMetadata
+                ? LoadAppleMetadataSpecs(plan)
+                : Array.Empty<(AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)>();
+            appInfoSpecs = plan.SyncAppInfo
+                ? LoadAppleAppInfoSpecs(plan)
+                : Array.Empty<(AppStoreConnectAppInfoMetadataSpec Spec, string ConfigPath)>();
+            appInfoSpecsByAppId = plan.SyncAppInfo
+                ? IndexAppInfoSpecsByAppId(
+                    appInfoSpecs,
+                    plan.Apps
+                        .Where(app => app.DistributionRoute == AppleDistributionRoute.AppStore &&
+                                      ShouldRunAppleShipAppStoreStep(plan, app))
+                        .ToArray())
+                : new Dictionary<string, AppStoreConnectAppInfoMetadataSpec[]>(StringComparer.OrdinalIgnoreCase);
+            pendingAppInfoAppIds = new HashSet<string>(appInfoSpecsByAppId.Keys, StringComparer.OrdinalIgnoreCase);
+            governanceSpecsByAppId = plan.CheckGovernance
+                ? LoadAppleGovernanceSpecs(plan)
+                : new Dictionary<string, AppStoreConnectGovernanceSpec>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        preflightAttempted.Clear();
+        foreach (var app in releaseApps)
+        {
+            var result = resultsByApp[app];
+            preflightAttempted.Add(app);
+            try
+            {
+                if (!screenshotIdentityPrepared.Contains(app))
+                {
+                    result.ProjectGenerated = PrepareAppleProjectAndReleaseIdentity(plan, app);
+                    if (RequiresAppleReleaseIdentity(plan))
+                        valuesByApp[app] = (app.MarketingVersion!, app.BuildNumber!);
                 }
 
                 var matchingScreenshotSpec = app.DistributionRoute == AppleDistributionRoute.AppStore &&

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -651,6 +651,8 @@ internal sealed partial class PowerForgeReleaseService
                 appleReleaseVersion,
                 request.SkipBuild,
                 selectedAppleTargets);
+            if (request.ValidateOnly)
+                ResolveAppleValidationTargetIdentities(applePlan);
             result.AppleAppPlan = applePlan;
             if (request.PlanOnly)
                 result.AppleReceipt = CreateApplePlanReceipt(applePlan);
@@ -2276,29 +2278,11 @@ internal sealed partial class PowerForgeReleaseService
             preflightAttempted.Add(app);
             try
             {
-                if (plan.Action != PowerForgeAppleReleaseAction.Cleanup)
-                    result.ProjectGenerated = _generateAppleProject(app);
-                if (plan.Action != PowerForgeAppleReleaseAction.Cleanup &&
-                    app.VersionUpdateRequested &&
-                    app.BuildNumberPolicy == AppleBuildNumberPolicy.IncrementExisting &&
-                    string.IsNullOrWhiteSpace(app.BuildNumber))
-                {
-                    app.BuildNumber = ResolveAppleBuildNumber(
-                        new AppleAppConfiguration
-                        {
-                            BuildNumberPolicy = app.BuildNumberPolicy
-                        },
-                        app.ProjectPath,
-                        new XcodeProjectVersionEditor());
-                }
-
+                result.ProjectGenerated = PrepareAppleProjectAndReleaseIdentity(plan, app);
                 var needsReleaseIdentity = RequiresAppleReleaseIdentity(plan);
                 if (needsReleaseIdentity)
                 {
-                    var values = ResolveAppleDistributionValues(app, versionUpdate: null);
-                    app.MarketingVersion = values.MarketingVersion;
-                    app.BuildNumber = values.BuildNumber;
-                    valuesByApp[app] = values;
+                    valuesByApp[app] = (app.MarketingVersion!, app.BuildNumber!);
                 }
 
                 var matchingScreenshotSpec = app.DistributionRoute == AppleDistributionRoute.AppStore &&
@@ -3003,7 +2987,9 @@ internal sealed partial class PowerForgeReleaseService
         paths.AddRange(plan.ScreenshotConfigPaths.Where(static path => !string.IsNullOrWhiteSpace(path)));
 
         return paths
-            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Distinct(FrameworkCompatibility.GetPathStringComparisonForPath(plan.ProjectRoot) == StringComparison.OrdinalIgnoreCase
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal)
             .Select(path =>
             {
                 var json = ReadApprovedMutationInputText(plan, path);

--- a/scripts/Invoke-PinnedPowerForge.Evidence.ps1
+++ b/scripts/Invoke-PinnedPowerForge.Evidence.ps1
@@ -152,7 +152,7 @@ function Get-AppleTargetResolutionArgumentList {
     $result = [Collections.Generic.List[string]]::new()
     for ($index = 0; $index -lt $Arguments.Count; $index++) {
         $argument = [string]$Arguments[$index]
-        if ($argument -in @('--plan', '--dry-run', '--validate', '--summary', '--confirm-apple-action')) { continue }
+        if ($argument -in @('--plan', '--dry-run', '--validate', '--summary', '--apple-resolve-target-identities', '--confirm-apple-action')) { continue }
         $optionWithValue = $null
         foreach ($candidate in @('--apple-expected-plan-sha256', '--output')) {
             if ($argument -eq $candidate -or $argument.StartsWith("$candidate=", [StringComparison]::OrdinalIgnoreCase)) {
@@ -168,6 +168,7 @@ function Get-AppleTargetResolutionArgumentList {
     }
     $result.Add('--validate')
     $result.Add('--summary')
+    $result.Add('--apple-resolve-target-identities')
     $result.Add('--output')
     $result.Add('json')
     return @($result)
@@ -644,7 +645,7 @@ function Assert-ScreenshotPublicationBinding {
     }
     Assert-UnlinkedDirectory -Path $retainedRoot -Name '--allowed-root'
     $retainedPrefix = $retainedRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
-    $pathComparison = if ($IsWindows) { [StringComparison]::OrdinalIgnoreCase } else { [StringComparison]::Ordinal }
+    $pathComparison = if ($pathComparer.Equals('a', 'A')) { [StringComparison]::OrdinalIgnoreCase } else { [StringComparison]::Ordinal }
     $counts = [Collections.Generic.Dictionary[string, int]]::new($pathComparer)
     foreach ($approved in $approvedItems) {
         if (-not $approved.Path.StartsWith($retainedPrefix, $pathComparison)) {

--- a/scripts/Invoke-PinnedPowerForge.Evidence.ps1
+++ b/scripts/Invoke-PinnedPowerForge.Evidence.ps1
@@ -173,6 +173,68 @@ function Get-AppleTargetResolutionArgumentList {
     return @($result)
 }
 
+function Get-AppleTargetResolutionSnapshotArgumentList {
+    param(
+        [Parameter(Mandatory)][string[]] $Arguments,
+        [Parameter(Mandatory)][string] $ConsumerRoot,
+        [Parameter(Mandatory)][string] $SnapshotRoot
+    )
+    $consumerRootPath = [IO.Path]::GetFullPath($ConsumerRoot)
+    $snapshotRootPath = [IO.Path]::GetFullPath($SnapshotRoot)
+    $comparison = if ($IsWindows) { [StringComparison]::OrdinalIgnoreCase } else { [StringComparison]::Ordinal }
+    $consumerPrefix = $consumerRootPath.TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
+    $result = [Collections.Generic.List[string]]::new()
+    foreach ($argument in @(Get-AppleTargetResolutionArgumentList -Arguments $Arguments)) { $result.Add($argument) }
+
+    $configIndex = -1
+    $configValue = $null
+    $configCombined = $false
+    for ($index = 0; $index -lt $result.Count; $index++) {
+        if ($result[$index] -eq '--config') {
+            if ($index + 1 -ge $result.Count) { throw 'Target resolution requires a value for --config.' }
+            if ($configIndex -ge 0) { throw 'Target resolution requires exactly one --config.' }
+            $configIndex = $index + 1
+            $configValue = $result[$configIndex]
+        } elseif ($result[$index].StartsWith('--config=', [StringComparison]::OrdinalIgnoreCase)) {
+            if ($configIndex -ge 0) { throw 'Target resolution requires exactly one --config.' }
+            $configIndex = $index
+            $configCombined = $true
+            $configValue = $result[$index].Substring('--config='.Length)
+        }
+    }
+    if ($configIndex -lt 0 -or [string]::IsNullOrWhiteSpace($configValue)) {
+        throw 'Target resolution requires exactly one --config.'
+    }
+
+    $sourceConfigPath = if ([IO.Path]::IsPathRooted($configValue)) {
+        [IO.Path]::GetFullPath($configValue)
+    } else {
+        [IO.Path]::GetFullPath((Join-Path $consumerRootPath $configValue))
+    }
+    if (-not $sourceConfigPath.StartsWith($consumerPrefix, $comparison)) {
+        throw 'Target-resolution --config must stay inside the exact consumer checkout.'
+    }
+    $relativeConfigPath = [IO.Path]::GetRelativePath($consumerRootPath, $sourceConfigPath)
+    $snapshotConfigPath = [IO.Path]::GetFullPath((Join-Path $snapshotRootPath $relativeConfigPath))
+    if (-not (Test-Path -LiteralPath $snapshotConfigPath -PathType Leaf)) {
+        throw 'Target-resolution --config was not materialized in the exact consumer snapshot.'
+    }
+
+    $release = Get-Content -LiteralPath $sourceConfigPath -Raw | ConvertFrom-Json
+    if ([IO.Path]::IsPathRooted([string]$release.AppleApps.ProjectRoot)) {
+        throw 'Pinned target resolution requires consumer-relative AppleApps.ProjectRoot.'
+    }
+    foreach ($app in @($release.AppleApps.Apps)) {
+        if ([IO.Path]::IsPathRooted([string]$app.ProjectPath)) {
+            throw "Pinned target resolution requires a consumer-relative ProjectPath for Apple app '$([string]$app.Name)'."
+        }
+    }
+
+    $replacement = $snapshotConfigPath
+    $result[$configIndex] = if ($configCombined) { "--config=$replacement" } else { $replacement }
+    return @($result)
+}
+
 function Read-ResolvedAppleTargets {
     param([Parameter(Mandatory)][string] $Path)
     try { $envelope = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json }
@@ -368,10 +430,9 @@ function Register-StandaloneScreenshotEvidence {
         $apple = $release.AppleApps
         $projectRootValue = if ([string]::IsNullOrWhiteSpace([string]$apple.ProjectRoot)) { '.' } else { [string]$apple.ProjectRoot }
         $projectRoot = Resolve-PathFromBase -BasePath (Split-Path -Parent $releaseConfigPath) -Value $projectRootValue
-        @(@([string]$apple.ScreenshotConfigPath) + @($apple.ScreenshotConfigPaths) |
+        @(Get-UniquePlatformPaths -Paths @(@([string]$apple.ScreenshotConfigPath) + @($apple.ScreenshotConfigPaths) |
             Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) } |
-            ForEach-Object { Resolve-PathFromBase -BasePath $projectRoot -Value ([string]$_) } |
-            Sort-Object -Unique)
+            ForEach-Object { Resolve-PathFromBase -BasePath $projectRoot -Value ([string]$_) }))
     } else {
         @(Resolve-OptionPath -Value (Get-OptionValue -Option '--config'))
     }
@@ -418,6 +479,29 @@ function Test-ScreenshotInventorySubsetCounts {
     return $true
 }
 
+function Get-ConsumerPathComparer {
+    $ignoreCase = Invoke-GitText -Root $consumer -Arguments @('config', '--bool', 'core.ignorecase')
+    if ($ignoreCase -eq 'true') { return [StringComparer]::OrdinalIgnoreCase }
+    if ($ignoreCase -eq 'false') { return [StringComparer]::Ordinal }
+    throw 'Consumer repository core.ignorecase must describe the checkout file-system semantics.'
+}
+
+function Get-UniquePlatformPaths {
+    param(
+        [string[]] $Paths,
+        [StringComparer] $Comparer = $(Get-ConsumerPathComparer)
+    )
+    $comparer = $Comparer
+    $seen = [Collections.Generic.HashSet[string]]::new($comparer)
+    $result = [Collections.Generic.List[string]]::new()
+    foreach ($path in @($Paths)) {
+        if (-not [string]::IsNullOrWhiteSpace($path) -and $seen.Add($path)) { $result.Add($path) }
+    }
+    $values = $result.ToArray()
+    [Array]::Sort($values, $comparer)
+    return $values
+}
+
 function Assert-ScreenshotPublicationBinding {
     param(
         [Parameter(Mandatory)][string] $SourceCommit,
@@ -432,12 +516,11 @@ function Assert-ScreenshotPublicationBinding {
     $apple = $release.AppleApps
     $projectRootValue = if ([string]::IsNullOrWhiteSpace([string]$apple.ProjectRoot)) { '.' } else { [string]$apple.ProjectRoot }
     $projectRoot = Resolve-PathFromBase -BasePath (Split-Path -Parent $releaseConfigPath) -Value $projectRootValue
-    $configValues = @(
+    $configValues = @(Get-UniquePlatformPaths -Paths @(
         @([string]$apple.ScreenshotConfigPath) + @($apple.ScreenshotConfigPaths) |
             Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) } |
-            ForEach-Object { Resolve-PathFromBase -BasePath $projectRoot -Value ([string]$_) } |
-            Sort-Object -Unique
-    )
+            ForEach-Object { Resolve-PathFromBase -BasePath $projectRoot -Value ([string]$_) }
+    ))
     $requiresBinding = $operation -eq 'Screenshots' -or
         ($operation -eq 'Advance' -and $apple.SyncScreenshots -eq $true -and $configValues.Count -gt 0)
     if (-not $requiresBinding) { return }
@@ -453,7 +536,7 @@ function Assert-ScreenshotPublicationBinding {
 
     $provenance = $script:validatedCaptureProvenance
     $provenanceEntries = @($provenance.screenshots)
-    $pathComparer = if ($IsWindows) { [StringComparer]::OrdinalIgnoreCase } else { [StringComparer]::Ordinal }
+    $pathComparer = Get-ConsumerPathComparer
     $inventoryCounts = [Collections.Generic.Dictionary[string, int]]::new($pathComparer)
     $provenancePaths = [Collections.Generic.HashSet[string]]::new($pathComparer)
     foreach ($entry in $provenanceEntries) {
@@ -464,7 +547,7 @@ function Assert-ScreenshotPublicationBinding {
         $inventoryCounts[$key] = 1
     }
     $approvedItems = [Collections.Generic.List[object]]::new()
-    $approvedPaths = [Collections.Generic.HashSet[string]]::new($pathComparer)
+    $approvedItemsByPath = [Collections.Generic.Dictionary[string, object]]::new($pathComparer)
     $manifestPaths = [Collections.Generic.List[string]]::new()
     $configuredScreenshots = [Collections.Generic.List[object]]::new()
     foreach ($screenshotConfigPath in $configValues) {
@@ -526,16 +609,28 @@ function Assert-ScreenshotPublicationBinding {
             throw "Screenshot approval manifest '$manifestPath' is not bound to the authoritative capture run, repository, workflow, source commit, and marketing version."
         }
         $manifestPaths.Add($manifestPath)
+        $manifestApprovedPaths = [Collections.Generic.HashSet[string]]::new($pathComparer)
         foreach ($entry in @($manifest.Screenshots)) {
             $approvedPath = Resolve-PathFromBase -BasePath (Split-Path -Parent $screenshotConfigPath) -Value ([string]$entry.File)
             if (-not (Test-Path -LiteralPath $approvedPath -PathType Leaf)) { throw "Approved screenshot was not found: $approvedPath" }
             Assert-UnlinkedPath -Path $approvedPath -Name 'Approved screenshot'
-            if (-not $approvedPaths.Add($approvedPath)) { throw "Screenshot approval manifests contain duplicate approved screenshot path '$approvedPath'." }
+            if (-not $manifestApprovedPaths.Add($approvedPath)) { throw "Screenshot approval manifest '$manifestPath' contains duplicate approved screenshot path '$approvedPath'." }
             $sha256 = ([string]$entry.Sha256).ToLowerInvariant()
             if (-not (Get-FileHash -LiteralPath $approvedPath -Algorithm SHA256).Hash.Equals($sha256, [StringComparison]::OrdinalIgnoreCase)) {
                 throw "Approved screenshot bytes do not match manifest: $approvedPath"
             }
-            $approvedItems.Add([pscustomobject]@{ Path = $approvedPath; Sha256 = $sha256; Width = [int]$entry.Width; Height = [int]$entry.Height })
+            $approved = [pscustomobject]@{ Path = $approvedPath; Sha256 = $sha256; Width = [int]$entry.Width; Height = [int]$entry.Height }
+            $existingApproved = $null
+            if ($approvedItemsByPath.TryGetValue($approvedPath, [ref]$existingApproved)) {
+                if (-not $existingApproved.Sha256.Equals($approved.Sha256, [StringComparison]::OrdinalIgnoreCase) -or
+                    $existingApproved.Width -ne $approved.Width -or
+                    $existingApproved.Height -ne $approved.Height) {
+                    throw "Screenshot approval manifests disagree about retained screenshot '$approvedPath'."
+                }
+            } else {
+                $approvedItemsByPath[$approvedPath] = $approved
+                $approvedItems.Add($approved)
+            }
         }
     }
 

--- a/scripts/Invoke-PinnedPowerForge.Evidence.ps1
+++ b/scripts/Invoke-PinnedPowerForge.Evidence.ps1
@@ -147,6 +147,56 @@ function Get-ForwardedArgumentList {
     return @($result)
 }
 
+function Get-AppleTargetResolutionArgumentList {
+    param([Parameter(Mandatory)][string[]] $Arguments)
+    $result = [Collections.Generic.List[string]]::new()
+    for ($index = 0; $index -lt $Arguments.Count; $index++) {
+        $argument = [string]$Arguments[$index]
+        if ($argument -in @('--plan', '--dry-run', '--validate', '--summary', '--confirm-apple-action')) { continue }
+        $optionWithValue = $null
+        foreach ($candidate in @('--apple-expected-plan-sha256', '--output')) {
+            if ($argument -eq $candidate -or $argument.StartsWith("$candidate=", [StringComparison]::OrdinalIgnoreCase)) {
+                $optionWithValue = $candidate
+                break
+            }
+        }
+        if ($optionWithValue) {
+            if ($argument -eq $optionWithValue -and $index + 1 -lt $Arguments.Count) { $index++ }
+            continue
+        }
+        $result.Add($argument)
+    }
+    $result.Add('--validate')
+    $result.Add('--summary')
+    $result.Add('--output')
+    $result.Add('json')
+    return @($result)
+}
+
+function Read-ResolvedAppleTargets {
+    param([Parameter(Mandatory)][string] $Path)
+    try { $envelope = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json }
+    catch { throw 'The exact PowerForge target-resolution output is not valid JSON.' }
+    if ($envelope.success -ne $true -or [string]$envelope.command -ne 'apple-release' -or
+        $envelope.result.validateOnly -ne $true -or $envelope.result.planOnly -ne $false) {
+        throw 'The exact PowerForge target-resolution output does not describe a successful validation-only Apple release plan.'
+    }
+    $targets = @($envelope.result.targets)
+    if ($targets.Count -eq 0) { throw 'The exact PowerForge target-resolution output contains no selected Apple targets.' }
+    foreach ($target in $targets) {
+        if ([string]::IsNullOrWhiteSpace([string]$target.name) -or
+            [string]::IsNullOrWhiteSpace([string]$target.platform) -or
+            [string]::IsNullOrWhiteSpace([string]$target.distributionRoute)) {
+            throw 'The exact PowerForge target-resolution output contains an incomplete Apple target identity.'
+        }
+        if ([string]$target.distributionRoute -eq 'AppStore' -and
+            [string]::IsNullOrWhiteSpace([string]$target.marketingVersion)) {
+            throw "The exact PowerForge target-resolution output contains no marketing version for App Store target '$([string]$target.name)'."
+        }
+    }
+    return $targets
+}
+
 function Assert-ConsumerRepositoryContent {
     $paths = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
     foreach ($arguments in @(
@@ -369,7 +419,10 @@ function Test-ScreenshotInventorySubsetCounts {
 }
 
 function Assert-ScreenshotPublicationBinding {
-    param([Parameter(Mandatory)][string] $SourceCommit)
+    param(
+        [Parameter(Mandatory)][string] $SourceCommit,
+        [object[]] $ResolvedTargets
+    )
     if ($ArgumentList[0] -ne 'apple-release' -or $ArgumentList.Count -lt 2) { return }
     $operation = $ArgumentList[1]
     if ($operation -notin @('Screenshots', 'Advance')) { return }
@@ -388,32 +441,10 @@ function Assert-ScreenshotPublicationBinding {
     $requiresBinding = $operation -eq 'Screenshots' -or
         ($operation -eq 'Advance' -and $apple.SyncScreenshots -eq $true -and $configValues.Count -gt 0)
     if (-not $requiresBinding) { return }
-    $selectedTargets = @((Get-OptionValue -Option '--target') -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
-    $enabledApps = @($apple.Apps | Where-Object { $_.Enabled -ne $false })
-    $missingTargets = @($selectedTargets | Where-Object {
-        $selectedTarget = $_
-        @($enabledApps | Where-Object {
-            $selectedTarget -eq ([string]$_.Name).Trim() -or
-            $selectedTarget -eq ([string]$_.Scheme).Trim() -or
-            $selectedTarget -eq ([string]$_.BundleId).Trim()
-        }).Count -eq 0
-    })
-    if ($missingTargets.Count -gt 0) {
-        throw "Unknown Apple app target(s): $($missingTargets -join ', ')"
+    if ($null -eq $ResolvedTargets) {
+        throw "apple-release $operation requires the exact engine-resolved Apple target summary before screenshot evidence can be admitted."
     }
-    $targetedApps = @($enabledApps | Where-Object {
-        $selectedTargets.Count -eq 0 -or $selectedTargets -contains ([string]$_.Name).Trim() -or
-        $selectedTargets -contains ([string]$_.Scheme).Trim() -or
-        $selectedTargets -contains ([string]$_.BundleId).Trim()
-    })
-    $appStoreApps = @($enabledApps | Where-Object {
-        $route = [string]$_.DistributionRoute
-        [string]::IsNullOrWhiteSpace($route) -or $route -eq 'AppStore'
-    })
-    $selectedApps = @($targetedApps | Where-Object {
-        $route = [string]$_.DistributionRoute
-        [string]::IsNullOrWhiteSpace($route) -or $route -eq 'AppStore'
-    })
+    $selectedApps = @($ResolvedTargets | Where-Object { [string]$_.distributionRoute -eq 'AppStore' })
     if ($selectedApps.Count -eq 0) { return }
     if ($configValues.Count -eq 0) { throw "apple-release $operation requires at least one screenshot configuration." }
     if ($null -eq $script:validatedCaptureProvenance) {
@@ -435,45 +466,45 @@ function Assert-ScreenshotPublicationBinding {
     $approvedItems = [Collections.Generic.List[object]]::new()
     $approvedPaths = [Collections.Generic.HashSet[string]]::new($pathComparer)
     $manifestPaths = [Collections.Generic.List[string]]::new()
-    $activeConfigs = [Collections.Generic.List[object]]::new()
+    $configuredScreenshots = [Collections.Generic.List[object]]::new()
     foreach ($screenshotConfigPath in $configValues) {
         $screenshotConfig = Get-Content -LiteralPath $screenshotConfigPath -Raw | ConvertFrom-Json
         $specVersion = if ([string]::IsNullOrWhiteSpace([string]$screenshotConfig.VersionString)) {
             $null
         } else { ([string]$screenshotConfig.VersionString).Trim() }
-        $versionMatches = ($screenshotConfig.UseReleaseVersion -eq $true -and $null -eq $specVersion) -or
-            ($null -ne $specVersion -and $specVersion.Equals([string]$provenance.marketingVersion, [StringComparison]::OrdinalIgnoreCase))
-        if (-not $versionMatches) { continue }
-        $activeConfigs.Add([pscustomobject]@{ Path = $screenshotConfigPath; Spec = $screenshotConfig })
+        $configuredScreenshots.Add([pscustomobject]@{
+            Path = $screenshotConfigPath
+            Spec = $screenshotConfig
+            VersionString = $specVersion
+        })
     }
-    if ($activeConfigs.Count -eq 0) { throw 'No screenshot configuration matches the selected release targets.' }
 
     $selectedConfigs = [Collections.Generic.Dictionary[string, object]]::new($pathComparer)
     foreach ($selectedApp in $selectedApps) {
-        $platformApps = @($appStoreApps | Where-Object { [string]$_.Platform -eq [string]$selectedApp.Platform })
-        $enabledPlatformApps = @($enabledApps | Where-Object { [string]$_.Platform -eq [string]$selectedApp.Platform })
-        $configuredAppIds = [Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
-        foreach ($platformApp in $enabledPlatformApps) {
-            if (-not [string]::IsNullOrWhiteSpace([string]$platformApp.AppStoreConnectAppId)) {
-                $null = $configuredAppIds.Add(([string]$platformApp.AppStoreConnectAppId).Trim())
-            }
+        $selectedAppId = ([string]$selectedApp.appId).Trim()
+        if ([string]::IsNullOrWhiteSpace($selectedAppId)) {
+            throw "The resolved Apple target '$([string]$selectedApp.name)' does not contain AppStoreConnectAppId."
         }
-        $blankIdApps = @($platformApps | Where-Object { [string]::IsNullOrWhiteSpace([string]$_.AppStoreConnectAppId) })
-        $matchingConfigs = @($activeConfigs | Where-Object {
+        $selectedVersion = ([string]$selectedApp.marketingVersion).Trim()
+        if ([string]::IsNullOrWhiteSpace($selectedVersion)) {
+            throw "The resolved Apple target '$([string]$selectedApp.name)' does not contain a marketing version."
+        }
+        if (-not $selectedVersion.Equals(([string]$provenance.marketingVersion).Trim(), [StringComparison]::OrdinalIgnoreCase)) {
+            throw "The authoritative capture provenance version '$([string]$provenance.marketingVersion)' does not match selected Apple app '$([string]$selectedApp.name)' version '$selectedVersion'."
+        }
+        $matchingConfigs = @($configuredScreenshots | Where-Object {
             $candidate = $_.Spec
-            if ([string]$candidate.Platform -ne [string]$selectedApp.Platform) { return $false }
+            if ([string]$candidate.Platform -ne [string]$selectedApp.platform) { return $false }
             $candidateAppId = ([string]$candidate.AppId).Trim()
-            $selectedAppId = ([string]$selectedApp.AppStoreConnectAppId).Trim()
-            if (-not [string]::IsNullOrWhiteSpace($selectedAppId)) {
-                return [string]::IsNullOrWhiteSpace($candidateAppId) -or
-                    $candidateAppId.Equals($selectedAppId, [StringComparison]::OrdinalIgnoreCase)
-            }
-            if ([string]::IsNullOrWhiteSpace($candidateAppId)) { return $true }
-            return $blankIdApps.Count -eq 1 -and -not $configuredAppIds.Contains($candidateAppId)
+            $appIdMatches = [string]::IsNullOrWhiteSpace($candidateAppId) -or
+                $candidateAppId.Equals($selectedAppId, [StringComparison]::OrdinalIgnoreCase)
+            $versionMatches = ($candidate.UseReleaseVersion -eq $true -and $null -eq $_.VersionString) -or
+                ($null -ne $_.VersionString -and $_.VersionString.Equals($selectedVersion, [StringComparison]::OrdinalIgnoreCase))
+            return $appIdMatches -and $versionMatches
         })
         if ($matchingConfigs.Count -ne 1) {
             $reason = if ($matchingConfigs.Count -eq 0) { 'No' } else { 'Multiple' }
-            throw "$reason screenshot configurations match selected Apple app '$([string]$selectedApp.Name)' version '$([string]$provenance.marketingVersion)' platform '$([string]$selectedApp.Platform)'. Configure AppStoreConnectAppId explicitly when discovery would otherwise be ambiguous."
+            throw "$reason screenshot configurations match selected Apple app '$([string]$selectedApp.name)' version '$selectedVersion' platform '$([string]$selectedApp.platform)'."
         }
         $selectedConfigs[$matchingConfigs[0].Path] = $matchingConfigs[0]
     }

--- a/scripts/Invoke-PinnedPowerForge.Evidence.ps1
+++ b/scripts/Invoke-PinnedPowerForge.Evidence.ps1
@@ -436,31 +436,24 @@ function Assert-ScreenshotPublicationBinding {
     }
     if ($matchedConfigCount -eq 0) { throw 'No screenshot configuration matches the selected release targets.' }
 
-    $candidateRoots = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    if ([string]::IsNullOrWhiteSpace([string]$script:validatedCaptureProvenancePath)) {
+        throw 'Screenshot publication requires the validated local capture provenance path.'
+    }
+    $retainedRoot = [IO.Path]::GetFullPath((Split-Path -Parent $script:validatedCaptureProvenancePath))
+    $retainedPrefix = $retainedRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
+    $pathComparison = if ($IsWindows -or $IsMacOS) { [StringComparison]::OrdinalIgnoreCase } else { [StringComparison]::Ordinal }
+    $counts = @{}
     foreach ($approved in $approvedItems) {
-        foreach ($entry in $provenanceEntries | Where-Object {
-            ([string]$_.sha256).Equals($approved.Sha256, [StringComparison]::OrdinalIgnoreCase) -and
-            [int]$_.width -eq $approved.Width -and [int]$_.height -eq $approved.Height
-        }) {
-            $nativePath = ([string]$entry.path).Replace('/', [IO.Path]::DirectorySeparatorChar)
-            $suffix = [string][IO.Path]::DirectorySeparatorChar + $nativePath
-            if ($approved.Path.EndsWith($suffix, [StringComparison]::Ordinal)) {
-                $root = $approved.Path.Substring(0, $approved.Path.Length - $nativePath.Length).TrimEnd([IO.Path]::DirectorySeparatorChar)
-                $null = $candidateRoots.Add($root)
-            }
+        if (-not $approved.Path.StartsWith($retainedPrefix, $pathComparison)) {
+            throw 'Screenshot approval manifests do not identify one exact retained capture root and approved inventory.'
         }
+        $relative = [IO.Path]::GetRelativePath($retainedRoot, $approved.Path).Replace('\', '/')
+        $key = Get-ScreenshotInventoryKey -Path $relative -Sha256 $approved.Sha256 -Width $approved.Width -Height $approved.Height
+        $counts[$key] = 1 + [int]($counts[$key] ?? 0)
     }
-    $validRoots = [Collections.Generic.List[string]]::new()
-    foreach ($root in $candidateRoots) {
-        $counts = @{}
-        foreach ($approved in $approvedItems) {
-            $relative = [IO.Path]::GetRelativePath($root, $approved.Path).Replace('\', '/')
-            $key = Get-ScreenshotInventoryKey -Path $relative -Sha256 $approved.Sha256 -Width $approved.Width -Height $approved.Height
-            $counts[$key] = 1 + [int]($counts[$key] ?? 0)
-        }
-        if (Test-ScreenshotInventorySubsetCounts -Expected $inventoryCounts -Actual $counts) { $validRoots.Add($root) }
+    if (-not (Test-ScreenshotInventorySubsetCounts -Expected $inventoryCounts -Actual $counts)) {
+        throw 'Screenshot approval manifests do not identify one exact retained capture root and approved inventory.'
     }
-    if ($validRoots.Count -ne 1) { throw 'Screenshot approval manifests do not identify one exact retained capture root and approved inventory.' }
     foreach ($path in $manifestPaths) { Add-AllowedConsumerEvidencePath -Path $path -Name 'Screenshot approval manifest' }
     foreach ($approved in $approvedItems) { Add-AllowedConsumerEvidencePath -Path $approved.Path -Name 'Approved screenshot' }
 }

--- a/scripts/Invoke-PinnedPowerForge.Evidence.ps1
+++ b/scripts/Invoke-PinnedPowerForge.Evidence.ps1
@@ -337,11 +337,11 @@ function Assert-CaptureScreenshotEntry {
     return $relative
 }
 
-function Test-ScreenshotInventoryCounts {
+function Test-ScreenshotInventorySubsetCounts {
     param([Parameter(Mandatory)][hashtable] $Expected, [Parameter(Mandatory)][hashtable] $Actual)
-    if ($Expected.Count -ne $Actual.Count) { return $false }
-    foreach ($key in $Expected.Keys) {
-        if ([int]$Actual[$key] -ne [int]$Expected[$key]) { return $false }
+    if ($Actual.Count -eq 0 -or $Actual.Count -gt $Expected.Count) { return $false }
+    foreach ($key in $Actual.Keys) {
+        if ([int]$Actual[$key] -ne 1 -or [int]$Expected[$key] -ne 1) { return $false }
     }
     return $true
 }
@@ -374,8 +374,11 @@ function Assert-ScreenshotPublicationBinding {
     $provenance = $script:validatedCaptureProvenance
     $provenanceEntries = @($provenance.screenshots)
     $inventoryCounts = @{}
+    $pathComparer = if ($IsWindows -or $IsMacOS) { [StringComparer]::OrdinalIgnoreCase } else { [StringComparer]::Ordinal }
+    $provenancePaths = [Collections.Generic.HashSet[string]]::new($pathComparer)
     foreach ($entry in $provenanceEntries) {
         $relative = Assert-CaptureScreenshotEntry -Entry $entry
+        if (-not $provenancePaths.Add($relative)) { throw "Capture provenance contains duplicate screenshot path '$relative'." }
         $key = Get-ScreenshotInventoryKey -Path $relative -Sha256 ([string]$entry.sha256) -Width ([int]$entry.width) -Height ([int]$entry.height)
         if ($inventoryCounts.ContainsKey($key)) { throw "Capture provenance contains duplicate screenshot inventory entry '$relative'." }
         $inventoryCounts[$key] = 1
@@ -391,6 +394,7 @@ function Assert-ScreenshotPublicationBinding {
     }
 
     $approvedItems = [Collections.Generic.List[object]]::new()
+    $approvedPaths = [Collections.Generic.HashSet[string]]::new($pathComparer)
     $manifestPaths = [Collections.Generic.List[string]]::new()
     $matchedConfigCount = 0
     foreach ($screenshotConfigPath in $configValues) {
@@ -422,6 +426,7 @@ function Assert-ScreenshotPublicationBinding {
             $approvedPath = Resolve-PathFromBase -BasePath (Split-Path -Parent $screenshotConfigPath) -Value ([string]$entry.File)
             if (-not (Test-Path -LiteralPath $approvedPath -PathType Leaf)) { throw "Approved screenshot was not found: $approvedPath" }
             Assert-UnlinkedPath -Path $approvedPath -Name 'Approved screenshot'
+            if (-not $approvedPaths.Add($approvedPath)) { throw "Screenshot approval manifests contain duplicate approved screenshot path '$approvedPath'." }
             $sha256 = ([string]$entry.Sha256).ToLowerInvariant()
             if (-not (Get-FileHash -LiteralPath $approvedPath -Algorithm SHA256).Hash.Equals($sha256, [StringComparison]::OrdinalIgnoreCase)) {
                 throw "Approved screenshot bytes do not match manifest: $approvedPath"
@@ -453,9 +458,9 @@ function Assert-ScreenshotPublicationBinding {
             $key = Get-ScreenshotInventoryKey -Path $relative -Sha256 $approved.Sha256 -Width $approved.Width -Height $approved.Height
             $counts[$key] = 1 + [int]($counts[$key] ?? 0)
         }
-        if (Test-ScreenshotInventoryCounts -Expected $inventoryCounts -Actual $counts) { $validRoots.Add($root) }
+        if (Test-ScreenshotInventorySubsetCounts -Expected $inventoryCounts -Actual $counts) { $validRoots.Add($root) }
     }
-    if ($validRoots.Count -ne 1) { throw 'Screenshot approval manifests do not identify one exact retained capture root and inventory.' }
+    if ($validRoots.Count -ne 1) { throw 'Screenshot approval manifests do not identify one exact retained capture root and approved inventory.' }
     foreach ($path in $manifestPaths) { Add-AllowedConsumerEvidencePath -Path $path -Name 'Screenshot approval manifest' }
     foreach ($approved in $approvedItems) { Add-AllowedConsumerEvidencePath -Path $approved.Path -Name 'Approved screenshot' }
 }

--- a/scripts/Invoke-PinnedPowerForge.Evidence.ps1
+++ b/scripts/Invoke-PinnedPowerForge.Evidence.ps1
@@ -83,14 +83,33 @@ function Get-ForwardedArgumentList {
     }
 
     $withoutLocalEvidence = [Collections.Generic.List[string]]::new()
+    $seenLocalOptions = [Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
     for ($index = 0; $index -lt $ArgumentList.Count; $index++) {
         $argument = $ArgumentList[$index]
-        if ($argument -eq '--capture-provenance') {
-            if ($index + 1 -ge $ArgumentList.Count) { throw 'Missing value for --capture-provenance.' }
-            $index++
+        $localOption = $null
+        foreach ($candidate in @('--capture-provenance', '--allowed-root')) {
+            if ($argument -eq $candidate -or $argument.StartsWith("$candidate=", [StringComparison]::OrdinalIgnoreCase)) {
+                $localOption = $candidate
+                break
+            }
+        }
+        if ($localOption) {
+            if (-not $seenLocalOptions.Add($localOption)) { throw "$localOption must be specified at most once." }
+            if ($argument -eq $localOption) {
+                if ($index + 1 -ge $ArgumentList.Count) { throw "Missing value for $localOption." }
+                if ([string]::IsNullOrWhiteSpace([string]$ArgumentList[$index + 1]) -or
+                    ([string]$ArgumentList[$index + 1]).StartsWith('-', [StringComparison]::Ordinal)) {
+                    throw "Missing value for $localOption. Prefix a dash-leading path with './'."
+                }
+                $index++
+            } else {
+                $localValue = $argument.Substring($localOption.Length + 1)
+                if ([string]::IsNullOrWhiteSpace($localValue) -or $localValue.StartsWith('-', [StringComparison]::Ordinal)) {
+                    throw "Missing value for $localOption. Prefix a dash-leading path with './'."
+                }
+            }
             continue
         }
-        if ($argument.StartsWith('--capture-provenance=', [StringComparison]::OrdinalIgnoreCase)) { continue }
         $withoutLocalEvidence.Add($argument)
     }
 
@@ -338,7 +357,10 @@ function Assert-CaptureScreenshotEntry {
 }
 
 function Test-ScreenshotInventorySubsetCounts {
-    param([Parameter(Mandatory)][hashtable] $Expected, [Parameter(Mandatory)][hashtable] $Actual)
+    param(
+        [Parameter(Mandatory)][Collections.Generic.Dictionary[string, int]] $Expected,
+        [Parameter(Mandatory)][Collections.Generic.Dictionary[string, int]] $Actual
+    )
     if ($Actual.Count -eq 0 -or $Actual.Count -gt $Expected.Count) { return $false }
     foreach ($key in $Actual.Keys) {
         if ([int]$Actual[$key] -ne 1 -or [int]$Expected[$key] -ne 1) { return $false }
@@ -364,8 +386,35 @@ function Assert-ScreenshotPublicationBinding {
             Sort-Object -Unique
     )
     $requiresBinding = $operation -eq 'Screenshots' -or
-        ($operation -eq 'Advance' -and $apple.SyncScreenshots -eq $true)
+        ($operation -eq 'Advance' -and $apple.SyncScreenshots -eq $true -and $configValues.Count -gt 0)
     if (-not $requiresBinding) { return }
+    $selectedTargets = @((Get-OptionValue -Option '--target') -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+    $enabledApps = @($apple.Apps | Where-Object { $_.Enabled -ne $false })
+    $missingTargets = @($selectedTargets | Where-Object {
+        $selectedTarget = $_
+        @($enabledApps | Where-Object {
+            $selectedTarget -eq ([string]$_.Name).Trim() -or
+            $selectedTarget -eq ([string]$_.Scheme).Trim() -or
+            $selectedTarget -eq ([string]$_.BundleId).Trim()
+        }).Count -eq 0
+    })
+    if ($missingTargets.Count -gt 0) {
+        throw "Unknown Apple app target(s): $($missingTargets -join ', ')"
+    }
+    $targetedApps = @($enabledApps | Where-Object {
+        $selectedTargets.Count -eq 0 -or $selectedTargets -contains ([string]$_.Name).Trim() -or
+        $selectedTargets -contains ([string]$_.Scheme).Trim() -or
+        $selectedTargets -contains ([string]$_.BundleId).Trim()
+    })
+    $appStoreApps = @($enabledApps | Where-Object {
+        $route = [string]$_.DistributionRoute
+        [string]::IsNullOrWhiteSpace($route) -or $route -eq 'AppStore'
+    })
+    $selectedApps = @($targetedApps | Where-Object {
+        $route = [string]$_.DistributionRoute
+        [string]::IsNullOrWhiteSpace($route) -or $route -eq 'AppStore'
+    })
+    if ($selectedApps.Count -eq 0) { return }
     if ($configValues.Count -eq 0) { throw "apple-release $operation requires at least one screenshot configuration." }
     if ($null -eq $script:validatedCaptureProvenance) {
         throw "apple-release $operation requires --capture-provenance so screenshot publication remains bound to the retained capture artifact."
@@ -373,8 +422,8 @@ function Assert-ScreenshotPublicationBinding {
 
     $provenance = $script:validatedCaptureProvenance
     $provenanceEntries = @($provenance.screenshots)
-    $inventoryCounts = @{}
-    $pathComparer = if ($IsWindows -or $IsMacOS) { [StringComparer]::OrdinalIgnoreCase } else { [StringComparer]::Ordinal }
+    $pathComparer = if ($IsWindows) { [StringComparer]::OrdinalIgnoreCase } else { [StringComparer]::Ordinal }
+    $inventoryCounts = [Collections.Generic.Dictionary[string, int]]::new($pathComparer)
     $provenancePaths = [Collections.Generic.HashSet[string]]::new($pathComparer)
     foreach ($entry in $provenanceEntries) {
         $relative = Assert-CaptureScreenshotEntry -Entry $entry
@@ -383,31 +432,55 @@ function Assert-ScreenshotPublicationBinding {
         if ($inventoryCounts.ContainsKey($key)) { throw "Capture provenance contains duplicate screenshot inventory entry '$relative'." }
         $inventoryCounts[$key] = 1
     }
-    $selectedTargets = @((Get-OptionValue -Option '--target') -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
-    $selectedApps = @($apple.Apps | Where-Object {
-        $_.Enabled -ne $false -and
-        ($selectedTargets.Count -eq 0 -or $selectedTargets -contains [string]$_.Name -or
-         $selectedTargets -contains [string]$_.Scheme -or $selectedTargets -contains [string]$_.BundleId)
-    })
-    if ($selectedTargets.Count -gt 0 -and $selectedApps.Count -eq 0) {
-        throw "--target does not match an enabled Apple app in '$releaseConfigPath'."
-    }
-
     $approvedItems = [Collections.Generic.List[object]]::new()
     $approvedPaths = [Collections.Generic.HashSet[string]]::new($pathComparer)
     $manifestPaths = [Collections.Generic.List[string]]::new()
-    $matchedConfigCount = 0
+    $activeConfigs = [Collections.Generic.List[object]]::new()
     foreach ($screenshotConfigPath in $configValues) {
         $screenshotConfig = Get-Content -LiteralPath $screenshotConfigPath -Raw | ConvertFrom-Json
-        if ($selectedTargets.Count -gt 0) {
-            $matchesSelectedApp = @($selectedApps | Where-Object {
-                ([string]::IsNullOrWhiteSpace([string]$screenshotConfig.AppId) -or
-                 [string]$screenshotConfig.AppId -eq [string]$_.AppStoreConnectAppId) -and
-                [string]$screenshotConfig.Platform -eq [string]$_.Platform
-            }).Count -gt 0
-            if (-not $matchesSelectedApp) { continue }
+        $specVersion = if ([string]::IsNullOrWhiteSpace([string]$screenshotConfig.VersionString)) {
+            $null
+        } else { ([string]$screenshotConfig.VersionString).Trim() }
+        $versionMatches = ($screenshotConfig.UseReleaseVersion -eq $true -and $null -eq $specVersion) -or
+            ($null -ne $specVersion -and $specVersion.Equals([string]$provenance.marketingVersion, [StringComparison]::OrdinalIgnoreCase))
+        if (-not $versionMatches) { continue }
+        $activeConfigs.Add([pscustomobject]@{ Path = $screenshotConfigPath; Spec = $screenshotConfig })
+    }
+    if ($activeConfigs.Count -eq 0) { throw 'No screenshot configuration matches the selected release targets.' }
+
+    $selectedConfigs = [Collections.Generic.Dictionary[string, object]]::new($pathComparer)
+    foreach ($selectedApp in $selectedApps) {
+        $platformApps = @($appStoreApps | Where-Object { [string]$_.Platform -eq [string]$selectedApp.Platform })
+        $enabledPlatformApps = @($enabledApps | Where-Object { [string]$_.Platform -eq [string]$selectedApp.Platform })
+        $configuredAppIds = [Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+        foreach ($platformApp in $enabledPlatformApps) {
+            if (-not [string]::IsNullOrWhiteSpace([string]$platformApp.AppStoreConnectAppId)) {
+                $null = $configuredAppIds.Add(([string]$platformApp.AppStoreConnectAppId).Trim())
+            }
         }
-        $matchedConfigCount++
+        $blankIdApps = @($platformApps | Where-Object { [string]::IsNullOrWhiteSpace([string]$_.AppStoreConnectAppId) })
+        $matchingConfigs = @($activeConfigs | Where-Object {
+            $candidate = $_.Spec
+            if ([string]$candidate.Platform -ne [string]$selectedApp.Platform) { return $false }
+            $candidateAppId = ([string]$candidate.AppId).Trim()
+            $selectedAppId = ([string]$selectedApp.AppStoreConnectAppId).Trim()
+            if (-not [string]::IsNullOrWhiteSpace($selectedAppId)) {
+                return [string]::IsNullOrWhiteSpace($candidateAppId) -or
+                    $candidateAppId.Equals($selectedAppId, [StringComparison]::OrdinalIgnoreCase)
+            }
+            if ([string]::IsNullOrWhiteSpace($candidateAppId)) { return $true }
+            return $blankIdApps.Count -eq 1 -and -not $configuredAppIds.Contains($candidateAppId)
+        })
+        if ($matchingConfigs.Count -ne 1) {
+            $reason = if ($matchingConfigs.Count -eq 0) { 'No' } else { 'Multiple' }
+            throw "$reason screenshot configurations match selected Apple app '$([string]$selectedApp.Name)' version '$([string]$provenance.marketingVersion)' platform '$([string]$selectedApp.Platform)'. Configure AppStoreConnectAppId explicitly when discovery would otherwise be ambiguous."
+        }
+        $selectedConfigs[$matchingConfigs[0].Path] = $matchingConfigs[0]
+    }
+
+    foreach ($selectedConfig in $selectedConfigs.Values) {
+        $screenshotConfigPath = [string]$selectedConfig.Path
+        $screenshotConfig = $selectedConfig.Spec
         $manifestValue = [string]$screenshotConfig.Quality.ApprovalManifestPath
         if ([string]::IsNullOrWhiteSpace($manifestValue)) {
             throw "Screenshot configuration '$screenshotConfigPath' must name Quality.ApprovalManifestPath."
@@ -434,15 +507,19 @@ function Assert-ScreenshotPublicationBinding {
             $approvedItems.Add([pscustomobject]@{ Path = $approvedPath; Sha256 = $sha256; Width = [int]$entry.Width; Height = [int]$entry.Height })
         }
     }
-    if ($matchedConfigCount -eq 0) { throw 'No screenshot configuration matches the selected release targets.' }
 
-    if ([string]::IsNullOrWhiteSpace([string]$script:validatedCaptureProvenancePath)) {
-        throw 'Screenshot publication requires the validated local capture provenance path.'
+    $retainedRootValue = Get-OptionValue -Option '--allowed-root'
+    if ([string]::IsNullOrWhiteSpace([string]$retainedRootValue)) {
+        throw "apple-release $operation requires --allowed-root to bind screenshots to the retained capture inventory."
     }
-    $retainedRoot = [IO.Path]::GetFullPath((Split-Path -Parent $script:validatedCaptureProvenancePath))
+    $retainedRoot = Resolve-OptionPath -Value $retainedRootValue
+    if (-not (Test-Path -LiteralPath $retainedRoot -PathType Container)) {
+        throw "--allowed-root must identify the retained screenshot capture directory: $retainedRoot"
+    }
+    Assert-UnlinkedDirectory -Path $retainedRoot -Name '--allowed-root'
     $retainedPrefix = $retainedRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
-    $pathComparison = if ($IsWindows -or $IsMacOS) { [StringComparison]::OrdinalIgnoreCase } else { [StringComparison]::Ordinal }
-    $counts = @{}
+    $pathComparison = if ($IsWindows) { [StringComparison]::OrdinalIgnoreCase } else { [StringComparison]::Ordinal }
+    $counts = [Collections.Generic.Dictionary[string, int]]::new($pathComparer)
     foreach ($approved in $approvedItems) {
         if (-not $approved.Path.StartsWith($retainedPrefix, $pathComparison)) {
             throw 'Screenshot approval manifests do not identify one exact retained capture root and approved inventory.'

--- a/scripts/Invoke-PinnedPowerForge.ps1
+++ b/scripts/Invoke-PinnedPowerForge.ps1
@@ -402,6 +402,27 @@ function New-TrackedToolSnapshot {
     return $snapshotRoot
 }
 
+function New-ExactConsumerResolutionCheckout {
+    param([Parameter(Mandatory)][string] $SourceCommit)
+    $snapshotRoot = Join-Path $temporaryRoot 'consumer-source'
+    & $script:gitPath clone --quiet --no-checkout --local --no-hardlinks -- $consumer $snapshotRoot
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath (Join-Path $snapshotRoot '.git'))) {
+        throw 'Unable to clone the exact consumer source for target resolution.'
+    }
+    & $script:gitPath -C $snapshotRoot checkout --quiet --detach $SourceCommit
+    if ($LASTEXITCODE -ne 0) { throw 'Unable to check out the exact consumer commit for target resolution.' }
+    $snapshotHead = (& $script:gitPath -C $snapshotRoot rev-parse HEAD 2>$null).Trim().ToLowerInvariant()
+    if ($LASTEXITCODE -ne 0 -or $snapshotHead -ne $SourceCommit.ToLowerInvariant()) {
+        throw 'Consumer target-resolution checkout does not match the exact reviewed commit.'
+    }
+    $snapshotItem = Get-Item -LiteralPath $snapshotRoot -Force
+    if (-not $snapshotItem.PSIsContainer -or $snapshotItem.LinkType -or
+        ($snapshotItem.Attributes -band [IO.FileAttributes]::ReparsePoint)) {
+        throw 'Consumer target-resolution checkout must be an unlinked directory.'
+    }
+    return $snapshotRoot
+}
+
 function Assert-AuthoritativeCaptureProvenance {
     param(
         [Parameter(Mandatory)][string] $GhPath,
@@ -608,11 +629,15 @@ try {
     $resolvedAppleTargets = $null
     if ($ArgumentList[0] -eq 'apple-release' -and $ArgumentList.Count -gt 1 -and
         $ArgumentList[1] -in @('Screenshots', 'Advance')) {
+        $consumerResolutionRoot = New-ExactConsumerResolutionCheckout -SourceCommit $consumerHead
         $resolutionOutput = Join-Path $temporaryRoot 'apple-target-resolution.json'
-        $resolutionArguments = Get-AppleTargetResolutionArgumentList -Arguments $forwardedArgumentList
+        $resolutionArguments = Get-AppleTargetResolutionSnapshotArgumentList `
+            -Arguments $forwardedArgumentList `
+            -ConsumerRoot $consumer `
+            -SnapshotRoot $consumerResolutionRoot
         $resolutionExitCode = Invoke-RedactedProcess `
             -FilePath $dotnet `
-            -WorkingDirectory $consumer `
+            -WorkingDirectory $consumerResolutionRoot `
             -Arguments (@($cliAssembly) + $resolutionArguments) `
             -NuGetPackagesPath $nugetPackages `
             -CaptureStandardOutputPath $resolutionOutput `

--- a/scripts/Invoke-PinnedPowerForge.ps1
+++ b/scripts/Invoke-PinnedPowerForge.ps1
@@ -502,6 +502,7 @@ function Invoke-RedactedProcess {
         [Parameter(Mandatory)][string] $WorkingDirectory,
         [Parameter(Mandatory)][string[]] $Arguments,
         [Parameter(Mandatory)][string] $NuGetPackagesPath,
+        [string] $CaptureStandardOutputPath,
         [switch] $IncludeAppleCredentials
     )
     $start = [Diagnostics.ProcessStartInfo]::new()
@@ -542,7 +543,9 @@ function Invoke-RedactedProcess {
         $process.WaitForExit()
         $safeStdOut = Get-RedactedToolText -Text ($stdout.GetAwaiter().GetResult())
         $safeStdErr = Get-RedactedToolText -Text ($stderr.GetAwaiter().GetResult())
-        if ($safeStdOut.Length -gt 0) { [Console]::Out.Write($safeStdOut) }
+        if (-not [string]::IsNullOrWhiteSpace($CaptureStandardOutputPath)) {
+            [IO.File]::WriteAllText($CaptureStandardOutputPath, $safeStdOut)
+        } elseif ($safeStdOut.Length -gt 0) { [Console]::Out.Write($safeStdOut) }
         if ($safeStdErr.Length -gt 0) { [Console]::Error.Write($safeStdErr) }
         return $process.ExitCode
     } finally {
@@ -578,11 +581,6 @@ try {
         $gh = Resolve-FixedTool -Name gh
         Assert-AuthoritativeCaptureProvenance -GhPath $gh -SourceCommit $consumerHead
     }
-    Register-StandaloneScreenshotEvidence
-    Assert-ScreenshotPublicationBinding -SourceCommit $consumerHead
-    Register-AppleAutomationEvidence -SourceCommit $consumerHead
-    Assert-ConsumerRepositoryContent
-    Assert-TrackedSourceLinks
     $tar = Resolve-FixedTool -Name tar
     $buildToolRoot = New-TrackedToolSnapshot -TarPath $tar
     $cliProject = Join-Path $buildToolRoot 'PowerForge.Cli/PowerForge.Cli.csproj'
@@ -606,6 +604,33 @@ try {
     if ($buildExitCode -ne 0) { exit $buildExitCode }
     $cliAssembly = Join-Path $cliOutput 'PowerForge.Cli.dll'
     if (-not (Test-Path -LiteralPath $cliAssembly -PathType Leaf)) { throw "PowerForge CLI build output is missing: $cliAssembly" }
+
+    $resolvedAppleTargets = $null
+    if ($ArgumentList[0] -eq 'apple-release' -and $ArgumentList.Count -gt 1 -and
+        $ArgumentList[1] -in @('Screenshots', 'Advance')) {
+        $resolutionOutput = Join-Path $temporaryRoot 'apple-target-resolution.json'
+        $resolutionArguments = Get-AppleTargetResolutionArgumentList -Arguments $forwardedArgumentList
+        $resolutionExitCode = Invoke-RedactedProcess `
+            -FilePath $dotnet `
+            -WorkingDirectory $consumer `
+            -Arguments (@($cliAssembly) + $resolutionArguments) `
+            -NuGetPackagesPath $nugetPackages `
+            -CaptureStandardOutputPath $resolutionOutput `
+            -IncludeAppleCredentials
+        if ($resolutionExitCode -ne 0) {
+            if (Test-Path -LiteralPath $resolutionOutput -PathType Leaf) {
+                [Console]::Error.Write((Get-Content -LiteralPath $resolutionOutput -Raw))
+            }
+            exit $resolutionExitCode
+        }
+        $resolvedAppleTargets = @(Read-ResolvedAppleTargets -Path $resolutionOutput)
+    }
+
+    Register-StandaloneScreenshotEvidence
+    Assert-ScreenshotPublicationBinding -SourceCommit $consumerHead -ResolvedTargets $resolvedAppleTargets
+    Register-AppleAutomationEvidence -SourceCommit $consumerHead
+    Assert-ConsumerRepositoryContent
+    Assert-TrackedSourceLinks
 
     Write-Host "PowerForge source: $toolHead"
     Write-Host "Consumer source: $consumerHead"

--- a/scripts/Invoke-PinnedPowerForge.ps1
+++ b/scripts/Invoke-PinnedPowerForge.ps1
@@ -442,6 +442,7 @@ function Assert-AuthoritativeCaptureProvenance {
     $actualHash = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash
     if ($expectedHash -ne $actualHash) { throw 'Local capture provenance differs from the retained GitHub Actions artifact.' }
     $script:validatedCaptureProvenance = $provenance
+    $script:validatedCaptureProvenancePath = $path
     Add-AllowedConsumerEvidencePath -Path $path -Name '--capture-provenance'
 }
 

--- a/scripts/Invoke-PinnedPowerForge.ps1
+++ b/scripts/Invoke-PinnedPowerForge.ps1
@@ -442,7 +442,6 @@ function Assert-AuthoritativeCaptureProvenance {
     $actualHash = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash
     if ($expectedHash -ne $actualHash) { throw 'Local capture provenance differs from the retained GitHub Actions artifact.' }
     $script:validatedCaptureProvenance = $provenance
-    $script:validatedCaptureProvenancePath = $path
     Add-AllowedConsumerEvidencePath -Path $path -Name '--capture-provenance'
 }
 


### PR DESCRIPTION
## Summary

- allow App Store approval manifests to authorize a reviewed subset of a larger retained screenshot artifact
- require one explicit retained root and enforce exact path, hash, dimensions, source, app, platform, and release-version binding with checkout-filesystem case semantics
- resolve selected Apple targets through the exact pinned PowerForge engine in a disposable exact-commit consumer checkout, including XcodeGen output, App Store ID discovery, and deferred build-number policy
- keep ordinary validation read-only; project generation is available only through the pinned helper's explicit isolated target-resolution mode
- resolve screenshot-bearing execution identities before binding mutation evidence, then freeze the exact selected inputs before any remote action
- bind Apple plan and execution evidence only to screenshot configs, approval manifests, and pixels selected for resolved App Store targets
- keep Ship version checkpoints independent from later screenshot payloads, while allowing separately approved apps to reuse identical retained pixels
- reject duplicate, conflicting, blank, malformed, or option-shaped evidence inputs

## Why it matters

A capture may retain Store screenshots alongside website derivatives, while GitHub stores PNGs and provenance as separate artifacts. Local publication can now select only reviewed Store images without inferring a root or weakening provenance checks. Targeted TestFlight-only and direct-distribution advances remain independent from unrelated App Store screenshot policy. Target identity resolution does not modify the reviewed consumer checkout, and execution binds the version produced by configured project generation before admitting screenshot evidence.

## Operator note

Pinned local `apple-release Screenshots` and screenshot-enabled `Advance` calls must pass the retained screenshot directory as `--allowed-root`. The local operator validates and consumes this option before invoking the release engine. App Store IDs and versions may remain discoverable from App Store Connect and Xcode project generation; resolution runs against a disposable exact-source checkout. One capture provenance artifact can authorize selected App Store targets on that exact marketing version.

## Validation

Focused pinned-evidence, target-identity, execution-order, validation-isolation, Ship-checkpoint, shared-pixel, and selected-input regressions pass. Both PowerShell wrappers parse. The broader release-service slice passed 562 tests; its eight established host/source-fixture failures are unrelated to this change. All review findings through the previous head are addressed and their threads are resolved.
