### PR TITLE
Use mounted-volume free space for Apple releases

### DIFF
--- a/PowerForge.Tests/AppleReleaseArtifactServiceTests.cs
+++ b/PowerForge.Tests/AppleReleaseArtifactServiceTests.cs
@@ -3,6 +3,56 @@ namespace PowerForge.Tests;
 public sealed class AppleReleaseArtifactServiceTests
 {
     [Fact]
+    public void ResolveOwningDriveRoot_PrefersDeepestMountedVolume()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.AppleVolume", Guid.NewGuid().ToString("N"));
+        var mountedVolume = Path.Combine(root, "external-volume");
+        var projectRoot = Path.Combine(mountedVolume, "repo");
+        Directory.CreateDirectory(projectRoot);
+        try
+        {
+            var resolved = AppleReleaseArtifactService.ResolveOwningDriveRoot(
+                projectRoot,
+                [Path.GetPathRoot(root)!, root, mountedVolume]);
+
+            Assert.Equal(AppleReleaseArtifactService.ResolvePhysicalPath(mountedVolume), resolved);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void ResolveOwningDriveRoot_FollowsLinkedProjectAncestor()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var container = Path.Combine(Path.GetTempPath(), "PowerForge.AppleVolume", Guid.NewGuid().ToString("N"));
+        var physicalVolume = Path.Combine(container, "physical-volume");
+        var physicalProject = Path.Combine(physicalVolume, "repo");
+        var linkedVolume = Path.Combine(container, "linked-volume");
+        var linkedProject = Path.Combine(linkedVolume, "repo");
+        Directory.CreateDirectory(physicalProject);
+        Directory.CreateSymbolicLink(linkedVolume, physicalVolume);
+        try
+        {
+            var resolved = AppleReleaseArtifactService.ResolveOwningDriveRoot(
+                linkedProject,
+                [Path.GetPathRoot(container)!, physicalVolume]);
+
+            Assert.Equal(AppleReleaseArtifactService.ResolvePhysicalPath(physicalVolume), resolved);
+        }
+        finally
+        {
+            Directory.Delete(linkedVolume);
+            Directory.Delete(container, true);
+        }
+    }
+
+    [Fact]
     public void RemoveCurrentArtifacts_RefusesPathsOutsideConfiguredProjectRoot()
     {
         var root = Path.Combine(Path.GetTempPath(), "PowerForge.AppleCleanup", Guid.NewGuid().ToString("N"));

--- a/PowerForge/Services/AppleReleaseArtifactService.cs
+++ b/PowerForge/Services/AppleReleaseArtifactService.cs
@@ -348,10 +348,84 @@ internal sealed class AppleReleaseArtifactService
 
     private static long GetAvailableBytes(string path)
     {
-        var root = Path.GetPathRoot(Path.GetFullPath(path));
-        if (string.IsNullOrWhiteSpace(root))
+        var drives = DriveInfo.GetDrives()
+            .Where(static drive => drive.IsReady)
+            .ToArray();
+        var root = ResolveOwningDriveRoot(path, drives.Select(static drive => drive.Name));
+        var drive = drives.FirstOrDefault(candidate => ResolvePhysicalPath(candidate.Name).Equals(
+                root,
+                StringComparison.Ordinal))
+            ?? new DriveInfo(root);
+        return drive.AvailableFreeSpace;
+    }
+
+    /// <summary>
+    /// Resolves the deepest mounted drive root that contains a path. This is
+    /// required on Unix, where <see cref="Path.GetPathRoot(string)"/> returns
+    /// <c>/</c> for paths hosted by separately mounted volumes.
+    /// </summary>
+    internal static string ResolveOwningDriveRoot(string path, IEnumerable<string> driveRoots)
+    {
+        if (driveRoots is null)
+            throw new ArgumentNullException(nameof(driveRoots));
+
+        var fullPath = ResolvePhysicalPath(path);
+        var mountedRoot = driveRoots
+            .Where(static root => !string.IsNullOrWhiteSpace(root))
+            .Select(ResolvePhysicalPath)
+            .Where(root => IsWithinRoot(fullPath, root))
+            .OrderByDescending(static root => root.TrimEnd(
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar).Length)
+            .FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(mountedRoot))
+            return mountedRoot;
+
+        var fallbackRoot = Path.GetPathRoot(fullPath);
+        if (string.IsNullOrWhiteSpace(fallbackRoot))
             throw new InvalidOperationException($"Unable to resolve disk root for '{path}'.");
-        return new DriveInfo(root).AvailableFreeSpace;
+        return fallbackRoot;
+    }
+
+    /// <summary>
+    /// Resolves symbolic links and junctions in every existing path component
+    /// so volume selection follows the physical project location.
+    /// </summary>
+    internal static string ResolvePhysicalPath(string path)
+    {
+#if NET8_0_OR_GREATER
+        var fullPath = Path.GetFullPath(path);
+        var pathRoot = Path.GetPathRoot(fullPath);
+        if (string.IsNullOrWhiteSpace(pathRoot))
+            return fullPath;
+
+        var current = pathRoot;
+        var components = fullPath[pathRoot.Length..].Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+        foreach (var component in components)
+        {
+            var candidate = Path.Combine(current, component);
+            FileSystemInfo? info = Directory.Exists(candidate)
+                ? new DirectoryInfo(candidate)
+                : File.Exists(candidate)
+                    ? new FileInfo(candidate)
+                    : null;
+            if (info?.LinkTarget is not null)
+            {
+                var resolvedTarget = info.ResolveLinkTarget(returnFinalTarget: true)?.FullName;
+                current = string.IsNullOrWhiteSpace(resolvedTarget)
+                    ? candidate
+                    : ResolvePhysicalPath(resolvedTarget);
+            }
+            else
+                current = candidate;
+        }
+
+        return Path.GetFullPath(current);
+#else
+        return Path.GetFullPath(path);
+#endif
     }
 
     private static long GigabytesToBytes(double value)


### PR DESCRIPTION
## Summary

- resolve the physical project path before selecting the owning drive
- prefer the deepest mounted volume on Unix instead of defaulting to `/`
- follow symlink and junction ancestors consistently while preserving the existing minimum-free-space gate
- cover nested mounts and linked project ancestors with focused regression tests

This keeps large Apple archives on an external build volume from being blocked by unrelated free space on the system volume.