### PR TITLE
Fix exact-source Apple Doctor source inspection

### DIFF
--- a/PowerForge.Tests/AppleReleaseSourceTrustBuildSettingReferenceTests.cs
+++ b/PowerForge.Tests/AppleReleaseSourceTrustBuildSettingReferenceTests.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+
+namespace PowerForge.Tests;
+
+public sealed class AppleReleaseSourceTrustBuildSettingReferenceTests
+{
+    [Fact]
+    public void ValidateUnclassifiedBuildSettingReferences_AllowsStandardBuildProductsDirectory()
+    {
+        var exception = Record.Exception(() => ValidateReferences(
+            "TEST_HOST",
+            "$(BUILT_PRODUCTS_DIR)/Example.app/Example"));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void ValidateUnclassifiedBuildSettingReferences_StillRejectsHostEnvironmentReferences()
+    {
+        var exception = Assert.Throws<TargetInvocationException>(() =>
+            ValidateReferences("TEST_HOST", "$(HOME)/Example.app/Example"));
+        var inner = Assert.IsType<InvalidOperationException>(exception.InnerException);
+
+        Assert.Contains("unapproved host or environment reference", inner.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void ValidateReferences(string key, string value)
+    {
+        var method = typeof(AppleReleaseSourceTrustService).GetMethod(
+            "ValidateUnclassifiedBuildSettingReferences",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        method!.Invoke(null, new object?[] { key, value, "PBX build settings", null });
+    }
+}

--- a/PowerForge.Tests/AppleReleaseSourceTrustExecutionMetadataTests.cs
+++ b/PowerForge.Tests/AppleReleaseSourceTrustExecutionMetadataTests.cs
@@ -1,0 +1,31 @@
+namespace PowerForge.Tests;
+
+public sealed class AppleReleaseSourceTrustExecutionMetadataTests
+{
+    [Theory]
+    [InlineData("PBXShellScriptBuildPhase", "shell-script build phases")]
+    [InlineData("PBXBuildRule", "custom build rules")]
+    [InlineData("PBXLegacyTarget", "legacy targets")]
+    public void BuildExecution_rejects_unproven_execution_metadata(string isa, string expectedMessage)
+    {
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            AppleReleaseSourceTrustService.EnsureExecutionMetadataAccepted(
+                isa,
+                "/repo/App.xcodeproj/project.pbxproj",
+                AppleReleaseSourceTrustValidationScope.BuildExecution));
+
+        Assert.Contains(expectedMessage, error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("PBXShellScriptBuildPhase")]
+    [InlineData("PBXBuildRule")]
+    [InlineData("PBXLegacyTarget")]
+    public void SourceInspection_accepts_execution_metadata_that_will_not_run(string isa)
+    {
+        AppleReleaseSourceTrustService.EnsureExecutionMetadataAccepted(
+            isa,
+            "/repo/App.xcodeproj/project.pbxproj",
+            AppleReleaseSourceTrustValidationScope.SourceInspection);
+    }
+}

--- a/PowerForge.Tests/AppleReleaseSourceTrustInfoPlistTests.cs
+++ b/PowerForge.Tests/AppleReleaseSourceTrustInfoPlistTests.cs
@@ -1,0 +1,65 @@
+using System.Reflection;
+
+namespace PowerForge.Tests;
+
+public sealed class AppleReleaseSourceTrustInfoPlistTests
+{
+    [Theory]
+    [InlineData("PRODUCT_BUNDLE_PACKAGE_TYPE")]
+    [InlineData("MACOSX_DEPLOYMENT_TARGET")]
+    [InlineData("IPHONEOS_DEPLOYMENT_TARGET")]
+    [InlineData("TVOS_DEPLOYMENT_TARGET")]
+    [InlineData("WATCHOS_DEPLOYMENT_TARGET")]
+    [InlineData("XROS_DEPLOYMENT_TARGET")]
+    [InlineData("DRIVERKIT_DEPLOYMENT_TARGET")]
+    public void ValidateInfoPlistBuildSettingReferences_AllowsStandardProductAndDeploymentReferences(
+        string reference)
+    {
+        var root = Directory.CreateTempSubdirectory("PowerForge.InfoPlist.");
+        try
+        {
+            var plistPath = Path.Combine(root.FullName, "Info.plist");
+            File.WriteAllText(plistPath, $"<plist><string>$({reference})</string></plist>");
+
+            var exception = Record.Exception(() => ValidateInfoPlist(root.FullName, plistPath));
+
+            Assert.Null(exception);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ValidateInfoPlistBuildSettingReferences_StillRejectsHostEnvironmentReferences()
+    {
+        var root = Directory.CreateTempSubdirectory("PowerForge.InfoPlist.");
+        try
+        {
+            var plistPath = Path.Combine(root.FullName, "Info.plist");
+            File.WriteAllText(plistPath, "<plist><string>$(HOME)</string></plist>");
+
+            var exception = Assert.Throws<TargetInvocationException>(
+                () => ValidateInfoPlist(root.FullName, plistPath));
+            var inner = Assert.IsType<InvalidOperationException>(exception.InnerException);
+            Assert.Contains("unapproved host or environment reference", inner.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    private static void ValidateInfoPlist(string repositoryRoot, string plistPath)
+    {
+        var method = typeof(AppleReleaseSourceTrustService).GetMethod(
+            "ValidateInfoPlistBuildSettingReferences",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        method!.Invoke(
+            new AppleReleaseSourceTrustService(),
+            new object[] { repositoryRoot, plistPath, "PBX build settings", false });
+    }
+}

--- a/PowerForge/Services/AppleReleaseSourceSnapshot.cs
+++ b/PowerForge/Services/AppleReleaseSourceSnapshot.cs
@@ -126,7 +126,10 @@ internal sealed class AppleReleaseSourceSnapshot : IDisposable
         {
             var configPath = Path.GetFullPath(plan.ExactSourceConfigPath!);
             EnsureContained(repositoryRoot, configPath, "Apple exact-source config path");
-            var trust = new AppleReleaseSourceTrustService().Capture(repositoryRoot, configPath);
+            var validationScope = plan.Archive
+                ? AppleReleaseSourceTrustValidationScope.BuildExecution
+                : AppleReleaseSourceTrustValidationScope.SourceInspection;
+            var trust = new AppleReleaseSourceTrustService().Capture(repositoryRoot, configPath, validationScope);
             ValidateExpectedConfigurationSha256(trust.ExactConfigurationSha256, plan.ExactSourceConfigSha256);
             observedCommit = trust.SourceCommit;
         }

--- a/PowerForge/Services/AppleReleaseSourceTrustService.Xcode.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.Xcode.cs
@@ -317,23 +317,7 @@ internal sealed partial class AppleReleaseSourceTrustService
 
         foreach (var item in objects.Values)
         {
-            if (item.Isa.Equals("PBXShellScriptBuildPhase", StringComparison.OrdinalIgnoreCase))
-            {
-                throw new InvalidOperationException(
-                    $"PBX shell-script build phases are not accepted for exact-source checkpoints because arbitrary runtime inputs cannot be proven: {metadataPath}");
-            }
-
-            if (item.Isa.Equals("PBXBuildRule", StringComparison.OrdinalIgnoreCase))
-            {
-                throw new InvalidOperationException(
-                    $"PBX custom build rules are not accepted for exact-source checkpoints because their runtime inputs cannot be proven: {metadataPath}");
-            }
-
-            if (item.Isa.Equals("PBXLegacyTarget", StringComparison.OrdinalIgnoreCase))
-            {
-                throw new InvalidOperationException(
-                    $"PBX legacy targets are not accepted for exact-source checkpoints because their external build tool cannot be proven: {metadataPath}");
-            }
+            EnsureExecutionMetadataAccepted(item.Isa, metadataPath, _validationScope);
 
             if (item.Isa.Equals("PBXBuildFile", StringComparison.OrdinalIgnoreCase))
             {
@@ -389,6 +373,33 @@ internal sealed partial class AppleReleaseSourceTrustService
                 generatedOutputPaths,
                 buildFileReferences,
                 shippingSources);
+        }
+    }
+
+    internal static void EnsureExecutionMetadataAccepted(
+        string isa,
+        string metadataPath,
+        AppleReleaseSourceTrustValidationScope validationScope)
+    {
+        if (validationScope == AppleReleaseSourceTrustValidationScope.SourceInspection)
+            return;
+
+        if (isa.Equals("PBXShellScriptBuildPhase", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"PBX shell-script build phases are not accepted for exact-source checkpoints because arbitrary runtime inputs cannot be proven: {metadataPath}");
+        }
+
+        if (isa.Equals("PBXBuildRule", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"PBX custom build rules are not accepted for exact-source checkpoints because their runtime inputs cannot be proven: {metadataPath}");
+        }
+
+        if (isa.Equals("PBXLegacyTarget", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"PBX legacy targets are not accepted for exact-source checkpoints because their external build tool cannot be proven: {metadataPath}");
         }
     }
 

--- a/PowerForge/Services/AppleReleaseSourceTrustService.XcodeParsing.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.XcodeParsing.cs
@@ -152,7 +152,8 @@ internal sealed partial class AppleReleaseSourceTrustService
         var approvedReferences = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "inherited", "TARGET_NAME", "PRODUCT_NAME", "EXECUTABLE_NAME", "WRAPPER_NAME",
-            "FULL_PRODUCT_NAME", "CONTENTS_FOLDER_PATH", "INFOPLIST_PATH", "TEST_HOST"
+            "FULL_PRODUCT_NAME", "CONTENTS_FOLDER_PATH", "INFOPLIST_PATH", "TEST_HOST",
+            "BUILT_PRODUCTS_DIR"
         };
         foreach (var reference in ReadBuildSettingReferences(value, key, source))
         {

--- a/PowerForge/Services/AppleReleaseSourceTrustService.XcodeParsing.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.XcodeParsing.cs
@@ -205,7 +205,9 @@ internal sealed partial class AppleReleaseSourceTrustService
         var plistReferences = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "DEVELOPMENT_LANGUAGE", "PRODUCT_BUNDLE_IDENTIFIER", "MARKETING_VERSION",
-            "CURRENT_PROJECT_VERSION", "PRODUCT_MODULE_NAME"
+            "CURRENT_PROJECT_VERSION", "PRODUCT_MODULE_NAME", "PRODUCT_BUNDLE_PACKAGE_TYPE",
+            "MACOSX_DEPLOYMENT_TARGET", "IPHONEOS_DEPLOYMENT_TARGET", "TVOS_DEPLOYMENT_TARGET",
+            "WATCHOS_DEPLOYMENT_TARGET", "XROS_DEPLOYMENT_TARGET", "DRIVERKIT_DEPLOYMENT_TARGET"
         };
         var bytes = File.ReadAllBytes(plistPath);
         if (bytes.Length >= 8 &&

--- a/PowerForge/Services/AppleReleaseSourceTrustService.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.cs
@@ -50,10 +50,13 @@ internal sealed partial class AppleReleaseSourceTrustService
     internal string ResolveExactCommit(string repositoryRoot, string configPath)
         => Capture(repositoryRoot, configPath).SourceCommit;
 
+    internal AppleReleaseSourceTrustSnapshot Capture(string repositoryRoot, string configPath)
+        => Capture(repositoryRoot, configPath, AppleReleaseSourceTrustValidationScope.BuildExecution);
+
     internal AppleReleaseSourceTrustSnapshot Capture(
         string repositoryRoot,
         string configPath,
-        AppleReleaseSourceTrustValidationScope validationScope = AppleReleaseSourceTrustValidationScope.BuildExecution)
+        AppleReleaseSourceTrustValidationScope validationScope)
     {
         lock (_validationGate)
         {

--- a/PowerForge/Services/AppleReleaseSourceTrustService.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.cs
@@ -11,6 +11,8 @@ namespace PowerForge;
 /// </summary>
 internal sealed partial class AppleReleaseSourceTrustService
 {
+    private AppleReleaseSourceTrustValidationScope _validationScope =
+        AppleReleaseSourceTrustValidationScope.BuildExecution;
     private static readonly HashSet<string> AlwaysRejectedIgnoredExtensions = new(StringComparer.OrdinalIgnoreCase)
     {
         ".swift", ".m", ".mm", ".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp",
@@ -48,11 +50,15 @@ internal sealed partial class AppleReleaseSourceTrustService
     internal string ResolveExactCommit(string repositoryRoot, string configPath)
         => Capture(repositoryRoot, configPath).SourceCommit;
 
-    internal AppleReleaseSourceTrustSnapshot Capture(string repositoryRoot, string configPath)
+    internal AppleReleaseSourceTrustSnapshot Capture(
+        string repositoryRoot,
+        string configPath,
+        AppleReleaseSourceTrustValidationScope validationScope = AppleReleaseSourceTrustValidationScope.BuildExecution)
     {
         lock (_validationGate)
         {
             ResetValidationState();
+            _validationScope = validationScope;
             try
             {
                 return CaptureCore(repositoryRoot, configPath);
@@ -60,6 +66,7 @@ internal sealed partial class AppleReleaseSourceTrustService
             finally
             {
                 ResetValidationState();
+                _validationScope = AppleReleaseSourceTrustValidationScope.BuildExecution;
             }
         }
     }
@@ -740,6 +747,12 @@ internal sealed partial class AppleReleaseSourceTrustService
 
     private static StringComparer GetPathComparer()
         => Path.DirectorySeparatorChar == '\\' ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+}
+
+internal enum AppleReleaseSourceTrustValidationScope
+{
+    SourceInspection,
+    BuildExecution
 }
 
 internal sealed class AppleReleaseSourceTrustSnapshot


### PR DESCRIPTION
## Summary

- allow standard Apple product-package, platform deployment, and test-host build product references in tracked Xcode inputs
- distinguish read-only exact-source inspection from Xcode build execution metadata validation
- keep archive and other build-execution checkpoints strict for shell phases, custom build rules, and legacy targets
- preserve the existing strict two-argument source-trust API used by PowerForge Studio

## Why

The shared Apple Doctor validates an exact, clean downstream source commit without executing Xcode build phases. Tracked Xcode projects in downstream consumers use standard Info.plist substitutions, Xcode test-host output references, and—in one private consumer—a shell build phase. Treating those standard or non-executing inputs as unproven archive inputs produced false incidents. Actual archive execution remains subject to the existing strict rejection of runtime inputs that cannot be proven.

## Validation

- current-head Windows, Linux, macOS, dependency-audit, product-smoke, workflow-lint, and focused-test CI passed
- 19 focused source-trust and exact-source tests passed locally before the final standard-reference regression test was added; the current-head CI test matrix includes that regression
- PowerForge Studio Orchestrator builds with zero warnings and zero errors
- exact pinned-source downstream Apple Doctor completed successfully and reported converged governance for the source-inspection change
- independent read-only security review found one method-group compatibility issue; fixed and targeted-confirmed
