### PR TITLE
feat(project): ⚡ Add publish-owned build mode

### DIFF
--- a/Docs/PSPublishModule.ProjectBuild.md
+++ b/Docs/PSPublishModule.ProjectBuild.md
@@ -29,8 +29,13 @@ PowerShell-authored project release objects
   - `-PublishToolGitHub`
   - `-SkipRestore`
   - `-SkipBuild`
+  - `-BuildDuringPublish`
   - `-ToolOutput <Tool|Portable|Installer|Store>`
   - `-SkipToolOutput <...>`
+- By default, PowerForge runs a separate build and publishes with `--no-build`. Use
+  `-BuildDuringPublish` for runtime matrices where each authoritative `dotnet publish` invocation
+  should perform its own build. This removes the separate prebuild step; it does not skip compilation
+  or replace MSBuild evaluation. `-SkipBuild` remains the explicit choice for consuming existing outputs.
 - Project objects can now round-trip through JSON:
   - `Export-ConfigurationProject -Project $project -OutputPath '.\Build\project.release.json'`
   - `Import-ConfigurationProject -Path '.\Build\project.release.json'`

--- a/Module/Docs/New-ConfigurationProjectRelease.md
+++ b/Module/Docs/New-ConfigurationProjectRelease.md
@@ -11,7 +11,7 @@ Creates release-level defaults for a PowerShell-authored project build.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-New-ConfigurationProjectRelease [-Configuration <string>] [-PublishToolGitHub] [-SkipRestore] [-SkipBuild] [-ToolOutput <ConfigurationProjectReleaseOutputType[]>] [-SkipToolOutput <ConfigurationProjectReleaseOutputType[]>] [<CommonParameters>]
+New-ConfigurationProjectRelease [-Configuration <string>] [-PublishToolGitHub] [-SkipRestore] [-SkipBuild] [-BuildDuringPublish] [-ToolOutput <ConfigurationProjectReleaseOutputType[]>] [-SkipToolOutput <ConfigurationProjectReleaseOutputType[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -21,11 +21,28 @@ Creates release-level defaults for a PowerShell-authored project build.
 
 ### EXAMPLE 1
 ```powershell
-New-ConfigurationProjectRelease -Configuration 'Value'
+New-ConfigurationProjectRelease -BuildDuringPublish
 ```
 
 
 ## PARAMETERS
+
+### -BuildDuringPublish
+Lets each dotnet publish invocation perform its own authoritative build instead of
+consuming outputs from a separate prebuild step.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Configuration
 Build configuration used by the generated release object.

--- a/Module/en-US/PSPublishModule-help.xml
+++ b/Module/en-US/PSPublishModule-help.xml
@@ -13645,12 +13645,12 @@ the private runtime copy without relying on PSModulePath discovery.</maml:para>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
         <maml:name>Path</maml:name>
         <maml:description>
           <maml:para>Installed dependency root or module-dependencies.json receipt path.</maml:para>
         </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
           <maml:name>String</maml:name>
           <maml:uri />
@@ -14917,12 +14917,12 @@ non-secret bootstrap package for other machines.</maml:para>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="Name,Profile">
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="Name,Profile">
         <maml:name>ProfileName</maml:name>
         <maml:description>
           <maml:para>Saved repository profile name. When used with Path, selects one imported profile from the file. When used with Azure Artifacts feed details, creates that profile name.</maml:para>
         </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
           <maml:name>String</maml:name>
           <maml:uri />
@@ -50762,6 +50762,19 @@ module build should coordinate with that package lane.</maml:para>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>New-ConfigurationProjectRelease</maml:name>
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BuildDuringPublish</maml:name>
+          <maml:description>
+            <maml:para>Lets each dotnet publish invocation perform its own authoritative build instead of&#xD;
+consuming outputs from a separate prebuild step.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Configuration</maml:name>
           <maml:description>
             <maml:para>Build configuration used by the generated release object.</maml:para>
@@ -50848,6 +50861,19 @@ module build should coordinate with that package lane.</maml:para>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BuildDuringPublish</maml:name>
+        <maml:description>
+          <maml:para>Lets each dotnet publish invocation perform its own authoritative build instead of&#xD;
+consuming outputs from a separate prebuild step.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Configuration</maml:name>
         <maml:description>
@@ -50955,7 +50981,7 @@ module build should coordinate with that package lane.</maml:para>
     <command:examples>
       <command:example>
         <maml:title>EXAMPLE 1</maml:title>
-        <dev:code>New-ConfigurationProjectRelease -Configuration 'Value'</dev:code>
+        <dev:code>New-ConfigurationProjectRelease -BuildDuringPublish</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
@@ -54033,12 +54059,12 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Type</maml:name>
         <maml:description>
           <maml:para>Choose between PowerShellGallery and GitHub.</maml:para>
         </maml:description>
-        <command:parameterValue required="true" variableLength="false">PublishDestination</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">PublishDestination</command:parameterValue>
         <command:parameterValueGroup>
           <command:parameterValue required="false" variableLength="false">PowerShellGallery</command:parameterValue>
           <command:parameterValue required="false" variableLength="false">GitHub</command:parameterValue>
@@ -60787,12 +60813,12 @@ This makes repeated publishing runs idempotent when the package already exists.<
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>ApiKey</maml:name>
         <maml:description>
           <maml:para>API key used to authenticate against the NuGet feed. For Azure Artifacts profiles this defaults to a non-secret placeholder used by NuGet clients; for GitHub Packages profiles this defaults from GITHUB_TOKEN or GH_TOKEN.</maml:para>
         </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
           <maml:name>String</maml:name>
           <maml:uri />

--- a/PSPublishModule/Cmdlets/NewConfigurationProjectReleaseCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationProjectReleaseCommand.cs
@@ -37,6 +37,13 @@ public sealed class NewConfigurationProjectReleaseCommand : PSCmdlet
     public SwitchParameter SkipBuild { get; set; }
 
     /// <summary>
+    /// Lets each <c>dotnet publish</c> invocation perform its own authoritative build instead of
+    /// consuming outputs from a separate prebuild step.
+    /// </summary>
+    [Parameter]
+    public SwitchParameter BuildDuringPublish { get; set; }
+
+    /// <summary>
     /// Optional default release output selection.
     /// </summary>
     [Parameter]
@@ -59,6 +66,7 @@ public sealed class NewConfigurationProjectReleaseCommand : PSCmdlet
             PublishToolGitHub = PublishToolGitHub.IsPresent,
             SkipRestore = SkipRestore.IsPresent,
             SkipBuild = SkipBuild.IsPresent,
+            BuildDuringPublish = BuildDuringPublish.IsPresent,
             ToolOutput = ToolOutput?.Distinct().ToArray() ?? Array.Empty<ConfigurationProjectReleaseOutputType>(),
             SkipToolOutput = SkipToolOutput?.Distinct().ToArray() ?? Array.Empty<ConfigurationProjectReleaseOutputType>()
         });

--- a/PowerForge.Tests/PowerForgeProjectConfigurationJsonServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeProjectConfigurationJsonServiceTests.cs
@@ -18,6 +18,7 @@ public sealed class PowerForgeProjectConfigurationJsonServiceTests
                     Configuration = "Release",
                     PublishToolGitHub = true,
                     SkipRestore = true,
+                    BuildDuringPublish = true,
                     ToolOutput = new[] { ConfigurationProjectReleaseOutputType.Portable }
                 },
                 Signing = new ConfigurationProjectSigning
@@ -52,6 +53,7 @@ public sealed class PowerForgeProjectConfigurationJsonServiceTests
             Assert.Equal("Release", loaded.Release.Configuration);
             Assert.True(loaded.Release.PublishToolGitHub);
             Assert.True(loaded.Release.SkipRestore);
+            Assert.True(loaded.Release.BuildDuringPublish);
             Assert.Single(loaded.Release.ToolOutput);
             Assert.Equal(ConfigurationProjectReleaseOutputType.Portable, loaded.Release.ToolOutput[0]);
             Assert.Single(loaded.Targets);

--- a/PowerForge.Tests/PowerForgeProjectDslMapperTests.cs
+++ b/PowerForge.Tests/PowerForgeProjectDslMapperTests.cs
@@ -139,8 +139,42 @@ public sealed class PowerForgeProjectDslMapperTests
         Assert.Single(spec.Tools.DotNetPublish.Targets);
         Assert.Empty(spec.Tools.DotNetPublish.Bundles);
         Assert.Empty(spec.Tools.DotNetPublish.Installers);
+        Assert.True(spec.Tools.DotNetPublish.DotNet.Build);
+        Assert.True(spec.Tools.DotNetPublish.DotNet.NoBuildInPublish);
         Assert.Single(request.ToolOutputs);
         Assert.Equal(PowerForgeReleaseToolOutputKind.Tool, request.ToolOutputs[0]);
+    }
+
+    [Fact]
+    public void CreateRelease_BuildDuringPublishUsesPublishOwnedBuild()
+    {
+        var project = new ConfigurationProject
+        {
+            Name = "Demo",
+            Release = new ConfigurationProjectRelease
+            {
+                BuildDuringPublish = true
+            },
+            Targets = new[]
+            {
+                new ConfigurationProjectTarget
+                {
+                    Name = "Cli",
+                    ProjectPath = "src/Cli/Cli.csproj",
+                    Framework = "net10.0",
+                    Runtimes = new[] { "win-x64", "linux-x64" }
+                }
+            }
+        };
+
+        var (spec, _) = PowerForgeProjectDslMapper.CreateRelease(
+            project,
+            @"C:\repo\.powerforge\project.release.json",
+            @"C:\repo");
+
+        Assert.NotNull(spec.Tools?.DotNetPublish);
+        Assert.False(spec.Tools!.DotNetPublish!.DotNet.Build);
+        Assert.False(spec.Tools.DotNetPublish.DotNet.NoBuildInPublish);
     }
 
     [Fact]

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -4146,7 +4146,7 @@ public sealed partial class PowerForgeReleaseServiceTests
     }
 
     [Fact]
-    public void Execute_SkipRestoreAndBuild_ApplyToDotNetToolPlan()
+    public void Execute_SkipRestoreAndBuild_ApplyToPublishOwnedDotNetToolPlan()
     {
         var root = CreateSandbox();
         try
@@ -4180,7 +4180,9 @@ public sealed partial class PowerForgeReleaseServiceTests
                                 ProjectRoot = ".",
                                 Configuration = "Release",
                                 Restore = true,
-                                Build = true
+                                Build = false,
+                                NoRestoreInPublish = false,
+                                NoBuildInPublish = false
                             },
                             Targets = new[]
                             {

--- a/PowerForge/Models/PowerForgeProjectDsl.cs
+++ b/PowerForge/Models/PowerForgeProjectDsl.cs
@@ -72,6 +72,12 @@ public sealed class ConfigurationProjectRelease
     public bool SkipBuild { get; set; }
 
     /// <summary>
+    /// When true, each <c>dotnet publish</c> invocation performs its own authoritative build
+    /// instead of consuming outputs from a separate prebuild step.
+    /// </summary>
+    public bool BuildDuringPublish { get; set; }
+
+    /// <summary>
     /// Optional release-level output selection defaults.
     /// </summary>
     public ConfigurationProjectReleaseOutputType[] ToolOutput { get; set; } = Array.Empty<ConfigurationProjectReleaseOutputType>();

--- a/PowerForge/Services/PowerForgeProjectDslMapper.cs
+++ b/PowerForge/Services/PowerForgeProjectDslMapper.cs
@@ -54,7 +54,9 @@ internal static class PowerForgeProjectDslMapper
                     DotNet = new DotNetPublishDotNetOptions
                     {
                         ProjectRoot = fullProjectRoot,
-                        Configuration = string.IsNullOrWhiteSpace(release.Configuration) ? "Release" : release.Configuration.Trim()
+                        Configuration = string.IsNullOrWhiteSpace(release.Configuration) ? "Release" : release.Configuration.Trim(),
+                        Build = !release.BuildDuringPublish,
+                        NoBuildInPublish = !release.BuildDuringPublish
                     },
                     Targets = dotNetTargets,
                     Bundles = bundles,


### PR DESCRIPTION
## Summary

- add `BuildDuringPublish` to the PowerShell-authored project release DSL
- preserve the existing separate-build plus `--no-build` behavior by default
- let runtime matrices opt into one authoritative build per `dotnet publish` invocation
- keep `SkipBuild` as the explicit existing-output path and document the distinction

PowerForge continues to orchestrate the release plan. Compilation and project evaluation remain owned by `dotnet publish` and MSBuild; this change adds no project evaluator or compiler semantics.

## Downstream relationship

[EventViewerX](https://github.com/EvotecIT/EventViewerX) is the first downstream consumer. Its six-runtime CLI packaging path uses this option to remove redundant prebuild work while preserving per-runtime native assets. PSPublishModule must be released before EventViewerX can adopt the public three-part module version.

## Validation

- project DSL mapping and JSON round-trip contracts
- `SkipRestore` and `SkipBuild` override behavior for publish-owned plans
- .NET Framework 4.7.2 build and Windows PowerShell 5.1 command surface
- generated Markdown/external-help parity and PowerShell 5.1 `Get-Help` discovery
- six-runtime EventViewerX package generation and native SQLite payload inspection