### PR TITLE
Harden signed .NET publish provenance

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerEnvironmentTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerEnvironmentTests.cs
@@ -135,6 +135,34 @@ public sealed class DotNetPublishPipelineRunnerEnvironmentTests
     }
 
     [Fact]
+    public void ControlledEvaluationProperties_OmitEnvironmentValuesNotAdmittedToControlledBuild()
+    {
+        IReadOnlyDictionary<string, string> properties =
+            DotNetPublishPipelineRunner.CreateControlledEvaluationProperties(
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Configuration"] = "Release",
+                    ["GLOBAL_BUILD_VALUE"] = "global-value"
+                },
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Configuration"] = "Release",
+                    ["GLOBAL_BUILD_VALUE"] = "environment-value",
+                    ["PRIVATE_BUILD_TOKEN"] = "secret-value",
+                    ["PUBLIC_BUILD_VALUE"] = "stable-value",
+                    ["ProjectProperty"] = "project-value"
+                },
+                ["GLOBAL_BUILD_VALUE", "PRIVATE_BUILD_TOKEN", "PUBLIC_BUILD_VALUE"],
+                ["PUBLIC_BUILD_VALUE"]);
+
+        Assert.Equal("Release", properties["Configuration"]);
+        Assert.Equal("global-value", properties["GLOBAL_BUILD_VALUE"]);
+        Assert.Equal("stable-value", properties["PUBLIC_BUILD_VALUE"]);
+        Assert.Equal("project-value", properties["ProjectProperty"]);
+        Assert.False(properties.ContainsKey("PRIVATE_BUILD_TOKEN"));
+    }
+
+    [Fact]
     public void Plan_ThrowsWhenRequiredDotNetEnvironmentVariableIsMissing()
     {
         var root = CreateTempRoot();

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerEnvironmentTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerEnvironmentTests.cs
@@ -49,6 +49,49 @@ public sealed class DotNetPublishPipelineRunnerEnvironmentTests
     }
 
     [Fact]
+    public void Plan_AdmitsOnlyExplicitNonSecretEnvironmentVariablesToControlledBuilds()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var projectPath = CreateProject(root);
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(
+                new DotNetPublishSpec
+                {
+                    DotNet = new DotNetPublishDotNetOptions
+                    {
+                        ProjectRoot = root,
+                        Restore = false,
+                        Build = false,
+                        Runtimes = new[] { "win-x64" },
+                        EnvironmentVariables = new Dictionary<string, DotNetPublishEnvironmentVariable>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["DETERMINISTIC_BUILD_VALUE"] = new()
+                            {
+                                Value = "2026-08-29T20:00:00Z",
+                                Secret = false
+                            },
+                            ["PRIVATE_BUILD_TOKEN"] = new()
+                            {
+                                Value = "private-token",
+                                Secret = true
+                            }
+                        }
+                    },
+                    Targets = new[] { NewTarget(projectPath) }
+                },
+                configPath: null);
+
+            Assert.Contains("DETERMINISTIC_BUILD_VALUE", plan.ControlledBuildEnvironmentVariableNames);
+            Assert.DoesNotContain("PRIVATE_BUILD_TOKEN", plan.ControlledBuildEnvironmentVariableNames);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Plan_ThrowsWhenRequiredDotNetEnvironmentVariableIsMissing()
     {
         var root = CreateTempRoot();

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerEnvironmentTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerEnvironmentTests.cs
@@ -92,6 +92,49 @@ public sealed class DotNetPublishPipelineRunnerEnvironmentTests
     }
 
     [Fact]
+    public void Plan_UsesNormalizedWinningEnvironmentDefinitionForControlledBuildAdmission()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var projectPath = CreateProject(root);
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(
+                new DotNetPublishSpec
+                {
+                    DotNet = new DotNetPublishDotNetOptions
+                    {
+                        ProjectRoot = root,
+                        Restore = false,
+                        Build = false,
+                        Runtimes = new[] { "win-x64" },
+                        EnvironmentVariables = new Dictionary<string, DotNetPublishEnvironmentVariable>(StringComparer.Ordinal)
+                        {
+                            [" BUILD_TOKEN "] = new()
+                            {
+                                Value = "public-value",
+                                Secret = false
+                            },
+                            ["BUILD_TOKEN"] = new()
+                            {
+                                Value = "secret-value",
+                                Secret = true
+                            }
+                        }
+                    },
+                    Targets = new[] { NewTarget(projectPath) }
+                },
+                configPath: null);
+
+            Assert.Equal("secret-value", plan.EnvironmentVariables["BUILD_TOKEN"]);
+            Assert.DoesNotContain("BUILD_TOKEN", plan.ControlledBuildEnvironmentVariableNames);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Plan_ThrowsWhenRequiredDotNetEnvironmentVariableIsMissing()
     {
         var root = CreateTempRoot();

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave34.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave34.cs
@@ -90,7 +90,9 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
             Assert.True(provenance.Dirty);
             Assert.Contains(
                 provenance.DirtyReasons,
-                reason => reason.Contains("Library.dll", StringComparison.OrdinalIgnoreCase));
+                reason => useEnvironmentVariable
+                    ? reason.Contains("MSBuild input evaluation failed", StringComparison.Ordinal)
+                    : reason.Contains("Library.dll", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave34.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave34.cs
@@ -90,9 +90,7 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
             Assert.True(provenance.Dirty);
             Assert.Contains(
                 provenance.DirtyReasons,
-                reason => useEnvironmentVariable
-                    ? reason.Contains("MSBuild input evaluation failed", StringComparison.Ordinal)
-                    : reason.Contains("Library.dll", StringComparison.OrdinalIgnoreCase));
+                reason => reason.Contains("Library.dll", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {
@@ -101,7 +99,7 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
     }
 
     [Fact]
-    public void ReadSourceProvenance_RemapPreservesTrackedAbsolutePropertyInput()
+    public void ReadSourceProvenance_RemapPreservesTrackedAbsoluteGlobalPropertyTaskInput()
     {
         string root = Directory.CreateTempSubdirectory().FullName;
         try
@@ -129,8 +127,7 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
                 <Project Sdk="Microsoft.NET.Sdk">
                   <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>
                   <Target Name="ReplaceOutputFromTrackedProperty"
-                          AfterTargets="Build"
-                          Condition="Exists('$(PayloadPath)')">
+                          AfterTargets="Build">
                     <Copy SourceFiles="$(PayloadPath)" DestinationFiles="$(TargetPath)" />
                   </Target>
                 </Project>

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave38.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave38.cs
@@ -87,6 +87,33 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
     }
 
     [Fact]
+    public void ControlledBuildEnvironment_ReplaysOnlyAdmittedNonSecretPlanValues()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        string controlledRoot = Directory.CreateDirectory(Path.Combine(root, "controlled")).FullName;
+        try
+        {
+            Assert.True(DotNetPublishPipelineRunner.TryCreateControlledBuildEnvironment(
+                new Dictionary<string, string?>
+                {
+                    ["DETERMINISTIC_BUILD_VALUE"] = "2026-08-29T20:00:00Z",
+                    ["PRIVATE_BUILD_TOKEN"] = "private-token"
+                },
+                ["DETERMINISTIC_BUILD_VALUE"],
+                root,
+                controlledRoot,
+                out IReadOnlyDictionary<string, string?> environment));
+
+            Assert.Equal("2026-08-29T20:00:00Z", environment["DETERMINISTIC_BUILD_VALUE"]);
+            Assert.False(environment.ContainsKey("PRIVATE_BUILD_TOKEN"));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
     public void ReadSourceProvenance_RecoversPropertyFunctionTaskOutputItemName()
     {
         DotNetPublishPipelineRunner.SourceProvenance provenance = ReadProjectReferencePropertyRecoveryFixture(

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave46.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave46.cs
@@ -137,5 +137,7 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
             "isolated.lock.json");
 
         Assert.Contains("-noAutoResponse", arguments);
+        Assert.Contains("-maxCpuCount:1", arguments);
+        Assert.Contains("-nodeReuse:false", arguments);
     }
 }

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave77.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave77.cs
@@ -153,7 +153,7 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
                 Path.Combine(libraryDirectory, "Library.cs"),
                 "public static class Library { public const int Value = 1; }");
             File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
-            RunDotNet(root, $"restore \"{appProject}\" --runtime win-x64 --use-lock-file --nologo");
+            RunDotNet(root, $"restore \"{appProject}\" --use-lock-file --nologo");
             RunGit(root, "add .");
             RunGit(root, "commit -m \"approved source and dependency graph\"");
             var plan = new DotNetPublishPlan
@@ -171,7 +171,6 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
                             new DotNetPublishTargetCombination
                             {
                                 Framework = "net10.0",
-                                Runtime = "win-x64",
                                 Style = DotNetPublishStyle.FrameworkDependent
                             }
                         ]
@@ -189,7 +188,6 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
                 "bin",
                 "Release",
                 "net8.0",
-                "win-x64",
                 "Library.dll")));
         }
         finally

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave77.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave77.cs
@@ -82,6 +82,123 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
     }
 
     [Fact]
+    public void GeneratedProjectReferenceContext_SelectsOneResolvedEvaluationForTheSourceProject()
+    {
+        string project = Path.GetFullPath(Path.Combine("src", "Library.csproj"));
+
+        Assert.True(DotNetPublishPipelineRunner.TrySelectSingleResolvedGeneratedProjectReferenceEvaluationKey(
+            project,
+            [
+                new KeyValuePair<string, string>(project, "resolved-key"),
+                new KeyValuePair<string, string>(project, "resolved-key")
+            ],
+            out string key));
+        Assert.Equal("resolved-key", key);
+    }
+
+    [Fact]
+    public void GeneratedProjectReferenceContext_RejectsAmbiguousResolvedEvaluations()
+    {
+        string project = Path.GetFullPath(Path.Combine("src", "Library.csproj"));
+
+        Assert.False(DotNetPublishPipelineRunner.TrySelectSingleResolvedGeneratedProjectReferenceEvaluationKey(
+            project,
+            [
+                new KeyValuePair<string, string>(project, "first-key"),
+                new KeyValuePair<string, string>(project, "second-key")
+            ],
+            out string key));
+        Assert.Equal(string.Empty, key);
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void ReadSourceProvenance_IgnoresAbsentCrossTargetEmbeddedProjectReferenceOutput()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string appDirectory = Directory.CreateDirectory(Path.Combine(root, "App")).FullName;
+            string libraryDirectory = Directory.CreateDirectory(Path.Combine(root, "Library")).FullName;
+            string appProject = Path.Combine(appDirectory, "App.csproj");
+            string libraryProject = Path.Combine(libraryDirectory, "Library.csproj");
+            File.WriteAllText(appProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <ProjectReference Include="../Library/Library.csproj" />
+                    <ProjectReference Include="../Library/Library.csproj"
+                                      SetTargetFramework="TargetFramework=net8.0"
+                                      ReferenceOutputAssembly="false"
+                                      OutputItemType="EmbeddedResource"
+                                      LogicalName="App.Payloads.Library.net8.0.dll" />
+                  </ItemGroup>
+                </Project>
+                """);
+            File.WriteAllText(libraryProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup><TargetFrameworks>net8.0;net10.0</TargetFrameworks></PropertyGroup>
+                </Project>
+                """);
+            File.WriteAllText(
+                Path.Combine(appDirectory, "Program.cs"),
+                "internal static class Program { private static void Main() { _ = Library.Value; } }");
+            File.WriteAllText(
+                Path.Combine(libraryDirectory, "Library.cs"),
+                "public static class Library { public const int Value = 1; }");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
+            RunDotNet(root, $"restore \"{appProject}\" --runtime win-x64 --use-lock-file --nologo");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source and dependency graph\"");
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Configuration = "Release",
+                Targets =
+                [
+                    new DotNetPublishTargetPlan
+                    {
+                        Name = "App",
+                        ProjectPath = appProject,
+                        Combinations =
+                        [
+                            new DotNetPublishTargetCombination
+                            {
+                                Framework = "net10.0",
+                                Runtime = "win-x64",
+                                Style = DotNetPublishStyle.FrameworkDependent
+                            }
+                        ]
+                    }
+                ]
+            };
+
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(root, buildPlan: plan);
+
+            Assert.False(provenance.Dirty, string.Join(Environment.NewLine, provenance.DirtyReasons));
+            Assert.Empty(provenance.DirtyPaths);
+            Assert.False(File.Exists(Path.Combine(
+                libraryDirectory,
+                "bin",
+                "Release",
+                "net8.0",
+                "win-x64",
+                "Library.dll")));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
     public void DotNetExecutionEnvironment_ClearsAmbientRuntimeInjectionVariables()
     {
         IReadOnlyDictionary<string, string?> environment =
@@ -117,6 +234,33 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
         Assert.Equal("0", environment["DOTNET_MULTILEVEL_LOOKUP"]);
         Assert.Equal("false", environment["ImportUserLocationsByWildcardBeforeMicrosoftCommonProps"]);
         Assert.Equal("false", environment["ImportUserLocationsByWildcardAfterMicrosoftCommonTargets"]);
+    }
+
+    [Fact]
+    public void DotNetExecutionEnvironment_UsesResolvedChildForRuntimeRoot()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string resolvedDotNet = Path.Combine(
+                root,
+                OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet");
+            File.WriteAllText(resolvedDotNet, "resolved child");
+
+            IReadOnlyDictionary<string, string?> environment =
+                DotNetPublishPipelineRunner.CreateSafeDotNetChildEnvironment(
+                    environmentVariables: null,
+                    resolvedDotNetExecutablePath: resolvedDotNet);
+
+            Assert.Equal(
+                root,
+                environment["DOTNET_ROOT"],
+                OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
     }
 
     [Theory]

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave90.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave90.cs
@@ -1,0 +1,168 @@
+using PowerForge;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
+{
+    [Theory]
+    [InlineData("BeforeTargets")]
+    [InlineData("DependsOnTargets")]
+    public void ControlledBuildInputs_RejectPrerequisiteActivationOfEvaluatedInactiveTarget(
+        string schedulingMode)
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        string externalRoot = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string projectPath = Path.Combine(root, "App.proj");
+            string externalPath = Path.Combine(externalRoot, "payload.txt");
+            string linkedPath = Path.Combine(root, "payload-link.txt");
+            File.WriteAllText(externalPath, "untracked external payload");
+            try
+            {
+                File.CreateSymbolicLink(linkedPath, externalPath);
+            }
+            catch (Exception exception) when (
+                exception is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                return;
+            }
+            string buildDependencies = schedulingMode == "DependsOnTargets"
+                ? " DependsOnTargets=\"ActivateExternalInput\""
+                : string.Empty;
+            string activationSchedule = schedulingMode == "BeforeTargets"
+                ? " BeforeTargets=\"Build\""
+                : string.Empty;
+            File.WriteAllText(
+                projectPath,
+                $"""
+                <Project>
+                  <PropertyGroup><UseExternal>false</UseExternal></PropertyGroup>
+                  <Target Name="ActivateExternalInput"{activationSchedule}>
+                    <PropertyGroup><UseExternal>true</UseExternal></PropertyGroup>
+                  </Target>
+                  <Target Name="Build"{buildDependencies}
+                          Condition="'$(UseExternal)' == 'true'">
+                    <Copy SourceFiles="payload-link.txt" DestinationFolder="output" />
+                  </Target>
+                </Project>
+                """);
+
+            Assert.False(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
+                root,
+                [projectPath],
+                [projectPath],
+                evaluatedGlobalProperties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["UseExternal"] = "false"
+                }));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+            DeleteTestRepository(externalRoot);
+        }
+    }
+
+    [Fact]
+    public void ControlledBuildInputs_RejectInputActivatedWhenOmittedEnvironmentPropertyIsAbsent()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        string externalRoot = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string projectPath = Path.Combine(root, "App.proj");
+            string externalPath = Path.Combine(externalRoot, "payload.txt");
+            string linkedPath = Path.Combine(root, "payload-link.txt");
+            File.WriteAllText(externalPath, "untracked external payload");
+            try
+            {
+                File.CreateSymbolicLink(linkedPath, externalPath);
+            }
+            catch (Exception exception) when (
+                exception is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                return;
+            }
+            File.WriteAllText(
+                projectPath,
+                """
+                <Project>
+                  <Target Name="Build" Condition="'$(PRIVATE_BUILD_TOKEN)' == ''">
+                    <Copy SourceFiles="payload-link.txt" DestinationFolder="output" />
+                  </Target>
+                </Project>
+                """);
+
+            Assert.False(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
+                root,
+                [projectPath],
+                [projectPath],
+                evaluatedGlobalProperties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+            DeleteTestRepository(externalRoot);
+        }
+    }
+
+    [Fact]
+    public void ControlledBuildInputs_RejectImportedPrerequisiteActivationOfInactiveTarget()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        string externalRoot = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string projectPath = Path.Combine(root, "App.proj");
+            string targetsPath = Path.Combine(root, "BuildHooks.targets");
+            string externalPath = Path.Combine(externalRoot, "payload.txt");
+            string linkedPath = Path.Combine(root, "payload-link.txt");
+            File.WriteAllText(externalPath, "untracked external payload");
+            try
+            {
+                File.CreateSymbolicLink(linkedPath, externalPath);
+            }
+            catch (Exception exception) when (
+                exception is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                return;
+            }
+            File.WriteAllText(
+                targetsPath,
+                """
+                <Project>
+                  <Target Name="ActivateExternalInput" BeforeTargets="Build">
+                    <PropertyGroup><UseExternal>true</UseExternal></PropertyGroup>
+                  </Target>
+                </Project>
+                """);
+            File.WriteAllText(
+                projectPath,
+                """
+                <Project>
+                  <Import Project="BuildHooks.targets" />
+                  <PropertyGroup><UseExternal>false</UseExternal></PropertyGroup>
+                  <Target Name="Build" Condition="'$(UseExternal)' == 'true'">
+                    <Copy SourceFiles="payload-link.txt" DestinationFolder="output" />
+                  </Target>
+                </Project>
+                """);
+
+            Assert.False(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
+                root,
+                [projectPath, targetsPath],
+                [projectPath, targetsPath],
+                evaluatedGlobalProperties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["UseExternal"] = "false"
+                }));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+            DeleteTestRepository(externalRoot);
+        }
+    }
+}

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.QuotedSeparatorLiterals.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.QuotedSeparatorLiterals.cs
@@ -1,0 +1,506 @@
+using System.Reflection;
+using PowerForge;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
+{
+    [Fact]
+    public void ProjectEvaluationIdentityHash_IsDeterministicWithoutExposingTheValue()
+    {
+        const string value = "private-build-credential";
+
+        string first = DotNetPublishPipelineRunner.HashProjectEvaluationIdentityValue(value);
+        string second = DotNetPublishPipelineRunner.HashProjectEvaluationIdentityValue(value);
+
+        Assert.Equal(first, second);
+        Assert.Equal(64, first.Length);
+        Assert.DoesNotContain(value, first, StringComparison.Ordinal);
+        Assert.NotEqual(
+            first,
+            DotNetPublishPipelineRunner.HashProjectEvaluationIdentityValue(value + "-different"));
+    }
+
+    [Fact]
+    public void PowerForgeSdkPackageLock_ReadsVersionedPackageHashes()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string lockPath = Path.Combine(root, "packages.powerforge.lock.json");
+            File.WriteAllText(
+                lockPath,
+                """
+                {
+                  "version": 1,
+                  "sdkManagedPackages": {
+                    "Microsoft.NETCore.App.Runtime.win-x64": {
+                      "version": "10.0.11",
+                      "contentHash": "sha512-runtime"
+                    }
+                  }
+                }
+                """);
+
+            Type catalogType = typeof(DotNetPublishPipelineRunner).GetNestedType(
+                "VerifiedPackageInputCatalog",
+                BindingFlags.NonPublic)!;
+            MethodInfo read = catalogType.GetMethod(
+                "TryReadPowerForgeSdkPackageHashes",
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+            object?[] arguments = [lockPath, null];
+
+            Assert.True((bool)read.Invoke(null, arguments)!);
+            var hashes = Assert.IsType<Dictionary<string, string>>(arguments[1]);
+            Assert.Equal(
+                "sha512-runtime",
+                hashes["Microsoft.NETCore.App.Runtime.win-x64|10.0.11"]);
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Theory]
+    [InlineData("2", "10.0.11", "sha512-runtime")]
+    [InlineData("1", "not-a-version", "sha512-runtime")]
+    [InlineData("1", "10.0.11", "")]
+    public void PowerForgeSdkPackageLock_RejectsMalformedEntries(
+        string schemaVersion,
+        string packageVersion,
+        string contentHash)
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string lockPath = Path.Combine(root, "packages.powerforge.lock.json");
+            File.WriteAllText(
+                lockPath,
+                $$"""
+                {
+                  "version": {{schemaVersion}},
+                  "sdkManagedPackages": {
+                    "Microsoft.NETCore.App.Runtime.win-x64": {
+                      "version": "{{packageVersion}}",
+                      "contentHash": "{{contentHash}}"
+                    }
+                  }
+                }
+                """);
+
+            Type catalogType = typeof(DotNetPublishPipelineRunner).GetNestedType(
+                "VerifiedPackageInputCatalog",
+                BindingFlags.NonPublic)!;
+            MethodInfo read = catalogType.GetMethod(
+                "TryReadPowerForgeSdkPackageHashes",
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+            object?[] arguments = [lockPath, null];
+
+            Assert.False((bool)read.Invoke(null, arguments)!);
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Theory]
+    [InlineData("$([System.String]::Copy('$(MSBuildProjectDirectory)').Replace('\\','/'))")]
+    [InlineData("$([System.String]::Copy('$(MSBuildProjectDirectory)').Replace('/','\\'))")]
+    public void ControlledBuildInputScanner_AllowsQuotedDirectorySeparatorLiterals(string value)
+    {
+        Assert.False(DotNetPublishPipelineRunner.ContainsRootedBuildValue(value, gitRoot: null));
+    }
+
+    [Fact]
+    public void ControlledBuildInputScanner_StillRejectsQuotedRootedReplacement()
+    {
+        string rooted = OperatingSystem.IsWindows()
+            ? @"C:\outside\payload"
+            : "/outside/payload";
+        string value =
+            "$([System.String]::Copy('$(MSBuildProjectDirectory)').Replace('\\','" + rooted + "'))";
+
+        Assert.True(DotNetPublishPipelineRunner.ContainsRootedBuildValue(value, gitRoot: null));
+    }
+
+    [Fact]
+    public void EvaluatedPropertyQueries_AreSplitBelowTheCommandLengthBudget()
+    {
+        string[] commonArguments = ["msbuild", "App.csproj", "-nologo", "-verbosity:quiet"];
+        string[] propertyNames = Enumerable.Range(0, 18)
+            .Select(index => "ConditionProperty" + index.ToString("D3") + new string('X', 12))
+            .ToArray();
+
+        string[][] batches = DotNetPublishPipelineRunner.BuildEvaluatedPropertyQueryBatches(
+            commonArguments,
+            propertyNames,
+            maximumCommandLength: 180);
+
+        Assert.True(batches.Length > 1);
+        Assert.Equal(
+            propertyNames.OrderBy(name => name, StringComparer.OrdinalIgnoreCase),
+            batches.SelectMany(batch => batch));
+        Assert.All(batches, batch =>
+        {
+            int estimatedLength = commonArguments.Sum(argument => argument.Length + 3) +
+                                  "-getProperty:MSBuildProjectFullPath".Length + 3 +
+                                  batch.Sum(name => "-getProperty:".Length + name.Length + 3);
+            Assert.InRange(estimatedLength, 1, 180);
+        });
+    }
+
+
+    [Fact]
+    public void ControlledBuildInputs_AcceptProjectDirectorySeparatorNormalization()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string projectPath = Path.Combine(root, "App.proj");
+            File.WriteAllText(
+                projectPath,
+                """
+                <Project>
+                  <PropertyGroup>
+                    <NormalizedProjectDirectory>$([System.String]::Copy('$(MSBuildProjectDirectory)').Replace('\','/'))</NormalizedProjectDirectory>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            Assert.True(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
+                root,
+                [projectPath],
+                [projectPath]));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    public void ControlledBuildInputs_AcceptUnsafeValueOnlyWhenEveryEvaluatedContextDisablesIt()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string projectPath = WriteConditionalExternalPathProject(root);
+            IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>[]> contexts =
+                new Dictionary<string, IReadOnlyDictionary<string, string>[]>(
+                    OperatingSystem.IsWindows()
+                        ? StringComparer.OrdinalIgnoreCase
+                        : StringComparer.Ordinal)
+                {
+                    [Path.GetFullPath(projectPath)] =
+                    [
+                        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["UseLocalDependency"] = "false"
+                        },
+                        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["UseLocalDependency"] = "false",
+                            ["TargetFramework"] = "net10.0"
+                        }
+                    ]
+                };
+
+            Assert.True(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
+                root,
+                [projectPath],
+                [projectPath],
+                evaluatedProjectContexts: contexts));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    public void ControlledBuildInputs_IgnoreExistsInputInsideInactiveTarget()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string projectPath = Path.Combine(root, "App.proj");
+            File.WriteAllText(
+                projectPath,
+                """
+                <Project>
+                  <PropertyGroup>
+                    <EnableNativeCopy>$([System.String]::Copy('$(MSBuildProjectName)').ToUpperInvariant().StartsWith('CERTNOOB'))</EnableNativeCopy>
+                  </PropertyGroup>
+                  <Target Name="CopyNative" Condition="'$(EnableNativeCopy)' == 'true'">
+                    <ItemGroup>
+                      <NativeFile Include="$(OutDir)native.dll" Condition="Exists('$(OutDir)native.dll')" />
+                    </ItemGroup>
+                    <Copy SourceFiles="$(OutDir)native.dll" DestinationFiles="$(OutDir)copied-native.dll" />
+                  </Target>
+                </Project>
+                """);
+
+            Assert.True(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
+                root,
+                [projectPath],
+                [projectPath],
+                evaluatedGlobalProperties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["EnableNativeCopy"] = "false"
+                }));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    public void ControlledBuildInputs_AllowNonFileConditionWithUnevaluatedProperty()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string projectPath = Path.Combine(root, "App.proj");
+            File.WriteAllText(
+                projectPath,
+                """
+                <Project>
+                  <PropertyGroup Condition="'$(OptionalFeature)' == ''">
+                    <FeatureState>disabled</FeatureState>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            Assert.True(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
+                root,
+                [projectPath],
+                [projectPath],
+                evaluatedGlobalProperties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    public void ControlledBuildInputs_IgnoreExistsOperandAfterTrueOrBranch()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string projectPath = Path.Combine(root, "App.proj");
+            File.WriteAllText(
+                projectPath,
+                """
+                <Project>
+                  <ItemGroup Condition="'$(OptionalPath)' == '' or !Exists('$(OptionalPath)')">
+                    <Compile Include="Program.cs" />
+                  </ItemGroup>
+                </Project>
+                """);
+
+            Assert.True(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
+                root,
+                [projectPath],
+                [projectPath],
+                evaluatedGlobalProperties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["OptionalPath"] = string.Empty
+                }));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    public void ControlledBuildInputs_RejectEmptyExistsOperandBeforeTrueOrBranch()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string projectPath = Path.Combine(root, "App.proj");
+            File.WriteAllText(
+                projectPath,
+                """
+                <Project>
+                  <ItemGroup Condition="Exists('$(OptionalPath)') or 'true' == 'true'">
+                    <Compile Include="Program.cs" />
+                  </ItemGroup>
+                </Project>
+                """);
+
+            Assert.False(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
+                root,
+                [projectPath],
+                [projectPath],
+                evaluatedGlobalProperties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["OptionalPath"] = string.Empty
+                }));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData(null)]
+    public void ControlledBuildInputs_RejectUnresolvedExistsInputWhenTargetCanRun(string? enabled)
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string projectPath = Path.Combine(root, "App.proj");
+            File.WriteAllText(
+                projectPath,
+                """
+                <Project>
+                  <PropertyGroup>
+                    <EnableNativeCopy>$([System.String]::Copy('$(MSBuildProjectName)').ToUpperInvariant().StartsWith('CERTNOOB'))</EnableNativeCopy>
+                  </PropertyGroup>
+                  <Target Name="CopyNative" Condition="'$(EnableNativeCopy)' == 'true'">
+                    <ItemGroup>
+                      <NativeFile Include="$(OutDir)native.dll" Condition="Exists('$(OutDir)native.dll')" />
+                    </ItemGroup>
+                    <Copy SourceFiles="$(OutDir)native.dll" DestinationFiles="$(OutDir)copied-native.dll" />
+                  </Target>
+                </Project>
+                """);
+            IReadOnlyDictionary<string, string> properties = enabled is null
+                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["EnableNativeCopy"] = enabled
+                };
+
+            Assert.False(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
+                root,
+                [projectPath],
+                [projectPath],
+                evaluatedGlobalProperties: properties));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    public void ControlledBuildInputs_AggregateProjectContextsForSharedProps()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string propsPath = WriteConditionalExternalPathProject(root, "Directory.Build.props");
+            string projectPath = Path.Combine(root, "App.proj");
+            File.WriteAllText(projectPath, "<Project />");
+            IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>[]> contexts =
+                new Dictionary<string, IReadOnlyDictionary<string, string>[]>(
+                    OperatingSystem.IsWindows()
+                        ? StringComparer.OrdinalIgnoreCase
+                        : StringComparer.Ordinal)
+                {
+                    [Path.GetFullPath(projectPath)] =
+                    [
+                        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["TargetFramework"] = "net10.0"
+                        }
+                    ]
+                };
+            IReadOnlyDictionary<string, string> globalProperties =
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["UseLocalDependency"] = "false"
+                };
+
+            Assert.True(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
+                root,
+                [propsPath, projectPath],
+                [propsPath, projectPath],
+                evaluatedGlobalProperties: globalProperties,
+                controlledProjectPath: projectPath,
+                evaluatedProjectContexts: contexts));
+
+            contexts = new Dictionary<string, IReadOnlyDictionary<string, string>[]>(
+                OperatingSystem.IsWindows()
+                    ? StringComparer.OrdinalIgnoreCase
+                    : StringComparer.Ordinal)
+            {
+                [Path.GetFullPath(projectPath)] =
+                [
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["UseLocalDependency"] = "true"
+                    }
+                ]
+            };
+            Assert.False(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
+                root,
+                [propsPath, projectPath],
+                [propsPath, projectPath],
+                evaluatedGlobalProperties: globalProperties,
+                controlledProjectPath: projectPath,
+                evaluatedProjectContexts: contexts));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData(null)]
+    public void ControlledBuildInputs_RejectUnsafeValueWhenConditionIsActiveOrUnproven(
+        string? useLocalDependency)
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string projectPath = WriteConditionalExternalPathProject(root);
+            IReadOnlyDictionary<string, string> properties = useLocalDependency is null
+                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["UseLocalDependency"] = useLocalDependency
+                };
+
+            Assert.False(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
+                root,
+                [projectPath],
+                [projectPath],
+                evaluatedGlobalProperties: properties));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    private static string WriteConditionalExternalPathProject(
+        string root,
+        string fileName = "App.proj")
+    {
+        string projectPath = Path.Combine(root, fileName);
+        File.WriteAllText(
+            projectPath,
+            """
+            <Project>
+              <PropertyGroup Condition="'$(UseLocalDependency)' == 'true' and Exists('$(MSBuildThisFileDirectory)marker.txt')">
+                <LocalDependencyRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\LocalDependency'))</LocalDependencyRoot>
+              </PropertyGroup>
+            </Project>
+            """);
+        return projectPath;
+    }
+}

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.QuotedSeparatorLiterals.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.QuotedSeparatorLiterals.cs
@@ -259,6 +259,48 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
     }
 
     [Fact]
+    public void ControlledBuildInputs_RejectTargetTimeActivationOfEvaluatedInactiveCopyInput()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        string externalRoot = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string projectPath = Path.Combine(root, "App.proj");
+            string externalPath = Path.Combine(externalRoot, "payload.txt");
+            File.WriteAllText(externalPath, "untracked external payload");
+            var project = new System.Xml.Linq.XDocument(
+                new System.Xml.Linq.XElement("Project",
+                    new System.Xml.Linq.XElement("PropertyGroup",
+                        new System.Xml.Linq.XElement("UseExternal", "false")),
+                    new System.Xml.Linq.XElement("Target",
+                        new System.Xml.Linq.XAttribute("Name", "Build"),
+                        new System.Xml.Linq.XElement("PropertyGroup",
+                            new System.Xml.Linq.XElement("UseExternal", "true")),
+                        new System.Xml.Linq.XElement("Copy",
+                            new System.Xml.Linq.XAttribute(
+                                "Condition",
+                                "'$(UseExternal)' == 'true'"),
+                            new System.Xml.Linq.XAttribute("SourceFiles", externalPath),
+                            new System.Xml.Linq.XAttribute("DestinationFolder", "output")))));
+            project.Save(projectPath);
+
+            Assert.False(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
+                root,
+                [projectPath],
+                [projectPath],
+                evaluatedGlobalProperties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["UseExternal"] = "false"
+                }));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+            DeleteTestRepository(externalRoot);
+        }
+    }
+
+    [Fact]
     public void ControlledBuildInputs_AllowNonFileConditionWithUnevaluatedProperty()
     {
         string root = Directory.CreateTempSubdirectory().FullName;

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.QuotedSeparatorLiterals.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.QuotedSeparatorLiterals.cs
@@ -362,66 +362,6 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
     }
 
     [Fact]
-    public void ControlledBuildInputs_RejectImportedPrerequisiteTargetActivationOfInactiveCopyInput()
-    {
-        string root = Directory.CreateTempSubdirectory().FullName;
-        string externalRoot = Directory.CreateTempSubdirectory().FullName;
-        try
-        {
-            string projectPath = Path.Combine(root, "App.proj");
-            string targetsPath = Path.Combine(root, "BuildHooks.targets");
-            string externalPath = Path.Combine(externalRoot, "payload.txt");
-            string linkedPath = Path.Combine(root, "payload-link.txt");
-            File.WriteAllText(externalPath, "untracked external payload");
-            try
-            {
-                File.CreateSymbolicLink(linkedPath, externalPath);
-            }
-            catch (Exception exception) when (
-                exception is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
-            {
-                return;
-            }
-            File.WriteAllText(
-                targetsPath,
-                """
-                <Project>
-                  <Target Name="ActivateExternalInput" BeforeTargets="Build">
-                    <PropertyGroup><UseExternal>true</UseExternal></PropertyGroup>
-                  </Target>
-                </Project>
-                """);
-            File.WriteAllText(
-                projectPath,
-                """
-                <Project>
-                  <Import Project="BuildHooks.targets" />
-                  <PropertyGroup><UseExternal>false</UseExternal></PropertyGroup>
-                  <Target Name="Build">
-                    <Copy Condition="'$(UseExternal)' == 'true'"
-                          SourceFiles="payload-link.txt"
-                          DestinationFolder="output" />
-                  </Target>
-                </Project>
-                """);
-
-            Assert.False(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
-                root,
-                [projectPath, targetsPath],
-                [projectPath, targetsPath],
-                evaluatedGlobalProperties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    ["UseExternal"] = "false"
-                }));
-        }
-        finally
-        {
-            DeleteTestRepository(root);
-            DeleteTestRepository(externalRoot);
-        }
-    }
-
-    [Fact]
     public void ControlledBuildInputs_AllowNonFileConditionWithUnevaluatedProperty()
     {
         string root = Directory.CreateTempSubdirectory().FullName;

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.QuotedSeparatorLiterals.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.QuotedSeparatorLiterals.cs
@@ -300,6 +300,127 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
         }
     }
 
+    [Theory]
+    [InlineData("BeforeTargets")]
+    [InlineData("DependsOnTargets")]
+    public void ControlledBuildInputs_RejectPrerequisiteTargetActivationOfEvaluatedInactiveCopyInput(
+        string schedulingMode)
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        string externalRoot = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string projectPath = Path.Combine(root, "App.proj");
+            string externalPath = Path.Combine(externalRoot, "payload.txt");
+            string linkedPath = Path.Combine(root, "payload-link.txt");
+            File.WriteAllText(externalPath, "untracked external payload");
+            try
+            {
+                File.CreateSymbolicLink(linkedPath, externalPath);
+            }
+            catch (Exception exception) when (
+                exception is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                return;
+            }
+            string buildDependencies = schedulingMode == "DependsOnTargets"
+                ? " DependsOnTargets=\"ActivateExternalInput\""
+                : string.Empty;
+            string activationSchedule = schedulingMode == "BeforeTargets"
+                ? " BeforeTargets=\"Build\""
+                : string.Empty;
+            File.WriteAllText(
+                projectPath,
+                $"""
+                <Project>
+                  <PropertyGroup><UseExternal>false</UseExternal></PropertyGroup>
+                  <Target Name="ActivateExternalInput"{activationSchedule}>
+                    <PropertyGroup><UseExternal>true</UseExternal></PropertyGroup>
+                  </Target>
+                  <Target Name="Build"{buildDependencies}>
+                    <Copy Condition="'$(UseExternal)' == 'true'"
+                          SourceFiles="payload-link.txt"
+                          DestinationFolder="output" />
+                  </Target>
+                </Project>
+                """);
+
+            Assert.False(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
+                root,
+                [projectPath],
+                [projectPath],
+                evaluatedGlobalProperties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["UseExternal"] = "false"
+                }));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+            DeleteTestRepository(externalRoot);
+        }
+    }
+
+    [Fact]
+    public void ControlledBuildInputs_RejectImportedPrerequisiteTargetActivationOfInactiveCopyInput()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        string externalRoot = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string projectPath = Path.Combine(root, "App.proj");
+            string targetsPath = Path.Combine(root, "BuildHooks.targets");
+            string externalPath = Path.Combine(externalRoot, "payload.txt");
+            string linkedPath = Path.Combine(root, "payload-link.txt");
+            File.WriteAllText(externalPath, "untracked external payload");
+            try
+            {
+                File.CreateSymbolicLink(linkedPath, externalPath);
+            }
+            catch (Exception exception) when (
+                exception is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                return;
+            }
+            File.WriteAllText(
+                targetsPath,
+                """
+                <Project>
+                  <Target Name="ActivateExternalInput" BeforeTargets="Build">
+                    <PropertyGroup><UseExternal>true</UseExternal></PropertyGroup>
+                  </Target>
+                </Project>
+                """);
+            File.WriteAllText(
+                projectPath,
+                """
+                <Project>
+                  <Import Project="BuildHooks.targets" />
+                  <PropertyGroup><UseExternal>false</UseExternal></PropertyGroup>
+                  <Target Name="Build">
+                    <Copy Condition="'$(UseExternal)' == 'true'"
+                          SourceFiles="payload-link.txt"
+                          DestinationFolder="output" />
+                  </Target>
+                </Project>
+                """);
+
+            Assert.False(DotNetPublishPipelineRunner.HasOnlyControlledBuildFileInputs(
+                root,
+                [projectPath, targetsPath],
+                [projectPath, targetsPath],
+                evaluatedGlobalProperties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["UseExternal"] = "false"
+                }));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+            DeleteTestRepository(externalRoot);
+        }
+    }
+
     [Fact]
     public void ControlledBuildInputs_AllowNonFileConditionWithUnevaluatedProperty()
     {

--- a/PowerForge/Models/DotNetPublish/DotNetPublishPlan.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishPlan.cs
@@ -71,6 +71,9 @@ public sealed class DotNetPublishPlan
     /// <summary>Resolved environment variables passed to dotnet commands.</summary>
     public Dictionary<string, string?> EnvironmentVariables { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>Explicit non-secret environment variables admitted to controlled provenance builds.</summary>
+    internal string[] ControlledBuildEnvironmentVariableNames { get; set; } = Array.Empty<string>();
+
     /// <summary>Resolved targets (paths + publish options).</summary>
     public DotNetPublishTargetPlan[] Targets { get; set; } = Array.Empty<DotNetPublishTargetPlan>();
 

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ConditionInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ConditionInputs.cs
@@ -21,7 +21,18 @@ public sealed partial class DotNetPublishPipelineRunner
                          "Condition",
                          StringComparison.OrdinalIgnoreCase)))
         {
+            if (evaluatedGlobalProperties is not null &&
+                conditionAttribute.Parent is not null &&
+                IsDefinitelyInactiveMsBuildElement(
+                    conditionAttribute.Parent,
+                    evaluatedGlobalProperties,
+                    declaringPath))
+            {
+                continue;
+            }
             string condition = DecodeMsBuildEscapes(conditionAttribute.Value);
+            if (!TryReadExistsConditionOperands(condition, out string[] declaredOperands))
+                return false;
             if (!TryExpandControlledTaskInputValues(
                     condition,
                     declaringPath,
@@ -31,11 +42,16 @@ public sealed partial class DotNetPublishPipelineRunner
                     out string[] expandedConditions,
                     consumingElement: conditionAttribute.Parent))
             {
+                // Conditions without an Exists call do not consume file-system state.
+                // Preserve ordinary unevaluated feature conditions, but fail closed when
+                // a declared Exists operand could not be expanded safely.
+                if (declaredOperands.Length == 0)
+                    continue;
                 return false;
             }
             foreach (string expandedCondition in expandedConditions)
             {
-                if (!TryReadExistsConditionOperands(expandedCondition, out string[] operands))
+                if (!TryReadReachableExistsConditionOperands(expandedCondition, out string[] operands))
                     return false;
                 foreach (string operand in operands)
                 {
@@ -48,9 +64,7 @@ public sealed partial class DotNetPublishPipelineRunner
                             out string[] expandedValues,
                             consumingElement: conditionAttribute.Parent) ||
                         expandedValues.Length == 0)
-                    {
                         return false;
-                    }
 
                     foreach (string expandedValue in expandedValues)
                     {
@@ -66,9 +80,7 @@ public sealed partial class DotNetPublishPipelineRunner
                                 declaringAllowedRoot,
                                 taskInputAllowedRoot,
                                 out string inputPath))
-                        {
                             return false;
-                        }
 
                         if (isControlledInput?.Invoke(inputPath) is true)
                             continue;
@@ -77,15 +89,73 @@ public sealed partial class DotNetPublishPipelineRunner
                             : taskInputAllowedRoot;
                         if ((File.Exists(inputPath) || Directory.Exists(inputPath)) &&
                             isControlledInput is not null)
-                        {
                             return false;
-                        }
                         if (HasReparsePointInExistingAncestors(inputPath, allowedRoot))
                             return false;
                     }
                 }
             }
         }
+        return true;
+    }
+
+    private static bool TryReadReachableExistsConditionOperands(
+        string expression,
+        out string[] operands)
+    {
+        var values = new List<string>();
+        bool success = TryReadReachableExistsConditionOperands(expression, values, 0);
+        operands = success ? values.ToArray() : Array.Empty<string>();
+        return success;
+    }
+
+    private static bool TryReadReachableExistsConditionOperands(
+        string expression,
+        ICollection<string> operands,
+        int depth)
+    {
+        if (depth >= 64)
+            return false;
+
+        expression = TrimOuterConditionParentheses(expression.Trim());
+        if (TrySplitTopLevelCondition(expression, "or", out string[] orParts))
+        {
+            foreach (string part in orParts)
+            {
+                if (!TryReadReachableExistsConditionOperands(part, operands, depth + 1))
+                    return false;
+                if (TryEvaluateSimpleMsBuildBooleanExpression(part, out bool value) && value)
+                    break;
+            }
+
+            return true;
+        }
+
+        if (TrySplitTopLevelCondition(expression, "and", out string[] andParts))
+        {
+            foreach (string part in andParts)
+            {
+                if (!TryReadReachableExistsConditionOperands(part, operands, depth + 1))
+                    return false;
+                if (TryEvaluateSimpleMsBuildBooleanExpression(part, out bool value) && !value)
+                    break;
+            }
+
+            return true;
+        }
+
+        if (expression.StartsWith("!", StringComparison.Ordinal))
+        {
+            return TryReadReachableExistsConditionOperands(
+                expression.Substring(1),
+                operands,
+                depth + 1);
+        }
+
+        if (!TryReadExistsConditionOperands(expression, out string[] values))
+            return false;
+        foreach (string value in values)
+            operands.Add(value);
         return true;
     }
 

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ConditionInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ConditionInputs.cs
@@ -26,7 +26,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 IsDefinitelyInactiveControlledBuildOperation(
                     conditionAttribute.Parent,
                     evaluatedGlobalProperties,
-                    declaringPath))
+                    declaringPath,
+                    relatedDocuments.Select(related => related.Document)))
             {
                 continue;
             }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ConditionInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ConditionInputs.cs
@@ -23,7 +23,7 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             if (evaluatedGlobalProperties is not null &&
                 conditionAttribute.Parent is not null &&
-                IsDefinitelyInactiveMsBuildElement(
+                IsDefinitelyInactiveControlledBuildOperation(
                     conditionAttribute.Parent,
                     evaluatedGlobalProperties,
                     declaringPath))

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ControlledCheckout.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ControlledCheckout.cs
@@ -9,6 +9,21 @@ public sealed partial class DotNetPublishPipelineRunner
         out IReadOnlyDictionary<string, string?> controlledEnvironment)
         => TryCreateControlledBuildEnvironment(
             environmentVariables,
+            Array.Empty<string>(),
+            gitRoot,
+            controlledSourceRoot,
+            gitRoot,
+            out controlledEnvironment);
+
+    internal static bool TryCreateControlledBuildEnvironment(
+        IReadOnlyDictionary<string, string?> environmentVariables,
+        IReadOnlyCollection<string> controlledEnvironmentVariableNames,
+        string gitRoot,
+        string controlledSourceRoot,
+        out IReadOnlyDictionary<string, string?> controlledEnvironment)
+        => TryCreateControlledBuildEnvironment(
+            environmentVariables,
+            controlledEnvironmentVariableNames,
             gitRoot,
             controlledSourceRoot,
             gitRoot,
@@ -16,6 +31,7 @@ public sealed partial class DotNetPublishPipelineRunner
 
     private static bool TryCreateControlledBuildEnvironment(
         IReadOnlyDictionary<string, string?> environmentVariables,
+        IReadOnlyCollection<string> controlledEnvironmentVariableNames,
         string gitRoot,
         string controlledSourceRoot,
         string buildInputBaseDirectory,
@@ -47,6 +63,9 @@ public sealed partial class DotNetPublishPipelineRunner
         values["TMP"] = temporaryRoot;
         values["TMPDIR"] = temporaryRoot;
         values["NUGET_PACKAGES"] = packageRoot;
+        var controlledNames = new HashSet<string>(
+            controlledEnvironmentVariableNames,
+            StringComparer.OrdinalIgnoreCase);
         foreach (KeyValuePair<string, string?> variable in environmentVariables)
         {
             if (IsUncontrolledRuntimeInjectionEnvironmentVariable(variable.Key))
@@ -54,9 +73,19 @@ public sealed partial class DotNetPublishPipelineRunner
                 controlledEnvironment = values;
                 return false;
             }
-            // The controlled proof is offline and intentionally does not replay
-            // ordinary plan variables such as private-feed credentials. Values
-            // needed by the proof are assigned below from trusted inputs.
+            if (!controlledNames.Contains(variable.Key) || variable.Value is null)
+                continue;
+            if (!TryRemapControlledBuildValue(
+                    variable.Value,
+                    gitRoot,
+                    controlledSourceRoot,
+                    buildInputBaseDirectory,
+                    out string controlledValue))
+            {
+                controlledEnvironment = values;
+                return false;
+            }
+            values[variable.Key] = controlledValue;
         }
         if (!TryResolveTrustedBuildTool("dotnet", out string dotNetPath))
         {
@@ -230,7 +259,31 @@ public sealed partial class DotNetPublishPipelineRunner
             {
                 continue;
             }
-            string candidate = value.Substring(index).TrimStart('\'', '"');
+            int candidateStart = index;
+            char quote = '\0';
+            if (value[index] == '\'' || value[index] == '"')
+            {
+                quote = value[index];
+                candidateStart++;
+            }
+            else if (index > 0 && (value[index - 1] == '\'' || value[index - 1] == '"'))
+            {
+                quote = value[index - 1];
+            }
+
+            string candidate = value.Substring(candidateStart);
+            if (quote != '\0')
+            {
+                int closingQuote = candidate.IndexOf(quote);
+                if (closingQuote >= 0)
+                    candidate = candidate.Substring(0, closingQuote);
+            }
+            if (candidate.Length == 1 &&
+                (candidate[0] == Path.DirectorySeparatorChar ||
+                 candidate[0] == Path.AltDirectorySeparatorChar))
+            {
+                continue;
+            }
             if (Path.IsPathRooted(candidate))
                 return true;
         }
@@ -445,9 +498,7 @@ public sealed partial class DotNetPublishPipelineRunner
             if (string.IsNullOrWhiteSpace(gitRoot) ||
                 string.IsNullOrWhiteSpace(revision) ||
                 !IsSameOrBelowBuildInputPath(projectPath, gitRoot!))
-            {
                 return false;
-            }
 
             string relativeProjectPath = FrameworkCompatibility.GetRelativePath(
                 Path.GetFullPath(gitRoot!),
@@ -473,9 +524,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 TimeSpan.FromMinutes(2),
                 BuildControlledGitConfiguration(filterNames));
             if (checkout.ExitCode != 0 || checkout.TimedOut || !File.Exists(controlledProjectPath))
-            {
                 return false;
-            }
             if (!TryVerifyControlledGitConfiguration(
                     gitRoot!,
                     revision!,
@@ -484,14 +533,10 @@ public sealed partial class DotNetPublishPipelineRunner
                     checkoutRoot,
                     revision!,
                     filterNames))
-            {
                 return false;
-            }
 
             if (!TryInitializeControlledSubmodules(checkoutRoot, filterNames))
-            {
                 return false;
-            }
 
             var controlledBuildInputs = new HashSet<string>(
                 IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
@@ -529,6 +574,9 @@ public sealed partial class DotNetPublishPipelineRunner
                 if (File.Exists(controlledInput))
                     controlledMsBuildInputs.Add(controlledInput);
             }
+            var controlledPropertyNames = new HashSet<string>(
+                ReadControlledBuildPropertyNames(controlledMsBuildInputs),
+                StringComparer.OrdinalIgnoreCase);
 
             var controlledGlobalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (KeyValuePair<string, string> property in evaluatedGlobalProperties)
@@ -539,9 +587,7 @@ public sealed partial class DotNetPublishPipelineRunner
                         checkoutRoot,
                         projectDirectory,
                         out string controlledValue))
-                {
                     return false;
-                }
                 controlledGlobalProperties[property.Key] = controlledValue;
             }
 
@@ -555,17 +601,13 @@ public sealed partial class DotNetPublishPipelineRunner
             {
                 string fullProjectPath = Path.GetFullPath(project.Key);
                 if (!IsSameOrBelowBuildInputPath(fullProjectPath, gitRoot!))
-                {
                     return false;
-                }
                 string controlledContextProjectPath = Path.GetFullPath(Path.Combine(
                     checkoutRoot,
                     FrameworkCompatibility.GetRelativePath(gitRoot!, fullProjectPath)));
                 if (!IsSameOrBelowBuildInputPath(controlledContextProjectPath, checkoutRoot) ||
                     !controlledMsBuildInputs.Contains(controlledContextProjectPath))
-                {
                     return false;
-                }
 
                 var contexts = new List<IReadOnlyDictionary<string, string>>();
                 foreach (IReadOnlyDictionary<string, string> context in project.Value)
@@ -573,15 +615,15 @@ public sealed partial class DotNetPublishPipelineRunner
                     var controlledContext = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                     foreach (KeyValuePair<string, string> property in context)
                     {
+                        if (!controlledPropertyNames.Contains(property.Key))
+                            continue;
                         if (!TryRemapControlledBuildValue(
                                 property.Value,
                                 gitRoot!,
                                 checkoutRoot,
                                 Path.GetDirectoryName(fullProjectPath)!,
                                 out string controlledValue))
-                        {
                             return false;
-                        }
                         controlledContext[property.Key] = controlledValue;
                     }
                     contexts.Add(controlledContext);
@@ -597,9 +639,7 @@ public sealed partial class DotNetPublishPipelineRunner
                     Path.GetDirectoryName(controlledProjectPath!)!,
                     controlledProjectPath,
                     controlledProjectContexts))
-            {
                 return false;
-            }
 
             string? controlledRevision = ReadGitText(checkoutRoot, "rev-parse HEAD");
             if (!TryVerifyControlledGitConfiguration(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ControlledEvaluationProperties.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ControlledEvaluationProperties.cs
@@ -1,0 +1,34 @@
+namespace PowerForge;
+
+public sealed partial class DotNetPublishPipelineRunner
+{
+    internal static IReadOnlyDictionary<string, string> CreateControlledEvaluationProperties(
+        IReadOnlyDictionary<string, string> effectiveGlobalProperties,
+        IReadOnlyDictionary<string, string> evaluatedProperties,
+        IEnumerable<string> configuredEnvironmentNames,
+        IReadOnlyCollection<string> controlledEnvironmentNames)
+    {
+        var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (KeyValuePair<string, string> property in effectiveGlobalProperties)
+            properties[property.Key] = property.Value;
+        foreach (KeyValuePair<string, string> property in evaluatedProperties)
+            properties[property.Key] = property.Value;
+
+        var controlledNames = new HashSet<string>(
+            controlledEnvironmentNames,
+            StringComparer.OrdinalIgnoreCase);
+        foreach (string environmentName in configuredEnvironmentNames)
+        {
+            if (effectiveGlobalProperties.TryGetValue(environmentName, out string? globalValue))
+            {
+                properties[environmentName] = globalValue;
+            }
+            else if (!controlledNames.Contains(environmentName))
+            {
+                properties.Remove(environmentName);
+            }
+        }
+
+        return properties;
+    }
+}

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ControlledInputFiles.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ControlledInputFiles.cs
@@ -154,11 +154,13 @@ public sealed partial class DotNetPublishPipelineRunner
                 var controlledValues = document.DescendantNodes()
                     .OfType<XText>()
                     .Select(text => (
+                        Node: (XObject)text,
                         Value: text.Value,
                         BaseDirectory: Path.GetDirectoryName(path)!,
                         ProjectReferenceOperation: false,
                         OverwrittenIntermediateProperty: IsControlledIntermediateOutputProperty(text)))
                     .Concat(document.Descendants().Attributes().Select(attribute => (
+                        Node: (XObject)attribute,
                         Value: attribute.Value,
                         BaseDirectory: IsProjectReferenceItemOperationAttribute(attribute)
                             ? normalizedTaskInputBaseDirectory
@@ -180,7 +182,12 @@ public sealed partial class DotNetPublishPipelineRunner
                               checkoutRoot) ||
                           ContainsUncontrolledEnvironmentReference(entry.Value) ||
                           ContainsUncontrolledAmbientPropertyFunction(entry.Value) ||
-                          ContainsUncontrolledFileSystemPropertyFunction(entry.Value)))
+                          ContainsUncontrolledFileSystemPropertyFunction(entry.Value)) ||
+                        IsDefinitelyInactiveControlledBuildValue(
+                            entry.Node,
+                            path,
+                            evaluatedGlobalProperties,
+                            evaluatedProjectContexts))
                     {
                         continue;
                     }
@@ -191,9 +198,7 @@ public sealed partial class DotNetPublishPipelineRunner
             foreach ((XDocument document, string path) in executableDocuments)
             {
                 if (ContainsControlledBuildPropertyEscape(document))
-                {
                     return false;
-                }
                 IReadOnlyDictionary<string, string>[] propertyContexts =
                     evaluatedProjectContexts is not null &&
                     evaluatedProjectContexts.TryGetValue(
@@ -216,9 +221,7 @@ public sealed partial class DotNetPublishPipelineRunner
                             properties,
                             outputProjectPath,
                             readLines: ReadControlledCheckoutTextInput)))
-                {
                     return false;
-                }
             }
 
             return !controlledDocuments.Any(document =>
@@ -231,6 +234,69 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             return false;
         }
+    }
+
+    private static bool IsDefinitelyInactiveControlledBuildValue(
+        XObject node,
+        string declaringPath,
+        IReadOnlyDictionary<string, string>? evaluatedGlobalProperties,
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>[]>? evaluatedProjectContexts)
+    {
+        if (node is not XText text || text.Parent is null)
+            return false;
+
+        XAttribute[] conditions = text.Parent
+            .AncestorsAndSelf()
+            .SelectMany(element => element.Attributes())
+            .Where(attribute => attribute.Name.LocalName.Equals(
+                "Condition",
+                StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (conditions.Length == 0)
+            return false;
+
+        IReadOnlyDictionary<string, string>[] contexts;
+        if (evaluatedProjectContexts is not null &&
+            evaluatedProjectContexts.TryGetValue(
+                Path.GetFullPath(declaringPath),
+                out IReadOnlyDictionary<string, string>[]? projectContexts))
+        {
+            contexts = projectContexts;
+        }
+        else if (evaluatedProjectContexts is not null)
+        {
+            contexts = evaluatedProjectContexts.Values
+                .SelectMany(value => value)
+                .ToArray();
+        }
+        else if (evaluatedGlobalProperties is not null)
+        {
+            contexts = [evaluatedGlobalProperties];
+        }
+        else
+        {
+            return false;
+        }
+
+        if (evaluatedGlobalProperties is not null && evaluatedProjectContexts is not null)
+        {
+            contexts = contexts.Select(context =>
+            {
+                var merged = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (KeyValuePair<string, string> property in evaluatedGlobalProperties)
+                    merged[property.Key] = property.Value;
+                foreach (KeyValuePair<string, string> property in context)
+                    merged[property.Key] = property.Value;
+                return (IReadOnlyDictionary<string, string>)merged;
+            }).ToArray();
+        }
+
+        if (contexts.Length == 0)
+            return false;
+
+        return contexts.All(properties => conditions.Any(condition =>
+            TryEvaluateSimpleMsBuildCondition(condition.Value, properties, out bool active) &&
+            !active));
     }
 
     private static bool IsProjectReferenceItemOperationAttribute(XAttribute attribute)
@@ -366,11 +432,14 @@ public sealed partial class DotNetPublishPipelineRunner
             return true;
         }
 
-        return ContainsUncontrolledImportActivation(reachableDocument) ||
-               ContainsUncontrolledTaskInputPropertyFunction(reachableDocument, reachableDocuments) ||
-               ContainsUncontrolledSdkTaskExecutionOverride(reachableDocument) ||
-               ContainsUncontrolledCompilerOptionOverride(reachableDocument) ||
-               reachableDocument.Descendants().Any(element =>
+        bool importActivation = ContainsUncontrolledImportActivation(reachableDocument);
+        bool taskPropertyFunction = ContainsUncontrolledTaskInputPropertyFunction(
+            reachableDocument,
+            reachableDocuments,
+            evaluatedProperties);
+        bool sdkOverride = ContainsUncontrolledSdkTaskExecutionOverride(reachableDocument);
+        bool compilerOverride = ContainsUncontrolledCompilerOptionOverride(reachableDocument);
+        XElement? uncontrolledElement = reachableDocument.Descendants().FirstOrDefault(element =>
             element.Name.LocalName.Equals("UsingTask", StringComparison.OrdinalIgnoreCase) ||
             (IsControlledBuildTaskElement(element) &&
              (!IsModeledControlledBuildTask(element.Name.LocalName) ||
@@ -386,6 +455,8 @@ public sealed partial class DotNetPublishPipelineRunner
               element.Name.LocalName.Equals("MSBuild", StringComparison.OrdinalIgnoreCase) ||
               element.Name.LocalName.Equals("XmlPeek", StringComparison.OrdinalIgnoreCase) ||
               element.Name.LocalName.Equals("JsonPeek", StringComparison.OrdinalIgnoreCase))));
+        return importActivation || taskPropertyFunction || sdkOverride || compilerOverride ||
+               uncontrolledElement is not null;
     }
 
     private static bool ContainsUncontrolledTaskExecutionOverride(XElement task)
@@ -704,6 +775,7 @@ public sealed partial class DotNetPublishPipelineRunner
             "MSBuildProjectExtensionsPath",
             "IntermediateOutputPath",
             "NuGetLockFilePath",
+            "PowerForgeSdkPackageLockFile",
             "NuGetAudit",
             "RunAnalyzers",
             "RunAnalyzersDuringBuild",

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ControlledPublishItemInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ControlledPublishItemInputs.cs
@@ -34,6 +34,15 @@ public sealed partial class DotNetPublishPipelineRunner
                       ControlledPublishFileItemNames.Contains(element.Name.LocalName)) &&
                      IsControlledBuildTargetItem(element, relatedDocuments)))
         {
+            if (evaluatedGlobalProperties is not null &&
+                IsDefinitelyInactiveMsBuildElement(
+                    item,
+                    evaluatedGlobalProperties,
+                    declaringPath))
+            {
+                continue;
+            }
+
             if (IsAmbientReferenceResolutionItem(item.Name.LocalName))
                 return false;
 

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ControlledPublishItemInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ControlledPublishItemInputs.cs
@@ -38,7 +38,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 IsDefinitelyInactiveControlledBuildOperation(
                     item,
                     evaluatedGlobalProperties,
-                    declaringPath))
+                    declaringPath,
+                    relatedDocuments.Select(related => related.Document)))
             {
                 continue;
             }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ControlledPublishItemInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ControlledPublishItemInputs.cs
@@ -35,7 +35,7 @@ public sealed partial class DotNetPublishPipelineRunner
                      IsControlledBuildTargetItem(element, relatedDocuments)))
         {
             if (evaluatedGlobalProperties is not null &&
-                IsDefinitelyInactiveMsBuildElement(
+                IsDefinitelyInactiveControlledBuildOperation(
                     item,
                     evaluatedGlobalProperties,
                     declaringPath))

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ResourceTaskInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ResourceTaskInputs.cs
@@ -19,7 +19,7 @@ public sealed partial class DotNetPublishPipelineRunner
                      element.Name.LocalName.Equals("GenerateResource", StringComparison.OrdinalIgnoreCase)))
         {
             if (evaluatedGlobalProperties is not null &&
-                IsDefinitelyInactiveMsBuildElement(
+                IsDefinitelyInactiveControlledBuildOperation(
                     task,
                     evaluatedGlobalProperties,
                     declaringPath))

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ResourceTaskInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ResourceTaskInputs.cs
@@ -22,7 +22,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 IsDefinitelyInactiveControlledBuildOperation(
                     task,
                     evaluatedGlobalProperties,
-                    declaringPath))
+                    declaringPath,
+                    relatedDocuments.Select(related => related.Document)))
             {
                 continue;
             }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ResourceTaskInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ResourceTaskInputs.cs
@@ -18,6 +18,15 @@ public sealed partial class DotNetPublishPipelineRunner
                      IsControlledBuildTaskElement(element) &&
                      element.Name.LocalName.Equals("GenerateResource", StringComparison.OrdinalIgnoreCase)))
         {
+            if (evaluatedGlobalProperties is not null &&
+                IsDefinitelyInactiveMsBuildElement(
+                    task,
+                    evaluatedGlobalProperties,
+                    declaringPath))
+            {
+                continue;
+            }
+
             XAttribute? sources = task.Attributes().FirstOrDefault(attribute =>
                 attribute.Name.LocalName.Equals("Sources", StringComparison.OrdinalIgnoreCase));
             if (sources is null || string.IsNullOrWhiteSpace(sources.Value))

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TargetTimeConditions.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TargetTimeConditions.cs
@@ -8,7 +8,8 @@ public sealed partial class DotNetPublishPipelineRunner
     private static bool IsDefinitelyInactiveControlledBuildOperation(
         XElement element,
         IReadOnlyDictionary<string, string> evaluatedProperties,
-        string? definingProjectPath)
+        string? definingProjectPath,
+        IEnumerable<XDocument>? relatedDocuments = null)
     {
         if (!IsDefinitelyInactiveMsBuildElement(element, evaluatedProperties, definingProjectPath))
             return false;
@@ -27,8 +28,22 @@ public sealed partial class DotNetPublishPipelineRunner
         if (conditionProperties.Count == 0)
             return true;
 
+        IEnumerable<XElement> precedingTargetElements = target.Descendants()
+            .TakeWhile(candidate => !ReferenceEquals(candidate, element));
+        IEnumerable<XDocument> assignmentDocuments = relatedDocuments ?? Enumerable.Empty<XDocument>();
+        if (target.Document is not null)
+            assignmentDocuments = assignmentDocuments.Prepend(target.Document);
+        IEnumerable<XElement> otherTargetElements = assignmentDocuments
+            .SelectMany(document => document.Descendants())
+            .Where(candidate =>
+            {
+                XElement? candidateTarget = candidate.AncestorsAndSelf().FirstOrDefault(ancestor =>
+                    ancestor.Name.LocalName.Equals("Target", StringComparison.OrdinalIgnoreCase));
+                return candidateTarget is not null && !ReferenceEquals(candidateTarget, target);
+            });
+
         return !CanAssignTargetTimeConditionProperty(
-            target.Descendants().TakeWhile(candidate => !ReferenceEquals(candidate, element)),
+            precedingTargetElements.Concat(otherTargetElements),
             conditionProperties);
     }
 
@@ -66,10 +81,10 @@ public sealed partial class DotNetPublishPipelineRunner
     }
 
     private static bool CanAssignTargetTimeConditionProperty(
-        IEnumerable<XElement> precedingElements,
+        IEnumerable<XElement> candidateElements,
         ISet<string> conditionProperties)
     {
-        foreach (XElement element in precedingElements)
+        foreach (XElement element in candidateElements)
         {
             if (element.Parent?.Name.LocalName.Equals(
                     "PropertyGroup",

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TargetTimeConditions.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TargetTimeConditions.cs
@@ -1,0 +1,101 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace PowerForge;
+
+public sealed partial class DotNetPublishPipelineRunner
+{
+    private static bool IsDefinitelyInactiveControlledBuildOperation(
+        XElement element,
+        IReadOnlyDictionary<string, string> evaluatedProperties,
+        string? definingProjectPath)
+    {
+        if (!IsDefinitelyInactiveMsBuildElement(element, evaluatedProperties, definingProjectPath))
+            return false;
+
+        XElement? target = element.AncestorsAndSelf().FirstOrDefault(candidate =>
+            candidate.Name.LocalName.Equals("Target", StringComparison.OrdinalIgnoreCase));
+        if (target is null ||
+            IsDefinitelyInactiveMsBuildElement(target, evaluatedProperties, definingProjectPath))
+        {
+            return true;
+        }
+
+        HashSet<string> conditionProperties = ReadControlledBuildConditionPropertyNames(
+            element,
+            target);
+        if (conditionProperties.Count == 0)
+            return true;
+
+        return !CanAssignTargetTimeConditionProperty(
+            target.Descendants().TakeWhile(candidate => !ReferenceEquals(candidate, element)),
+            conditionProperties);
+    }
+
+    private static HashSet<string> ReadControlledBuildConditionPropertyNames(
+        XElement element,
+        XElement target)
+    {
+        var propertyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        IEnumerable<string> conditions = element.AncestorsAndSelf()
+            .TakeWhile(candidate => !ReferenceEquals(candidate, target))
+            .Select(candidate => candidate.Attribute("Condition")?.Value)
+            .Where(value => !string.IsNullOrWhiteSpace(value))!;
+        IEnumerable<string> precedingWhenConditions = element.AncestorsAndSelf()
+            .TakeWhile(candidate => !ReferenceEquals(candidate, target))
+            .Where(candidate =>
+                candidate.Name.LocalName.Equals("When", StringComparison.OrdinalIgnoreCase) ||
+                candidate.Name.LocalName.Equals("Otherwise", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(branch => branch.ElementsBeforeSelf())
+            .Where(candidate => candidate.Name.LocalName.Equals("When", StringComparison.OrdinalIgnoreCase))
+            .Select(candidate => candidate.Attribute("Condition")?.Value)
+            .Where(value => !string.IsNullOrWhiteSpace(value))!;
+
+        foreach (string condition in conditions.Concat(precedingWhenConditions))
+        {
+            foreach (Match match in Regex.Matches(
+                         condition,
+                         @"\$\(([A-Za-z_][A-Za-z0-9_.-]*)\)",
+                         RegexOptions.CultureInvariant))
+            {
+                propertyNames.Add(match.Groups[1].Value);
+            }
+        }
+
+        return propertyNames;
+    }
+
+    private static bool CanAssignTargetTimeConditionProperty(
+        IEnumerable<XElement> precedingElements,
+        ISet<string> conditionProperties)
+    {
+        foreach (XElement element in precedingElements)
+        {
+            if (element.Parent?.Name.LocalName.Equals(
+                    "PropertyGroup",
+                    StringComparison.OrdinalIgnoreCase) == true &&
+                conditionProperties.Contains(element.Name.LocalName))
+            {
+                return true;
+            }
+
+            if (!element.Name.LocalName.Equals("Output", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            string? propertyName = element.Attributes()
+                .FirstOrDefault(attribute => attribute.Name.LocalName.Equals(
+                    "PropertyName",
+                    StringComparison.OrdinalIgnoreCase))?
+                .Value;
+            if (string.IsNullOrWhiteSpace(propertyName))
+                continue;
+            if (ContainsUnresolvedBuildExpression(propertyName!) ||
+                conditionProperties.Contains(DecodeMsBuildEscapes(propertyName!).Trim()))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TargetTimeConditions.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TargetTimeConditions.cs
@@ -16,15 +16,18 @@ public sealed partial class DotNetPublishPipelineRunner
 
         XElement? target = element.AncestorsAndSelf().FirstOrDefault(candidate =>
             candidate.Name.LocalName.Equals("Target", StringComparison.OrdinalIgnoreCase));
-        if (target is null ||
-            IsDefinitelyInactiveMsBuildElement(target, evaluatedProperties, definingProjectPath))
-        {
+        if (target is null)
             return true;
-        }
+
+        bool targetIsDefinitelyInactive = IsDefinitelyInactiveMsBuildElement(
+            target,
+            evaluatedProperties,
+            definingProjectPath);
 
         HashSet<string> conditionProperties = ReadControlledBuildConditionPropertyNames(
             element,
-            target);
+            target,
+            includeTargetCondition: targetIsDefinitelyInactive);
         if (conditionProperties.Count == 0)
             return true;
 
@@ -49,13 +52,16 @@ public sealed partial class DotNetPublishPipelineRunner
 
     private static HashSet<string> ReadControlledBuildConditionPropertyNames(
         XElement element,
-        XElement target)
+        XElement target,
+        bool includeTargetCondition)
     {
         var propertyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         IEnumerable<string> conditions = element.AncestorsAndSelf()
             .TakeWhile(candidate => !ReferenceEquals(candidate, target))
             .Select(candidate => candidate.Attribute("Condition")?.Value)
             .Where(value => !string.IsNullOrWhiteSpace(value))!;
+        if (includeTargetCondition && !string.IsNullOrWhiteSpace(target.Attribute("Condition")?.Value))
+            conditions = conditions.Prepend(target.Attribute("Condition")!.Value);
         IEnumerable<string> precedingWhenConditions = element.AncestorsAndSelf()
             .TakeWhile(candidate => !ReferenceEquals(candidate, target))
             .Where(candidate =>

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskInputs.cs
@@ -52,7 +52,8 @@ public sealed partial class DotNetPublishPipelineRunner
 
     private static bool ContainsUncontrolledTaskInputPropertyFunction(
         XDocument document,
-        IReadOnlyCollection<XDocument> relatedDocuments)
+        IReadOnlyCollection<XDocument> relatedDocuments,
+        IReadOnlyDictionary<string, string> evaluatedProperties)
     {
         if (relatedDocuments
             .SelectMany(related => related.Descendants())
@@ -61,18 +62,20 @@ public sealed partial class DotNetPublishPipelineRunner
                 element.Parent.Name.LocalName.Equals("PropertyGroup", StringComparison.OrdinalIgnoreCase) &&
                 ControlledSdkEnvironmentProperties.Contains(element.Name.LocalName))
             .Any(element => ContainsUncontrolledEnvironmentAssignments(element.Value)))
-        {
             return true;
-        }
 
         IEnumerable<string> taskInputs = document.Descendants()
-            .Where(IsControlledBuildTaskElement)
+            .Where(element =>
+                IsControlledBuildTaskElement(element) &&
+                !IsDefinitelyInactiveMsBuildElement(element, evaluatedProperties))
             .SelectMany(element => element.Attributes())
             .Where(attribute =>
                 !attribute.Name.LocalName.Equals("ContinueOnError", StringComparison.OrdinalIgnoreCase))
             .Select(attribute => attribute.Value);
         IEnumerable<string> conditions = document.Descendants()
-            .Where(IsControlledBuildTaskElement)
+            .Where(element =>
+                IsControlledBuildTaskElement(element) &&
+                !IsDefinitelyInactiveMsBuildElement(element, evaluatedProperties))
             .SelectMany(task => task.AncestorsAndSelf())
             .SelectMany(element => element.Attributes())
             .Where(attribute => attribute.Name.LocalName.Equals(
@@ -102,9 +105,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 decodedExpression.IndexOf("$($(", StringComparison.Ordinal) >= 0 ||
                 decodedExpression.IndexOf("@($(", StringComparison.Ordinal) >= 0 ||
                 decodedExpression.IndexOf("%($(", StringComparison.Ordinal) >= 0)
-            {
                 return true;
-            }
 
             foreach (Match match in Regex.Matches(
                          expression,
@@ -112,7 +113,11 @@ public sealed partial class DotNetPublishPipelineRunner
                          RegexOptions.CultureInvariant))
             {
                 string propertyName = match.Groups[1].Value;
-                if (HasTaskOutputAssignment(relatedDocuments, "PropertyName", propertyName))
+                if (HasTaskOutputAssignment(
+                        relatedDocuments,
+                        "PropertyName",
+                        propertyName,
+                        evaluatedProperties))
                     return true;
                 foreach (XElement property in relatedDocuments
                              .SelectMany(related => related.Descendants())
@@ -133,7 +138,11 @@ public sealed partial class DotNetPublishPipelineRunner
                          RegexOptions.CultureInvariant))
             {
                 string itemName = match.Groups[1].Value;
-                if (HasTaskOutputAssignment(relatedDocuments, "ItemName", itemName))
+                if (HasTaskOutputAssignment(
+                        relatedDocuments,
+                        "ItemName",
+                        itemName,
+                        evaluatedProperties))
                     return true;
                 foreach (XElement item in relatedDocuments
                              .SelectMany(related => related.Descendants())
@@ -177,7 +186,8 @@ public sealed partial class DotNetPublishPipelineRunner
     private static bool HasTaskOutputAssignment(
         IReadOnlyCollection<XDocument> relatedDocuments,
         string assignmentAttributeName,
-        string referencedName)
+        string referencedName,
+        IReadOnlyDictionary<string, string> evaluatedProperties)
     {
         foreach (XElement output in relatedDocuments
                      .SelectMany(related => related.Descendants())
@@ -185,6 +195,7 @@ public sealed partial class DotNetPublishPipelineRunner
                          element.Name.LocalName.Equals("Output", StringComparison.OrdinalIgnoreCase) &&
                          element.Parent is not null &&
                          IsControlledBuildTaskElement(element.Parent) &&
+                         !IsDefinitelyInactiveMsBuildElement(element.Parent, evaluatedProperties) &&
                          !element.Parent.Name.LocalName.Equals(
                              "ReadLinesFromFile",
                              StringComparison.OrdinalIgnoreCase)))

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskInputs.cs
@@ -70,7 +70,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 !IsDefinitelyInactiveControlledBuildOperation(
                     element,
                     evaluatedProperties,
-                    definingProjectPath: null))
+                    definingProjectPath: null,
+                    relatedDocuments))
             .SelectMany(element => element.Attributes())
             .Where(attribute =>
                 !attribute.Name.LocalName.Equals("ContinueOnError", StringComparison.OrdinalIgnoreCase))
@@ -81,7 +82,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 !IsDefinitelyInactiveControlledBuildOperation(
                     element,
                     evaluatedProperties,
-                    definingProjectPath: null))
+                    definingProjectPath: null,
+                    relatedDocuments))
             .SelectMany(task => task.AncestorsAndSelf())
             .SelectMany(element => element.Attributes())
             .Where(attribute => attribute.Name.LocalName.Equals(
@@ -204,7 +206,8 @@ public sealed partial class DotNetPublishPipelineRunner
                          !IsDefinitelyInactiveControlledBuildOperation(
                              element.Parent,
                              evaluatedProperties,
-                             definingProjectPath: null) &&
+                             definingProjectPath: null,
+                             relatedDocuments) &&
                          !element.Parent.Name.LocalName.Equals(
                              "ReadLinesFromFile",
                              StringComparison.OrdinalIgnoreCase)))

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskInputs.cs
@@ -67,7 +67,10 @@ public sealed partial class DotNetPublishPipelineRunner
         IEnumerable<string> taskInputs = document.Descendants()
             .Where(element =>
                 IsControlledBuildTaskElement(element) &&
-                !IsDefinitelyInactiveMsBuildElement(element, evaluatedProperties))
+                !IsDefinitelyInactiveControlledBuildOperation(
+                    element,
+                    evaluatedProperties,
+                    definingProjectPath: null))
             .SelectMany(element => element.Attributes())
             .Where(attribute =>
                 !attribute.Name.LocalName.Equals("ContinueOnError", StringComparison.OrdinalIgnoreCase))
@@ -75,7 +78,10 @@ public sealed partial class DotNetPublishPipelineRunner
         IEnumerable<string> conditions = document.Descendants()
             .Where(element =>
                 IsControlledBuildTaskElement(element) &&
-                !IsDefinitelyInactiveMsBuildElement(element, evaluatedProperties))
+                !IsDefinitelyInactiveControlledBuildOperation(
+                    element,
+                    evaluatedProperties,
+                    definingProjectPath: null))
             .SelectMany(task => task.AncestorsAndSelf())
             .SelectMany(element => element.Attributes())
             .Where(attribute => attribute.Name.LocalName.Equals(
@@ -195,7 +201,10 @@ public sealed partial class DotNetPublishPipelineRunner
                          element.Name.LocalName.Equals("Output", StringComparison.OrdinalIgnoreCase) &&
                          element.Parent is not null &&
                          IsControlledBuildTaskElement(element.Parent) &&
-                         !IsDefinitelyInactiveMsBuildElement(element.Parent, evaluatedProperties) &&
+                         !IsDefinitelyInactiveControlledBuildOperation(
+                             element.Parent,
+                             evaluatedProperties,
+                             definingProjectPath: null) &&
                          !element.Parent.Name.LocalName.Equals(
                              "ReadLinesFromFile",
                              StringComparison.OrdinalIgnoreCase)))

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskLoadedFileInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskLoadedFileInputs.cs
@@ -20,7 +20,7 @@ public sealed partial class DotNetPublishPipelineRunner
                          ancestor.Name.LocalName.Equals("Target", StringComparison.OrdinalIgnoreCase))))
         {
             if (evaluatedGlobalProperties is not null &&
-                IsDefinitelyInactiveMsBuildElement(
+                IsDefinitelyInactiveControlledBuildOperation(
                     task,
                     evaluatedGlobalProperties,
                     declaringPath))

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskLoadedFileInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskLoadedFileInputs.cs
@@ -23,7 +23,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 IsDefinitelyInactiveControlledBuildOperation(
                     task,
                     evaluatedGlobalProperties,
-                    declaringPath))
+                    declaringPath,
+                    relatedDocuments.Select(related => related.Document)))
             {
                 continue;
             }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskLoadedFileInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskLoadedFileInputs.cs
@@ -19,6 +19,15 @@ public sealed partial class DotNetPublishPipelineRunner
                      element.Ancestors().Any(ancestor =>
                          ancestor.Name.LocalName.Equals("Target", StringComparison.OrdinalIgnoreCase))))
         {
+            if (evaluatedGlobalProperties is not null &&
+                IsDefinitelyInactiveMsBuildElement(
+                    task,
+                    evaluatedGlobalProperties,
+                    declaringPath))
+            {
+                continue;
+            }
+
             string? fileValue = task.Attributes()
                 .FirstOrDefault(attribute => attribute.Name.LocalName.Equals(
                     "File",

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskLoadedInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskLoadedInputs.cs
@@ -77,7 +77,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 IsDefinitelyInactiveControlledBuildOperation(
                     task,
                     evaluatedGlobalProperties,
-                    declaringPath))
+                    declaringPath,
+                    relatedDocuments.Select(related => related.Document)))
             {
                 continue;
             }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskLoadedInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskLoadedInputs.cs
@@ -73,6 +73,15 @@ public sealed partial class DotNetPublishPipelineRunner
     {
         foreach (XElement task in document.Descendants().Where(IsControlledBuildTaskElement))
         {
+            if (evaluatedGlobalProperties is not null &&
+                IsDefinitelyInactiveMsBuildElement(
+                    task,
+                    evaluatedGlobalProperties,
+                    declaringPath))
+            {
+                continue;
+            }
+
             if (!ControlledTaskFileInputAttributes.TryGetValue(
                     task.Name.LocalName,
                     out string[]? inputAttributes))

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskLoadedInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskLoadedInputs.cs
@@ -74,7 +74,7 @@ public sealed partial class DotNetPublishPipelineRunner
         foreach (XElement task in document.Descendants().Where(IsControlledBuildTaskElement))
         {
             if (evaluatedGlobalProperties is not null &&
-                IsDefinitelyInactiveMsBuildElement(
+                IsDefinitelyInactiveControlledBuildOperation(
                     task,
                     evaluatedGlobalProperties,
                     declaringPath))

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskOutputValidation.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskOutputValidation.cs
@@ -17,7 +17,7 @@ public sealed partial class DotNetPublishPipelineRunner
         foreach (XElement task in document.Descendants().Where(IsControlledBuildTaskElement))
         {
             if (evaluatedGlobalProperties is not null &&
-                IsDefinitelyInactiveMsBuildElement(
+                IsDefinitelyInactiveControlledBuildOperation(
                     task,
                     evaluatedGlobalProperties,
                     declaringPath))

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskOutputValidation.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskOutputValidation.cs
@@ -16,6 +16,15 @@ public sealed partial class DotNetPublishPipelineRunner
     {
         foreach (XElement task in document.Descendants().Where(IsControlledBuildTaskElement))
         {
+            if (evaluatedGlobalProperties is not null &&
+                IsDefinitelyInactiveMsBuildElement(
+                    task,
+                    evaluatedGlobalProperties,
+                    declaringPath))
+            {
+                continue;
+            }
+
             if (!ControlledTaskFileOutputAttributes.TryGetValue(
                     task.Name.LocalName,
                     out string[]? outputAttributes))

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskOutputValidation.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.TaskOutputValidation.cs
@@ -20,7 +20,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 IsDefinitelyInactiveControlledBuildOperation(
                     task,
                     evaluatedGlobalProperties,
-                    declaringPath))
+                    declaringPath,
+                    relatedDocuments.Select(related => related.Document)))
             {
                 continue;
             }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
@@ -172,12 +172,8 @@ public sealed partial class DotNetPublishPipelineRunner
             Directory.CreateDirectory(controlledOutputRoot);
             IReadOnlyDictionary<string, string> effectiveGlobalProperties =
                 request.ReadEffectiveGlobalProperties();
-            var controlledEvaluationProperties = new Dictionary<string, string>(
-                StringComparer.OrdinalIgnoreCase);
-            foreach (KeyValuePair<string, string> property in effectiveGlobalProperties)
-                controlledEvaluationProperties[property.Key] = property.Value;
-            foreach (KeyValuePair<string, string> property in evaluatedProperties)
-                controlledEvaluationProperties[property.Key] = property.Value;
+            IReadOnlyDictionary<string, string> controlledEvaluationProperties =
+                request.BuildControlledEvaluationProperties(evaluatedProperties);
             if (!TryCreateControlledSourceCheckout(
                     request.ProjectPath,
                     controlledSourceRoot,
@@ -713,6 +709,14 @@ public sealed partial class DotNetPublishPipelineRunner
                 properties["TargetFramework"] = TargetFramework!;
             return properties;
         }
+
+        internal IReadOnlyDictionary<string, string> BuildControlledEvaluationProperties(
+            IReadOnlyDictionary<string, string> evaluatedProperties)
+            => CreateControlledEvaluationProperties(
+                ReadEffectiveGlobalProperties(),
+                evaluatedProperties,
+                EnvironmentVariables.Keys,
+                ControlledBuildEnvironmentVariableNames);
 
         internal ProjectEvaluationRequest ForProject(string projectPath, string? targetFramework)
             => new(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Xml.Linq;
 
@@ -128,6 +130,7 @@ public sealed partial class DotNetPublishPipelineRunner
         IReadOnlyCollection<string> candidatePaths,
         IReadOnlyCollection<string> evaluatedBuildInputs,
         IReadOnlyCollection<string> evaluatedMsBuildInputs,
+        IReadOnlyDictionary<string, string> evaluatedProperties,
         string? evaluatedPathMap,
         VerifiedPackageInputCatalog? verifiedPackages,
         IDictionary<string, bool> cache)
@@ -173,7 +176,11 @@ public sealed partial class DotNetPublishPipelineRunner
                     evaluatedBuildInputs,
                     evaluatedMsBuildInputs,
                     request.ReadEffectiveGlobalProperties(),
-                    evaluatedProjectContexts: null,
+                    new Dictionary<string, IReadOnlyDictionary<string, string>[]>(
+                        IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
+                    {
+                        [Path.GetFullPath(request.ProjectPath)] = [evaluatedProperties]
+                    },
                     out controlledGitRoot,
                     out string? controlledProjectPath))
             {
@@ -181,6 +188,7 @@ public sealed partial class DotNetPublishPipelineRunner
             }
             if (!TryCreateControlledBuildEnvironment(
                     request.EnvironmentVariables,
+                    request.ControlledBuildEnvironmentVariableNames,
                     controlledGitRoot!,
                     controlledSourceRoot,
                     Path.GetDirectoryName(request.ProjectPath)!,
@@ -374,6 +382,8 @@ public sealed partial class DotNetPublishPipelineRunner
         string lockFilePath)
     {
         arguments.Add("-noAutoResponse");
+        arguments.Add("-maxCpuCount:1");
+        arguments.Add("-nodeReuse:false");
         arguments.Add("-p:RestoreConfigFile=" + EscapeMsBuildPropertyValue(nuGetConfig));
         arguments.Add("-p:RestoreSources=" + EscapeMsBuildPropertyValue(packageSource));
         arguments.Add("-p:RestoreAdditionalProjectSources=");
@@ -660,13 +670,20 @@ public sealed partial class DotNetPublishPipelineRunner
             string? targetFramework,
             string? configuration,
             IReadOnlyDictionary<string, string>? globalProperties,
-            IReadOnlyDictionary<string, string?>? environmentVariables)
+            IReadOnlyDictionary<string, string?>? environmentVariables,
+            IReadOnlyCollection<string>? controlledBuildEnvironmentVariableNames = null)
         {
             ProjectPath = projectPath;
             TargetFramework = targetFramework;
             Configuration = configuration;
             GlobalProperties = globalProperties ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             EnvironmentVariables = environmentVariables ?? new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            ControlledBuildEnvironmentVariableNames = controlledBuildEnvironmentVariableNames?
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Select(name => name.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+                .ToArray() ?? Array.Empty<string>();
         }
 
         internal string ProjectPath { get; }
@@ -675,6 +692,7 @@ public sealed partial class DotNetPublishPipelineRunner
         internal string? Configuration { get; }
         internal IReadOnlyDictionary<string, string> GlobalProperties { get; }
         internal IReadOnlyDictionary<string, string?> EnvironmentVariables { get; }
+        internal IReadOnlyCollection<string> ControlledBuildEnvironmentVariableNames { get; }
 
         internal IReadOnlyDictionary<string, string> ReadEffectiveGlobalProperties()
         {
@@ -694,7 +712,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 targetFramework,
                 Configuration,
                 GlobalProperties,
-                EnvironmentVariables);
+                EnvironmentVariables,
+                ControlledBuildEnvironmentVariableNames);
 
         internal ProjectEvaluationRequest ForProject(EvaluatedProjectReference projectReference)
         {
@@ -727,7 +746,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 targetFramework,
                 configuration,
                 properties,
-                EnvironmentVariables);
+                EnvironmentVariables,
+                ControlledBuildEnvironmentVariableNames);
         }
 
         internal string BuildVisitKey()
@@ -747,7 +767,7 @@ public sealed partial class DotNetPublishPipelineRunner
             {
                 AppendProjectReferenceKeySegment(key, "Property");
                 AppendProjectReferenceKeySegment(key, NormalizeMsBuildPropertyIdentityName(property.Key));
-                AppendProjectReferenceKeySegment(key, property.Value);
+                AppendProjectReferenceKeySegment(key, HashProjectEvaluationIdentityValue(property.Value));
             }
             foreach (KeyValuePair<string, string?> environmentVariable in EnvironmentVariables.OrderBy(
                          entry => entry.Key,
@@ -755,10 +775,24 @@ public sealed partial class DotNetPublishPipelineRunner
             {
                 AppendProjectReferenceKeySegment(key, "Environment");
                 AppendProjectReferenceKeySegment(key, NormalizeEnvironmentIdentityName(environmentVariable.Key));
-                AppendProjectReferenceKeySegment(key, environmentVariable.Value ?? string.Empty);
+                AppendProjectReferenceKeySegment(
+                    key,
+                    HashProjectEvaluationIdentityValue(environmentVariable.Value ?? string.Empty));
+            }
+            foreach (string name in ControlledBuildEnvironmentVariableNames)
+            {
+                AppendProjectReferenceKeySegment(key, "ControlledEnvironment");
+                AppendProjectReferenceKeySegment(key, NormalizeEnvironmentIdentityName(name));
             }
             return key.ToString();
         }
+    }
+
+    internal static string HashProjectEvaluationIdentityValue(string value)
+    {
+        using SHA256 sha256 = SHA256.Create();
+        return BitConverter.ToString(sha256.ComputeHash(Encoding.UTF8.GetBytes(value)))
+            .Replace("-", string.Empty);
     }
 
     private sealed class EvaluatedProjectInputs
@@ -778,6 +812,7 @@ public sealed partial class DotNetPublishPipelineRunner
             EvaluatedPublishInput[] publishInputs,
             VerifiedPackageInputCatalog? verifiedPackages,
             string[] trustedBuildInfrastructureRoots,
+            IReadOnlyDictionary<string, string> evaluatedProperties,
             string? customAfterMicrosoftCommonTargets)
         {
             BuildInputs = buildInputs;
@@ -794,6 +829,7 @@ public sealed partial class DotNetPublishPipelineRunner
             PublishInputs = publishInputs;
             VerifiedPackages = verifiedPackages;
             TrustedBuildInfrastructureRoots = trustedBuildInfrastructureRoots;
+            EvaluatedProperties = evaluatedProperties;
             CustomAfterMicrosoftCommonTargets = customAfterMicrosoftCommonTargets;
         }
 
@@ -811,6 +847,7 @@ public sealed partial class DotNetPublishPipelineRunner
         internal EvaluatedPublishInput[] PublishInputs { get; }
         internal VerifiedPackageInputCatalog? VerifiedPackages { get; }
         internal string[] TrustedBuildInfrastructureRoots { get; }
+        internal IReadOnlyDictionary<string, string> EvaluatedProperties { get; }
         internal string? CustomAfterMicrosoftCommonTargets { get; }
     }
 

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
@@ -170,16 +170,24 @@ public sealed partial class DotNetPublishPipelineRunner
             if (fullCandidatePaths.Any(path => !File.Exists(path)))
                 return CacheAll(false);
             Directory.CreateDirectory(controlledOutputRoot);
+            IReadOnlyDictionary<string, string> effectiveGlobalProperties =
+                request.ReadEffectiveGlobalProperties();
+            var controlledEvaluationProperties = new Dictionary<string, string>(
+                StringComparer.OrdinalIgnoreCase);
+            foreach (KeyValuePair<string, string> property in effectiveGlobalProperties)
+                controlledEvaluationProperties[property.Key] = property.Value;
+            foreach (KeyValuePair<string, string> property in evaluatedProperties)
+                controlledEvaluationProperties[property.Key] = property.Value;
             if (!TryCreateControlledSourceCheckout(
                     request.ProjectPath,
                     controlledSourceRoot,
                     evaluatedBuildInputs,
                     evaluatedMsBuildInputs,
-                    request.ReadEffectiveGlobalProperties(),
+                    effectiveGlobalProperties,
                     new Dictionary<string, IReadOnlyDictionary<string, string>[]>(
                         IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
                     {
-                        [Path.GetFullPath(request.ProjectPath)] = [evaluatedProperties]
+                        [Path.GetFullPath(request.ProjectPath)] = [controlledEvaluationProperties]
                     },
                     out controlledGitRoot,
                     out string? controlledProjectPath))

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ControlledProjectReferences.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ControlledProjectReferences.cs
@@ -31,7 +31,60 @@ public sealed partial class DotNetPublishPipelineRunner
         try
         {
             Directory.CreateDirectory(controlledOutputRoot);
-            IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>[]> projectContexts =
+            string? contextGitRoot = ReadGitText(
+                Path.GetDirectoryName(request.ProjectPath)!,
+                "rev-parse --show-toplevel");
+            if (string.IsNullOrWhiteSpace(contextGitRoot))
+                return false;
+            string? trackedInputList = ReadGitRawText(contextGitRoot!, "ls-files -z");
+            if (trackedInputList is null)
+                return false;
+            var trackedInputPaths = new HashSet<string>(
+                trackedInputList.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(path => path.Replace('\\', '/').TrimStart('/')),
+                IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+            string[] controlledConditionPropertyNames = ReadControlledBuildPropertyNames(
+                executableMsBuildInputs
+                    .Where(path =>
+                    {
+                        string? relativePath = ToGitRelativeExclusion(
+                            contextGitRoot!,
+                            contextGitRoot!,
+                            path);
+                        return relativePath is not null &&
+                               trackedInputPaths.Contains(relativePath.Replace('\\', '/'));
+                    })
+                    .Append(request.ProjectPath));
+            var controlledConditionPropertyNameSet = new HashSet<string>(
+                controlledConditionPropertyNames,
+                StringComparer.OrdinalIgnoreCase);
+            IReadOnlyDictionary<string, string> BuildProjectContext(
+                ProjectEvaluationRequest contextRequest,
+                IReadOnlyDictionary<string, string>? knownEvaluatedProperties = null)
+            {
+                var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (KeyValuePair<string, string> property in contextRequest.ReadEffectiveGlobalProperties())
+                {
+                    if (controlledConditionPropertyNameSet.Contains(property.Key))
+                        properties[property.Key] = property.Value;
+                }
+                foreach (KeyValuePair<string, string> property in knownEvaluatedProperties ??
+                         ReadEvaluatedProjectProperties(
+                             contextRequest,
+                             controlledConditionPropertyNames))
+                {
+                    if (controlledConditionPropertyNameSet.Contains(property.Key))
+                        properties[property.Key] = property.Value;
+                }
+                if (!properties.ContainsKey("TargetFramework") &&
+                    contextRequest.HasExplicitTargetFramework)
+                {
+                    properties["TargetFramework"] = contextRequest.TargetFramework!;
+                }
+                return properties;
+            }
+
+            Dictionary<string, IReadOnlyDictionary<string, string>[]> projectContexts =
                 evaluatedProjectReferences
                     .Where(reference => File.Exists(reference.ProjectPath))
                     .GroupBy(
@@ -42,18 +95,8 @@ public sealed partial class DotNetPublishPipelineRunner
                         group => group
                             .Select(reference =>
                             {
-                                var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                                foreach (KeyValuePair<string, string> property in
-                                         request.ForProject(reference).ReadEffectiveGlobalProperties())
-                                {
-                                    properties[property.Key] = property.Value;
-                                }
-                                if (!properties.ContainsKey("TargetFramework") &&
-                                    request.HasExplicitTargetFramework)
-                                {
-                                    properties["TargetFramework"] = request.TargetFramework!;
-                                }
-                                return (IReadOnlyDictionary<string, string>)properties;
+                                ProjectEvaluationRequest contextRequest = request.ForProject(reference);
+                                return BuildProjectContext(contextRequest);
                             })
                             .GroupBy(
                                 properties => string.Join("\n", properties.OrderBy(
@@ -64,6 +107,24 @@ public sealed partial class DotNetPublishPipelineRunner
                             .Select(context => (IReadOnlyDictionary<string, string>)context.First())
                             .ToArray(),
                         IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+            string rootProjectPath = Path.GetFullPath(request.ProjectPath);
+            IReadOnlyDictionary<string, string> rootContext = BuildProjectContext(
+                request,
+                evaluatedConditionProperties);
+            projectContexts[rootProjectPath] = projectContexts.TryGetValue(
+                    rootProjectPath,
+                    out IReadOnlyDictionary<string, string>[]? existingRootContexts)
+                ? existingRootContexts
+                    .Append(rootContext)
+                    .GroupBy(
+                        properties => string.Join("\n", properties.OrderBy(
+                            property => property.Key,
+                            StringComparer.OrdinalIgnoreCase).Select(property =>
+                                property.Key + "=" + property.Value)),
+                        StringComparer.Ordinal)
+                    .Select(context => (IReadOnlyDictionary<string, string>)context.First())
+                    .ToArray()
+                : [rootContext];
             if (!TryCreateControlledSourceCheckout(
                     request.ProjectPath,
                     controlledSourceRoot,
@@ -73,11 +134,10 @@ public sealed partial class DotNetPublishPipelineRunner
                     projectContexts,
                     out originalGitRoot,
                     out string? controlledProjectPath))
-            {
                 return false;
-            }
             if (!TryCreateControlledBuildEnvironment(
                     request.EnvironmentVariables,
+                    request.ControlledBuildEnvironmentVariableNames,
                     originalGitRoot!,
                     controlledSourceRoot,
                     Path.GetDirectoryName(request.ProjectPath)!,
@@ -183,8 +243,6 @@ public sealed partial class DotNetPublishPipelineRunner
                 "msbuild",
                 controlledProjectPath!,
                 "-nologo",
-                "-maxCpuCount:1",
-                "-nodeReuse:false",
                 "-verbosity:quiet",
                 "-restore",
                 "-target:ResolveReferences",
@@ -234,9 +292,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 controlledEnvironment,
                 TimeSpan.FromMinutes(5));
             if (process.ExitCode != 0 || process.TimedOut)
-            {
                 return false;
-            }
 
             int itemsMarker = process.StdOut.LastIndexOf("\"Items\"", StringComparison.Ordinal);
             int jsonStart = itemsMarker < 0
@@ -244,15 +300,11 @@ public sealed partial class DotNetPublishPipelineRunner
                 : process.StdOut.LastIndexOf('{', itemsMarker);
             int jsonEnd = process.StdOut.LastIndexOf('}');
             if (jsonStart < 0 || jsonEnd < jsonStart)
-            {
                 return false;
-            }
             using JsonDocument document = JsonDocument.Parse(
                 process.StdOut.Substring(jsonStart, jsonEnd - jsonStart + 1));
             if (!document.RootElement.TryGetProperty("Items", out JsonElement items))
-            {
                 return false;
-            }
             if (!controlledEnvironment.TryGetValue("NUGET_PACKAGES", out string? controlledPackageRoot) ||
                 string.IsNullOrWhiteSpace(controlledPackageRoot))
             {
@@ -268,9 +320,7 @@ public sealed partial class DotNetPublishPipelineRunner
                     controlledPackageRoot!,
                     verifiedPackages,
                     out resolvedItemsJson))
-            {
                 return false;
-            }
             using JsonDocument mappedDocument = JsonDocument.Parse(resolvedItemsJson);
             if (!TryReadControlledProjectReferences(
                     mappedDocument.RootElement,
@@ -281,9 +331,7 @@ public sealed partial class DotNetPublishPipelineRunner
                     taskWidePropertyRemovals,
                     allowAmbiguousEvaluatedAssignments,
                     out EvaluatedProjectReference[] controlledReferences))
-            {
                 return false;
-            }
             references = controlledReferences
                 .GroupBy(BuildEvaluatedProjectReferenceKey, StringComparer.Ordinal)
                 .Select(group => group.First())

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ControlledProjectReferences.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ControlledProjectReferences.cs
@@ -63,15 +63,12 @@ public sealed partial class DotNetPublishPipelineRunner
                 IReadOnlyDictionary<string, string>? knownEvaluatedProperties = null)
             {
                 var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                foreach (KeyValuePair<string, string> property in contextRequest.ReadEffectiveGlobalProperties())
-                {
-                    if (controlledConditionPropertyNameSet.Contains(property.Key))
-                        properties[property.Key] = property.Value;
-                }
-                foreach (KeyValuePair<string, string> property in knownEvaluatedProperties ??
-                         ReadEvaluatedProjectProperties(
-                             contextRequest,
-                             controlledConditionPropertyNames))
+                IReadOnlyDictionary<string, string> evaluatedContext =
+                    contextRequest.BuildControlledEvaluationProperties(
+                        knownEvaluatedProperties ?? ReadEvaluatedProjectProperties(
+                            contextRequest,
+                            controlledConditionPropertyNames));
+                foreach (KeyValuePair<string, string> property in evaluatedContext)
                 {
                     if (controlledConditionPropertyNameSet.Contains(property.Key))
                         properties[property.Key] = property.Value;

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ControlledPublishItems.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ControlledPublishItems.cs
@@ -15,6 +15,7 @@ public sealed partial class DotNetPublishPipelineRunner
         string? evaluatedPathMap,
         bool proveControlledGeneratedInputs,
         IReadOnlyCollection<ControlledPublishGraphNode> graphBuildNodes,
+        IReadOnlyDictionary<string, string> evaluatedProperties,
         out EvaluatedPublishInput[] publishInputs)
     {
         publishInputs = Array.Empty<EvaluatedPublishInput>();
@@ -32,7 +33,10 @@ public sealed partial class DotNetPublishPipelineRunner
                     evaluatedBuildInputs,
                     executableMsBuildInputs,
                     request.ReadEffectiveGlobalProperties(),
-                    BuildControlledPublishProjectContexts(request, graphBuildNodes),
+                    BuildControlledPublishProjectContexts(
+                        request,
+                        evaluatedProperties,
+                        graphBuildNodes),
                     out controlledGitRoot,
                     out string? controlledProjectPath))
             {
@@ -40,6 +44,7 @@ public sealed partial class DotNetPublishPipelineRunner
             }
             if (!TryCreateControlledBuildEnvironment(
                     request.EnvironmentVariables,
+                    request.ControlledBuildEnvironmentVariableNames,
                     controlledGitRoot!,
                     controlledSourceRoot,
                     Path.GetDirectoryName(request.ProjectPath)!,
@@ -292,19 +297,25 @@ public sealed partial class DotNetPublishPipelineRunner
     private static IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>[]>
         BuildControlledPublishProjectContexts(
             ProjectEvaluationRequest rootRequest,
+            IReadOnlyDictionary<string, string> rootEvaluatedProperties,
             IReadOnlyCollection<ControlledPublishGraphNode> graphBuildNodes)
     {
         StringComparer comparer = IsWindows()
             ? StringComparer.OrdinalIgnoreCase
             : StringComparer.Ordinal;
         return graphBuildNodes
-            .Select(node => node.Request)
-            .Concat(new[] { rootRequest })
-            .GroupBy(node => Path.GetFullPath(node.ProjectPath), comparer)
+            .Select(node => (
+                Request: node.Request,
+                EvaluatedProperties: node.EvaluatedProperties))
+            .Concat(new[]
+            {
+                (Request: rootRequest, EvaluatedProperties: rootEvaluatedProperties)
+            })
+            .GroupBy(node => Path.GetFullPath(node.Request.ProjectPath), comparer)
             .ToDictionary(
                 group => group.Key,
                 group => group
-                    .Select(node => node.ReadEffectiveGlobalProperties())
+                    .Select(node => node.EvaluatedProperties)
                     .GroupBy(
                         properties => string.Join("\n", properties.OrderBy(
                             property => property.Key,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ControlledPublishItems.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ControlledPublishItems.cs
@@ -315,7 +315,8 @@ public sealed partial class DotNetPublishPipelineRunner
             .ToDictionary(
                 group => group.Key,
                 group => group
-                    .Select(node => node.EvaluatedProperties)
+                    .Select(node => node.Request.BuildControlledEvaluationProperties(
+                        node.EvaluatedProperties))
                     .GroupBy(
                         properties => string.Join("\n", properties.OrderBy(
                             property => property.Key,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ProjectItemLists.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ProjectItemLists.cs
@@ -103,15 +103,21 @@ public sealed partial class DotNetPublishPipelineRunner
 
     private sealed class ControlledPublishGraphNode
     {
-        internal ControlledPublishGraphNode(ProjectEvaluationRequest request, string? pathMap)
+        internal ControlledPublishGraphNode(
+            ProjectEvaluationRequest request,
+            string? pathMap,
+            IReadOnlyDictionary<string, string> evaluatedProperties)
         {
             Request = request;
             PathMap = pathMap;
+            EvaluatedProperties = evaluatedProperties;
         }
 
         internal ProjectEvaluationRequest Request { get; }
 
         internal string? PathMap { get; }
+
+        internal IReadOnlyDictionary<string, string> EvaluatedProperties { get; }
     }
 
     private static string[] ReadProjectReferenceItemListNames(
@@ -266,6 +272,7 @@ public sealed partial class DotNetPublishPipelineRunner
         string? evaluatedPathMap,
         bool proveControlledGeneratedInputs,
         IReadOnlyCollection<ControlledPublishGraphNode> graphBuildNodes,
+        IReadOnlyDictionary<string, string> evaluatedProperties,
         out EvaluatedPublishInput[] publishInputs)
     {
         publishInputs = Array.Empty<EvaluatedPublishInput>();
@@ -289,6 +296,7 @@ public sealed partial class DotNetPublishPipelineRunner
             evaluatedPathMap,
             proveControlledGeneratedInputs,
             graphBuildNodes,
+            evaluatedProperties,
             out publishInputs);
     }
 
@@ -315,7 +323,8 @@ public sealed partial class DotNetPublishPipelineRunner
             .Where(key => !key.Equals(rootKey, StringComparison.Ordinal))
             .Select(key => new ControlledPublishGraphNode(
                 requestsByEvaluation[key],
-                pathMapsByEvaluation[key]))
+                pathMapsByEvaluation[key],
+                evaluationsByEvaluation[key].EvaluatedProperties))
             .ToArray();
         return true;
 
@@ -325,16 +334,21 @@ public sealed partial class DotNetPublishPipelineRunner
                 return state == 2;
             if (!requestsByEvaluation.TryGetValue(key, out ProjectEvaluationRequest? request) ||
                 !evaluationsByEvaluation.TryGetValue(key, out EvaluatedProjectInputs? evaluation))
-            {
                 return false;
-            }
 
             states[key] = 1;
             foreach (EvaluatedProjectReference reference in evaluation.ProjectReferences)
             {
                 if (!File.Exists(reference.ProjectPath))
                     continue;
-                string childKey = request.ForProject(reference).BuildVisitKey();
+                ProjectEvaluationRequest childRequest = request.ForProject(reference);
+                if (!TryResolveProjectEvaluationKey(
+                        childRequest,
+                        request.TargetFramework,
+                        requestsByEvaluation,
+                        evaluationsByEvaluation,
+                        out string childKey))
+                    return false;
                 if (states.TryGetValue(childKey, out int childState) && childState == 1)
                     return false;
                 if (!Visit(childKey))
@@ -344,7 +358,133 @@ public sealed partial class DotNetPublishPipelineRunner
             orderedKeys.Add(key);
             return true;
         }
+
     }
+
+    private static bool TryResolveProjectEvaluationKey(
+        ProjectEvaluationRequest candidate,
+        string? inheritedTargetFramework,
+        IReadOnlyDictionary<string, ProjectEvaluationRequest> requestsByEvaluation,
+        IReadOnlyDictionary<string, EvaluatedProjectInputs> evaluationsByEvaluation,
+        out string key)
+    {
+        key = candidate.BuildVisitKey();
+        if (!string.IsNullOrWhiteSpace(candidate.TargetFramework))
+        {
+            return requestsByEvaluation.ContainsKey(key) &&
+                   evaluationsByEvaluation.ContainsKey(key);
+        }
+
+        if (!string.IsNullOrWhiteSpace(inheritedTargetFramework))
+        {
+            ProjectEvaluationRequest inherited = candidate.ForProject(
+                candidate.ProjectPath,
+                inheritedTargetFramework);
+            string inheritedKey = inherited.BuildVisitKey();
+            if (requestsByEvaluation.ContainsKey(inheritedKey) &&
+                evaluationsByEvaluation.ContainsKey(inheritedKey))
+            {
+                key = inheritedKey;
+                return true;
+            }
+        }
+        if (requestsByEvaluation.ContainsKey(key) && evaluationsByEvaluation.ContainsKey(key))
+            return true;
+
+        string[] matches = requestsByEvaluation
+            .Where(entry =>
+                evaluationsByEvaluation.ContainsKey(entry.Key) &&
+                !string.IsNullOrWhiteSpace(entry.Value.TargetFramework) &&
+                HasSameProjectEvaluationContext(candidate, entry.Value))
+            .Select(entry => entry.Key)
+            .ToArray();
+        if (matches.Length != 1)
+            return false;
+        key = matches[0];
+        return true;
+    }
+
+    private static bool TryResolveGeneratedProjectReferenceEvaluationKey(
+        ProjectEvaluationRequest parentRequest,
+        EvaluatedProjectReference generatedReference,
+        IReadOnlyCollection<EvaluatedProjectReference> resolvedReferences,
+        IReadOnlyDictionary<string, ProjectEvaluationRequest> requestsByEvaluation,
+        IReadOnlyDictionary<string, EvaluatedProjectInputs> evaluationsByEvaluation,
+        out string key)
+    {
+        key = string.Empty;
+        string generatedProjectPath = NormalizeProjectReferenceIdentityPath(
+            generatedReference.ProjectPath);
+        KeyValuePair<string, string>[] matches = resolvedReferences
+            .Select(parentRequest.ForProject)
+            .Select(candidate =>
+            {
+                if (!TryResolveProjectEvaluationKey(
+                        candidate,
+                        parentRequest.TargetFramework,
+                        requestsByEvaluation,
+                        evaluationsByEvaluation,
+                        out string candidateKey))
+                {
+                    return (KeyValuePair<string, string>?)null;
+                }
+                return new KeyValuePair<string, string>(candidate.ProjectPath, candidateKey);
+            })
+            .Where(candidate => candidate.HasValue)
+            .Select(candidate => candidate!.Value)
+            .ToArray();
+        return TrySelectSingleResolvedGeneratedProjectReferenceEvaluationKey(
+            generatedProjectPath,
+            matches,
+            out key);
+    }
+
+    internal static bool TrySelectSingleResolvedGeneratedProjectReferenceEvaluationKey(
+        string generatedProjectPath,
+        IEnumerable<KeyValuePair<string, string>> resolvedCandidates,
+        out string key)
+    {
+        key = string.Empty;
+        StringComparison comparison = IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        string[] matches = resolvedCandidates
+            .Where(candidate => NormalizeProjectReferenceIdentityPath(candidate.Key).Equals(
+                NormalizeProjectReferenceIdentityPath(generatedProjectPath),
+                comparison))
+            .Select(candidate => candidate.Value)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (matches.Length != 1)
+            return false;
+
+        key = matches[0];
+        return true;
+    }
+
+    private static bool HasSameProjectEvaluationContext(
+        ProjectEvaluationRequest left,
+        ProjectEvaluationRequest right)
+        => NormalizeProjectReferenceIdentityPath(left.ProjectPath).Equals(
+               NormalizeProjectReferenceIdentityPath(right.ProjectPath),
+               StringComparison.Ordinal) &&
+           string.Equals(left.Configuration, right.Configuration, StringComparison.Ordinal) &&
+           HasSameProjectEvaluationProperties(left.GlobalProperties, right.GlobalProperties) &&
+           HasSameProjectEvaluationEnvironment(left.EnvironmentVariables, right.EnvironmentVariables);
+
+    private static bool HasSameProjectEvaluationProperties(
+        IReadOnlyDictionary<string, string> left,
+        IReadOnlyDictionary<string, string> right)
+        => left.Count == right.Count && left.All(property =>
+            right.TryGetValue(property.Key, out string? value) &&
+            string.Equals(property.Value, value, StringComparison.Ordinal));
+
+    private static bool HasSameProjectEvaluationEnvironment(
+        IReadOnlyDictionary<string, string?> left,
+        IReadOnlyDictionary<string, string?> right)
+        => left.Count == right.Count && left.All(variable =>
+            right.TryGetValue(variable.Key, out string? value) &&
+            string.Equals(variable.Value, value, StringComparison.Ordinal));
 
     private static bool ContainsPotentialPublishItemMutation(
         string projectPath,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ProjectReferenceConditions.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ProjectReferenceConditions.cs
@@ -80,20 +80,17 @@ public sealed partial class DotNetPublishPipelineRunner
         if (propertyNames.Count == 0)
             return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        var arguments = new List<string>
+        var commonArguments = new List<string>
         {
             "msbuild",
             request.ProjectPath,
             "-nologo",
-            "-verbosity:quiet",
-            "-getProperty:MSBuildProjectFullPath"
+            "-verbosity:quiet"
         };
-        foreach (string propertyName in propertyNames)
-            arguments.Add("-getProperty:" + propertyName);
         if (request.Configuration is not null)
-            arguments.Add("-p:Configuration=" + EscapeMsBuildPropertyValue(request.Configuration));
+            commonArguments.Add("-p:Configuration=" + EscapeMsBuildPropertyValue(request.Configuration));
         if (request.HasExplicitTargetFramework)
-            arguments.Add("-p:TargetFramework=" + EscapeMsBuildPropertyValue(request.TargetFramework));
+            commonArguments.Add("-p:TargetFramework=" + EscapeMsBuildPropertyValue(request.TargetFramework));
         foreach (KeyValuePair<string, string> property in request.GlobalProperties.OrderBy(
                      entry => entry.Key,
                      StringComparer.OrdinalIgnoreCase))
@@ -104,35 +101,44 @@ public sealed partial class DotNetPublishPipelineRunner
                 continue;
             }
 
-            arguments.Add("-p:" + property.Key + "=" + EscapeMsBuildPropertyValue(property.Value));
+            commonArguments.Add("-p:" + property.Key + "=" + EscapeMsBuildPropertyValue(property.Value));
         }
         try
         {
-            var process = RunBuildInputEvaluationProcess(
-                "dotnet",
-                Path.GetDirectoryName(request.ProjectPath)!,
-                arguments,
-                request.EnvironmentVariables,
-                TimeSpan.FromMinutes(2));
-            if (process.ExitCode != 0 || process.TimedOut)
-                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
-            int jsonStart = process.StdOut.IndexOf('{');
-            int jsonEnd = process.StdOut.LastIndexOf('}');
-            if (jsonStart < 0 || jsonEnd < jsonStart)
-                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
-            using JsonDocument document = JsonDocument.Parse(
-                process.StdOut.Substring(jsonStart, jsonEnd - jsonStart + 1));
-            if (!document.RootElement.TryGetProperty("Properties", out JsonElement properties))
-                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
             var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            foreach (string propertyName in propertyNames)
+            foreach (string[] propertyBatch in BuildEvaluatedPropertyQueryBatches(
+                         commonArguments,
+                         propertyNames))
             {
-                string? value = ReadItemText(properties, propertyName);
-                if (value is not null)
-                    result[propertyName] = value;
+                string[] arguments = commonArguments
+                    .Concat(new[] { "-getProperty:MSBuildProjectFullPath" })
+                    .Concat(propertyBatch.Select(propertyName => "-getProperty:" + propertyName))
+                    .ToArray();
+                var process = RunBuildInputEvaluationProcess(
+                    "dotnet",
+                    Path.GetDirectoryName(request.ProjectPath)!,
+                    arguments,
+                    request.EnvironmentVariables,
+                    TimeSpan.FromMinutes(2));
+                if (process.ExitCode != 0 || process.TimedOut)
+                    return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+                int jsonStart = process.StdOut.IndexOf('{');
+                int jsonEnd = process.StdOut.LastIndexOf('}');
+                if (jsonStart < 0 || jsonEnd < jsonStart)
+                    return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+                using JsonDocument document = JsonDocument.Parse(
+                    process.StdOut.Substring(jsonStart, jsonEnd - jsonStart + 1));
+                if (!document.RootElement.TryGetProperty("Properties", out JsonElement properties))
+                    return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (string propertyName in propertyBatch)
+                {
+                    string? value = ReadItemText(properties, propertyName);
+                    if (value is not null)
+                        result[propertyName] = value;
+                }
             }
             return result;
         }
@@ -140,6 +146,36 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
+    }
+
+    internal static string[][] BuildEvaluatedPropertyQueryBatches(
+        IReadOnlyCollection<string> commonArguments,
+        IEnumerable<string> propertyNames,
+        int maximumCommandLength = 24000)
+    {
+        int commonLength = commonArguments.Sum(argument => argument.Length + 3) +
+                           "-getProperty:MSBuildProjectFullPath".Length + 3;
+        var batches = new List<string[]>();
+        var current = new List<string>();
+        int currentLength = commonLength;
+        foreach (string propertyName in propertyNames
+                     .Where(name => !string.IsNullOrWhiteSpace(name))
+                     .Distinct(StringComparer.OrdinalIgnoreCase)
+                     .OrderBy(name => name, StringComparer.OrdinalIgnoreCase))
+        {
+            int argumentLength = "-getProperty:".Length + propertyName.Length + 3;
+            if (current.Count > 0 && currentLength + argumentLength > maximumCommandLength)
+            {
+                batches.Add(current.ToArray());
+                current.Clear();
+                currentLength = commonLength;
+            }
+            current.Add(propertyName);
+            currentLength += argumentLength;
+        }
+        if (current.Count > 0)
+            batches.Add(current.ToArray());
+        return batches.ToArray();
     }
 
     private static void AddConditionPropertyNames(string condition, ISet<string> names)
@@ -249,14 +285,6 @@ public sealed partial class DotNetPublishPipelineRunner
                 ? value
                 : match.Value,
             RegexOptions.CultureInvariant);
-        if (expanded.IndexOf("$(", StringComparison.Ordinal) >= 0 ||
-            expanded.IndexOf("@(", StringComparison.Ordinal) >= 0 ||
-            expanded.IndexOf("%(", StringComparison.Ordinal) >= 0)
-        {
-            result = false;
-            return false;
-        }
-
         return TryEvaluateSimpleMsBuildBooleanExpression(expanded, out result);
     }
 
@@ -322,6 +350,13 @@ public sealed partial class DotNetPublishPipelineRunner
             "^\\s*(['\\\"])(.*?)\\1\\s*(==|!=)\\s*(['\\\"])(.*?)\\4\\s*$",
             RegexOptions.CultureInvariant);
         if (!comparison.Success)
+        {
+            result = false;
+            return false;
+        }
+
+        if (ContainsUnresolvedBuildExpression(comparison.Groups[2].Value) ||
+            ContainsUnresolvedBuildExpression(comparison.Groups[5].Value))
         {
             result = false;
             return false;

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ProjectReferenceOutputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ProjectReferenceOutputs.cs
@@ -428,8 +428,23 @@ public sealed partial class DotNetPublishPipelineRunner
                 outputItemType,
                 msBuildToolsPath,
                 msBuildSdksPath,
-                declaredOutputs!) ||
-            !TryReadEvaluatedProjectReferences(
+                declaredOutputs!))
+        {
+            return false;
+        }
+
+        // ResolveReferences reports the future target output for explicitly declared
+        // analyzer and embedded-resource ProjectReferences even before the child build.
+        // A safely absent generated path is not a current provenance input. Existing
+        // outputs still require a controlled rebuild, while absent paths beneath links
+        // remain fail closed.
+        if (!File.Exists(fullPath) &&
+            !HasUnsafeAbsentProjectReferenceOutputPath(fullPath, declaringProjectPath))
+        {
+            return true;
+        }
+
+        if (!TryReadEvaluatedProjectReferences(
                 item,
                 declaringProjectPath,
                 "MSBuildSourceProjectFile",

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ProjectReferencePropertyDiscovery.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ProjectReferencePropertyDiscovery.cs
@@ -4,6 +4,36 @@ namespace PowerForge;
 
 public sealed partial class DotNetPublishPipelineRunner
 {
+    private static string[] ReadControlledBuildPropertyNames(IEnumerable<string> projectPaths)
+    {
+        string[] paths = projectPaths
+            .Where(path => !string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            .Distinct(IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
+            .ToArray();
+        var names = new HashSet<string>(
+            ReadProjectReferenceConditionPropertyNames(paths),
+            StringComparer.OrdinalIgnoreCase);
+        foreach (string path in paths)
+        {
+            try
+            {
+                XDocument document = XDocument.Load(path, LoadOptions.None);
+                foreach (string value in document.DescendantNodes()
+                             .OfType<XText>()
+                             .Select(text => text.Value)
+                             .Concat(document.Descendants().Attributes().Select(attribute => attribute.Value)))
+                {
+                    AddConditionPropertyNames(value, names);
+                }
+            }
+            catch
+            {
+                // Unknown controlled inputs stay fail closed during the later document scan.
+            }
+        }
+        return names.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToArray();
+    }
+
     private static string[] ReadProjectReferenceConditionPropertyNames(IEnumerable<string> projectPaths)
     {
         var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -27,6 +57,16 @@ public sealed partial class DotNetPublishPipelineRunner
                         propertyDefinitions[property.Name.LocalName] = definitions;
                     }
                     definitions.Add(property);
+                }
+
+                foreach (string condition in document.Descendants()
+                             .Attributes()
+                             .Where(attribute => attribute.Name.LocalName.Equals(
+                                 "Condition",
+                                 StringComparison.OrdinalIgnoreCase))
+                             .Select(attribute => attribute.Value))
+                {
+                    AddConditionPropertyNames(condition, names);
                 }
 
                 foreach (XElement projectReference in document.Descendants().Where(element =>

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ProjectReferenceRemovals.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ProjectReferenceRemovals.cs
@@ -28,6 +28,10 @@ public sealed partial class DotNetPublishPipelineRunner
                         evaluatedConditionProperties,
                         definition.DefiningProjectPath)))
             {
+                foreach (PreprocessedProjectPropertyDefinition definition in propertyDefinitions.Where(definition =>
+                             definition.Element.Name.LocalName.Equals(
+                                 "_GlobalPropertiesToRemoveFromProjectReferences",
+                                 StringComparison.OrdinalIgnoreCase)))
                 return false;
             }
             return true;
@@ -36,9 +40,7 @@ public sealed partial class DotNetPublishPipelineRunner
             value.IndexOf("@(", StringComparison.Ordinal) >= 0 ||
             value.IndexOf("%(", StringComparison.Ordinal) >= 0 ||
             !TryUnescapeMsBuildLiteral(value, out string? decoded))
-        {
             return false;
-        }
 
         removals = ReadProjectReferencePropertyNames(decoded);
         return true;

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
@@ -465,6 +465,7 @@ public sealed partial class DotNetPublishPipelineRunner
                     pathMapsByEvaluation[evaluationKey],
                     buildPlan?.NoBuildInPublish == true,
                     graphNodes,
+                    evaluationsByEvaluation[evaluationKey].EvaluatedProperties,
                     out EvaluatedPublishInput[] publishInputs))
             {
                 projectDirectories = directories.ToArray();
@@ -543,9 +544,31 @@ public sealed partial class DotNetPublishPipelineRunner
         foreach ((ProjectEvaluationRequest request, GeneratedProjectReferenceOutput output) in generatedProjectReferenceOutputs)
         {
             ProjectEvaluationRequest referencedProject = request.ForProject(output.ProjectReference);
-            if (outputRootsByEvaluation.TryGetValue(referencedProject.BuildVisitKey(), out string[]? outputRoots) &&
+            if (!TryResolveProjectEvaluationKey(
+                    referencedProject,
+                    request.TargetFramework,
+                    requestsByEvaluation,
+                    evaluationsByEvaluation,
+                    out string referencedProjectKey) &&
+                (!evaluationsByEvaluation.TryGetValue(
+                     request.BuildVisitKey(),
+                     out EvaluatedProjectInputs? parentEvaluation) ||
+                 !TryResolveGeneratedProjectReferenceEvaluationKey(
+                     request,
+                     output.ProjectReference,
+                     parentEvaluation.ProjectReferences,
+                     requestsByEvaluation,
+                     evaluationsByEvaluation,
+                     out referencedProjectKey)))
+            {
+                buildInputs.Add(output.OutputPath);
+                sourceInputs.Add(output.OutputPath);
+                continue;
+            }
+            referencedProject = requestsByEvaluation[referencedProjectKey];
+            if (outputRootsByEvaluation.TryGetValue(referencedProjectKey, out string[]? outputRoots) &&
                 expectedOutputPathsByEvaluation.TryGetValue(
-                    referencedProject.BuildVisitKey(),
+                    referencedProjectKey,
                     out string[]? expectedOutputPaths) &&
                 IsTrustedGeneratedOutputPath(
                     output.OutputPath,
@@ -557,22 +580,27 @@ public sealed partial class DotNetPublishPipelineRunner
                     referencedProject,
                     new[] { output.OutputPath },
                     buildInputsByEvaluation.TryGetValue(
-                        referencedProject.BuildVisitKey(),
+                        referencedProjectKey,
                         out string[]? evaluatedBuildInputs)
                         ? evaluatedBuildInputs
                         : Array.Empty<string>(),
                     msBuildInputsByEvaluation.TryGetValue(
-                        referencedProject.BuildVisitKey(),
+                        referencedProjectKey,
                         out string[]? evaluatedMsBuildInputs)
                         ? evaluatedMsBuildInputs
                         : Array.Empty<string>(),
+                    evaluationsByEvaluation.TryGetValue(
+                        referencedProjectKey,
+                        out EvaluatedProjectInputs? referencedEvaluation)
+                        ? referencedEvaluation.EvaluatedProperties
+                        : referencedProject.ReadEffectiveGlobalProperties(),
                     pathMapsByEvaluation.TryGetValue(
-                        referencedProject.BuildVisitKey(),
+                        referencedProjectKey,
                         out string? pathMap)
                         ? pathMap
                         : null,
                     verifiedPackagesByEvaluation.TryGetValue(
-                        referencedProject.BuildVisitKey(),
+                        referencedProjectKey,
                         out VerifiedPackageInputCatalog? verifiedPackages)
                         ? verifiedPackages
                         : null,
@@ -618,7 +646,8 @@ public sealed partial class DotNetPublishPipelineRunner
                         targetFramework: null,
                         effectiveConfiguration,
                         globalProperties: null,
-                        buildPlan!.EnvironmentVariables);
+                        buildPlan!.EnvironmentVariables,
+                        buildPlan.ControlledBuildEnvironmentVariableNames);
                     continue;
                 }
 
@@ -633,7 +662,8 @@ public sealed partial class DotNetPublishPipelineRunner
                         combination.Framework,
                         effectiveConfiguration,
                         properties,
-                        buildPlan!.EnvironmentVariables);
+                        buildPlan!.EnvironmentVariables,
+                        buildPlan.ControlledBuildEnvironmentVariableNames);
                 }
             }
 
@@ -718,6 +748,7 @@ public sealed partial class DotNetPublishPipelineRunner
             "-getProperty:NuGetPackageFolders",
             "-getProperty:ProjectAssetsFile",
             "-getProperty:NuGetLockFilePath",
+            "-getProperty:PowerForgeSdkPackageLockFile",
             "-getProperty:MSBuildToolsPath",
             "-getProperty:MSBuildSDKsPath",
             "-getProperty:CustomAfterMicrosoftCommonTargets"
@@ -887,6 +918,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 {
                     return false;
                 }
+                evaluatedProjectReferenceConditionProperties =
+                    ReadEvaluatedProjectReferenceConditionProperties(request, importPaths);
                 if (projectReferenceDeclarations.Length > 0 ||
                     hasDynamicProjectReferenceTaskOutputs ||
                     preResolvePropertyDefinitions.Any(definition =>
@@ -894,8 +927,6 @@ public sealed partial class DotNetPublishPipelineRunner
                             "_GlobalPropertiesToRemoveFromProjectReferences",
                             StringComparison.OrdinalIgnoreCase)))
                 {
-                    evaluatedProjectReferenceConditionProperties =
-                        ReadEvaluatedProjectReferenceConditionProperties(request, importPaths);
                     if (!TryReadPreResolveTaskWideProjectReferencePropertyRemovals(
                             preResolvePropertyDefinitions,
                             evaluatedProjectReferenceConditionProperties,
@@ -1146,6 +1177,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 publishInputs,
                 verifiedPackages,
                 trustedBuildInfrastructureRoots,
+                evaluatedProjectReferenceConditionProperties,
                 ResolveExistingCustomAfterTargets(
                     customAfterMicrosoftCommonTargets,
                     Path.GetDirectoryName(request.ProjectPath)!));
@@ -1254,7 +1286,9 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             try
             {
-                environmentVariables = CreateSafeDotNetChildEnvironment(environmentVariables);
+                environmentVariables = CreateSafeDotNetChildEnvironment(
+                    environmentVariables,
+                    effectiveFileName);
             }
             catch (Exception exception)
             {

--- a/PowerForge/Services/DotNetPublishPipelineRunner.NoBuildPublishInputSnapshot.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.NoBuildPublishInputSnapshot.cs
@@ -83,7 +83,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 framework,
                 plan.Configuration,
                 properties,
-                plan.EnvironmentVariables)
+                plan.EnvironmentVariables,
+                plan.ControlledBuildEnvironmentVariableNames)
             .BuildVisitKey();
     }
 

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Xml.Linq;
 using NuGet.Packaging;
 using NuGet.Packaging.Signing;
+using NuGet.Versioning;
 
 namespace PowerForge;
 
@@ -127,6 +128,17 @@ public sealed partial class DotNetPublishPipelineRunner
         if (!string.IsNullOrWhiteSpace(evaluatedLockFile))
             AddBuildControlCandidate(
                 evaluatedLockFile!,
+                inputs,
+                sourceInputs,
+                new HashSet<string>(IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal));
+
+        string? sdkPackageLockFile = ReadEvaluatedPath(
+            properties,
+            "PowerForgeSdkPackageLockFile",
+            projectDirectory);
+        if (!string.IsNullOrWhiteSpace(sdkPackageLockFile))
+            AddBuildControlCandidate(
+                sdkPackageLockFile!,
                 inputs,
                 sourceInputs,
                 new HashSet<string>(IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal));
@@ -424,6 +436,25 @@ public sealed partial class DotNetPublishPipelineRunner
             bool hasCommittedLock = TryReadLockedPackageHashes(
                 lockFilePath,
                 out Dictionary<string, string> hashes);
+            string? sdkPackageLockFile = ReadEvaluatedPath(
+                properties,
+                "PowerForgeSdkPackageLockFile",
+                projectDirectory);
+            var sdkPackageLockHashes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (!string.IsNullOrWhiteSpace(sdkPackageLockFile) &&
+                !TryReadPowerForgeSdkPackageHashes(sdkPackageLockFile!, out sdkPackageLockHashes))
+            {
+                return false;
+            }
+            foreach (KeyValuePair<string, string> package in sdkPackageLockHashes)
+            {
+                if (hashes.TryGetValue(package.Key, out string? existing) &&
+                    !string.Equals(existing, package.Value, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+                hashes[package.Key] = package.Value;
+            }
             var committedPackageHashes = new Dictionary<string, string>(
                 hashes,
                 StringComparer.OrdinalIgnoreCase);
@@ -592,6 +623,60 @@ public sealed partial class DotNetPublishPipelineRunner
                 }
 
                 return hashes.Count > 0;
+            }
+            catch
+            {
+                hashes.Clear();
+                return false;
+            }
+        }
+
+        private static bool TryReadPowerForgeSdkPackageHashes(
+            string lockFilePath,
+            out Dictionary<string, string> hashes)
+        {
+            hashes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                using JsonDocument document = JsonDocument.Parse(File.ReadAllText(lockFilePath));
+                if (!document.RootElement.TryGetProperty("version", out JsonElement version) ||
+                    version.ValueKind != JsonValueKind.Number ||
+                    !version.TryGetInt32(out int schemaVersion) ||
+                    schemaVersion != 1 ||
+                    !document.RootElement.TryGetProperty(
+                        "sdkManagedPackages",
+                        out JsonElement packages) ||
+                    packages.ValueKind != JsonValueKind.Object)
+                {
+                    return false;
+                }
+
+                foreach (JsonProperty package in packages.EnumerateObject())
+                {
+                    if (string.IsNullOrWhiteSpace(package.Name) ||
+                        package.Name.IndexOf('|') >= 0 ||
+                        package.Value.ValueKind != JsonValueKind.Object ||
+                        !package.Value.TryGetProperty("version", out JsonElement packageVersion) ||
+                        packageVersion.ValueKind != JsonValueKind.String ||
+                        !NuGetVersion.TryParse(packageVersion.GetString(), out NuGetVersion? parsedVersion) ||
+                        !package.Value.TryGetProperty("contentHash", out JsonElement contentHash) ||
+                        contentHash.ValueKind != JsonValueKind.String ||
+                        string.IsNullOrWhiteSpace(contentHash.GetString()))
+                    {
+                        hashes.Clear();
+                        return false;
+                    }
+
+                    string key = package.Name + "|" + parsedVersion!.ToNormalizedString();
+                    if (hashes.ContainsKey(key))
+                    {
+                        hashes.Clear();
+                        return false;
+                    }
+                    hashes.Add(key, contentHash.GetString()!);
+                }
+
+                return true;
             }
             catch
             {

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -557,6 +557,22 @@ public sealed partial class DotNetPublishPipelineRunner
             sourceRevision.Any(character => !Uri.IsHexDigit(character)))
             sourceRevision = string.Empty;
 
+        Dictionary<string, string?> resolvedEnvironmentVariables = ResolveDotNetEnvironmentVariables(
+            spec.DotNet.EnvironmentVariables,
+            projectRoot,
+            enforceRequiredEnvironmentVariables);
+        string[] controlledBuildEnvironmentVariableNames =
+            (spec.DotNet.EnvironmentVariables ??
+             new Dictionary<string, DotNetPublishEnvironmentVariable>(StringComparer.OrdinalIgnoreCase))
+            .Where(entry =>
+                !string.IsNullOrWhiteSpace(entry.Key) &&
+                entry.Value?.Secret == false &&
+                resolvedEnvironmentVariables.ContainsKey(entry.Key.Trim()))
+            .Select(entry => entry.Key.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
         var plan = new DotNetPublishPlan
         {
             ProjectRoot = projectRoot,
@@ -577,10 +593,8 @@ public sealed partial class DotNetPublishPipelineRunner
             NoRestoreInPublish = spec.DotNet.NoRestoreInPublish,
             NoBuildInPublish = spec.DotNet.NoBuildInPublish,
             MsBuildProperties = msbuildProps,
-            EnvironmentVariables = ResolveDotNetEnvironmentVariables(
-                spec.DotNet.EnvironmentVariables,
-                projectRoot,
-                enforceRequiredEnvironmentVariables),
+            EnvironmentVariables = resolvedEnvironmentVariables,
+            ControlledBuildEnvironmentVariableNames = controlledBuildEnvironmentVariableNames,
             Targets = targets.ToArray(),
             Bundles = bundles,
             Installers = installers,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -557,19 +557,19 @@ public sealed partial class DotNetPublishPipelineRunner
             sourceRevision.Any(character => !Uri.IsHexDigit(character)))
             sourceRevision = string.Empty;
 
+        Dictionary<string, DotNetPublishEnvironmentVariable> normalizedEnvironmentVariables =
+            CloneEnvironmentVariables(spec.DotNet.EnvironmentVariables) ??
+            new Dictionary<string, DotNetPublishEnvironmentVariable>(StringComparer.OrdinalIgnoreCase);
         Dictionary<string, string?> resolvedEnvironmentVariables = ResolveDotNetEnvironmentVariables(
-            spec.DotNet.EnvironmentVariables,
+            normalizedEnvironmentVariables,
             projectRoot,
             enforceRequiredEnvironmentVariables);
         string[] controlledBuildEnvironmentVariableNames =
-            (spec.DotNet.EnvironmentVariables ??
-             new Dictionary<string, DotNetPublishEnvironmentVariable>(StringComparer.OrdinalIgnoreCase))
+            normalizedEnvironmentVariables
             .Where(entry =>
-                !string.IsNullOrWhiteSpace(entry.Key) &&
                 entry.Value?.Secret == false &&
-                resolvedEnvironmentVariables.ContainsKey(entry.Key.Trim()))
-            .Select(entry => entry.Key.Trim())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
+                resolvedEnvironmentVariables.ContainsKey(entry.Key))
+            .Select(entry => entry.Key)
             .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.cs
@@ -561,7 +561,8 @@ public sealed partial class DotNetPublishPipelineRunner
             ? CreateSafeDotNetChildEnvironment(
                 environmentVariables,
                 inheritedVariableNames,
-                removeUnapprovedAmbient: ActiveStrictDotNetEnvironment.Value)
+                removeUnapprovedAmbient: ActiveStrictDotNetEnvironment.Value,
+                resolvedDotNetExecutablePath: fileName)
             : CreateSafeMsBuildChildEnvironment(
                 environmentVariables,
                 inheritedVariableNames,
@@ -802,7 +803,22 @@ public sealed partial class DotNetPublishPipelineRunner
                 .Cast<object?>()
                 .Select(key => key?.ToString())
                 .Where(name => !string.IsNullOrWhiteSpace(name))
-                .Select(name => name!));
+                .Select(name => name!),
+            removeUnapprovedAmbient: true,
+            resolvedDotNetExecutablePath: null);
+
+    internal static IReadOnlyDictionary<string, string?> CreateSafeDotNetChildEnvironment(
+        IReadOnlyDictionary<string, string?>? environmentVariables,
+        string resolvedDotNetExecutablePath)
+        => CreateSafeDotNetChildEnvironment(
+            environmentVariables,
+            Environment.GetEnvironmentVariables().Keys
+                .Cast<object?>()
+                .Select(key => key?.ToString())
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Select(name => name!),
+            removeUnapprovedAmbient: true,
+            resolvedDotNetExecutablePath: resolvedDotNetExecutablePath);
 
     internal static IReadOnlyDictionary<string, string?> CreateSafeDotNetChildEnvironment(
         IReadOnlyDictionary<string, string?>? environmentVariables,
@@ -810,17 +826,20 @@ public sealed partial class DotNetPublishPipelineRunner
         => CreateSafeDotNetChildEnvironment(
             environmentVariables,
             inheritedVariableNames,
-            removeUnapprovedAmbient: true);
+            removeUnapprovedAmbient: true,
+            resolvedDotNetExecutablePath: null);
 
     internal static IReadOnlyDictionary<string, string?> CreateSafeDotNetChildEnvironment(
         IReadOnlyDictionary<string, string?>? environmentVariables,
         IEnumerable<string> inheritedVariableNames,
-        bool removeUnapprovedAmbient)
+        bool removeUnapprovedAmbient,
+        string? resolvedDotNetExecutablePath = null)
         => CreateSafeBuildChildEnvironment(
             environmentVariables,
             inheritedVariableNames,
             removeUnapprovedAmbient,
-            configureDotNetRuntime: true);
+            configureDotNetRuntime: true,
+            resolvedDotNetExecutablePath: resolvedDotNetExecutablePath);
 
     internal static IReadOnlyDictionary<string, string?> CreateSafeMsBuildChildEnvironment(
         IReadOnlyDictionary<string, string?>? environmentVariables,
@@ -830,13 +849,15 @@ public sealed partial class DotNetPublishPipelineRunner
             environmentVariables,
             inheritedVariableNames,
             removeUnapprovedAmbient,
-            configureDotNetRuntime: false);
+            configureDotNetRuntime: false,
+            resolvedDotNetExecutablePath: null);
 
     private static IReadOnlyDictionary<string, string?> CreateSafeBuildChildEnvironment(
         IReadOnlyDictionary<string, string?>? environmentVariables,
         IEnumerable<string> inheritedVariableNames,
         bool removeUnapprovedAmbient,
-        bool configureDotNetRuntime)
+        bool configureDotNetRuntime,
+        string? resolvedDotNetExecutablePath)
     {
         ValidateExplicitDotNetEnvironmentVariables(environmentVariables);
         var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
@@ -854,16 +875,21 @@ public sealed partial class DotNetPublishPipelineRunner
                  !IsApprovedDotNetChildAmbientEnvironmentVariable(name))))
                 values[name] = null;
         }
-        values["DOTNET_ROOT"] = configureDotNetRuntime
-            ? Path.GetDirectoryName(ResolveDotNetChildExecutable("dotnet"))
+        string? resolvedDotNetPath = configureDotNetRuntime
+            ? string.IsNullOrWhiteSpace(resolvedDotNetExecutablePath)
+                ? ResolveDotNetChildExecutable("dotnet")
+                : Path.GetFullPath(resolvedDotNetExecutablePath)
             : null;
+        values["DOTNET_ROOT"] = resolvedDotNetPath is null
+            ? null
+            : Path.GetDirectoryName(resolvedDotNetPath);
         values["DOTNET_ROOT(x86)"] = null;
         values["DOTNET_MULTILEVEL_LOOKUP"] = configureDotNetRuntime ? "0" : null;
         foreach (string name in DisabledUserMsBuildImportEnvironmentVariables)
             values[name] = "false";
         if (configureDotNetRuntime && ActiveNativeAotPublish.Value)
         {
-            string dotNetPath = ResolveDotNetChildExecutable("dotnet");
+            string dotNetPath = resolvedDotNetPath!;
             string trustedNativeAotPath = BuildTrustedNativeAotPath(
                 dotNetPath,
                 Environment.GetEnvironmentVariable("PATH"));


### PR DESCRIPTION
## What changed

PowerForge now preserves and verifies the inputs that can affect a controlled signed .NET publish, including project-reference contexts, conditions, property removals, package locks, generated publish items, task assemblies, and no-build snapshots.

The controlled build also:

- replays only configuration-declared, non-secret environment variables from one normalized winning definition;
- isolates inherited process and toolchain state;
- distinguishes safely absent future generated outputs from existing or untrusted outputs;
- limits MSBuild to one non-reusable node for deterministic proof;
- fails closed when a file-bearing condition or publish input cannot be resolved safely;
- accounts for target-time property assignments in the current target and reachable prerequisite targets, including imported targets;
- reevaluates controlled proof without omitted secret environment state, so absence-based conditions cannot be hidden by the planning environment;
- rechecks target-level conditions after reachable prerequisite assignments can activate a target;
- preserves effective global MSBuild properties when scanning generated-output task inputs.

## Downstream impact

TestimoX.Monitoring can complete locked restore, provenance verification, and single-file publish through this owner path without a downstream compatibility shim. The downstream TestimoX change should consume the released PowerForge/PSPublishModule owner after this PR is merged and published.

## Validation

- PSPublishModule solution Release build completed with no warnings or errors across the configured target frameworks.
- 34 .NET publish PR-gate tests passed on the remediated head.
- 21 focused environment normalization, omitted-environment, target-time activation, prerequisite scheduling, inactive-target, and global-property provenance contracts passed.
- A clean TestimoX.Monitoring locked restore, provenance check, and 193.9 MB single-file build completed through the updated owner before the final owner-contract remediation.

The local Azure signing process timed out before producing a signature, so successful certificate signing and post-signature integrity remain release-boundary proof rather than a claim of this PR.