### PR TITLE
Keep generated project pages current and reader-facing

### DIFF
--- a/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
@@ -104,6 +104,7 @@ public class WebPipelineRunnerProjectCatalogTests
                       "mode": "hub-full",
                       "hubPath": "projects\\pspublishmodule",
                       "githubRepo": "EvotecIT/PSPublishModule",
+                      "version": "1.4.0",
                       "status": "active",
                       "listed": false,
                       "surfaces": {
@@ -112,6 +113,12 @@ public class WebPipelineRunnerProjectCatalogTests
                         "apiPowerShell": true,
                         "changelog": true,
                         "releases": true
+                      },
+                      "metrics": {
+                        "nuget": {
+                          "id": "PSPublishModule",
+                          "version": "1.7.0"
+                        }
                       }
                     }
                   ]
@@ -148,6 +155,9 @@ public class WebPipelineRunnerProjectCatalogTests
             Assert.Contains("project-catalog ok", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
             var page = File.ReadAllText(Path.Combine(root, "content", "projects", "pspublishmodule.md"));
             Assert.Contains("meta.project_hub_path: \"/projects/pspublishmodule/\"", page, StringComparison.Ordinal);
+            Assert.Contains("meta.project_version: \"1.7.0\"", page, StringComparison.Ordinal);
+            Assert.Contains("- Latest known version: 1.7.0", page, StringComparison.Ordinal);
+            Assert.DoesNotContain("hosted as part of the main hub", page, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
@@ -85,7 +85,7 @@ public class WebPipelineRunnerProjectCatalogTests
     }
 
     [Fact]
-    public void RunPipeline_ProjectCatalog_AllowsHubFullSurfacesWithoutExplicitLinks()
+    public void RunPipeline_ProjectCatalog_AllowsHubFullSurfacesAndUsesLatestPublishedPackageVersionAcrossFeeds()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-project-catalog-hub-full-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
@@ -104,7 +104,7 @@ public class WebPipelineRunnerProjectCatalogTests
                       "mode": "hub-full",
                       "hubPath": "projects\\pspublishmodule",
                       "githubRepo": "EvotecIT/PSPublishModule",
-                      "version": "1.4.0",
+                      "version": "2.0.0",
                       "status": "active",
                       "listed": false,
                       "surfaces": {

--- a/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
@@ -118,6 +118,10 @@ public class WebPipelineRunnerProjectCatalogTests
                         "nuget": {
                           "id": "PSPublishModule",
                           "version": "1.7.0"
+                        },
+                        "powerShellGallery": {
+                          "id": "PSPublishModule",
+                          "version": "1.8.0"
                         }
                       }
                     }
@@ -155,8 +159,8 @@ public class WebPipelineRunnerProjectCatalogTests
             Assert.Contains("project-catalog ok", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
             var page = File.ReadAllText(Path.Combine(root, "content", "projects", "pspublishmodule.md"));
             Assert.Contains("meta.project_hub_path: \"/projects/pspublishmodule/\"", page, StringComparison.Ordinal);
-            Assert.Contains("meta.project_version: \"1.7.0\"", page, StringComparison.Ordinal);
-            Assert.Contains("- Latest known version: 1.7.0", page, StringComparison.Ordinal);
+            Assert.Contains("meta.project_version: \"1.8.0\"", page, StringComparison.Ordinal);
+            Assert.Contains("- Latest known version: 1.8.0", page, StringComparison.Ordinal);
             Assert.DoesNotContain("hosted as part of the main hub", page, StringComparison.OrdinalIgnoreCase);
         }
         finally

--- a/PowerForge.Tests/packages.lock.json
+++ b/PowerForge.Tests/packages.lock.json
@@ -1147,6 +1147,7 @@
         "type": "Project",
         "dependencies": {
           "DBAClientX.SQLite": "[0.15.0, )",
+          "NuGet.Versioning": "[7.9.0, )",
           "PowerForge.Web": "[3.0.124, )"
         }
       },

--- a/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj
+++ b/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj
@@ -32,6 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="DBAClientX.SQLite" Version="0.15.0" />
+    <PackageReference Include="NuGet.Versioning" Version="7.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -1071,7 +1071,7 @@ internal static partial class WebPipelineRunner
             project.ManifestGeneratedAt = NormalizeOptionalString(project.ManifestGeneratedAt);
             project.ManifestCommit = NormalizeOptionalString(project.ManifestCommit);
             project.ManifestPath = NormalizeOptionalString(project.ManifestPath);
-            project.Version = NormalizeOptionalString(project.Version);
+            project.Version = ResolveCurrentProjectVersion(project);
             if (project.Product is not null)
             {
                 project.Kind = NormalizeProjectKind(project.Kind, "product");
@@ -1744,8 +1744,6 @@ internal static partial class WebPipelineRunner
                     lines.Add("This project is marked as dedicated-external but no `externalUrl` is configured.");
                     lines.Add(string.Empty);
                 }
-                lines.Add("This hub page exists for discovery, aliases, and navigation continuity.");
-                lines.Add(string.Empty);
                 if (!string.IsNullOrWhiteSpace(docsLink))
                     lines.Add($"- Docs: [{docsLink}]({docsLink})");
                 if (!string.IsNullOrWhiteSpace(apiLink))
@@ -1764,8 +1762,6 @@ internal static partial class WebPipelineRunner
                 var apiLink = GetProjectApiLink(project);
                 var examplesLink = GetProjectExamplesLink(project);
 
-                lines.Add("This project is hosted as part of the main hub website.");
-                lines.Add(string.Empty);
                 if (!string.IsNullOrWhiteSpace(docsLink))
                     lines.Add($"- Docs: {docsLink}");
                 if (!string.IsNullOrWhiteSpace(apiLink))
@@ -1782,6 +1778,9 @@ internal static partial class WebPipelineRunner
                 var repoUrl = $"https://github.com/{project.GitHubRepo}";
                 lines.Add($"- Source: [{project.GitHubRepo}]({repoUrl})");
             }
+
+            while (lines.Count > 0 && string.IsNullOrEmpty(lines[^1]))
+                lines.RemoveAt(lines.Count - 1);
 
             WriteMarkdown(outputPath, lines);
             written++;
@@ -1842,6 +1841,13 @@ internal static partial class WebPipelineRunner
         {
             skipped++;
         }
+    }
+
+    private static string? ResolveCurrentProjectVersion(ProjectCatalogEntry project)
+    {
+        return NormalizeOptionalString(project.Metrics?.NuGet?.Version) ??
+               NormalizeOptionalString(project.Metrics?.PowerShellGallery?.Version) ??
+               NormalizeOptionalString(project.Version);
     }
 
     private static void GenerateProjectSectionPages(

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -1849,8 +1849,7 @@ internal static partial class WebPipelineRunner
         var candidates = new[]
         {
             NormalizeOptionalString(project.Metrics?.NuGet?.Version),
-            NormalizeOptionalString(project.Metrics?.PowerShellGallery?.Version),
-            NormalizeOptionalString(project.Version)
+            NormalizeOptionalString(project.Metrics?.PowerShellGallery?.Version)
         };
 
         string? latestText = null;
@@ -1867,7 +1866,7 @@ internal static partial class WebPipelineRunner
             }
         }
 
-        return latestText ?? candidates.FirstOrDefault(static candidate => candidate is not null);
+        return latestText ?? NormalizeOptionalString(project.Version);
     }
 
     private static void GenerateProjectSectionPages(

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -10,6 +10,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using NuGet.Versioning;
 using PowerForge.Web;
 
 namespace PowerForge.Web.Cli;
@@ -1845,9 +1846,28 @@ internal static partial class WebPipelineRunner
 
     private static string? ResolveCurrentProjectVersion(ProjectCatalogEntry project)
     {
-        return NormalizeOptionalString(project.Metrics?.NuGet?.Version) ??
-               NormalizeOptionalString(project.Metrics?.PowerShellGallery?.Version) ??
-               NormalizeOptionalString(project.Version);
+        var candidates = new[]
+        {
+            NormalizeOptionalString(project.Metrics?.NuGet?.Version),
+            NormalizeOptionalString(project.Metrics?.PowerShellGallery?.Version),
+            NormalizeOptionalString(project.Version)
+        };
+
+        string? latestText = null;
+        NuGetVersion? latestVersion = null;
+        foreach (var candidate in candidates)
+        {
+            if (candidate is null || !NuGetVersion.TryParse(candidate, out var parsed))
+                continue;
+
+            if (latestVersion is null || parsed.CompareTo(latestVersion) > 0)
+            {
+                latestText = candidate;
+                latestVersion = parsed;
+            }
+        }
+
+        return latestText ?? candidates.FirstOrDefault(static candidate => candidate is not null);
     }
 
     private static void GenerateProjectSectionPages(

--- a/PowerForge.Web.Cli/packages.lock.json
+++ b/PowerForge.Web.Cli/packages.lock.json
@@ -14,6 +14,12 @@
           "SQLitePCLRaw.core": "3.0.5"
         }
       },
+      "NuGet.Versioning": {
+        "type": "Direct",
+        "requested": "[7.9.0, )",
+        "resolved": "7.9.0",
+        "contentHash": "r4sZuVpVqwSBLe4qYDrnpScqdyctlRXg0HSF5OoCGkeBc8b+o8BBYHuI/u1RoWYX78PbieijU13TBt71/Xf3lw=="
+      },
       "Acornima": {
         "type": "Transitive",
         "resolved": "1.6.2",
@@ -209,11 +215,6 @@
           "NuGet.Versioning": "7.9.0",
           "System.Security.Cryptography.Pkcs": "8.0.1"
         }
-      },
-      "NuGet.Versioning": {
-        "type": "Transitive",
-        "resolved": "7.9.0",
-        "contentHash": "r4sZuVpVqwSBLe4qYDrnpScqdyctlRXg0HSF5OoCGkeBc8b+o8BBYHuI/u1RoWYX78PbieijU13TBt71/Xf3lw=="
       },
       "NUglify": {
         "type": "Transitive",


### PR DESCRIPTION
## What changed

- choose the newest valid version across NuGet and PowerShell Gallery when generating project pages
- fall back to imported manifest metadata only when neither public package feed has a valid version
- remove internal hosting and routing-strategy prose from public project copy
- retain useful project links and status information

## Why

EvotecIT/Website#77 consumes the generated project catalog. This keeps its project pages current and reader-facing without advertising an unpublished manifest version or adding Website-only overrides.

## Validation

The focused project-catalog suite passes 8/8. Its cross-feed regression deliberately sets the manifest to unpublished 2.0.0 and confirms PowerShell Gallery 1.8.0 wins over NuGet 1.7.0. The CLI also succeeds under exact locked restore with NuGet.Versioning recorded as a direct dependency.