### PR TITLE
Accept benign Xcode archive manifest events

### DIFF
--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleIntegrityClosureRegressions.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleIntegrityClosureRegressions.cs
@@ -335,8 +335,12 @@ public sealed partial class PowerForgeReleaseServiceTests {
         }
     }
 
-    [Fact]
-    public void AppleArchiveUploadSnapshot_allows_xcode_changed_signal_for_unchanged_archive_info_plist() {
+    [Theory]
+    [InlineData(WatcherChangeTypes.Changed)]
+    [InlineData(WatcherChangeTypes.Created)]
+    [InlineData(WatcherChangeTypes.Deleted)]
+    public void AppleArchiveUploadSnapshot_allows_xcode_manifest_signal_for_unchanged_archive_info_plist(
+        WatcherChangeTypes changeType) {
         var root = CreateSandbox();
         try {
             var archive = Directory.CreateDirectory(Path.Combine(root, "approved.xcarchive"));
@@ -347,8 +351,32 @@ public sealed partial class PowerForgeReleaseServiceTests {
             using var snapshot = AppleArchiveUploadSnapshot.Create(archive.FullName, expectedSha256);
 
             Assert.True(snapshot.IsExpectedXcodeExportMutation(
-                new FileSystemEventArgs(WatcherChangeTypes.Changed, snapshot.ArchivePath, "Info.plist")));
+                new FileSystemEventArgs(changeType, snapshot.ArchivePath, "Info.plist")));
             snapshot.ValidateUnchanged(expectedSha256);
+        } finally {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void AppleArchiveUploadSnapshot_rejects_real_manifest_replacement_after_an_accepted_signal() {
+        var root = CreateSandbox();
+        try {
+            var archive = Directory.CreateDirectory(Path.Combine(root, "approved.xcarchive"));
+            var infoPlist = Path.Combine(archive.FullName, "Info.plist");
+            File.WriteAllText(infoPlist, "approved bytes");
+            var expectedSha256 = AppleNotarizationService.ComputeArtifactSha256(archive.FullName);
+
+            using var snapshot = AppleArchiveUploadSnapshot.Create(archive.FullName, expectedSha256);
+
+            Assert.True(snapshot.IsExpectedXcodeExportMutation(
+                new FileSystemEventArgs(WatcherChangeTypes.Created, snapshot.ArchivePath, "Info.plist")));
+            File.Delete(Path.Combine(snapshot.ArchivePath, "Info.plist"));
+            File.WriteAllText(Path.Combine(snapshot.ArchivePath, "Info.plist"), "approved bytes");
+
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => snapshot.ValidateUnchanged(expectedSha256));
+            Assert.Contains("file identity changed", exception.Message, StringComparison.OrdinalIgnoreCase);
         } finally {
             TryDelete(root);
         }

--- a/PowerForge/Services/AppleArchiveUploadSnapshot.cs
+++ b/PowerForge/Services/AppleArchiveUploadSnapshot.cs
@@ -120,7 +120,9 @@ internal sealed class AppleArchiveUploadSnapshot : IDisposable
 
         var path = Path.GetFullPath(args.FullPath);
         var archiveInfoPlist = Path.Combine(ArchivePath, "Info.plist");
-        if (args.ChangeType == WatcherChangeTypes.Changed &&
+        if ((args.ChangeType == WatcherChangeTypes.Changed ||
+             args.ChangeType == WatcherChangeTypes.Created ||
+             args.ChangeType == WatcherChangeTypes.Deleted) &&
             path.Equals(
                 archiveInfoPlist,
                 Path.DirectorySeparatorChar == '\\'
@@ -128,10 +130,11 @@ internal sealed class AppleArchiveUploadSnapshot : IDisposable
                     : StringComparison.Ordinal) &&
             _identity.ApprovedFiles.Contains("Info.plist"))
         {
-            // xcodebuild exportArchive emits a Changed notification while reading the
-            // approved top-level archive manifest. The complete content and physical
-            // mutation identities are revalidated after export, so a real write,
-            // replacement, or transient hard-link alias still fails closed.
+            // macOS can coalesce Xcode's reads of the approved top-level archive manifest
+            // into Changed, Created, or Deleted notifications even though the path and bytes
+            // remain unchanged. Renames stay fail-closed above. The complete content and
+            // physical mutation identities are revalidated after export, so a real write,
+            // replacement, deletion, or transient hard-link alias still fails closed.
             return true;
         }
 


### PR DESCRIPTION
## Summary

- accept macOS `Changed`, `Created`, and `Deleted` watcher notifications for the exact approved top-level archive `Info.plist` during Xcode export
- keep renames and every other archive path fail-closed
- retain complete post-export archive hashing and physical file-identity verification, so real writes, deletion, replacement, and hard-link aliases still fail

## Release impact

This prevents a successful App Store upload from being reported as failed when macOS coalesces Xcode manifest access into a non-`Changed` filesystem notification. A durable upload attestation can then be reconciled without repeating an already successful upload.

## Validation

- 48 focused Apple upload and archive-snapshot tests passed
- independent read-only release-integrity review found no P0-P3 findings
- real archive replacement with identical restored bytes remains rejected by physical-identity validation

The final live proof is the resumed macOS App Store upload after this exact revision is merged and pinned.