### PR TITLE
Admit verified SDK runtime packs in publish proofs

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave78.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave78.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text.Json;
+using NuGet.Packaging;
 using PowerForge;
 using Xunit;
 
@@ -232,11 +233,7 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
                 var archivesByPackageKey = Assert.IsAssignableFrom<IReadOnlyDictionary<string, string>>(
                     catalogType.GetField("_archivePathsByPackageKey", BindingFlags.Instance | BindingFlags.NonPublic)!
                         .GetValue(catalog));
-                var sdkManagedArchives = Assert.IsAssignableFrom<IReadOnlyCollection<string>>(
-                    catalogType.GetField("_sdkManagedArchivePaths", BindingFlags.Instance | BindingFlags.NonPublic)!
-                        .GetValue(catalog));
                 Assert.Empty(archivesByPackageKey);
-                Assert.Empty(sdkManagedArchives);
             }
             finally
             {
@@ -250,30 +247,87 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
     }
 
     [Fact]
-    public void SdkManagedPackageKey_RequiresMatchingCommittedLockHash()
+    public void VerifiedPackageCatalog_IgnoresPresentAssetsOnlyAutoReferencedArchive()
     {
-        Type runnerType = typeof(DotNetPublishPipelineRunner);
-        MethodInfo add = runnerType.GetMethod(
-            "AddSdkManagedPackageKey",
-            BindingFlags.Static | BindingFlags.NonPublic)!;
-        var sdkManaged = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        const string packageKey = "Microsoft.NETCore.App.Runtime.win-x64|10.0.0";
-        const string contentHash = "sha512-committed";
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            const string packageId = "Runtime.Pack";
+            const string packageVersion = "1.0.0";
+            string projectDirectory = Directory.CreateDirectory(Path.Combine(root, "src")).FullName;
+            string packageRoot = Directory.CreateDirectory(Path.Combine(root, "packages")).FullName;
+            string packageDirectory = Directory.CreateDirectory(Path.Combine(
+                packageRoot,
+                packageId.ToLowerInvariant(),
+                packageVersion)).FullName;
+            string packagePath = Path.Combine(
+                packageDirectory,
+                packageId + "." + packageVersion + ".nupkg");
+            WriteTestPackage(packagePath, "assets-only");
+            string contentHash;
+            using (FileStream stream = File.OpenRead(packagePath))
+            using (var reader = new PackageArchiveReader(stream, leaveStreamOpen: false))
+                contentHash = reader.GetContentHash(CancellationToken.None);
 
-        add.Invoke(null, [packageKey, contentHash, new Dictionary<string, string>(), sdkManaged]);
-        Assert.Empty(sdkManaged);
-
-        add.Invoke(
-            null,
-            [
-                packageKey,
-                contentHash,
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            string projectPath = Path.Combine(projectDirectory, "App.csproj");
+            File.WriteAllText(projectPath, "<Project />");
+            string objDirectory = Directory.CreateDirectory(Path.Combine(projectDirectory, "obj")).FullName;
+            File.WriteAllText(
+                Path.Combine(objDirectory, "project.assets.json"),
+                $$"""
                 {
-                    [packageKey] = contentHash
-                },
-                sdkManaged
-            ]);
-        Assert.Contains(packageKey, sdkManaged);
+                  "project": {
+                    "frameworks": {
+                      "net8.0": {
+                        "dependencies": {
+                          "{{packageId}}": { "autoReferenced": true }
+                        }
+                      }
+                    }
+                  },
+                  "libraries": {
+                    "{{packageId}}/{{packageVersion}}": {
+                      "type": "package",
+                      "sha512": "{{contentHash}}"
+                    }
+                  }
+                }
+                """);
+            using JsonDocument propertiesDocument = JsonDocument.Parse("{}");
+            Type runnerType = typeof(DotNetPublishPipelineRunner);
+            Type catalogType = runnerType.GetNestedType(
+                "VerifiedPackageInputCatalog",
+                BindingFlags.NonPublic)!;
+            Type cacheType = runnerType.GetNestedType(
+                "VerifiedPackageArchiveCache",
+                BindingFlags.NonPublic)!;
+            object cache = Activator.CreateInstance(cacheType, nonPublic: true)!;
+            try
+            {
+                MethodInfo create = catalogType.GetMethod(
+                    "TryCreate",
+                    BindingFlags.Static | BindingFlags.NonPublic)!;
+                object?[] arguments =
+                    [projectPath, propertiesDocument.RootElement, new[] { packageRoot }, cache, null];
+
+                Assert.True((bool)create.Invoke(null, arguments)!);
+                Assert.NotNull(arguments[4]);
+                object catalog = arguments[4]!;
+                var archivesByPackageKey = Assert.IsAssignableFrom<IReadOnlyDictionary<string, string>>(
+                    catalogType.GetField(
+                            "_archivePathsByPackageKey",
+                            BindingFlags.Instance | BindingFlags.NonPublic)!
+                        .GetValue(catalog));
+                Assert.Empty(archivesByPackageKey);
+            }
+            finally
+            {
+                (cache as IDisposable)?.Dispose();
+            }
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
     }
 }

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerSdkRuntimePackProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerSdkRuntimePackProvenanceTests.cs
@@ -157,6 +157,7 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
         Assert.Contains("-p:TargetFramework=net10.0", arguments);
         Assert.Single(arguments, value => value.StartsWith("-p:RestoreSources=", StringComparison.OrdinalIgnoreCase));
         Assert.Contains("-p:RestoreSources=C:\\isolated\\verified", arguments);
+        Assert.Contains("-p:DisableImplicitFrameworkReferences=true", arguments);
         Assert.Contains("-p:ImportDirectoryBuildProps=false", arguments);
         Assert.Contains("-p:ImportDirectoryBuildTargets=false", arguments);
         Assert.Contains("-p:ImportDirectoryPackagesProps=false", arguments);
@@ -218,6 +219,45 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
             {
                 (cache as IDisposable)?.Dispose();
             }
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void SdkEvidence_RejectsPackageArchiveMutationAfterTrustedSnapshot()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            const string packageId = "sdk.test.package";
+            const string packageVersion = "1.0.0";
+            string packageDirectory = Directory.CreateDirectory(
+                Path.Combine(root, packageId, packageVersion)).FullName;
+            string packagePath = Path.Combine(
+                packageDirectory,
+                packageId + "." + packageVersion + ".nupkg");
+            WriteTestPackage(packagePath, "trusted");
+            string contentHash;
+            using (FileStream stream = File.OpenRead(packagePath))
+            using (var reader = new PackageArchiveReader(stream, leaveStreamOpen: false))
+                contentHash = reader.GetContentHash(CancellationToken.None);
+
+            MethodInfo verify = typeof(DotNetPublishPipelineRunner).GetMethod(
+                "TryVerifyCurrentSdkPackageArchives",
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+            var hashes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [packageId + "|" + packageVersion] = contentHash
+            };
+
+            Assert.True(Assert.IsType<bool>(verify.Invoke(null, [root, hashes])));
+            File.Delete(packagePath);
+            WriteTestPackage(packagePath, "mutated");
+            Assert.False(Assert.IsType<bool>(verify.Invoke(null, [root, hashes])));
         }
         finally
         {

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerSdkRuntimePackProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerSdkRuntimePackProvenanceTests.cs
@@ -28,9 +28,6 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
                   <PropertyGroup>
                     <OutputType>Exe</OutputType>
                     <TargetFramework>{{targetFramework}}</TargetFramework>
-                    <RuntimeIdentifier>{{runtime}}</RuntimeIdentifier>
-                    <PublishSingleFile>true</PublishSingleFile>
-                    <SelfContained>true</SelfContained>
                     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
                     {{platformProperty}}
                   </PropertyGroup>
@@ -45,7 +42,8 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
             RunGit(root, "commit -m \"approved source\"");
             RunDotNet(
                 root,
-                $"build \"{projectPath}\" -c Release -f {targetFramework} -r {runtime} --no-restore --nologo");
+                $"build \"{projectPath}\" -c Release -f {targetFramework} -r {runtime} --no-restore --nologo " +
+                "-p:SelfContained=true -p:PublishSingleFile=true");
 
             var plan = new DotNetPublishPlan
             {

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerSdkRuntimePackProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerSdkRuntimePackProvenanceTests.cs
@@ -1,3 +1,7 @@
+using System.Collections;
+using System.Reflection;
+using System.Text.Json;
+using NuGet.Packaging;
 using PowerForge;
 using Xunit;
 
@@ -10,6 +14,7 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
     public void ReadSourceProvenance_AcceptsVerifiedSdkRuntimePacksForSingleFilePublish()
     {
         string root = Directory.CreateTempSubdirectory().FullName;
+        string externalRoot = Directory.CreateTempSubdirectory().FullName;
         try
         {
             RunGit(root, "init");
@@ -22,6 +27,9 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
             string platformProperty = OperatingSystem.IsWindows()
                 ? "<UseWindowsForms>true</UseWindowsForms>"
                 : string.Empty;
+            string privateFeed = Directory.CreateDirectory(Path.Combine(externalRoot, "feed")).FullName;
+            string packageRoot = Directory.CreateDirectory(Path.Combine(externalRoot, "packages")).FullName;
+            WriteTestPackage(Path.Combine(privateFeed, "Package.Snapshot.1.0.0.nupkg"), "private-feed");
             string projectPath = Path.Combine(root, "App.csproj");
             File.WriteAllText(projectPath, $$"""
                 <Project Sdk="Microsoft.NET.Sdk">
@@ -31,13 +39,42 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
                     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
                     {{platformProperty}}
                   </PropertyGroup>
+                  <ItemGroup>
+                    <PackageReference Include="Package.Snapshot" Version="1.0.0" />
+                  </ItemGroup>
                 </Project>
                 """);
             File.WriteAllText(
                 Path.Combine(root, "Program.cs"),
                 "internal static class Program { private static void Main() { } }");
             File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
-            RunDotNet(root, $"restore \"{projectPath}\" -r {runtime} --use-lock-file --nologo");
+            string nuGetConfigPath = Path.Combine(root, "NuGet.Config");
+            File.WriteAllText(
+                nuGetConfigPath,
+                $$"""
+                <configuration>
+                  <packageSources>
+                    <clear />
+                    <add key="private" value="{{privateFeed}}" />
+                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+                  </packageSources>
+                </configuration>
+                """);
+            RunDotNet(
+                root,
+                $"restore \"{projectPath}\" -r {runtime} --use-lock-file --nologo " +
+                $"--packages \"{packageRoot}\" --configfile \"{nuGetConfigPath}\"");
+            string unavailableSource = Path.Combine(externalRoot, "unavailable-after-lock");
+            File.WriteAllText(
+                nuGetConfigPath,
+                $$"""
+                <configuration>
+                  <packageSources>
+                    <clear />
+                    <add key="unavailable" value="{{unavailableSource}}" />
+                  </packageSources>
+                </configuration>
+                """);
             RunGit(root, "add .");
             RunGit(root, "commit -m \"approved source\"");
             RunDotNet(
@@ -79,6 +116,79 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
 
             Assert.False(provenance.Dirty, string.Join(Environment.NewLine, provenance.DirtyReasons));
             Assert.Empty(provenance.DirtyPaths);
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+            DeleteTestRepository(externalRoot);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void SdkEvidenceProperties_ReplaySafePlanPropertiesWithoutSourceOverrides()
+    {
+        using JsonDocument properties = JsonDocument.Parse("{\"TargetFramework\":\"net10.0\"}");
+        var arguments = new List<string>();
+        var effectiveProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["EnableWindowsTargeting"] = "true",
+            ["TargetLatestRuntimePatch"] = "false",
+            ["RestoreSources"] = "https://untrusted.example.invalid/v3/index.json"
+        };
+        MethodInfo append = typeof(DotNetPublishPipelineRunner).GetMethod(
+            "AppendSdkEvidenceProperties",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        append.Invoke(null, [arguments, properties.RootElement, effectiveProperties]);
+
+        Assert.Contains("-p:EnableWindowsTargeting=true", arguments);
+        Assert.Contains("-p:TargetLatestRuntimePatch=false", arguments);
+        Assert.Contains("-p:TargetFramework=net10.0", arguments);
+        Assert.DoesNotContain(arguments, value => value.StartsWith("-p:RestoreSources=", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void VerifiedPackageArchiveCache_DeduplicatesIdenticalEvidenceArchivesByContentHash()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string firstPath = Path.Combine(root, "first.nupkg");
+            string secondPath = Path.Combine(root, "second.nupkg");
+            WriteTestPackage(firstPath, "deduplicated");
+            File.Copy(firstPath, secondPath);
+            string contentHash;
+            using (FileStream stream = File.OpenRead(firstPath))
+            using (var reader = new PackageArchiveReader(stream, leaveStreamOpen: false))
+                contentHash = reader.GetContentHash(CancellationToken.None);
+
+            Type cacheType = typeof(DotNetPublishPipelineRunner).GetNestedType(
+                "VerifiedPackageArchiveCache",
+                BindingFlags.NonPublic)!;
+            object cache = Activator.CreateInstance(cacheType, nonPublic: true)!;
+            try
+            {
+                MethodInfo open = cacheType.GetMethod(
+                    "TryGetOrOpen",
+                    BindingFlags.Instance | BindingFlags.NonPublic)!;
+                Assert.NotNull(open.Invoke(cache, [firstPath, contentHash]));
+                Assert.NotNull(open.Invoke(cache, [secondPath, contentHash]));
+
+                var paths = Assert.IsAssignableFrom<IDictionary>(cacheType
+                    .GetField("_archives", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .GetValue(cache));
+                var hashes = Assert.IsAssignableFrom<IDictionary>(cacheType
+                    .GetField("_archivesByContentHash", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .GetValue(cache));
+                Assert.Equal(2, paths.Count);
+                Assert.Single(hashes.Keys.Cast<object>());
+            }
+            finally
+            {
+                (cache as IDisposable)?.Dispose();
+            }
         }
         finally
         {

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerSdkRuntimePackProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerSdkRuntimePackProvenanceTests.cs
@@ -157,6 +157,7 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
         Assert.Contains("-p:TargetFramework=net10.0", arguments);
         Assert.Single(arguments, value => value.StartsWith("-p:RestoreSources=", StringComparison.OrdinalIgnoreCase));
         Assert.Contains("-p:RestoreSources=C:\\isolated\\verified", arguments);
+        Assert.Contains("-p:RestoreOutputPath=C:\\isolated\\obj\\", arguments);
         Assert.Contains("-p:DisableImplicitFrameworkReferences=true", arguments);
         Assert.Contains("-p:ImportDirectoryBuildProps=false", arguments);
         Assert.Contains("-p:ImportDirectoryBuildTargets=false", arguments);

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerSdkRuntimePackProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerSdkRuntimePackProvenanceTests.cs
@@ -142,17 +142,39 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
         MethodInfo appendOwned = typeof(DotNetPublishPipelineRunner).GetMethod(
             "AppendSdkEvidenceOwnedProperties",
             BindingFlags.Static | BindingFlags.NonPublic)!;
+        MethodInfo appendSyntheticIsolation = typeof(DotNetPublishPipelineRunner).GetMethod(
+            "AppendSyntheticSdkEvidenceProjectIsolationProperties",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
 
         append.Invoke(null, [arguments, properties.RootElement, effectiveProperties]);
         appendOwned.Invoke(
             null,
             [arguments, "C:\\isolated\\obj\\", "C:\\isolated\\NuGet.Config", "C:\\isolated\\verified"]);
+        appendSyntheticIsolation.Invoke(null, [arguments]);
 
         Assert.Contains("-p:EnableWindowsTargeting=true", arguments);
         Assert.Contains("-p:TargetLatestRuntimePatch=false", arguments);
         Assert.Contains("-p:TargetFramework=net10.0", arguments);
         Assert.Single(arguments, value => value.StartsWith("-p:RestoreSources=", StringComparison.OrdinalIgnoreCase));
         Assert.Contains("-p:RestoreSources=C:\\isolated\\verified", arguments);
+        Assert.Contains("-p:ImportDirectoryBuildProps=false", arguments);
+        Assert.Contains("-p:ImportDirectoryBuildTargets=false", arguments);
+        Assert.Contains("-p:ImportDirectoryPackagesProps=false", arguments);
+    }
+
+    [Theory]
+    [InlineData("Microsoft.NET.ILLink.Tasks", true)]
+    [InlineData("Package.Snapshot", false)]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void SdkEvidence_AutoReferencedBypassRequiresSdkOwnedPackageIdentity(
+        string packageId,
+        bool expected)
+    {
+        MethodInfo method = typeof(DotNetPublishPipelineRunner).GetMethod(
+            "IsTrustedSdkAutoReferencedPackageId",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        Assert.Equal(expected, Assert.IsType<bool>(method.Invoke(null, [packageId])));
     }
 
     [Fact]

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerSdkRuntimePackProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerSdkRuntimePackProvenanceTests.cs
@@ -139,13 +139,20 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
         MethodInfo append = typeof(DotNetPublishPipelineRunner).GetMethod(
             "AppendSdkEvidenceProperties",
             BindingFlags.Static | BindingFlags.NonPublic)!;
+        MethodInfo appendOwned = typeof(DotNetPublishPipelineRunner).GetMethod(
+            "AppendSdkEvidenceOwnedProperties",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
 
         append.Invoke(null, [arguments, properties.RootElement, effectiveProperties]);
+        appendOwned.Invoke(
+            null,
+            [arguments, "C:\\isolated\\obj\\", "C:\\isolated\\NuGet.Config", "C:\\isolated\\verified"]);
 
         Assert.Contains("-p:EnableWindowsTargeting=true", arguments);
         Assert.Contains("-p:TargetLatestRuntimePatch=false", arguments);
         Assert.Contains("-p:TargetFramework=net10.0", arguments);
-        Assert.DoesNotContain(arguments, value => value.StartsWith("-p:RestoreSources=", StringComparison.OrdinalIgnoreCase));
+        Assert.Single(arguments, value => value.StartsWith("-p:RestoreSources=", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("-p:RestoreSources=C:\\isolated\\verified", arguments);
     }
 
     [Fact]

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerSdkRuntimePackProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerSdkRuntimePackProvenanceTests.cs
@@ -1,0 +1,90 @@
+using PowerForge;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
+{
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void ReadSourceProvenance_AcceptsVerifiedSdkRuntimePacksForSingleFilePublish()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string runtime = OperatingSystem.IsWindows()
+                ? "win-x64"
+                : OperatingSystem.IsMacOS() ? "osx-x64" : "linux-x64";
+            string targetFramework = OperatingSystem.IsWindows() ? "net10.0-windows" : "net10.0";
+            string platformProperty = OperatingSystem.IsWindows()
+                ? "<UseWindowsForms>true</UseWindowsForms>"
+                : string.Empty;
+            string projectPath = Path.Combine(root, "App.csproj");
+            File.WriteAllText(projectPath, $$"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>{{targetFramework}}</TargetFramework>
+                    <RuntimeIdentifier>{{runtime}}</RuntimeIdentifier>
+                    <PublishSingleFile>true</PublishSingleFile>
+                    <SelfContained>true</SelfContained>
+                    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+                    {{platformProperty}}
+                  </PropertyGroup>
+                </Project>
+                """);
+            File.WriteAllText(
+                Path.Combine(root, "Program.cs"),
+                "internal static class Program { private static void Main() { } }");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
+            RunDotNet(root, $"restore \"{projectPath}\" -r {runtime} --use-lock-file --nologo");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source\"");
+            RunDotNet(
+                root,
+                $"build \"{projectPath}\" -c Release -f {targetFramework} -r {runtime} --no-restore --nologo");
+
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Configuration = "Release",
+                NoBuildInPublish = true,
+                NoRestoreInPublish = true,
+                Targets =
+                [
+                    new DotNetPublishTargetPlan
+                    {
+                        Name = "App",
+                        ProjectPath = projectPath,
+                        Publish = new DotNetPublishPublishOptions
+                        {
+                            Style = DotNetPublishStyle.Portable
+                        },
+                        Combinations =
+                        [
+                            new DotNetPublishTargetCombination
+                            {
+                                Framework = targetFramework,
+                                Runtime = runtime,
+                                Style = DotNetPublishStyle.Portable
+                            }
+                        ]
+                    }
+                ]
+            };
+
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(root, buildPlan: plan);
+
+            Assert.False(provenance.Dirty, string.Join(Environment.NewLine, provenance.DirtyReasons));
+            Assert.Empty(provenance.DirtyPaths);
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+}

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
@@ -196,7 +196,8 @@ public sealed partial class DotNetPublishPipelineRunner
                     offlinePackageSource,
                     controlledSourceRoot,
                     controlledProjectPath!,
-                    out offlinePackageSources))
+                    out offlinePackageSources,
+                    allowSdkManagedToolchainPackages: true))
                 return CacheAll(false);
             string controlledNuGetConfig = Path.Combine(controlledOutputRoot, "NuGet.Config");
             new XDocument(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ControlledPublishItems.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ControlledPublishItems.cs
@@ -20,7 +20,7 @@ public sealed partial class DotNetPublishPipelineRunner
         publishInputs = Array.Empty<EvaluatedPublishInput>();
         string controlledOutputRoot = Path.Combine(
             Path.GetTempPath(),
-            "powerforge-publish-inputs-" + Guid.NewGuid().ToString("N"));
+            "pfpi-" + Guid.NewGuid().ToString("N"));
         string controlledSourceRoot = Path.Combine(controlledOutputRoot, "source");
         string? controlledGitRoot = null;
         try
@@ -70,7 +70,8 @@ public sealed partial class DotNetPublishPipelineRunner
                         catalogSource,
                         controlledSourceRoot,
                         controlledProjectPath!,
-                        out string[] catalogSources))
+                        out string[] catalogSources,
+                        allowSdkManagedToolchainPackages: true))
                 {
                     return false;
                 }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
@@ -845,11 +845,12 @@ public sealed partial class DotNetPublishPipelineRunner
                 if (targetFrameworks.Count == 0)
                     AddSemicolonSeparatedValues(properties, "TargetFramework", targetFrameworks);
 
-                if (!VerifiedPackageInputCatalog.TryCreate(
+                if (!VerifiedPackageInputCatalog.TryCreateForEvaluation(
                         request.ProjectPath,
                         properties,
                         packageRoots,
                         verifiedPackageArchives,
+                        request.ReadEffectiveGlobalProperties(),
                         out verifiedPackages))
                 {
                     return false;

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
@@ -851,6 +851,7 @@ public sealed partial class DotNetPublishPipelineRunner
                         packageRoots,
                         verifiedPackageArchives,
                         request.ReadEffectiveGlobalProperties(),
+                        request.EnvironmentVariables,
                         out verifiedPackages))
                 {
                     return false;

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.ControlledBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.ControlledBuild.cs
@@ -130,6 +130,41 @@ public sealed partial class DotNetPublishPipelineRunner
 
     private sealed partial class VerifiedPackageArchiveCache
     {
+        internal bool TrySeedVerifiedRestoreSource(
+            string destination,
+            IReadOnlyDictionary<string, string> archivePathsByPackageKey)
+        {
+            try
+            {
+                Directory.CreateDirectory(destination);
+                foreach (KeyValuePair<string, string> package in archivePathsByPackageKey.OrderBy(
+                             entry => entry.Key,
+                             StringComparer.OrdinalIgnoreCase))
+                {
+                    string fullArchivePath = Path.GetFullPath(package.Value);
+                    if (!_archives.TryGetValue(fullArchivePath, out CacheEntry? cached))
+                        return false;
+
+                    int separator = package.Key.LastIndexOf('|');
+                    if (separator <= 0 || separator == package.Key.Length - 1)
+                        return false;
+                    string packageId = package.Key.Substring(0, separator);
+                    string packageVersion = package.Key.Substring(separator + 1);
+                    string destinationPath = Path.Combine(
+                        destination,
+                        packageId + "." + packageVersion + ".nupkg");
+                    if (File.Exists(destinationPath))
+                        return false;
+                    cached.Archive.CopyTo(destinationPath);
+                }
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
         internal bool TrySeedControlledPackageSource(
             string destination,
             IReadOnlyDictionary<string, string> archivePathsByPackageKey,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
@@ -399,6 +399,21 @@ public sealed partial class DotNetPublishPipelineRunner
             IEnumerable<string> packageRoots,
             VerifiedPackageArchiveCache archives,
             out VerifiedPackageInputCatalog? catalog)
+            => TryCreateForEvaluation(
+                projectPath,
+                properties,
+                packageRoots,
+                archives,
+                effectiveGlobalProperties: null,
+                out catalog);
+
+        internal static bool TryCreateForEvaluation(
+            string projectPath,
+            JsonElement properties,
+            IEnumerable<string> packageRoots,
+            VerifiedPackageArchiveCache archives,
+            IReadOnlyDictionary<string, string>? effectiveGlobalProperties,
+            out VerifiedPackageInputCatalog? catalog)
         {
             catalog = null;
             string projectDirectory = Path.GetDirectoryName(projectPath)!;
@@ -430,51 +445,58 @@ public sealed partial class DotNetPublishPipelineRunner
             var sdkDownloadPackageHashes = new Dictionary<string, string>(
                 StringComparer.OrdinalIgnoreCase);
             var sdkManagedPackageKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            AddSdkManagedPackageHashes(
+            string? sdkEvidenceRoot = AddSdkManagedPackageHashes(
                 projectPath,
                 properties,
                 allRoots,
-                committedPackageHashes,
                 sdkDownloadPackageHashes,
-                sdkManagedPackageKeys);
-            if (allRoots.Count == 0)
-                return !hasCommittedLock && sdkDownloadPackageHashes.Count == 0;
-            if (!TryPrimeLockedPackageArchives(
-                    allRoots,
-                    committedPackageHashes,
-                    archives,
-                    out Dictionary<string, string> archivePathsByPackageKey))
+                sdkManagedPackageKeys,
+                effectiveGlobalProperties);
+            try
             {
-                return false;
-            }
-            if (!TryPrimeLockedPackageArchives(
-                    allRoots,
-                    sdkDownloadPackageHashes,
-                    archives,
-                    out Dictionary<string, string> sdkDownloadArchivePaths))
-            {
-                return false;
-            }
-            foreach (KeyValuePair<string, string> entry in sdkDownloadArchivePaths)
-            {
-                if (archivePathsByPackageKey.TryGetValue(entry.Key, out string? existingPath) &&
-                    !Path.GetFullPath(existingPath).Equals(
-                        Path.GetFullPath(entry.Value),
-                        IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+                if (allRoots.Count == 0)
+                    return !hasCommittedLock && sdkDownloadPackageHashes.Count == 0;
+                if (!TryPrimeLockedPackageArchives(
+                        allRoots,
+                        committedPackageHashes,
+                        archives,
+                        out Dictionary<string, string> archivePathsByPackageKey))
                 {
                     return false;
                 }
-                archivePathsByPackageKey[entry.Key] = entry.Value;
+                if (!TryPrimeLockedPackageArchives(
+                        allRoots,
+                        sdkDownloadPackageHashes,
+                        archives,
+                        out Dictionary<string, string> sdkDownloadArchivePaths))
+                {
+                    return false;
+                }
+                foreach (KeyValuePair<string, string> entry in sdkDownloadArchivePaths)
+                {
+                    if (archivePathsByPackageKey.TryGetValue(entry.Key, out string? existingPath) &&
+                        !Path.GetFullPath(existingPath).Equals(
+                            Path.GetFullPath(entry.Value),
+                            IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+                    {
+                        return false;
+                    }
+                    archivePathsByPackageKey[entry.Key] = entry.Value;
+                }
+                foreach (KeyValuePair<string, string> entry in sdkDownloadPackageHashes)
+                    AddPackageHash(entry.Key, entry.Value, hashes);
+                catalog = new VerifiedPackageInputCatalog(
+                    allRoots,
+                    hashes,
+                    archives,
+                    archivePathsByPackageKey,
+                    sdkManagedPackageKeys);
+                return true;
             }
-            foreach (KeyValuePair<string, string> entry in sdkDownloadPackageHashes)
-                AddPackageHash(entry.Key, entry.Value, hashes);
-            catalog = new VerifiedPackageInputCatalog(
-                allRoots,
-                hashes,
-                archives,
-                archivePathsByPackageKey,
-                sdkManagedPackageKeys);
-            return true;
+            finally
+            {
+                TryDeleteSdkEvidenceRoot(sdkEvidenceRoot);
+            }
         }
 
         internal bool TryVerify(string path, out bool isPackageInput)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
@@ -439,7 +439,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 return !hasCommittedLock && hashes.Count == 0;
             if (!TryPrimeLockedPackageArchives(
                     allRoots,
-                    committedPackageHashes,
+                    hashes,
                     archives,
                     out Dictionary<string, string> archivePathsByPackageKey))
             {

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
@@ -427,24 +427,47 @@ public sealed partial class DotNetPublishPipelineRunner
             var committedPackageHashes = new Dictionary<string, string>(
                 hashes,
                 StringComparer.OrdinalIgnoreCase);
+            var sdkDownloadPackageHashes = new Dictionary<string, string>(
+                StringComparer.OrdinalIgnoreCase);
             var sdkManagedPackageKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             AddSdkManagedPackageHashes(
+                projectPath,
                 properties,
-                projectDirectory,
                 allRoots,
                 committedPackageHashes,
-                hashes,
+                sdkDownloadPackageHashes,
                 sdkManagedPackageKeys);
             if (allRoots.Count == 0)
-                return !hasCommittedLock && hashes.Count == 0;
+                return !hasCommittedLock && sdkDownloadPackageHashes.Count == 0;
             if (!TryPrimeLockedPackageArchives(
                     allRoots,
-                    hashes,
+                    committedPackageHashes,
                     archives,
                     out Dictionary<string, string> archivePathsByPackageKey))
             {
                 return false;
             }
+            if (!TryPrimeLockedPackageArchives(
+                    allRoots,
+                    sdkDownloadPackageHashes,
+                    archives,
+                    out Dictionary<string, string> sdkDownloadArchivePaths))
+            {
+                return false;
+            }
+            foreach (KeyValuePair<string, string> entry in sdkDownloadArchivePaths)
+            {
+                if (archivePathsByPackageKey.TryGetValue(entry.Key, out string? existingPath) &&
+                    !Path.GetFullPath(existingPath).Equals(
+                        Path.GetFullPath(entry.Value),
+                        IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+                {
+                    return false;
+                }
+                archivePathsByPackageKey[entry.Key] = entry.Value;
+            }
+            foreach (KeyValuePair<string, string> entry in sdkDownloadPackageHashes)
+                AddPackageHash(entry.Key, entry.Value, hashes);
             catalog = new VerifiedPackageInputCatalog(
                 allRoots,
                 hashes,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
@@ -405,6 +405,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 packageRoots,
                 archives,
                 effectiveGlobalProperties: null,
+                environmentVariables: null,
                 out catalog);
 
         internal static bool TryCreateForEvaluation(
@@ -413,6 +414,7 @@ public sealed partial class DotNetPublishPipelineRunner
             IEnumerable<string> packageRoots,
             VerifiedPackageArchiveCache archives,
             IReadOnlyDictionary<string, string>? effectiveGlobalProperties,
+            IReadOnlyDictionary<string, string?>? environmentVariables,
             out VerifiedPackageInputCatalog? catalog)
         {
             catalog = null;
@@ -445,25 +447,28 @@ public sealed partial class DotNetPublishPipelineRunner
             var sdkDownloadPackageHashes = new Dictionary<string, string>(
                 StringComparer.OrdinalIgnoreCase);
             var sdkManagedPackageKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (!TryPrimeLockedPackageArchives(
+                    allRoots,
+                    committedPackageHashes,
+                    archives,
+                    out Dictionary<string, string> archivePathsByPackageKey))
+            {
+                return false;
+            }
             string? sdkEvidenceRoot = AddSdkManagedPackageHashes(
                 projectPath,
                 properties,
                 allRoots,
                 sdkDownloadPackageHashes,
                 sdkManagedPackageKeys,
-                effectiveGlobalProperties);
+                effectiveGlobalProperties,
+                environmentVariables,
+                archivePathsByPackageKey,
+                archives);
             try
             {
                 if (allRoots.Count == 0)
                     return !hasCommittedLock && sdkDownloadPackageHashes.Count == 0;
-                if (!TryPrimeLockedPackageArchives(
-                        allRoots,
-                        committedPackageHashes,
-                        archives,
-                        out Dictionary<string, string> archivePathsByPackageKey))
-                {
-                    return false;
-                }
                 if (!TryPrimeLockedPackageArchives(
                         allRoots,
                         sdkDownloadPackageHashes,
@@ -662,6 +667,7 @@ public sealed partial class DotNetPublishPipelineRunner
     {
         private readonly Dictionary<string, CacheEntry> _archives = new(
             IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+        private readonly Dictionary<string, CacheEntry> _archivesByContentHash = new(StringComparer.Ordinal);
 
         internal VerifiedPackageArchive? TryGetOrOpen(string path, string expectedContentHash)
         {
@@ -673,17 +679,28 @@ public sealed partial class DotNetPublishPipelineRunner
                     : null;
             }
 
+            if (_archivesByContentHash.TryGetValue(expectedContentHash, out CacheEntry? cachedByHash))
+            {
+                _archives.Add(fullPath, cachedByHash);
+                return cachedByHash.Archive;
+            }
+
             VerifiedPackageArchive? archive = VerifiedPackageArchive.TryOpen(fullPath, expectedContentHash);
             if (archive is not null)
-                _archives.Add(fullPath, new CacheEntry(fullPath, expectedContentHash, archive));
+            {
+                var entry = new CacheEntry(fullPath, expectedContentHash, archive);
+                _archives.Add(fullPath, entry);
+                _archivesByContentHash.Add(expectedContentHash, entry);
+            }
             return archive;
         }
 
         public void Dispose()
         {
-            foreach (CacheEntry cached in _archives.Values)
+            foreach (CacheEntry cached in _archivesByContentHash.Values)
                 cached.Archive.Dispose();
             _archives.Clear();
+            _archivesByContentHash.Clear();
         }
 
         private sealed class CacheEntry

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SdkPackageProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SdkPackageProvenance.cs
@@ -347,6 +347,7 @@ public sealed partial class DotNetPublishPipelineRunner
     {
         arguments.Add("-p:MSBuildProjectExtensionsPath=" + EscapeMsBuildPropertyValue(intermediateRoot));
         arguments.Add("-p:RestoreConfigFile=" + EscapeMsBuildPropertyValue(configPath));
+        arguments.Add("-p:RestoreOutputPath=" + EscapeMsBuildPropertyValue(intermediateRoot));
         arguments.Add("-p:RestoreSources=" + EscapeMsBuildPropertyValue(restoreSource));
         arguments.Add("-p:RestoreFallbackFolders=");
         arguments.Add("-p:RestoreAdditionalProjectFallbackFolders=");

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SdkPackageProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SdkPackageProvenance.cs
@@ -5,18 +5,24 @@ namespace PowerForge;
 
 public sealed partial class DotNetPublishPipelineRunner
 {
-    private static void AddSdkManagedPackageHashes(
+    private static string? AddSdkManagedPackageHashes(
         string projectPath,
         JsonElement properties,
-        IEnumerable<string> packageRoots,
-        IReadOnlyDictionary<string, string> committedPackageHashes,
+        ICollection<string> packageRoots,
         Dictionary<string, string> hashes,
-        HashSet<string> sdkManagedPackageKeys)
+        HashSet<string> sdkManagedPackageKeys,
+        IReadOnlyDictionary<string, string>? effectiveGlobalProperties)
     {
-        if (!TryReadTrustedSdkRestoreGraph(projectPath, properties, out JsonDocument? document) ||
+        if (!TryReadTrustedSdkRestoreGraph(
+                projectPath,
+                properties,
+                effectiveGlobalProperties,
+                out JsonDocument? document,
+                out string? evidenceRoot,
+                out string? isolatedPackageRoot) ||
             document is null)
         {
-            return;
+            return null;
         }
 
         using (document)
@@ -25,7 +31,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 !project.TryGetProperty("frameworks", out JsonElement frameworks) ||
                 frameworks.ValueKind != JsonValueKind.Object)
             {
-                return;
+                TryDeleteSdkEvidenceRoot(evidenceRoot);
+                return null;
             }
 
             var downloads = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -35,9 +42,10 @@ public sealed partial class DotNetPublishPipelineRunner
                     dependencies.ValueKind == JsonValueKind.Object)
                 {
                     foreach (JsonProperty dependency in dependencies.EnumerateObject())
-                        AddTrustedAutoReferencedPackageKeys(
+                        AddTrustedAutoReferencedPackageKey(
                             dependency,
-                            committedPackageHashes,
+                            isolatedPackageRoot!,
+                            hashes,
                             sdkManagedPackageKeys);
                 }
 
@@ -45,16 +53,24 @@ public sealed partial class DotNetPublishPipelineRunner
             }
 
             foreach (string download in downloads)
-                AddSdkDownloadPackageHash(download, packageRoots, hashes);
+                AddSdkDownloadPackageHash(download, new[] { isolatedPackageRoot! }, hashes);
+
+            packageRoots.Add(isolatedPackageRoot!);
+            return evidenceRoot;
         }
     }
 
     private static bool TryReadTrustedSdkRestoreGraph(
         string projectPath,
         JsonElement properties,
-        out JsonDocument? document)
+        IReadOnlyDictionary<string, string>? effectiveGlobalProperties,
+        out JsonDocument? document,
+        out string? evidenceRoot,
+        out string? isolatedPackageRoot)
     {
         document = null;
+        evidenceRoot = null;
+        isolatedPackageRoot = null;
         string temporaryRoot = Path.Combine(
             Path.GetTempPath(),
             "pf-rg-" + Guid.NewGuid().ToString("N"));
@@ -62,8 +78,11 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             string intermediateRoot = Directory.CreateDirectory(
                 Path.Combine(temporaryRoot, "obj")).FullName + Path.DirectorySeparatorChar;
+            isolatedPackageRoot = Directory.CreateDirectory(
+                Path.Combine(temporaryRoot, "packages")).FullName;
             string graphPath = Path.Combine(temporaryRoot, "restore-graph.json");
-            var arguments = new List<string>
+            string lockPath = Path.Combine(temporaryRoot, "restore.lock.json");
+            var graphArguments = new List<string>
             {
                 "msbuild",
                 projectPath,
@@ -76,41 +95,48 @@ public sealed partial class DotNetPublishPipelineRunner
                 "-p:RestoreGraphOutputPath=" + EscapeMsBuildPropertyValue(graphPath),
                 "-p:MSBuildProjectExtensionsPath=" + EscapeMsBuildPropertyValue(intermediateRoot)
             };
-            foreach (string propertyName in new[]
-                     {
-                         "Configuration",
-                         "TargetFramework",
-                         "RuntimeIdentifier",
-                         "RuntimeIdentifiers",
-                         "SelfContained",
-                         "UseAppHost",
-                         "UseWPF",
-                         "UseWindowsForms",
-                         "PublishSingleFile",
-                         "PublishTrimmed",
-                         "PublishAot",
-                         "PublishReadyToRun"
-                     })
-            {
-                if (properties.TryGetProperty(propertyName, out JsonElement value) &&
-                    value.ValueKind == JsonValueKind.String &&
-                    !string.IsNullOrWhiteSpace(value.GetString()))
-                {
-                    arguments.Add(
-                        "-p:" + propertyName + "=" + EscapeMsBuildPropertyValue(value.GetString()!));
-                }
-            }
+            AppendSdkEvidenceProperties(graphArguments, properties, effectiveGlobalProperties);
 
-            var process = RunBuildInputEvaluationProcess(
+            var graphProcess = RunBuildInputEvaluationProcess(
                 "dotnet",
                 Path.GetDirectoryName(projectPath)!,
-                arguments,
+                graphArguments,
                 environmentVariables: null,
                 TimeSpan.FromMinutes(2));
-            if (process.ExitCode != 0 || process.TimedOut || !File.Exists(graphPath))
+            if (graphProcess.ExitCode != 0 || graphProcess.TimedOut || !File.Exists(graphPath))
+            {
                 return false;
+            }
+
+            var restoreArguments = new List<string>
+            {
+                "restore",
+                projectPath,
+                "--force-evaluate",
+                "--no-cache",
+                "--nologo",
+                "--packages",
+                isolatedPackageRoot,
+                "-p:RestorePackagesWithLockFile=true",
+                "-p:RestoreLockedMode=false",
+                "-p:NuGetLockFilePath=" + EscapeMsBuildPropertyValue(lockPath),
+                "-p:MSBuildProjectExtensionsPath=" + EscapeMsBuildPropertyValue(intermediateRoot),
+                "-p:NuGetAudit=false"
+            };
+            AppendSdkEvidenceProperties(restoreArguments, properties, effectiveGlobalProperties);
+            var restoreProcess = RunBuildInputEvaluationProcess(
+                "dotnet",
+                Path.GetDirectoryName(projectPath)!,
+                restoreArguments,
+                environmentVariables: null,
+                TimeSpan.FromMinutes(5));
+            if (restoreProcess.ExitCode != 0 || restoreProcess.TimedOut)
+            {
+                return false;
+            }
 
             document = JsonDocument.Parse(File.ReadAllText(graphPath));
+            evidenceRoot = temporaryRoot;
             return true;
         }
         catch
@@ -121,15 +147,61 @@ public sealed partial class DotNetPublishPipelineRunner
         }
         finally
         {
-            try
+            if (evidenceRoot is null)
+                TryDeleteSdkEvidenceRoot(temporaryRoot);
+        }
+    }
+
+    private static void AppendSdkEvidenceProperties(
+        ICollection<string> arguments,
+        JsonElement properties,
+        IReadOnlyDictionary<string, string>? effectiveGlobalProperties)
+    {
+        foreach (string propertyName in new[]
+                 {
+                     "Configuration",
+                     "TargetFramework",
+                     "RuntimeIdentifier",
+                     "RuntimeIdentifiers",
+                     "SelfContained",
+                     "UseAppHost",
+                     "UseWPF",
+                     "UseWindowsForms",
+                     "PublishSingleFile",
+                     "PublishTrimmed",
+                     "PublishAot",
+                     "PublishReadyToRun"
+                 })
+        {
+            string? value = effectiveGlobalProperties is not null &&
+                            effectiveGlobalProperties.TryGetValue(propertyName, out string? globalValue)
+                ? globalValue
+                : properties.TryGetProperty(propertyName, out JsonElement evaluatedValue) &&
+                  evaluatedValue.ValueKind == JsonValueKind.String
+                    ? evaluatedValue.GetString()
+                    : null;
+            if (!string.IsNullOrWhiteSpace(value))
+                arguments.Add("-p:" + propertyName + "=" + EscapeMsBuildPropertyValue(value!));
+        }
+    }
+
+    private static void TryDeleteSdkEvidenceRoot(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return;
+        try
+        {
+            string fullPath = Path.GetFullPath(path!);
+            string tempPath = Path.GetFullPath(Path.GetTempPath());
+            if (IsSameOrBelowBuildInputPath(fullPath, tempPath) &&
+                Path.GetFileName(fullPath).StartsWith("pf-rg-", StringComparison.Ordinal))
             {
-                if (Directory.Exists(temporaryRoot))
-                    Directory.Delete(temporaryRoot, recursive: true);
+                Directory.Delete(fullPath, recursive: true);
             }
-            catch
-            {
-                // A leftover temporary restore graph cannot make a package trusted.
-            }
+        }
+        catch
+        {
+            // Temporary SDK evidence cleanup is best effort only.
         }
     }
 
@@ -169,9 +241,10 @@ public sealed partial class DotNetPublishPipelineRunner
         return false;
     }
 
-    private static void AddTrustedAutoReferencedPackageKeys(
+    private static void AddTrustedAutoReferencedPackageKey(
         JsonProperty dependency,
-        IReadOnlyDictionary<string, string> committedPackageHashes,
+        string isolatedPackageRoot,
+        Dictionary<string, string> hashes,
         HashSet<string> sdkManagedPackageKeys)
     {
         if (!dependency.Value.TryGetProperty("autoReferenced", out JsonElement autoReferenced) ||
@@ -183,19 +256,24 @@ public sealed partial class DotNetPublishPipelineRunner
             return;
         }
 
-        foreach (KeyValuePair<string, string> package in committedPackageHashes)
+        string packageDirectory = Path.Combine(
+            isolatedPackageRoot,
+            dependency.Name.ToLowerInvariant());
+        if (!Directory.Exists(packageDirectory) || HasReparsePointBelowRoot(packageDirectory, isolatedPackageRoot))
+            return;
+        string[] candidates = Directory.EnumerateDirectories(packageDirectory, "*", SearchOption.TopDirectoryOnly)
+            .Where(path => NuGetVersion.TryParse(Path.GetFileName(path), out NuGetVersion? version) &&
+                           range.Satisfies(version))
+            .ToArray();
+        if (candidates.Length != 1)
+            return;
+        string resolvedVersion = Path.GetFileName(candidates[0]);
+        string packageKey = dependency.Name + "|" + resolvedVersion;
+        AddSdkDownloadPackageHash(packageKey, new[] { isolatedPackageRoot }, hashes);
+        if (hashes.TryGetValue(packageKey, out string? contentHash) &&
+            !string.IsNullOrWhiteSpace(contentHash))
         {
-            int separator = package.Key.LastIndexOf('|');
-            if (separator <= 0 || separator == package.Key.Length - 1 ||
-                !package.Key.Substring(0, separator).Equals(
-                    dependency.Name,
-                    StringComparison.OrdinalIgnoreCase) ||
-                !NuGetVersion.TryParse(package.Key.Substring(separator + 1), out NuGetVersion? resolved) ||
-                !range.Satisfies(resolved))
-            {
-                continue;
-            }
-            sdkManagedPackageKeys.Add(package.Key);
+            sdkManagedPackageKeys.Add(packageKey);
         }
     }
 

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SdkPackageProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SdkPackageProvenance.cs
@@ -204,6 +204,17 @@ public sealed partial class DotNetPublishPipelineRunner
             {
                 return false;
             }
+            if (!TryReadSdkPackageHashes(
+                    isolatedPackageRoot,
+                    sdkPackageKeys,
+                    out Dictionary<string, string> trustedSdkPackageHashes) ||
+                !TrySnapshotSdkPackageArchives(
+                    isolatedPackageRoot,
+                    trustedSdkPackageHashes,
+                    archives))
+            {
+                return false;
+            }
             if (!TryWriteSdkEvidenceNuGetConfig(
                     configPath,
                     verifiedPackageSource,
@@ -241,6 +252,17 @@ public sealed partial class DotNetPublishPipelineRunner
                 environmentVariables,
                 TimeSpan.FromMinutes(5));
             if (restoreProcess.ExitCode != 0 || restoreProcess.TimedOut)
+            {
+                return false;
+            }
+            if (!TryReadSdkPackageHashes(
+                    isolatedPackageRoot,
+                    sdkPackageKeys,
+                    out Dictionary<string, string> postRestoreSdkPackageHashes) ||
+                !HaveSamePackageHashes(trustedSdkPackageHashes, postRestoreSdkPackageHashes) ||
+                !TryVerifyCurrentSdkPackageArchives(
+                    isolatedPackageRoot,
+                    trustedSdkPackageHashes))
             {
                 return false;
             }
@@ -529,9 +551,97 @@ public sealed partial class DotNetPublishPipelineRunner
     private static void AppendSyntheticSdkEvidenceProjectIsolationProperties(
         ICollection<string> arguments)
     {
+        arguments.Add("-p:DisableImplicitFrameworkReferences=true");
         arguments.Add("-p:ImportDirectoryBuildProps=false");
         arguments.Add("-p:ImportDirectoryBuildTargets=false");
         arguments.Add("-p:ImportDirectoryPackagesProps=false");
+    }
+
+    private static bool TryReadSdkPackageHashes(
+        string isolatedPackageRoot,
+        IEnumerable<string> packageKeys,
+        out Dictionary<string, string> hashes)
+    {
+        hashes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        string[] expectedKeys = packageKeys
+            .Where(key => !string.IsNullOrWhiteSpace(key))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        foreach (string packageKey in expectedKeys)
+            AddSdkDownloadPackageHash(packageKey, new[] { isolatedPackageRoot }, hashes);
+
+        if (hashes.Count != expectedKeys.Length)
+            return false;
+        foreach (string key in expectedKeys)
+        {
+            if (!hashes.TryGetValue(key, out string? value) || string.IsNullOrWhiteSpace(value))
+                return false;
+        }
+        return true;
+    }
+
+    private static bool TrySnapshotSdkPackageArchives(
+        string isolatedPackageRoot,
+        IReadOnlyDictionary<string, string> hashes,
+        VerifiedPackageArchiveCache archives)
+    {
+        foreach (KeyValuePair<string, string> package in hashes)
+        {
+            if (!TryGetSdkPackageArchivePath(isolatedPackageRoot, package.Key, out string? archivePath) ||
+                archives.TryGetOrOpen(archivePath!, package.Value) is null)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static bool TryVerifyCurrentSdkPackageArchives(
+        string isolatedPackageRoot,
+        IReadOnlyDictionary<string, string> hashes)
+    {
+        foreach (KeyValuePair<string, string> package in hashes)
+        {
+            if (!TryGetSdkPackageArchivePath(isolatedPackageRoot, package.Key, out string? archivePath))
+                return false;
+            using VerifiedPackageArchive? archive = VerifiedPackageArchive.TryOpen(archivePath!, package.Value);
+            if (archive is null)
+                return false;
+        }
+        return true;
+    }
+
+    private static bool TryGetSdkPackageArchivePath(
+        string isolatedPackageRoot,
+        string packageKey,
+        out string? archivePath)
+    {
+        archivePath = null;
+        int separator = packageKey.LastIndexOf('|');
+        if (separator <= 0 || separator == packageKey.Length - 1)
+            return false;
+
+        string packageId = packageKey.Substring(0, separator).ToLowerInvariant();
+        string packageVersion = packageKey.Substring(separator + 1).ToLowerInvariant();
+        string candidate = Path.Combine(
+            Path.GetFullPath(isolatedPackageRoot),
+            packageId,
+            packageVersion,
+            packageId + "." + packageVersion + ".nupkg");
+        if (!File.Exists(candidate) || HasReparsePointBelowRoot(candidate, isolatedPackageRoot))
+            return false;
+
+        archivePath = candidate;
+        return true;
+    }
+
+    private static bool HaveSamePackageHashes(
+        IReadOnlyDictionary<string, string> expected,
+        IReadOnlyDictionary<string, string> actual)
+    {
+        return expected.Count == actual.Count &&
+               expected.All(package => actual.TryGetValue(package.Key, out string? hash) &&
+                                       string.Equals(package.Value, hash, StringComparison.Ordinal));
     }
 
     private static void TryDeleteSdkEvidenceRoot(string? path)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SdkPackageProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SdkPackageProvenance.cs
@@ -30,6 +30,13 @@ public sealed partial class DotNetPublishPipelineRunner
         },
         StringComparer.OrdinalIgnoreCase);
 
+    private static readonly HashSet<string> TrustedSdkAutoReferencedPackageIds = new(
+        new[]
+        {
+            "Microsoft.NET.ILLink.Tasks"
+        },
+        StringComparer.OrdinalIgnoreCase);
+
     private static string? AddSdkManagedPackageHashes(
         string projectPath,
         JsonElement properties,
@@ -356,6 +363,8 @@ public sealed partial class DotNetPublishPipelineRunner
                     if (dependency.Value.TryGetProperty("autoReferenced", out JsonElement autoReferenced) &&
                         autoReferenced.ValueKind == JsonValueKind.True)
                     {
+                        if (!IsTrustedSdkAutoReferencedPackageId(dependency.Name))
+                            continue;
                         if (!TryAddSdkEvidencePackageKey(
                                 dependency.Name,
                                 dependency.Value,
@@ -403,6 +412,9 @@ public sealed partial class DotNetPublishPipelineRunner
         packageKeys.Add(packageId + "|" + range.MinVersion.ToNormalizedString());
         return true;
     }
+
+    private static bool IsTrustedSdkAutoReferencedPackageId(string packageId)
+        => TrustedSdkAutoReferencedPackageIds.Contains(packageId);
 
     private static bool TryWriteSdkEvidenceNuGetConfig(
         string configPath,
@@ -498,6 +510,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 intermediateRoot,
                 configPath,
                 restoreSource);
+            AppendSyntheticSdkEvidenceProjectIsolationProperties(arguments);
             arguments.Add("-p:NuGetAudit=false");
             var process = RunBuildInputEvaluationProcess(
                 "dotnet",
@@ -511,6 +524,14 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             return false;
         }
+    }
+
+    private static void AppendSyntheticSdkEvidenceProjectIsolationProperties(
+        ICollection<string> arguments)
+    {
+        arguments.Add("-p:ImportDirectoryBuildProps=false");
+        arguments.Add("-p:ImportDirectoryBuildTargets=false");
+        arguments.Add("-p:ImportDirectoryPackagesProps=false");
     }
 
     private static void TryDeleteSdkEvidenceRoot(string? path)
@@ -577,6 +598,7 @@ public sealed partial class DotNetPublishPipelineRunner
     {
         if (!dependency.Value.TryGetProperty("autoReferenced", out JsonElement autoReferenced) ||
             autoReferenced.ValueKind != JsonValueKind.True ||
+            !IsTrustedSdkAutoReferencedPackageId(dependency.Name) ||
             !dependency.Value.TryGetProperty("version", out JsonElement version) ||
             version.ValueKind != JsonValueKind.String ||
             !VersionRange.TryParse(version.GetString()!, out VersionRange? range))

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SdkPackageProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SdkPackageProvenance.cs
@@ -124,8 +124,7 @@ public sealed partial class DotNetPublishPipelineRunner
             if (!TryWriteSdkEvidenceNuGetConfig(
                     configPath,
                     verifiedPackageSource,
-                    committedArchivePaths.Keys,
-                    Array.Empty<string>()))
+                    usePublicSource: false))
             {
                 return false;
             }
@@ -142,7 +141,11 @@ public sealed partial class DotNetPublishPipelineRunner
                 "-p:RestoreGraphOutputPath=" + EscapeMsBuildPropertyValue(graphPath)
             };
             AppendSdkEvidenceProperties(graphArguments, properties, effectiveGlobalProperties);
-            AppendSdkEvidenceOwnedProperties(graphArguments, intermediateRoot, configPath);
+            AppendSdkEvidenceOwnedProperties(
+                graphArguments,
+                intermediateRoot,
+                configPath,
+                verifiedPackageSource);
 
             var graphProcess = RunBuildInputEvaluationProcess(
                 "dotnet",
@@ -156,15 +159,48 @@ public sealed partial class DotNetPublishPipelineRunner
             }
 
             document = JsonDocument.Parse(File.ReadAllText(graphPath));
-            if (!TryReadSdkEvidencePackageIds(
+            if (!TryReadSdkEvidencePackageKeys(
                     document.RootElement,
                     projectPath,
-                    out HashSet<string> sdkPackageIds) ||
-                !TryWriteSdkEvidenceNuGetConfig(
+                    out HashSet<string> sdkPackageKeys))
+            {
+                return false;
+            }
+            if (!TryPrimeSdkEvidencePackages(
+                    temporaryRoot,
+                    isolatedPackageRoot,
+                    verifiedPackageSource,
+                    configPath,
+                    committedArchivePaths.Keys,
+                    "verified-lock",
+                    Path.GetDirectoryName(projectPath)!,
+                    environmentVariables))
+            {
+                return false;
+            }
+            if (!TryWriteSdkEvidenceNuGetConfig(
                     configPath,
                     verifiedPackageSource,
-                    committedArchivePaths.Keys,
-                    sdkPackageIds))
+                    usePublicSource: true))
+            {
+                return false;
+            }
+            if (!TryPrimeSdkEvidencePackages(
+                    temporaryRoot,
+                    isolatedPackageRoot,
+                    SdkEvidenceNuGetOrgSource,
+                    configPath,
+                    sdkPackageKeys,
+                    "sdk-packages",
+                    Path.GetDirectoryName(projectPath)!,
+                    environmentVariables))
+            {
+                return false;
+            }
+            if (!TryWriteSdkEvidenceNuGetConfig(
+                    configPath,
+                    verifiedPackageSource,
+                    usePublicSource: false))
             {
                 return false;
             }
@@ -182,7 +218,11 @@ public sealed partial class DotNetPublishPipelineRunner
                 configPath
             };
             AppendSdkEvidenceProperties(restoreArguments, properties, effectiveGlobalProperties);
-            AppendSdkEvidenceOwnedProperties(restoreArguments, intermediateRoot, configPath);
+            AppendSdkEvidenceOwnedProperties(
+                restoreArguments,
+                intermediateRoot,
+                configPath,
+                verifiedPackageSource);
             restoreArguments.Add("-p:RestorePackagesWithLockFile=true");
             restoreArguments.Add("-p:RestoreLockedMode=false");
             restoreArguments.Add("-p:NuGetLockFilePath=" + EscapeMsBuildPropertyValue(lockPath));
@@ -273,10 +313,12 @@ public sealed partial class DotNetPublishPipelineRunner
     private static void AppendSdkEvidenceOwnedProperties(
         ICollection<string> arguments,
         string intermediateRoot,
-        string configPath)
+        string configPath,
+        string restoreSource)
     {
         arguments.Add("-p:MSBuildProjectExtensionsPath=" + EscapeMsBuildPropertyValue(intermediateRoot));
         arguments.Add("-p:RestoreConfigFile=" + EscapeMsBuildPropertyValue(configPath));
+        arguments.Add("-p:RestoreSources=" + EscapeMsBuildPropertyValue(restoreSource));
         arguments.Add("-p:RestoreFallbackFolders=");
         arguments.Add("-p:RestoreAdditionalProjectFallbackFolders=");
         arguments.Add("-p:RestoreAdditionalProjectSources=");
@@ -291,12 +333,12 @@ public sealed partial class DotNetPublishPipelineRunner
             char.IsLetterOrDigit(character) || character == '_' || character == '-' || character == '.');
     }
 
-    private static bool TryReadSdkEvidencePackageIds(
+    private static bool TryReadSdkEvidencePackageKeys(
         JsonElement root,
         string projectPath,
-        out HashSet<string> packageIds)
+        out HashSet<string> packageKeys)
     {
-        packageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        packageKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (!TryReadRestoreGraphProject(root, projectPath, out JsonElement project) ||
             !project.TryGetProperty("frameworks", out JsonElement frameworks) ||
             frameworks.ValueKind != JsonValueKind.Object)
@@ -314,7 +356,13 @@ public sealed partial class DotNetPublishPipelineRunner
                     if (dependency.Value.TryGetProperty("autoReferenced", out JsonElement autoReferenced) &&
                         autoReferenced.ValueKind == JsonValueKind.True)
                     {
-                        packageIds.Add(dependency.Name);
+                        if (!TryAddSdkEvidencePackageKey(
+                                dependency.Name,
+                                dependency.Value,
+                                packageKeys))
+                        {
+                            return false;
+                        }
                     }
                 }
             }
@@ -326,75 +374,138 @@ public sealed partial class DotNetPublishPipelineRunner
             }
             foreach (JsonElement download in downloads.EnumerateArray())
             {
-                if (download.TryGetProperty("name", out JsonElement name) &&
-                    name.ValueKind == JsonValueKind.String &&
-                    !string.IsNullOrWhiteSpace(name.GetString()))
+                if (!download.TryGetProperty("name", out JsonElement name) ||
+                    name.ValueKind != JsonValueKind.String ||
+                    string.IsNullOrWhiteSpace(name.GetString()) ||
+                    !TryAddSdkEvidencePackageKey(name.GetString()!, download, packageKeys))
                 {
-                    packageIds.Add(name.GetString()!);
+                    return false;
                 }
             }
         }
+        return packageKeys.Count > 0;
+    }
+
+    private static bool TryAddSdkEvidencePackageKey(
+        string packageId,
+        JsonElement package,
+        ISet<string> packageKeys)
+    {
+        if (!package.TryGetProperty("version", out JsonElement versionElement) ||
+            versionElement.ValueKind != JsonValueKind.String ||
+            !VersionRange.TryParse(versionElement.GetString()!, out VersionRange? range) ||
+            range.MinVersion is null ||
+            !range.IsMinInclusive)
+        {
+            return false;
+        }
+
+        packageKeys.Add(packageId + "|" + range.MinVersion.ToNormalizedString());
         return true;
     }
 
     private static bool TryWriteSdkEvidenceNuGetConfig(
         string configPath,
         string verifiedPackageSource,
-        IEnumerable<string> committedPackageKeys,
-        IEnumerable<string> sdkPackageIds)
+        bool usePublicSource)
     {
         try
         {
-            var committedIds = new HashSet<string>(
-                committedPackageKeys.Select(key =>
-                {
-                    int separator = key.LastIndexOf('|');
-                    return separator > 0 ? key.Substring(0, separator) : string.Empty;
-                }).Where(id => !string.IsNullOrWhiteSpace(id)),
-                StringComparer.OrdinalIgnoreCase);
-            var publicSdkIds = new HashSet<string>(
-                sdkPackageIds.Where(id => !committedIds.Contains(id)),
-                StringComparer.OrdinalIgnoreCase);
-
+            string source = usePublicSource ? SdkEvidenceNuGetOrgSource : verifiedPackageSource;
             var packageSources = new XElement(
                 "packageSources",
                 new XElement("clear"),
-                new XElement("add", new XAttribute("key", "verified-lock"), new XAttribute("value", verifiedPackageSource)),
                 new XElement(
                     "add",
-                    new XAttribute("key", "nuget.org"),
-                    new XAttribute("value", SdkEvidenceNuGetOrgSource),
-                    new XAttribute("protocolVersion", "3")));
+                    new XAttribute("key", usePublicSource ? "nuget.org" : "verified-lock"),
+                    new XAttribute("value", source),
+                    usePublicSource ? new XAttribute("protocolVersion", "3") : null));
             var root = new XElement(
                 "configuration",
                 packageSources,
                 new XElement("fallbackPackageFolders", new XElement("clear")),
                 new XElement("disabledPackageSources", new XElement("clear")));
-
-            if (committedIds.Count > 0 || publicSdkIds.Count > 0)
-            {
-                var mappings = new XElement("packageSourceMapping");
-                if (committedIds.Count > 0)
-                {
-                    mappings.Add(new XElement(
-                        "packageSource",
-                        new XAttribute("key", "verified-lock"),
-                        committedIds.OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
-                            .Select(id => new XElement("package", new XAttribute("pattern", id)))));
-                }
-                if (publicSdkIds.Count > 0)
-                {
-                    mappings.Add(new XElement(
-                        "packageSource",
-                        new XAttribute("key", "nuget.org"),
-                        publicSdkIds.OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
-                            .Select(id => new XElement("package", new XAttribute("pattern", id)))));
-                }
-                root.Add(mappings);
-            }
-
             new XDocument(root).Save(configPath);
             return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool TryPrimeSdkEvidencePackages(
+        string temporaryRoot,
+        string isolatedPackageRoot,
+        string restoreSource,
+        string configPath,
+        IEnumerable<string> packageKeys,
+        string projectName,
+        string workingDirectory,
+        IReadOnlyDictionary<string, string?>? environmentVariables)
+    {
+        try
+        {
+            var packages = packageKeys
+                .Select(key =>
+                {
+                    int separator = key.LastIndexOf('|');
+                    return separator > 0 && separator < key.Length - 1
+                        ? (Id: key.Substring(0, separator), Version: key.Substring(separator + 1))
+                        : default;
+                })
+                .Where(package => !string.IsNullOrWhiteSpace(package.Id) &&
+                                  !string.IsNullOrWhiteSpace(package.Version))
+                .Distinct()
+                .OrderBy(package => package.Id, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(package => package.Version, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (packages.Length == 0)
+                return true;
+
+            string projectPath = Path.Combine(temporaryRoot, projectName + ".csproj");
+            string intermediateRoot = Directory.CreateDirectory(
+                Path.Combine(temporaryRoot, projectName + "-obj")).FullName + Path.DirectorySeparatorChar;
+            new XDocument(
+                new XElement(
+                    "Project",
+                    new XAttribute("Sdk", "Microsoft.NET.Sdk"),
+                    new XElement(
+                        "PropertyGroup",
+                        new XElement("TargetFramework", "net8.0")),
+                    new XElement(
+                        "ItemGroup",
+                        packages.Select(package => new XElement(
+                            "PackageDownload",
+                            new XAttribute("Include", package.Id),
+                            new XAttribute("Version", "[" + package.Version + "]"))))))
+                .Save(projectPath);
+
+            var arguments = new List<string>
+            {
+                "restore",
+                projectPath,
+                "--force-evaluate",
+                "--no-cache",
+                "--nologo",
+                "--packages",
+                isolatedPackageRoot,
+                "--configfile",
+                configPath
+            };
+            AppendSdkEvidenceOwnedProperties(
+                arguments,
+                intermediateRoot,
+                configPath,
+                restoreSource);
+            arguments.Add("-p:NuGetAudit=false");
+            var process = RunBuildInputEvaluationProcess(
+                "dotnet",
+                workingDirectory,
+                arguments,
+                environmentVariables,
+                TimeSpan.FromMinutes(2));
+            return process.ExitCode == 0 && !process.TimedOut;
         }
         catch
         {

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SdkPackageProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SdkPackageProvenance.cs
@@ -6,67 +6,196 @@ namespace PowerForge;
 public sealed partial class DotNetPublishPipelineRunner
 {
     private static void AddSdkManagedPackageHashes(
+        string projectPath,
         JsonElement properties,
-        string projectDirectory,
         IEnumerable<string> packageRoots,
         IReadOnlyDictionary<string, string> committedPackageHashes,
         Dictionary<string, string> hashes,
         HashSet<string> sdkManagedPackageKeys)
     {
-        string assetsPath = ReadEvaluatedPath(properties, "ProjectAssetsFile", projectDirectory)
-            ?? Path.Combine(projectDirectory, "obj", "project.assets.json");
-        try
+        if (!TryReadTrustedSdkRestoreGraph(projectPath, properties, out JsonDocument? document) ||
+            document is null)
         {
-            using JsonDocument document = JsonDocument.Parse(File.ReadAllText(assetsPath));
-            var autoReferenced = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var downloads = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            if (document.RootElement.TryGetProperty("project", out JsonElement project) &&
-                project.TryGetProperty("frameworks", out JsonElement frameworks) &&
-                frameworks.ValueKind == JsonValueKind.Object)
-            {
-                foreach (JsonProperty framework in frameworks.EnumerateObject())
-                {
-                    if (framework.Value.TryGetProperty("dependencies", out JsonElement dependencies) &&
-                        dependencies.ValueKind == JsonValueKind.Object)
-                    {
-                        foreach (JsonProperty dependency in dependencies.EnumerateObject())
-                        {
-                            if (dependency.Value.TryGetProperty("autoReferenced", out JsonElement value) &&
-                                value.ValueKind == JsonValueKind.True)
-                            {
-                                autoReferenced.Add(dependency.Name);
-                            }
-                        }
-                    }
+            return;
+        }
 
-                    AddSdkDownloadDependencies(framework.Value, downloads);
-                }
+        using (document)
+        {
+            if (!TryReadRestoreGraphProject(document.RootElement, projectPath, out JsonElement project) ||
+                !project.TryGetProperty("frameworks", out JsonElement frameworks) ||
+                frameworks.ValueKind != JsonValueKind.Object)
+            {
+                return;
             }
 
-            if (autoReferenced.Count > 0 &&
-                document.RootElement.TryGetProperty("libraries", out JsonElement libraries) &&
-                libraries.ValueKind == JsonValueKind.Object)
+            var downloads = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (JsonProperty framework in frameworks.EnumerateObject())
             {
-                foreach (JsonProperty library in libraries.EnumerateObject())
-                    AddAutoReferencedPackageHash(
-                        library,
-                        autoReferenced,
-                        committedPackageHashes,
-                        hashes,
-                        sdkManagedPackageKeys);
+                if (framework.Value.TryGetProperty("dependencies", out JsonElement dependencies) &&
+                    dependencies.ValueKind == JsonValueKind.Object)
+                {
+                    foreach (JsonProperty dependency in dependencies.EnumerateObject())
+                        AddTrustedAutoReferencedPackageKeys(
+                            dependency,
+                            committedPackageHashes,
+                            sdkManagedPackageKeys);
+                }
+
+                AddSdkDownloadDependencies(framework.Value, downloads);
             }
 
             foreach (string download in downloads)
-                AddSdkDownloadPackageHash(
-                    download,
-                    packageRoots,
-                    committedPackageHashes,
-                    hashes,
-                    sdkManagedPackageKeys);
+                AddSdkDownloadPackageHash(download, packageRoots, hashes);
+        }
+    }
+
+    private static bool TryReadTrustedSdkRestoreGraph(
+        string projectPath,
+        JsonElement properties,
+        out JsonDocument? document)
+    {
+        document = null;
+        string temporaryRoot = Path.Combine(
+            Path.GetTempPath(),
+            "pf-rg-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            string intermediateRoot = Directory.CreateDirectory(
+                Path.Combine(temporaryRoot, "obj")).FullName + Path.DirectorySeparatorChar;
+            string graphPath = Path.Combine(temporaryRoot, "restore-graph.json");
+            var arguments = new List<string>
+            {
+                "msbuild",
+                projectPath,
+                "-nologo",
+                "-maxCpuCount:1",
+                "-nodeReuse:false",
+                "-verbosity:quiet",
+                "-noAutoResponse",
+                "-target:GenerateRestoreGraphFile",
+                "-p:RestoreGraphOutputPath=" + EscapeMsBuildPropertyValue(graphPath),
+                "-p:MSBuildProjectExtensionsPath=" + EscapeMsBuildPropertyValue(intermediateRoot)
+            };
+            foreach (string propertyName in new[]
+                     {
+                         "Configuration",
+                         "TargetFramework",
+                         "RuntimeIdentifier",
+                         "RuntimeIdentifiers",
+                         "SelfContained",
+                         "UseAppHost",
+                         "UseWPF",
+                         "UseWindowsForms",
+                         "PublishSingleFile",
+                         "PublishTrimmed",
+                         "PublishAot",
+                         "PublishReadyToRun"
+                     })
+            {
+                if (properties.TryGetProperty(propertyName, out JsonElement value) &&
+                    value.ValueKind == JsonValueKind.String &&
+                    !string.IsNullOrWhiteSpace(value.GetString()))
+                {
+                    arguments.Add(
+                        "-p:" + propertyName + "=" + EscapeMsBuildPropertyValue(value.GetString()!));
+                }
+            }
+
+            var process = RunBuildInputEvaluationProcess(
+                "dotnet",
+                Path.GetDirectoryName(projectPath)!,
+                arguments,
+                environmentVariables: null,
+                TimeSpan.FromMinutes(2));
+            if (process.ExitCode != 0 || process.TimedOut || !File.Exists(graphPath))
+                return false;
+
+            document = JsonDocument.Parse(File.ReadAllText(graphPath));
+            return true;
         }
         catch
         {
-            // Only an exact SDK-managed package hash can extend the committed lock.
+            document?.Dispose();
+            document = null;
+            return false;
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(temporaryRoot))
+                    Directory.Delete(temporaryRoot, recursive: true);
+            }
+            catch
+            {
+                // A leftover temporary restore graph cannot make a package trusted.
+            }
+        }
+    }
+
+    private static bool TryReadRestoreGraphProject(
+        JsonElement root,
+        string projectPath,
+        out JsonElement project)
+    {
+        project = default;
+        if (!root.TryGetProperty("projects", out JsonElement projects) ||
+            projects.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        string fullProjectPath = Path.GetFullPath(projectPath);
+        foreach (JsonProperty candidate in projects.EnumerateObject())
+        {
+            string candidatePath;
+            try
+            {
+                candidatePath = Path.GetFullPath(candidate.Name);
+            }
+            catch
+            {
+                continue;
+            }
+            if (!candidatePath.Equals(
+                    fullProjectPath,
+                    IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+            {
+                continue;
+            }
+            project = candidate.Value;
+            return true;
+        }
+        return false;
+    }
+
+    private static void AddTrustedAutoReferencedPackageKeys(
+        JsonProperty dependency,
+        IReadOnlyDictionary<string, string> committedPackageHashes,
+        HashSet<string> sdkManagedPackageKeys)
+    {
+        if (!dependency.Value.TryGetProperty("autoReferenced", out JsonElement autoReferenced) ||
+            autoReferenced.ValueKind != JsonValueKind.True ||
+            !dependency.Value.TryGetProperty("version", out JsonElement version) ||
+            version.ValueKind != JsonValueKind.String ||
+            !VersionRange.TryParse(version.GetString()!, out VersionRange? range))
+        {
+            return;
+        }
+
+        foreach (KeyValuePair<string, string> package in committedPackageHashes)
+        {
+            int separator = package.Key.LastIndexOf('|');
+            if (separator <= 0 || separator == package.Key.Length - 1 ||
+                !package.Key.Substring(0, separator).Equals(
+                    dependency.Name,
+                    StringComparison.OrdinalIgnoreCase) ||
+                !NuGetVersion.TryParse(package.Key.Substring(separator + 1), out NuGetVersion? resolved) ||
+                !range.Satisfies(resolved))
+            {
+                continue;
+            }
+            sdkManagedPackageKeys.Add(package.Key);
         }
     }
 
@@ -100,42 +229,10 @@ public sealed partial class DotNetPublishPipelineRunner
         }
     }
 
-    private static void AddAutoReferencedPackageHash(
-        JsonProperty library,
-        HashSet<string> autoReferenced,
-        IReadOnlyDictionary<string, string> committedPackageHashes,
-        Dictionary<string, string> hashes,
-        HashSet<string> sdkManagedPackageKeys)
-    {
-        int separator = library.Name.LastIndexOf('/');
-        if (separator <= 0 || separator == library.Name.Length - 1)
-            return;
-
-        string packageId = library.Name.Substring(0, separator);
-        if (!autoReferenced.Contains(packageId) ||
-            !library.Value.TryGetProperty("type", out JsonElement type) ||
-            !string.Equals(type.GetString(), "package", StringComparison.OrdinalIgnoreCase) ||
-            !library.Value.TryGetProperty("sha512", out JsonElement sha512) ||
-            sha512.ValueKind != JsonValueKind.String)
-        {
-            return;
-        }
-
-        string packageKey = packageId + "|" + library.Name.Substring(separator + 1);
-        AddPackageHash(packageKey, sha512.GetString(), hashes);
-        AddSdkManagedPackageKey(
-            packageKey,
-            sha512.GetString(),
-            committedPackageHashes,
-            sdkManagedPackageKeys);
-    }
-
     private static void AddSdkDownloadPackageHash(
         string packageKey,
         IEnumerable<string> packageRoots,
-        IReadOnlyDictionary<string, string> committedPackageHashes,
-        Dictionary<string, string> hashes,
-        HashSet<string> sdkManagedPackageKeys)
+        Dictionary<string, string> hashes)
     {
         string[] parts = packageKey.Split('|');
         if (parts.Length != 2)
@@ -181,25 +278,6 @@ public sealed partial class DotNetPublishPipelineRunner
         }
 
         AddPackageHash(packageKey, discoveredHash, hashes);
-        AddSdkManagedPackageKey(
-            packageKey,
-            discoveredHash,
-            committedPackageHashes,
-            sdkManagedPackageKeys);
-    }
-
-    private static void AddSdkManagedPackageKey(
-        string packageKey,
-        string? expectedHash,
-        IReadOnlyDictionary<string, string> committedPackageHashes,
-        HashSet<string> sdkManagedPackageKeys)
-    {
-        if (!string.IsNullOrWhiteSpace(expectedHash) &&
-            committedPackageHashes.TryGetValue(packageKey, out string? actualHash) &&
-            string.Equals(actualHash, expectedHash, StringComparison.Ordinal))
-        {
-            sdkManagedPackageKeys.Add(packageKey);
-        }
     }
 
     private static void AddPackageHash(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SdkPackageProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SdkPackageProvenance.cs
@@ -1,22 +1,53 @@
 using System.Text.Json;
+using System.Xml.Linq;
 using NuGet.Versioning;
 
 namespace PowerForge;
 
 public sealed partial class DotNetPublishPipelineRunner
 {
+    private const string SdkEvidenceNuGetOrgSource = "https://api.nuget.org/v3/index.json";
+
+    private static readonly HashSet<string> SdkEvidenceOwnedProperties = new(
+        new[]
+        {
+            "MSBuildProjectExtensionsPath",
+            "NuGetLockFilePath",
+            "RestoreAdditionalProjectFallbackFolders",
+            "RestoreAdditionalProjectSources",
+            "RestoreConfigFile",
+            "RestoreFallbackFolders",
+            "RestoreGraphOutputPath",
+            "RestoreIgnoreFailedSources",
+            "RestoreLockedMode",
+            "RestoreNoCache",
+            "RestoreOutputPath",
+            "RestorePackagesPath",
+            "RestorePackagesWithLockFile",
+            "RestoreRecursive",
+            "RestoreRepositoryPath",
+            "RestoreSources"
+        },
+        StringComparer.OrdinalIgnoreCase);
+
     private static string? AddSdkManagedPackageHashes(
         string projectPath,
         JsonElement properties,
         ICollection<string> packageRoots,
         Dictionary<string, string> hashes,
         HashSet<string> sdkManagedPackageKeys,
-        IReadOnlyDictionary<string, string>? effectiveGlobalProperties)
+        IReadOnlyDictionary<string, string>? effectiveGlobalProperties,
+        IReadOnlyDictionary<string, string?>? environmentVariables,
+        IReadOnlyDictionary<string, string> committedArchivePaths,
+        VerifiedPackageArchiveCache archives)
     {
         if (!TryReadTrustedSdkRestoreGraph(
                 projectPath,
                 properties,
                 effectiveGlobalProperties,
+                environmentVariables,
+                committedArchivePaths,
+                archives,
                 out JsonDocument? document,
                 out string? evidenceRoot,
                 out string? isolatedPackageRoot) ||
@@ -64,6 +95,9 @@ public sealed partial class DotNetPublishPipelineRunner
         string projectPath,
         JsonElement properties,
         IReadOnlyDictionary<string, string>? effectiveGlobalProperties,
+        IReadOnlyDictionary<string, string?>? environmentVariables,
+        IReadOnlyDictionary<string, string> committedArchivePaths,
+        VerifiedPackageArchiveCache archives,
         out JsonDocument? document,
         out string? evidenceRoot,
         out string? isolatedPackageRoot)
@@ -80,8 +114,21 @@ public sealed partial class DotNetPublishPipelineRunner
                 Path.Combine(temporaryRoot, "obj")).FullName + Path.DirectorySeparatorChar;
             isolatedPackageRoot = Directory.CreateDirectory(
                 Path.Combine(temporaryRoot, "packages")).FullName;
+            string verifiedPackageSource = Directory.CreateDirectory(
+                Path.Combine(temporaryRoot, "verified-lock")).FullName;
+            if (!archives.TrySeedVerifiedRestoreSource(verifiedPackageSource, committedArchivePaths))
+                return false;
             string graphPath = Path.Combine(temporaryRoot, "restore-graph.json");
             string lockPath = Path.Combine(temporaryRoot, "restore.lock.json");
+            string configPath = Path.Combine(temporaryRoot, "NuGet.Config");
+            if (!TryWriteSdkEvidenceNuGetConfig(
+                    configPath,
+                    verifiedPackageSource,
+                    committedArchivePaths.Keys,
+                    Array.Empty<string>()))
+            {
+                return false;
+            }
             var graphArguments = new List<string>
             {
                 "msbuild",
@@ -92,18 +139,32 @@ public sealed partial class DotNetPublishPipelineRunner
                 "-verbosity:quiet",
                 "-noAutoResponse",
                 "-target:GenerateRestoreGraphFile",
-                "-p:RestoreGraphOutputPath=" + EscapeMsBuildPropertyValue(graphPath),
-                "-p:MSBuildProjectExtensionsPath=" + EscapeMsBuildPropertyValue(intermediateRoot)
+                "-p:RestoreGraphOutputPath=" + EscapeMsBuildPropertyValue(graphPath)
             };
             AppendSdkEvidenceProperties(graphArguments, properties, effectiveGlobalProperties);
+            AppendSdkEvidenceOwnedProperties(graphArguments, intermediateRoot, configPath);
 
             var graphProcess = RunBuildInputEvaluationProcess(
                 "dotnet",
                 Path.GetDirectoryName(projectPath)!,
                 graphArguments,
-                environmentVariables: null,
+                environmentVariables,
                 TimeSpan.FromMinutes(2));
             if (graphProcess.ExitCode != 0 || graphProcess.TimedOut || !File.Exists(graphPath))
+            {
+                return false;
+            }
+
+            document = JsonDocument.Parse(File.ReadAllText(graphPath));
+            if (!TryReadSdkEvidencePackageIds(
+                    document.RootElement,
+                    projectPath,
+                    out HashSet<string> sdkPackageIds) ||
+                !TryWriteSdkEvidenceNuGetConfig(
+                    configPath,
+                    verifiedPackageSource,
+                    committedArchivePaths.Keys,
+                    sdkPackageIds))
             {
                 return false;
             }
@@ -117,25 +178,26 @@ public sealed partial class DotNetPublishPipelineRunner
                 "--nologo",
                 "--packages",
                 isolatedPackageRoot,
-                "-p:RestorePackagesWithLockFile=true",
-                "-p:RestoreLockedMode=false",
-                "-p:NuGetLockFilePath=" + EscapeMsBuildPropertyValue(lockPath),
-                "-p:MSBuildProjectExtensionsPath=" + EscapeMsBuildPropertyValue(intermediateRoot),
-                "-p:NuGetAudit=false"
+                "--configfile",
+                configPath
             };
             AppendSdkEvidenceProperties(restoreArguments, properties, effectiveGlobalProperties);
+            AppendSdkEvidenceOwnedProperties(restoreArguments, intermediateRoot, configPath);
+            restoreArguments.Add("-p:RestorePackagesWithLockFile=true");
+            restoreArguments.Add("-p:RestoreLockedMode=false");
+            restoreArguments.Add("-p:NuGetLockFilePath=" + EscapeMsBuildPropertyValue(lockPath));
+            restoreArguments.Add("-p:NuGetAudit=false");
             var restoreProcess = RunBuildInputEvaluationProcess(
                 "dotnet",
                 Path.GetDirectoryName(projectPath)!,
                 restoreArguments,
-                environmentVariables: null,
+                environmentVariables,
                 TimeSpan.FromMinutes(5));
             if (restoreProcess.ExitCode != 0 || restoreProcess.TimedOut)
             {
                 return false;
             }
 
-            document = JsonDocument.Parse(File.ReadAllText(graphPath));
             evidenceRoot = temporaryRoot;
             return true;
         }
@@ -148,7 +210,11 @@ public sealed partial class DotNetPublishPipelineRunner
         finally
         {
             if (evidenceRoot is null)
+            {
+                document?.Dispose();
+                document = null;
                 TryDeleteSdkEvidenceRoot(temporaryRoot);
+            }
         }
     }
 
@@ -157,6 +223,7 @@ public sealed partial class DotNetPublishPipelineRunner
         JsonElement properties,
         IReadOnlyDictionary<string, string>? effectiveGlobalProperties)
     {
+        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (string propertyName in new[]
                  {
                      "Configuration",
@@ -181,7 +248,157 @@ public sealed partial class DotNetPublishPipelineRunner
                     ? evaluatedValue.GetString()
                     : null;
             if (!string.IsNullOrWhiteSpace(value))
-                arguments.Add("-p:" + propertyName + "=" + EscapeMsBuildPropertyValue(value!));
+                values[propertyName] = value!;
+        }
+
+        foreach (KeyValuePair<string, string> property in effectiveGlobalProperties ??
+                 new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase))
+        {
+            if (!string.IsNullOrWhiteSpace(property.Key) &&
+                !SdkEvidenceOwnedProperties.Contains(property.Key) &&
+                IsSafeSdkEvidencePropertyName(property.Key))
+            {
+                values[property.Key] = property.Value ?? string.Empty;
+            }
+        }
+
+        foreach (KeyValuePair<string, string> property in values.OrderBy(
+                     entry => entry.Key,
+                     StringComparer.OrdinalIgnoreCase))
+        {
+            arguments.Add("-p:" + property.Key + "=" + EscapeMsBuildPropertyValue(property.Value));
+        }
+    }
+
+    private static void AppendSdkEvidenceOwnedProperties(
+        ICollection<string> arguments,
+        string intermediateRoot,
+        string configPath)
+    {
+        arguments.Add("-p:MSBuildProjectExtensionsPath=" + EscapeMsBuildPropertyValue(intermediateRoot));
+        arguments.Add("-p:RestoreConfigFile=" + EscapeMsBuildPropertyValue(configPath));
+        arguments.Add("-p:RestoreFallbackFolders=");
+        arguments.Add("-p:RestoreAdditionalProjectFallbackFolders=");
+        arguments.Add("-p:RestoreAdditionalProjectSources=");
+        arguments.Add("-p:RestoreRecursive=false");
+    }
+
+    private static bool IsSafeSdkEvidencePropertyName(string name)
+    {
+        if (string.IsNullOrEmpty(name) || !(char.IsLetter(name[0]) || name[0] == '_'))
+            return false;
+        return name.Skip(1).All(character =>
+            char.IsLetterOrDigit(character) || character == '_' || character == '-' || character == '.');
+    }
+
+    private static bool TryReadSdkEvidencePackageIds(
+        JsonElement root,
+        string projectPath,
+        out HashSet<string> packageIds)
+    {
+        packageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!TryReadRestoreGraphProject(root, projectPath, out JsonElement project) ||
+            !project.TryGetProperty("frameworks", out JsonElement frameworks) ||
+            frameworks.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        foreach (JsonProperty framework in frameworks.EnumerateObject())
+        {
+            if (framework.Value.TryGetProperty("dependencies", out JsonElement dependencies) &&
+                dependencies.ValueKind == JsonValueKind.Object)
+            {
+                foreach (JsonProperty dependency in dependencies.EnumerateObject())
+                {
+                    if (dependency.Value.TryGetProperty("autoReferenced", out JsonElement autoReferenced) &&
+                        autoReferenced.ValueKind == JsonValueKind.True)
+                    {
+                        packageIds.Add(dependency.Name);
+                    }
+                }
+            }
+
+            if (!framework.Value.TryGetProperty("downloadDependencies", out JsonElement downloads) ||
+                downloads.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+            foreach (JsonElement download in downloads.EnumerateArray())
+            {
+                if (download.TryGetProperty("name", out JsonElement name) &&
+                    name.ValueKind == JsonValueKind.String &&
+                    !string.IsNullOrWhiteSpace(name.GetString()))
+                {
+                    packageIds.Add(name.GetString()!);
+                }
+            }
+        }
+        return true;
+    }
+
+    private static bool TryWriteSdkEvidenceNuGetConfig(
+        string configPath,
+        string verifiedPackageSource,
+        IEnumerable<string> committedPackageKeys,
+        IEnumerable<string> sdkPackageIds)
+    {
+        try
+        {
+            var committedIds = new HashSet<string>(
+                committedPackageKeys.Select(key =>
+                {
+                    int separator = key.LastIndexOf('|');
+                    return separator > 0 ? key.Substring(0, separator) : string.Empty;
+                }).Where(id => !string.IsNullOrWhiteSpace(id)),
+                StringComparer.OrdinalIgnoreCase);
+            var publicSdkIds = new HashSet<string>(
+                sdkPackageIds.Where(id => !committedIds.Contains(id)),
+                StringComparer.OrdinalIgnoreCase);
+
+            var packageSources = new XElement(
+                "packageSources",
+                new XElement("clear"),
+                new XElement("add", new XAttribute("key", "verified-lock"), new XAttribute("value", verifiedPackageSource)),
+                new XElement(
+                    "add",
+                    new XAttribute("key", "nuget.org"),
+                    new XAttribute("value", SdkEvidenceNuGetOrgSource),
+                    new XAttribute("protocolVersion", "3")));
+            var root = new XElement(
+                "configuration",
+                packageSources,
+                new XElement("fallbackPackageFolders", new XElement("clear")),
+                new XElement("disabledPackageSources", new XElement("clear")));
+
+            if (committedIds.Count > 0 || publicSdkIds.Count > 0)
+            {
+                var mappings = new XElement("packageSourceMapping");
+                if (committedIds.Count > 0)
+                {
+                    mappings.Add(new XElement(
+                        "packageSource",
+                        new XAttribute("key", "verified-lock"),
+                        committedIds.OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+                            .Select(id => new XElement("package", new XAttribute("pattern", id)))));
+                }
+                if (publicSdkIds.Count > 0)
+                {
+                    mappings.Add(new XElement(
+                        "packageSource",
+                        new XAttribute("key", "nuget.org"),
+                        publicSdkIds.OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+                            .Select(id => new XElement("package", new XAttribute("pattern", id)))));
+                }
+                root.Add(mappings);
+            }
+
+            new XDocument(root).Save(configPath);
+            return true;
+        }
+        catch
+        {
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary

- derive implicit SDK-tool classification from a fresh MSBuild restore graph using every safe effective publish-plan property and explicit build environment
- isolate package acquisition into two exact-source phases: committed-lock archives are restored only from a verified local feed, while only graph-identified exact SDK/runtime packages are restored from NuGet.org
- grant the build-input bypass only to independently allowlisted SDK-owned implicit tool packages; project-forged `autoReferenced` metadata remains an ordinary inspected dependency
- run generated download-only evidence projects without implicit framework references or ambient Directory.Build/Directory.Packages imports, and force all restore output into the isolated evidence directory
- snapshot and validate SDK package archives before project-controlled restore targets run, then reject archive or metadata mutation before admitting the real-project restore evidence
- deduplicate verified archive snapshots by NuGet content hash and preserve the originating project directory for SDK selection under `global.json`

## Why

Self-contained single-file publishing can require SDK `downloadDependencies` runtime packs that are not ordinary project package references. PowerForge previously could build the project but could not reproduce the portable bundle or MSI from its controlled package evidence.

The final contract does not trust ignored restore outputs, project-defined or ambient NuGet/MSBuild configuration, project-forged implicit-package metadata, or the user's mutable global package cache. PowerForge replays the effective restore and publish inputs into a fresh graph, primes committed dependencies from verified lock archives, admits only exact SDK package identities from NuGet.org, snapshots those archives before project restore hooks can run, and evaluates the real project from the isolated package root without network-source fallback.

## Operational requirement

The provenance check requires NuGet.org access when an exact SDK/runtime package is absent from the committed lock. Reusing an unauthenticated mutable global cache offline would recreate the trust gap this change closes. Air-gapped reuse needs a separate signed-package or committed-trust-anchor design and is not part of this PR.

## Validation

- cross-platform locked single-file provenance regression with a private locked dependency, an unavailable ambient source, and runtime/publish properties supplied by the external plan
- authoritative restore-source and restore-output overrides, synthetic-project isolation, SDK-owned implicit-package allowlist, safe property replay, identical archive deduplication, and post-snapshot archive mutation regressions
- assets-only `autoReferenced` mutation regressions with the archive both absent and present
- `DotNetPublishPrGate`: 39 passed
- PowerForge Release builds: net8.0 and net472, zero warnings/errors
- private downstream proof: controlled tray and bridge publishes, portable bundle, MSI, manifest, and packaged runtime isolation all passed on the final local candidate; downstream publication remains intentionally blocked until this owner change is released