### PR TITLE
Fix App Store availability local identifiers

### DIFF
--- a/PowerForge.Tests/AppStoreConnectGovernanceTests.cs
+++ b/PowerForge.Tests/AppStoreConnectGovernanceTests.cs
@@ -81,6 +81,13 @@ public sealed partial class AppStoreConnectClientTests
         Assert.Equal("https://api.appstoreconnect.apple.com/v2/appAvailabilities", Assert.Single(handler.RequestUris).ToString());
         using var body = JsonDocument.Parse(Assert.Single(handler.RequestBodies));
         var territory = Assert.Single(body.RootElement.GetProperty("included").EnumerateArray());
+        const string localTerritoryId = "${territory-availability-1}";
+        Assert.Equal(localTerritoryId, territory.GetProperty("id").GetString());
+        Assert.Equal(
+            localTerritoryId,
+            Assert.Single(body.RootElement.GetProperty("data").GetProperty("relationships")
+                .GetProperty("territoryAvailabilities").GetProperty("data").EnumerateArray())
+                .GetProperty("id").GetString());
         var attributes = territory.GetProperty("attributes");
         Assert.True(attributes.GetProperty("available").GetBoolean());
         Assert.False(attributes.TryGetProperty("releaseDate", out _));

--- a/PowerForge/Services/AppStoreConnectClient.Governance.cs
+++ b/PowerForge/Services/AppStoreConnectClient.Governance.cs
@@ -141,7 +141,7 @@ public sealed partial class AppStoreConnectClient
         ValidateTerritories(spec.Territories);
         var territories = spec.Territories.Select((territory, index) => new
         {
-            Id = $"territory-availability-{index + 1}",
+            Id = $"${{territory-availability-{index + 1}}}",
             Spec = territory
         }).ToArray();
         var body = new


### PR DESCRIPTION
Apple’s v2 app-availability endpoint requires inline territory resources to use `${local-id}` identifiers. PowerForge now emits that form and reuses each identifier in both the relationship linkage and included resource.

This restores reviewed availability creation for private downstream Apple app consumers. Existing availability reads and updates are unchanged.