### PR TITLE
Prevent false Apple upload failures during Xcode scratch cleanup

### DIFF
--- a/PowerForge.Tests/AppleReleaseSourceMutationMonitorTests.cs
+++ b/PowerForge.Tests/AppleReleaseSourceMutationMonitorTests.cs
@@ -3,6 +3,32 @@ namespace PowerForge.Tests;
 public sealed class AppleReleaseSourceMutationMonitorTests
 {
     [Fact]
+    public void ValidateNoChanges_keeps_monitoring_during_final_identity_validation()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForgeTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            using var monitor = new AppleReleaseSourceMutationMonitor(root);
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                monitor.ValidateNoChanges(() =>
+                {
+                    var transientPath = Path.Combine(root, "unapproved-transient");
+                    File.WriteAllText(transientPath, "unapproved bytes");
+                    File.Delete(transientPath);
+                }));
+
+            Assert.Contains("changed", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void CaptureExpectedProducerOutput_arms_monitor_only_at_completion_boundary()
     {
         var root = Directory.CreateDirectory(Path.Combine(

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleIntegrityClosureRegressions.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleIntegrityClosureRegressions.cs
@@ -335,6 +335,58 @@ public sealed partial class PowerForgeReleaseServiceTests {
         }
     }
 
+    [Fact]
+    public async Task Execute_AppleUpload_allows_delayed_xcode_sandbox_scratch_cleanup_after_process_exit() {
+        const string sourceCommit = "0123456789abcdef0123456789abcdef01234567";
+        var root = CreateSandbox();
+        Task? cleanup = null;
+        try {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.2.0", "9");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.MinimumFreeSpaceGB = 0;
+            spec.AppleApps.Automation.CleanupBeforeArchive = false;
+            spec.AppleApps.Automation.WaitForProcessing = false;
+
+            var result = CreateAppleAutomationService(
+                    request => CreateReleaseState(request, processingState: null),
+                    archiveAppleApp: request => {
+                        var archive = Directory.CreateDirectory(request.ArchivePath!);
+                        File.WriteAllText(Path.Combine(archive.FullName, "Info.plist"), "approved bytes");
+                        return CreateSuccessfulArchive(request);
+                    },
+                    uploadAppleApp: request => {
+                        var scratch = Path.Combine(
+                            request.ArchivePath!,
+                            "Info.plist.sb-2f65fadd-rg00hz");
+                        File.WriteAllText(scratch, "xcode scratch bytes");
+                        cleanup = Task.Run(() => {
+                            // Exceed the legacy 250 ms watcher drain so this proves the bounded
+                            // post-exit scratch-settling contract rather than the old behavior.
+                            Thread.Sleep(750);
+                            File.Delete(scratch);
+                        });
+                        return CreateSuccessfulUpload(request);
+                    })
+                .Execute(spec, new PowerForgeReleaseRequest {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    AppleAction = PowerForgeAppleReleaseAction.Upload,
+                    AppleSourceCommit = sourceCommit
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.True(Assert.Single(result.AppleApps).Upload?.Succeeded);
+        } finally {
+            try {
+                if (cleanup is not null)
+                    await cleanup;
+            } finally {
+                TryDelete(root);
+            }
+        }
+    }
+
     [Theory]
     [InlineData(WatcherChangeTypes.Changed)]
     [InlineData(WatcherChangeTypes.Created)]
@@ -377,6 +429,30 @@ public sealed partial class PowerForgeReleaseServiceTests {
             var exception = Assert.Throws<InvalidOperationException>(
                 () => snapshot.ValidateUnchanged(expectedSha256));
             Assert.Contains("file identity changed", exception.Message, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void AppleArchiveUploadSnapshot_rejects_persistent_xcode_scratch_after_bounded_settle() {
+        var root = CreateSandbox();
+        try {
+            var archive = Directory.CreateDirectory(Path.Combine(root, "approved.xcarchive"));
+            File.WriteAllText(Path.Combine(archive.FullName, "Info.plist"), "approved bytes");
+            var expectedSha256 = AppleNotarizationService.ComputeArtifactSha256(archive.FullName);
+
+            using var snapshot = AppleArchiveUploadSnapshot.Create(archive.FullName, expectedSha256);
+            File.WriteAllText(
+                Path.Combine(snapshot.ArchivePath, "Info.plist.sb-2f65fadd-rg00hz"),
+                "persistent scratch bytes");
+
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => {
+                    snapshot.WaitForExpectedXcodeExportScratchPathsToSettle(TimeSpan.FromMilliseconds(250));
+                    snapshot.ValidateUnchanged(expectedSha256);
+                });
+            Assert.Contains("snapshot changed", exception.Message, StringComparison.OrdinalIgnoreCase);
         } finally {
             TryDelete(root);
         }

--- a/PowerForge/Services/AppleArchiveUploadSnapshot.cs
+++ b/PowerForge/Services/AppleArchiveUploadSnapshot.cs
@@ -84,6 +84,34 @@ internal sealed class AppleArchiveUploadSnapshot : IDisposable
         }
     }
 
+    internal void WaitForExpectedXcodeExportScratchPathsToSettle(TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(2);
+        if (effectiveTimeout < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeout));
+
+        // xcodebuild can exit while its sandbox cleanup still owns a short-lived top-level
+        // Info.plist.sb-* file. Requiring several consecutive absent observations avoids
+        // racing that cleanup, while the bounded deadline and complete identity validation
+        // below keep persistent scratch files and every real archive mutation fail-closed.
+        const int requiredStablePasses = 5;
+        var stablePasses = 0;
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        do
+        {
+            var hasExpectedScratch = Directory.Exists(ArchivePath) &&
+                                     Directory.EnumerateFiles(ArchivePath, "*", SearchOption.TopDirectoryOnly)
+                                         .Any(IsExpectedXcodeExportScratchPath);
+            stablePasses = hasExpectedScratch ? 0 : stablePasses + 1;
+            if (stablePasses >= requiredStablePasses)
+                return;
+            if (stopwatch.Elapsed >= effectiveTimeout)
+                return;
+            Thread.Sleep(50);
+        }
+        while (true);
+    }
+
     internal static SnapshotIdentity CaptureCompleteIdentity(
         string archivePath,
         string description = "private Apple upload archive snapshot")

--- a/PowerForge/Services/AppleReleaseSourceMutationMonitor.cs
+++ b/PowerForge/Services/AppleReleaseSourceMutationMonitor.cs
@@ -56,11 +56,28 @@ internal sealed class AppleReleaseSourceMutationMonitor : IDisposable {
         _watcher.EnableRaisingEvents = true;
     }
 
-    internal void ValidateNoChanges() {
-        // macOS FSEvents delivery is asynchronous. Give the already-completed archive operation's
-        // notifications a short drain window before closing the monitor and accepting its output.
+    internal void ValidateNoChanges(Action? finalValidation = null) {
+        // Drain mutations from the completed reader first so established diagnostics retain the
+        // observed event rather than being replaced by a later identity-comparison message.
         Thread.Sleep(250);
+        ThrowIfMutationObserved();
+
+        // Keep the watcher active while the caller captures its final content and physical
+        // identities. A transient create/delete during that traversal may leave no final hash
+        // difference, so the watcher is the only evidence that the validation boundary changed.
+        finalValidation?.Invoke();
+        if (finalValidation is not null)
+        {
+            // macOS FSEvents delivery is asynchronous. Drain any mutation that occurred during
+            // final identity capture before closing the observation boundary.
+            Thread.Sleep(250);
+        }
         _watcher.EnableRaisingEvents = false;
+
+        ThrowIfMutationObserved();
+    }
+
+    private void ThrowIfMutationObserved() {
         if (_watcherError is not null) {
             throw new InvalidOperationException(
                 $"The {_scopeDescription} mutation monitor failed; its output cannot be trusted. " +

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -2626,9 +2626,20 @@ internal sealed partial class PowerForgeReleaseService
                 }
                 if (localExportOnly && upload.Succeeded)
                     directExportSnapshot!.BindProducedArtifact(upload.ExportArtifactPath, upload.ExportArtifactSha256);
-                uploadMutationMonitor?.ValidateNoChanges();
-                if (uploadSnapshot is not null)
-                    uploadSnapshot.ValidateUnchanged(approvedArchiveSha256!);
+                // xcodebuild can return before its approved Info.plist sandbox scratch file is
+                // removed. Let that narrowly recognized cleanup settle while the mutation monitor
+                // remains active, so every unrelated transient archive mutation still fails closed.
+                uploadSnapshot?.WaitForExpectedXcodeExportScratchPathsToSettle();
+                if (uploadMutationMonitor is not null && uploadSnapshot is not null)
+                {
+                    uploadMutationMonitor.ValidateNoChanges(
+                        () => uploadSnapshot.ValidateUnchanged(approvedArchiveSha256!));
+                }
+                else
+                {
+                    uploadMutationMonitor?.ValidateNoChanges();
+                    uploadSnapshot?.ValidateUnchanged(approvedArchiveSha256!);
+                }
                 if (!upload.Succeeded)
                 {
                     result.Success = false;


### PR DESCRIPTION
A successful App Store upload can finish before Xcode removes its top-level `Info.plist.sb-*` sandbox scratch file. PowerForge now gives that narrowly recognized cleanup a bounded settling window instead of reporting a changed private archive immediately.

The mutation watcher remains active throughout settling and the final SHA-256 plus physical-identity traversal. Persistent scratch files, replacements, hard-link changes, and unrelated transient mutations still fail closed.

Focused upload, snapshot, and mutation-monitor coverage passes. The broader release-service slice has the same eight host/source-fixture failures as untouched `main`, with the two new regressions passing.