### PR TITLE
Wait for App Store screenshot replacement convergence

### DIFF
--- a/PowerForge.Tests/AppStoreConnectClientTests.ScreenshotReplacementConvergence.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.ScreenshotReplacementConvergence.cs
@@ -1,0 +1,441 @@
+using System.Net;
+
+namespace PowerForge.Tests;
+
+public sealed partial class AppStoreConnectClientTests
+{
+    [Fact]
+    public async Task ScreenshotSyncService_ReplaceExistingWaitsForEventualInventoryConvergence()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var folder = Directory.CreateDirectory(Path.Combine(root.FullName, "iphone-6-5"));
+            await File.WriteAllBytesAsync(Path.Combine(folder.FullName, "01-home.png"), new byte[] { 1, 2, 3 });
+            var handler = new SequenceHandler(
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "version-1", "type": "appStoreVersions", "attributes": { "versionString": "1.0.0", "platform": "IOS" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "loc-1", "type": "appStoreVersionLocalizations", "attributes": { "locale": "en-US" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "set-1", "type": "appScreenshotSets", "attributes": { "screenshotDisplayType": "APP_IPHONE_65" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "old", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "old-checksum" } }] }"""),
+                new SequenceResponse(HttpStatusCode.NoContent, string.Empty),
+                ScreenshotReservation("approved", "01-home.png", 3),
+                ScreenshotCommit("approved", "01-home.png", "5289df737df57326fcdd22597afb1fac"),
+                new SequenceResponse(HttpStatusCode.OK,
+                    """{ "data": [{ "id": "old", "type": "appScreenshots", "attributes": {} }, { "id": "approved", "type": "appScreenshots", "attributes": {} }] }"""),
+                new SequenceResponse(HttpStatusCode.OK,
+                    """{ "data": [{ "id": "old", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "old-checksum" } }, { "id": "approved", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "5289df737df57326fcdd22597afb1fac" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK,
+                    """{ "data": [{ "id": "approved", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "5289df737df57326fcdd22597afb1fac" } }] }"""));
+            using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+            using var client = new AppStoreConnectClient(CreateCredential(), http);
+            var delayCount = 0;
+            var service = new AppStoreConnectScreenshotSyncService(
+                client,
+                (_, _) =>
+                {
+                    delayCount++;
+                    return Task.CompletedTask;
+                });
+
+            var result = await service.SyncAsync(new AppStoreConnectScreenshotSyncRequest
+            {
+                BaseDirectory = root.FullName,
+                ReplaceExisting = true,
+                Spec = new AppStoreConnectScreenshotSyncSpec
+                {
+                    AppId = "app-1",
+                    VersionString = "1.0.0",
+                    Platform = ApplePlatform.iOS,
+                    Locale = "en-US",
+                    ScreenshotSets =
+                    [
+                        new AppStoreConnectScreenshotSetSyncSpec
+                        {
+                            ScreenshotDisplayType = "APP_IPHONE_65",
+                            Path = "iphone-6-5"
+                        }
+                    ]
+                }
+            });
+
+            Assert.Equal(2, delayCount);
+            Assert.Equal("approved", Assert.Single(Assert.Single(result.ScreenshotSets).Uploaded).Screenshot.Id);
+            Assert.Equal(10, handler.RequestUris.Count);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ScreenshotSyncService_ReplaceExistingRejectsKnownAssetWithWrongChecksumWithoutPolling()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var folder = Directory.CreateDirectory(Path.Combine(root.FullName, "iphone-6-5"));
+            await File.WriteAllBytesAsync(Path.Combine(folder.FullName, "01-home.png"), new byte[] { 1, 2, 3 });
+            var handler = new SequenceHandler(
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "version-1", "type": "appStoreVersions", "attributes": { "versionString": "1.0.0", "platform": "IOS" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "loc-1", "type": "appStoreVersionLocalizations", "attributes": { "locale": "en-US" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "set-1", "type": "appScreenshotSets", "attributes": { "screenshotDisplayType": "APP_IPHONE_65" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "old", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "old-checksum" } }] }"""),
+                new SequenceResponse(HttpStatusCode.NoContent, string.Empty),
+                ScreenshotReservation("approved", "01-home.png", 3),
+                ScreenshotCommit("approved", "01-home.png", "5289df737df57326fcdd22597afb1fac"),
+                new SequenceResponse(HttpStatusCode.OK,
+                    """{ "data": [{ "id": "approved", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" } }] }"""));
+            using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+            using var client = new AppStoreConnectClient(CreateCredential(), http);
+            var delayCount = 0;
+            var service = new AppStoreConnectScreenshotSyncService(
+                client,
+                (_, _) =>
+                {
+                    delayCount++;
+                    return Task.CompletedTask;
+                });
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                service.SyncAsync(CreateSingleSetReplacementRequest(root.FullName)));
+
+            Assert.Contains("changed during replacement", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(0, delayCount);
+            Assert.Equal(8, handler.RequestUris.Count);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ScreenshotSyncService_ReplaceExistingBoundsConvergenceByElapsedTime()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var folder = Directory.CreateDirectory(Path.Combine(root.FullName, "iphone-6-5"));
+            await File.WriteAllBytesAsync(Path.Combine(folder.FullName, "01-home.png"), new byte[] { 1, 2, 3 });
+            var handler = new SequenceHandler(
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "version-1", "type": "appStoreVersions", "attributes": { "versionString": "1.0.0", "platform": "IOS" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "loc-1", "type": "appStoreVersionLocalizations", "attributes": { "locale": "en-US" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "set-1", "type": "appScreenshotSets", "attributes": { "screenshotDisplayType": "APP_IPHONE_65" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "old", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "old-checksum" } }] }"""),
+                new SequenceResponse(HttpStatusCode.NoContent, string.Empty),
+                ScreenshotReservation("approved", "01-home.png", 3),
+                ScreenshotCommit("approved", "01-home.png", "5289df737df57326fcdd22597afb1fac"),
+                new SequenceResponse(HttpStatusCode.OK,
+                    """{ "data": [{ "id": "old", "type": "appScreenshots", "attributes": {} }, { "id": "approved", "type": "appScreenshots", "attributes": {} }] }"""));
+            using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+            using var client = new AppStoreConnectClient(CreateCredential(), http);
+            var service = new AppStoreConnectScreenshotSyncService(
+                client,
+                static (_, token) => Task.Delay(TimeSpan.FromMinutes(1), token),
+                replacementInventoryTimeout: TimeSpan.FromMilliseconds(30));
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                service.SyncAsync(CreateSingleSetReplacementRequest(root.FullName)));
+
+            Assert.Contains("did not converge within", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(8, handler.RequestUris.Count);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ScreenshotSyncService_ReplaceExistingUsesConfiguredDeadlineBeyondThirtyPolls()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var folder = Directory.CreateDirectory(Path.Combine(root.FullName, "iphone-6-5"));
+            await File.WriteAllBytesAsync(Path.Combine(folder.FullName, "01-home.png"), new byte[] { 1, 2, 3 });
+            var responses = new List<SequenceResponse>
+            {
+                new(HttpStatusCode.OK, """{ "data": [{ "id": "version-1", "type": "appStoreVersions", "attributes": { "versionString": "1.0.0", "platform": "IOS" } }] }"""),
+                new(HttpStatusCode.OK, """{ "data": [{ "id": "loc-1", "type": "appStoreVersionLocalizations", "attributes": { "locale": "en-US" } }] }"""),
+                new(HttpStatusCode.OK, """{ "data": [{ "id": "set-1", "type": "appScreenshotSets", "attributes": { "screenshotDisplayType": "APP_IPHONE_65" } }] }"""),
+                new(HttpStatusCode.OK, """{ "data": [{ "id": "old", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "old-checksum" } }] }"""),
+                new(HttpStatusCode.NoContent, string.Empty),
+                ScreenshotReservation("approved", "01-home.png", 3),
+                ScreenshotCommit("approved", "01-home.png", "5289df737df57326fcdd22597afb1fac")
+            };
+            for (var index = 0; index < 31; index++)
+            {
+                responses.Add(new SequenceResponse(HttpStatusCode.OK,
+                    """{ "data": [{ "id": "old", "type": "appScreenshots", "attributes": {} }, { "id": "approved", "type": "appScreenshots", "attributes": {} }] }"""));
+            }
+            responses.Add(new SequenceResponse(HttpStatusCode.OK,
+                """{ "data": [{ "id": "approved", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "5289df737df57326fcdd22597afb1fac" } }] }"""));
+
+            var handler = new SequenceHandler(responses.ToArray());
+            using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+            using var client = new AppStoreConnectClient(CreateCredential(), http);
+            var delayCount = 0;
+            var service = new AppStoreConnectScreenshotSyncService(
+                client,
+                (_, _) =>
+                {
+                    delayCount++;
+                    return Task.CompletedTask;
+                },
+                replacementInventoryTimeout: TimeSpan.FromSeconds(5));
+
+            var result = await service.SyncAsync(CreateSingleSetReplacementRequest(root.FullName));
+
+            Assert.Equal(31, delayCount);
+            Assert.Equal("approved", Assert.Single(Assert.Single(result.ScreenshotSets).Uploaded).Screenshot.Id);
+            Assert.Equal(39, handler.RequestUris.Count);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ScreenshotSyncService_ReplaceExistingPropagatesCallerCancellation()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var folder = Directory.CreateDirectory(Path.Combine(root.FullName, "iphone-6-5"));
+            await File.WriteAllBytesAsync(Path.Combine(folder.FullName, "01-home.png"), new byte[] { 1, 2, 3 });
+            var handler = new SequenceHandler(
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "version-1", "type": "appStoreVersions", "attributes": { "versionString": "1.0.0", "platform": "IOS" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "loc-1", "type": "appStoreVersionLocalizations", "attributes": { "locale": "en-US" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "set-1", "type": "appScreenshotSets", "attributes": { "screenshotDisplayType": "APP_IPHONE_65" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "old", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "old-checksum" } }] }"""),
+                new SequenceResponse(HttpStatusCode.NoContent, string.Empty),
+                ScreenshotReservation("approved", "01-home.png", 3),
+                ScreenshotCommit("approved", "01-home.png", "5289df737df57326fcdd22597afb1fac"),
+                new SequenceResponse(HttpStatusCode.OK,
+                    """{ "data": [{ "id": "old", "type": "appScreenshots", "attributes": {} }, { "id": "approved", "type": "appScreenshots", "attributes": {} }] }"""));
+            using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+            using var client = new AppStoreConnectClient(CreateCredential(), http);
+            using var cancellationSource = new CancellationTokenSource();
+            var service = new AppStoreConnectScreenshotSyncService(
+                client,
+                (_, token) =>
+                {
+                    cancellationSource.Cancel();
+                    return Task.Delay(TimeSpan.FromMinutes(1), token);
+                },
+                replacementInventoryTimeout: TimeSpan.FromSeconds(5));
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                service.SyncAsync(CreateSingleSetReplacementRequest(root.FullName), cancellationSource.Token));
+            Assert.Equal(8, handler.RequestUris.Count);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ScreenshotSyncService_ReplaceExistingDoesNotRelabelIndependentOperationCancellationAsConvergenceTimeout()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var folder = Directory.CreateDirectory(Path.Combine(root.FullName, "iphone-6-5"));
+            await File.WriteAllBytesAsync(Path.Combine(folder.FullName, "01-home.png"), new byte[] { 1, 2, 3 });
+            var handler = new SequenceHandler(
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "version-1", "type": "appStoreVersions", "attributes": { "versionString": "1.0.0", "platform": "IOS" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "loc-1", "type": "appStoreVersionLocalizations", "attributes": { "locale": "en-US" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "set-1", "type": "appScreenshotSets", "attributes": { "screenshotDisplayType": "APP_IPHONE_65" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "old", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "old-checksum" } }] }"""),
+                new SequenceResponse(HttpStatusCode.NoContent, string.Empty),
+                ScreenshotReservation("approved", "01-home.png", 3),
+                ScreenshotCommit("approved", "01-home.png", "5289df737df57326fcdd22597afb1fac"),
+                new SequenceResponse(HttpStatusCode.OK,
+                    """{ "data": [{ "id": "old", "type": "appScreenshots", "attributes": {} }, { "id": "approved", "type": "appScreenshots", "attributes": {} }] }"""));
+            using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+            using var client = new AppStoreConnectClient(CreateCredential(), http);
+            var service = new AppStoreConnectScreenshotSyncService(
+                client,
+                static (_, _) => Task.FromException(new OperationCanceledException("independent timeout")),
+                replacementInventoryTimeout: TimeSpan.FromSeconds(5));
+
+            var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                service.SyncAsync(CreateSingleSetReplacementRequest(root.FullName)));
+
+            Assert.Equal("independent timeout", exception.Message);
+            Assert.Equal(8, handler.RequestUris.Count);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ScreenshotSyncService_ReplaceExistingRejectsLateDriftAcrossScreenshotSets()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var phone = Directory.CreateDirectory(Path.Combine(root.FullName, "iphone-6-5"));
+            var tablet = Directory.CreateDirectory(Path.Combine(root.FullName, "ipad-13"));
+            await File.WriteAllBytesAsync(Path.Combine(phone.FullName, "01-home.png"), new byte[] { 1, 2, 3 });
+            await File.WriteAllBytesAsync(Path.Combine(tablet.FullName, "01-home.png"), new byte[] { 4, 5, 6 });
+            var handler = new SequenceHandler(
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "version-1", "type": "appStoreVersions", "attributes": { "versionString": "1.0.0", "platform": "IOS" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "loc-1", "type": "appStoreVersionLocalizations", "attributes": { "locale": "en-US" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "set-phone", "type": "appScreenshotSets", "attributes": { "screenshotDisplayType": "APP_IPHONE_65" } }, { "id": "set-tablet", "type": "appScreenshotSets", "attributes": { "screenshotDisplayType": "APP_IPAD_PRO_3GEN_129" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "old-phone", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "old-phone-checksum" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "old-tablet", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "old-tablet-checksum" } }] }"""),
+                new SequenceResponse(HttpStatusCode.NoContent, string.Empty),
+                ScreenshotReservation("new-phone", "01-home.png", 3),
+                ScreenshotCommit("new-phone", "01-home.png", "5289df737df57326fcdd22597afb1fac"),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "new-phone", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "5289df737df57326fcdd22597afb1fac" } }] }"""),
+                new SequenceResponse(HttpStatusCode.NoContent, string.Empty),
+                ScreenshotReservation("new-tablet", "01-home.png", 3),
+                ScreenshotCommit("new-tablet", "01-home.png", "b4a3ba90641372b4e4eaa841a5a400ec"),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "new-tablet", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "b4a3ba90641372b4e4eaa841a5a400ec" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "new-phone", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "5289df737df57326fcdd22597afb1fac" } }, { "id": "concurrent", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" } }] }"""));
+            using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+            using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                new AppStoreConnectScreenshotSyncService(client).SyncAsync(new AppStoreConnectScreenshotSyncRequest
+                {
+                    BaseDirectory = root.FullName,
+                    ReplaceExisting = true,
+                    Spec = new AppStoreConnectScreenshotSyncSpec
+                    {
+                        AppId = "app-1",
+                        VersionString = "1.0.0",
+                        Platform = ApplePlatform.iOS,
+                        Locale = "en-US",
+                        ScreenshotSets =
+                        [
+                            new AppStoreConnectScreenshotSetSyncSpec
+                            {
+                                ScreenshotDisplayType = "APP_IPHONE_65",
+                                Path = "iphone-6-5"
+                            },
+                            new AppStoreConnectScreenshotSetSyncSpec
+                            {
+                                ScreenshotDisplayType = "APP_IPAD_PRO_3GEN_129",
+                                Path = "ipad-13"
+                            }
+                        ]
+                    }
+                }));
+
+            Assert.Contains("changed after screenshot replacement", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(14, handler.RequestUris.Count);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ScreenshotSyncService_ReplaceExistingWaitsForBenignStaleCrossSetInventory()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var phone = Directory.CreateDirectory(Path.Combine(root.FullName, "iphone-6-5"));
+            var tablet = Directory.CreateDirectory(Path.Combine(root.FullName, "ipad-13"));
+            await File.WriteAllBytesAsync(Path.Combine(phone.FullName, "01-home.png"), new byte[] { 1, 2, 3 });
+            await File.WriteAllBytesAsync(Path.Combine(tablet.FullName, "01-home.png"), new byte[] { 4, 5, 6 });
+            var handler = new SequenceHandler(
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "version-1", "type": "appStoreVersions", "attributes": { "versionString": "1.0.0", "platform": "IOS" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "loc-1", "type": "appStoreVersionLocalizations", "attributes": { "locale": "en-US" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "set-phone", "type": "appScreenshotSets", "attributes": { "screenshotDisplayType": "APP_IPHONE_65" } }, { "id": "set-tablet", "type": "appScreenshotSets", "attributes": { "screenshotDisplayType": "APP_IPAD_PRO_3GEN_129" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "old-phone", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "old-phone-checksum" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "old-tablet", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "old-tablet-checksum" } }] }"""),
+                new SequenceResponse(HttpStatusCode.NoContent, string.Empty),
+                ScreenshotReservation("new-phone", "01-home.png", 3),
+                ScreenshotCommit("new-phone", "01-home.png", "5289df737df57326fcdd22597afb1fac"),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "new-phone", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "5289df737df57326fcdd22597afb1fac" } }] }"""),
+                new SequenceResponse(HttpStatusCode.NoContent, string.Empty),
+                ScreenshotReservation("new-tablet", "01-home.png", 3),
+                ScreenshotCommit("new-tablet", "01-home.png", "b4a3ba90641372b4e4eaa841a5a400ec"),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "new-tablet", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "b4a3ba90641372b4e4eaa841a5a400ec" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "old-phone", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "old-phone-checksum" } }, { "id": "new-phone", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "5289df737df57326fcdd22597afb1fac" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "new-tablet", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "b4a3ba90641372b4e4eaa841a5a400ec" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "new-phone", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "5289df737df57326fcdd22597afb1fac" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "new-tablet", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "b4a3ba90641372b4e4eaa841a5a400ec" } }] }"""));
+            using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+            using var client = new AppStoreConnectClient(CreateCredential(), http);
+            var delayCount = 0;
+            var service = new AppStoreConnectScreenshotSyncService(
+                client,
+                (_, _) =>
+                {
+                    delayCount++;
+                    return Task.CompletedTask;
+                });
+
+            var result = await service.SyncAsync(CreateTwoSetReplacementRequest(root.FullName));
+
+            Assert.Equal(1, delayCount);
+            Assert.Equal(2, result.ScreenshotSets.Length);
+            Assert.Equal(17, handler.RequestUris.Count);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    private static AppStoreConnectScreenshotSyncRequest CreateSingleSetReplacementRequest(string baseDirectory)
+        => new()
+        {
+            BaseDirectory = baseDirectory,
+            ReplaceExisting = true,
+            Spec = new AppStoreConnectScreenshotSyncSpec
+            {
+                AppId = "app-1",
+                VersionString = "1.0.0",
+                Platform = ApplePlatform.iOS,
+                Locale = "en-US",
+                ScreenshotSets =
+                [
+                    new AppStoreConnectScreenshotSetSyncSpec
+                    {
+                        ScreenshotDisplayType = "APP_IPHONE_65",
+                        Path = "iphone-6-5"
+                    }
+                ]
+            }
+        };
+
+    private static AppStoreConnectScreenshotSyncRequest CreateTwoSetReplacementRequest(string baseDirectory)
+        => new()
+        {
+            BaseDirectory = baseDirectory,
+            ReplaceExisting = true,
+            Spec = new AppStoreConnectScreenshotSyncSpec
+            {
+                AppId = "app-1",
+                VersionString = "1.0.0",
+                Platform = ApplePlatform.iOS,
+                Locale = "en-US",
+                ScreenshotSets =
+                [
+                    new AppStoreConnectScreenshotSetSyncSpec
+                    {
+                        ScreenshotDisplayType = "APP_IPHONE_65",
+                        Path = "iphone-6-5"
+                    },
+                    new AppStoreConnectScreenshotSetSyncSpec
+                    {
+                        ScreenshotDisplayType = "APP_IPAD_PRO_3GEN_129",
+                        Path = "ipad-13"
+                    }
+                ]
+            }
+        };
+}

--- a/PowerForge/Services/AppStoreConnectScreenshotSyncService.ReplacementConvergence.cs
+++ b/PowerForge/Services/AppStoreConnectScreenshotSyncService.ReplacementConvergence.cs
@@ -1,0 +1,200 @@
+namespace PowerForge;
+
+public sealed partial class AppStoreConnectScreenshotSyncService
+{
+    private static readonly TimeSpan ReplacementInventoryPollInterval = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan DefaultReplacementInventoryTimeout = TimeSpan.FromMinutes(2);
+
+    private readonly Func<TimeSpan, CancellationToken, Task> _delay;
+    private readonly TimeSpan _replacementInventoryTimeout;
+
+    internal AppStoreConnectScreenshotSyncService(
+        AppStoreConnectClient client,
+        Func<TimeSpan, CancellationToken, Task> delay,
+        TimeSpan? replacementInventoryTimeout = null)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _delay = delay ?? throw new ArgumentNullException(nameof(delay));
+        _replacementInventoryTimeout = replacementInventoryTimeout ?? DefaultReplacementInventoryTimeout;
+        if (_replacementInventoryTimeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(replacementInventoryTimeout), "Replacement inventory timeout must be positive.");
+    }
+
+    private static ReplacementInventoryExpectation CreateReplacementInventoryExpectation(
+        string screenshotSetId,
+        string displayType,
+        IReadOnlyCollection<AppStoreConnectScreenshotInfo> replacedScreenshots,
+        IReadOnlyCollection<AppStoreConnectScreenshotUploadResult> uploaded,
+        IReadOnlyList<string> expectedChecksums)
+    {
+        var expectedIds = uploaded
+            .Select(static upload => upload.Screenshot.Id)
+            .ToArray();
+        if (expectedIds.Length != expectedChecksums.Count)
+            throw new InvalidOperationException($"Screenshot replacement evidence for '{displayType}' is incomplete.");
+
+        return new ReplacementInventoryExpectation(
+            screenshotSetId,
+            displayType,
+            replacedScreenshots.ToDictionary(static screenshot => screenshot.Id, StringComparer.Ordinal),
+            expectedIds,
+            expectedIds
+                .Select((id, index) => new KeyValuePair<string, string>(id, expectedChecksums[index]))
+                .ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal));
+    }
+
+    private async Task WaitForExactReplacementInventoryAsync(
+        ReplacementInventoryExpectation expectation,
+        ScreenshotSnapshot screenshotSnapshot,
+        CancellationToken cancellationToken)
+    {
+        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(_replacementInventoryTimeout);
+        var boundedToken = timeoutSource.Token;
+
+        try
+        {
+            while (true)
+            {
+                screenshotSnapshot.ValidateUnchanged();
+                var finalScreenshots = await _client.GetScreenshotsAsync(
+                        expectation.ScreenshotSetId,
+                        limit: 200,
+                        boundedToken)
+                    .ConfigureAwait(false);
+                if (expectation.IsExact(finalScreenshots))
+                    return;
+
+                if (expectation.FindConcurrentMutation(finalScreenshots) is not null)
+                {
+                    throw new InvalidOperationException(
+                        $"App Store Connect screenshot inventory for '{expectation.DisplayType}' changed during replacement. " +
+                        "The final remote inventory contains an asset outside the approved replacement operation; review and run a new plan before submission.");
+                }
+
+                await _delay(ReplacementInventoryPollInterval, boundedToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (
+            !cancellationToken.IsCancellationRequested &&
+            timeoutSource.IsCancellationRequested)
+        {
+            throw new InvalidOperationException(
+                $"App Store Connect screenshot inventory for '{expectation.DisplayType}' did not converge within {_replacementInventoryTimeout}. " +
+                "The final remote inventory could not be proven to match the approved screenshot bytes; review and run a new plan before submission.");
+        }
+
+    }
+
+    private async Task ValidateExactReplacementInventoriesAsync(
+        IReadOnlyCollection<ReplacementInventoryExpectation> expectations,
+        ScreenshotSnapshot screenshotSnapshot,
+        CancellationToken cancellationToken)
+    {
+        if (expectations.Count <= 1)
+            return;
+
+        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(_replacementInventoryTimeout);
+        var boundedToken = timeoutSource.Token;
+
+        try
+        {
+            while (true)
+            {
+                var allExact = true;
+                foreach (var expectation in expectations)
+                {
+                    screenshotSnapshot.ValidateUnchanged();
+                    var screenshots = await _client.GetScreenshotsAsync(
+                            expectation.ScreenshotSetId,
+                            limit: 200,
+                            boundedToken)
+                        .ConfigureAwait(false);
+                    if (expectation.IsExact(screenshots))
+                        continue;
+
+                    if (expectation.FindConcurrentMutation(screenshots) is not null)
+                    {
+                        throw new InvalidOperationException(
+                            $"App Store Connect screenshot inventory for '{expectation.DisplayType}' changed after screenshot replacement. " +
+                            "The final cross-set inventory contains an asset outside the approved replacement operation; review and run a new plan before submission.");
+                    }
+
+                    allExact = false;
+                }
+
+                if (allExact)
+                    return;
+
+                await _delay(ReplacementInventoryPollInterval, boundedToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (
+            !cancellationToken.IsCancellationRequested &&
+            timeoutSource.IsCancellationRequested)
+        {
+            throw new InvalidOperationException(
+                $"App Store Connect screenshot inventories could not be revalidated within {_replacementInventoryTimeout}. " +
+                "The final cross-set inventory could not be proven to match the approved screenshot bytes; review and run a new plan before submission.");
+        }
+    }
+
+    private sealed class ReplacementInventoryExpectation
+    {
+        public ReplacementInventoryExpectation(
+            string screenshotSetId,
+            string displayType,
+            IReadOnlyDictionary<string, AppStoreConnectScreenshotInfo> replacedById,
+            string[] expectedIds,
+            IReadOnlyDictionary<string, string> expectedById)
+        {
+            ScreenshotSetId = screenshotSetId;
+            DisplayType = displayType;
+            ReplacedById = replacedById;
+            ExpectedIds = expectedIds;
+            ExpectedById = expectedById;
+        }
+
+        public string ScreenshotSetId { get; }
+
+        public string DisplayType { get; }
+
+        private IReadOnlyDictionary<string, AppStoreConnectScreenshotInfo> ReplacedById { get; }
+
+        private string[] ExpectedIds { get; }
+
+        private IReadOnlyDictionary<string, string> ExpectedById { get; }
+
+        public bool IsExact(IReadOnlyCollection<AppStoreConnectScreenshotInfo> screenshots)
+        {
+            var observed = screenshots.ToArray();
+            return observed.Length == ExpectedIds.Length &&
+                   observed.Select(static screenshot => screenshot.Id).SequenceEqual(ExpectedIds, StringComparer.Ordinal) &&
+                   observed.Select(static screenshot => screenshot.SourceFileChecksum?.Trim() ?? string.Empty)
+                       .SequenceEqual(ExpectedIds.Select(id => ExpectedById[id]), StringComparer.OrdinalIgnoreCase);
+        }
+
+        public AppStoreConnectScreenshotInfo? FindConcurrentMutation(
+            IReadOnlyCollection<AppStoreConnectScreenshotInfo> screenshots)
+            => screenshots.FirstOrDefault(screenshot =>
+            {
+                if (ExpectedById.TryGetValue(screenshot.Id, out var expectedChecksum))
+                {
+                    var observedChecksum = screenshot.SourceFileChecksum?.Trim();
+                    return !string.IsNullOrWhiteSpace(observedChecksum) &&
+                           !string.Equals(observedChecksum, expectedChecksum, StringComparison.OrdinalIgnoreCase);
+                }
+
+                if (!ReplacedById.TryGetValue(screenshot.Id, out var replaced))
+                    return true;
+
+                var observedReplacedChecksum = screenshot.SourceFileChecksum?.Trim();
+                return !string.IsNullOrWhiteSpace(observedReplacedChecksum) &&
+                       !string.Equals(
+                           observedReplacedChecksum,
+                           replaced.SourceFileChecksum?.Trim(),
+                           StringComparison.OrdinalIgnoreCase);
+            });
+    }
+}

--- a/PowerForge/Services/AppStoreConnectScreenshotSyncService.cs
+++ b/PowerForge/Services/AppStoreConnectScreenshotSyncService.cs
@@ -14,8 +14,8 @@ public sealed partial class AppStoreConnectScreenshotSyncService
     /// </summary>
     /// <param name="client">App Store Connect client.</param>
     public AppStoreConnectScreenshotSyncService(AppStoreConnectClient client)
+        : this(client, Task.Delay)
     {
-        _client = client ?? throw new ArgumentNullException(nameof(client));
     }
 
     /// <summary>
@@ -229,6 +229,7 @@ public sealed partial class AppStoreConnectScreenshotSyncService
         }
 
         var results = new List<AppStoreConnectScreenshotSetSyncResult>();
+        var replacementInventories = new List<ReplacementInventoryExpectation>();
         foreach (var plannedSet in plannedSets)
         {
             var displayType = plannedSet.Preflighted.ScreenshotDisplayType;
@@ -280,32 +281,28 @@ public sealed partial class AppStoreConnectScreenshotSyncService
 
             if (request.ReplaceExisting)
             {
-                var finalScreenshots = await _client.GetScreenshotsAsync(
+                var replacementInventory = CreateReplacementInventoryExpectation(
                     set.Id,
-                    limit: 200,
-                    cancellationToken).ConfigureAwait(false);
-                var expectedChecksums = plannedSet.Preflighted.Files
-                    .Select(screenshotSnapshot.GetMd5)
-                    .ToArray();
-                var finalChecksums = finalScreenshots
-                    .Select(static screenshot => screenshot.SourceFileChecksum?.Trim() ?? string.Empty)
-                    .ToArray();
-                var expectedIds = uploaded
-                    .Select(static upload => upload.Screenshot.Id)
-                    .ToArray();
-                var finalIds = finalScreenshots
-                    .Select(static screenshot => screenshot.Id)
-                    .ToArray();
-                if (finalIds.Length != expectedIds.Length ||
-                    !finalIds.SequenceEqual(expectedIds, StringComparer.Ordinal) ||
-                    finalChecksums.Length != expectedChecksums.Length ||
-                    !finalChecksums.SequenceEqual(expectedChecksums, StringComparer.OrdinalIgnoreCase))
-                {
-                    throw new InvalidOperationException(
-                        $"App Store Connect screenshot inventory for '{displayType}' changed during replacement. " +
-                        "The final remote inventory does not exactly match the approved screenshot bytes; review and run a new plan before submission.");
-                }
+                    displayType,
+                    plannedSet.ExistingScreenshots,
+                    uploaded,
+                    plannedSet.Preflighted.Files.Select(screenshotSnapshot.GetMd5).ToArray());
+                await WaitForExactReplacementInventoryAsync(
+                        replacementInventory,
+                        screenshotSnapshot,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                replacementInventories.Add(replacementInventory);
             }
+        }
+
+        if (request.ReplaceExisting)
+        {
+            await ValidateExactReplacementInventoriesAsync(
+                    replacementInventories,
+                    screenshotSnapshot,
+                    cancellationToken)
+                .ConfigureAwait(false);
         }
 
         return new AppStoreConnectScreenshotSyncResult


### PR DESCRIPTION
## Summary

- wait for App Store Connect screenshot relationships to converge after destructive replacement
- keep unknown assets and nonblank checksum mismatches fail-closed
- make the configured elapsed-time deadline govern both per-set and cross-set polling
- revalidate every replaced screenshot set together before returning

## Why

App Store Connect can temporarily return both deleted and newly uploaded screenshot assets immediately after a successful replacement. The previous single read reported a false failure even though Apple accepted the exact reviewed bytes.

## Validation

- 12 focused replacement/convergence tests passed
- 23 screenshot sync service tests passed
- 165 AppStoreConnectClientTests passed
- independent local review confirmed both pre-publication material findings resolved
- automatic-review findings for attempt/deadline parity and benign cross-set stale reads reproduced and fixed
- diff check clean