### PR TITLE
Harden encrypted backup Git transport

### DIFF
--- a/.github/actions/powerforge-server-backup/Invoke-PowerForgeServerBackup.ps1
+++ b/.github/actions/powerforge-server-backup/Invoke-PowerForgeServerBackup.ps1
@@ -18,7 +18,8 @@ function Invoke-GitWithRetry {
         [Parameter(Mandatory)][string] $Operation,
         [Parameter(Mandatory)][string[]] $Arguments,
         [string] $ResetPath,
-        [ValidateRange(1, 5)][int] $MaxAttempts = 3
+        [ValidateRange(1, 5)][int] $MaxAttempts = 3,
+        [ValidateRange(0, 60)][int] $RetryDelaySeconds = 5
     )
 
     for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
@@ -33,10 +34,13 @@ function Invoke-GitWithRetry {
         }
         if ($attempt -lt $MaxAttempts) {
             Write-Warning "$Operation failed with exit code $exitCode; retrying ($attempt/$MaxAttempts)."
-            Start-Sleep -Seconds ($attempt * 5)
+            Start-Sleep -Seconds ($attempt * $RetryDelaySeconds)
         }
     }
 
+    if (-not [string]::IsNullOrWhiteSpace($ResetPath) -and (Test-Path -LiteralPath $ResetPath)) {
+        Remove-Item -LiteralPath $ResetPath -Recurse -Force
+    }
     throw "$Operation failed after $MaxAttempts attempts with exit code $exitCode."
 }
 

--- a/.github/actions/powerforge-server-backup/Invoke-PowerForgeServerBackup.ps1
+++ b/.github/actions/powerforge-server-backup/Invoke-PowerForgeServerBackup.ps1
@@ -13,6 +13,33 @@ function Assert-LastExitCode {
     }
 }
 
+function Invoke-GitWithRetry {
+    param(
+        [Parameter(Mandatory)][string] $Operation,
+        [Parameter(Mandatory)][string[]] $Arguments,
+        [string] $ResetPath,
+        [ValidateRange(1, 5)][int] $MaxAttempts = 3
+    )
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        if (-not [string]::IsNullOrWhiteSpace($ResetPath) -and (Test-Path -LiteralPath $ResetPath)) {
+            Remove-Item -LiteralPath $ResetPath -Recurse -Force
+        }
+
+        & git @Arguments
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -eq 0) {
+            return
+        }
+        if ($attempt -lt $MaxAttempts) {
+            Write-Warning "$Operation failed with exit code $exitCode; retrying ($attempt/$MaxAttempts)."
+            Start-Sleep -Seconds ($attempt * 5)
+        }
+    }
+
+    throw "$Operation failed after $MaxAttempts attempts with exit code $exitCode."
+}
+
 function Write-ActionOutput {
     param(
         [Parameter(Mandatory)][string] $Name,
@@ -275,8 +302,15 @@ exec /usr/bin/ssh -F "${POWERFORGE_SERVER_SSH_CONFIG:?}" "$@"
         }
     $hashLines | Set-Content -LiteralPath (Join-Path $captureRoot 'SHA256SUMS.txt') -Encoding utf8NoBOM
 
-    git clone --single-branch --branch $backupBranch "git@github.com-powerforge-backup:${backupRepository}.git" $backupCheckout
-    Assert-LastExitCode 'Cloning the private backup repository'
+    Invoke-GitWithRetry -Operation 'Cloning the private backup repository' -ResetPath $backupCheckout -Arguments @(
+        'clone',
+        '--depth', '1',
+        '--no-tags',
+        '--single-branch',
+        '--branch', $backupBranch,
+        "git@github.com-powerforge-backup:${backupRepository}.git",
+        $backupCheckout
+    )
 
     $checkout = [IO.Path]::GetFullPath($backupCheckout).TrimEnd([IO.Path]::DirectorySeparatorChar)
     $targetRoot = [IO.Path]::GetFullPath((Join-Path $checkout $backupPath))
@@ -308,8 +342,13 @@ exec /usr/bin/ssh -F "${POWERFORGE_SERVER_SSH_CONFIG:?}" "$@"
     $published = $false
     $publishedCommit = $null
     for ($attempt = 1; $attempt -le 3; $attempt++) {
-        git -C $checkout fetch origin $backupBranch
-        Assert-LastExitCode 'Fetching the backup branch'
+        Invoke-GitWithRetry -Operation 'Fetching the backup branch' -Arguments @(
+            '-C', $checkout,
+            'fetch',
+            '--no-tags',
+            'origin',
+            "+refs/heads/${backupBranch}:refs/remotes/origin/${backupBranch}"
+        )
         git -C $checkout rebase "origin/$backupBranch"
         if ($LASTEXITCODE -ne 0) {
             git -C $checkout rebase --abort 2>$null

--- a/PowerForge.Tests/GitHubServerBackupActionTests.cs
+++ b/PowerForge.Tests/GitHubServerBackupActionTests.cs
@@ -86,6 +86,20 @@ public sealed class GitHubServerBackupActionTests
     }
 
     [Fact]
+    public void Action_ShouldBoundAndRetryPrivateBackupGitTransport()
+    {
+        var script = ReadRepoFile(".github", "actions", "powerforge-server-backup", "Invoke-PowerForgeServerBackup.ps1");
+
+        Assert.Contains("function Invoke-GitWithRetry", script, StringComparison.Ordinal);
+        Assert.Contains("[ValidateRange(1, 5)][int] $MaxAttempts = 3", script, StringComparison.Ordinal);
+        Assert.Contains("'--depth', '1'", script, StringComparison.Ordinal);
+        Assert.Contains("'--no-tags'", script, StringComparison.Ordinal);
+        Assert.Contains("-ResetPath $backupCheckout", script, StringComparison.Ordinal);
+        Assert.Contains("Invoke-GitWithRetry -Operation 'Fetching the backup branch'", script, StringComparison.Ordinal);
+        Assert.Contains("+refs/heads/${backupBranch}:refs/remotes/origin/${backupBranch}", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Repository_ShouldHaveOneBackupImplementation()
     {
         Assert.False(File.Exists(GetRepoPath(".github", "workflows", "powerforge-server-backup.yml")));

--- a/PowerForge.Tests/GitHubServerBackupActionTests.cs
+++ b/PowerForge.Tests/GitHubServerBackupActionTests.cs
@@ -100,6 +100,35 @@ public sealed class GitHubServerBackupActionTests
     }
 
     [Fact]
+    public async Task GitRetry_ShouldRecoverFromTransientFailuresAndCleanTerminalPartialClone()
+    {
+        var testScript = GetRepoPath("PowerForge.Tests", "Scripts", "Test-GitWithRetry.ps1");
+        var startInfo = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "pwsh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add("-NoLogo");
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-NonInteractive");
+        startInfo.ArgumentList.Add("-File");
+        startInfo.ArgumentList.Add(testScript);
+
+        using var process = System.Diagnostics.Process.Start(startInfo);
+        Assert.NotNull(process);
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await process.WaitForExitAsync(timeout.Token);
+
+        Assert.True(
+            process.ExitCode == 0,
+            $"Git retry contract failed with exit code {process.ExitCode}.{Environment.NewLine}{await standardOutput}{Environment.NewLine}{await standardError}");
+    }
+
+    [Fact]
     public void Repository_ShouldHaveOneBackupImplementation()
     {
         Assert.False(File.Exists(GetRepoPath(".github", "workflows", "powerforge-server-backup.yml")));

--- a/PowerForge.Tests/Scripts/Test-GitWithRetry.ps1
+++ b/PowerForge.Tests/Scripts/Test-GitWithRetry.ps1
@@ -1,0 +1,78 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
+$actionScript = Join-Path $repositoryRoot '.github/actions/powerforge-server-backup/Invoke-PowerForgeServerBackup.ps1'
+$tokens = $null
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($actionScript, [ref]$tokens, [ref]$parseErrors)
+if ($parseErrors.Count -gt 0) {
+    throw "Unable to parse the server backup action: $($parseErrors[0].Message)"
+}
+
+$functionAst = $ast.Find({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq 'Invoke-GitWithRetry'
+    }, $true)
+if ($null -eq $functionAst) {
+    throw 'Invoke-GitWithRetry was not found in the server backup action.'
+}
+. ([scriptblock]::Create($functionAst.Extent.Text))
+
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) "powerforge-git-retry-$([Guid]::NewGuid().ToString('N'))"
+$resetPath = Join-Path $testRoot 'partial-clone'
+$script:attempt = 0
+$script:exitCodes = @()
+$script:expectedArguments = @('clone', '--depth', '1', 'repository', $resetPath)
+
+function git {
+    param([Parameter(ValueFromRemainingArguments)][object[]] $GitArguments)
+
+    $script:attempt++
+    if (Test-Path -LiteralPath $resetPath) {
+        throw "Partial clone was not reset before attempt $script:attempt."
+    }
+    if ([string]::Join("`n", $GitArguments) -ne [string]::Join("`n", $script:expectedArguments)) {
+        throw 'Git arguments changed while retrying.'
+    }
+
+    $exitCode = $script:exitCodes[$script:attempt - 1]
+    if ($exitCode -ne 0) {
+        New-Item -ItemType Directory -Path $resetPath | Out-Null
+    }
+    $global:LASTEXITCODE = $exitCode
+}
+
+try {
+    New-Item -ItemType Directory -Path $resetPath -Force | Out-Null
+    $script:attempt = 0
+    $script:exitCodes = @(128, 128, 0)
+    Invoke-GitWithRetry -Operation 'Transient clone' -Arguments $script:expectedArguments -ResetPath $resetPath -MaxAttempts 3 -RetryDelaySeconds 0
+    if ($script:attempt -ne 3 -or (Test-Path -LiteralPath $resetPath)) {
+        throw 'Transient clone retry did not recover cleanly on the third attempt.'
+    }
+
+    New-Item -ItemType Directory -Path $resetPath -Force | Out-Null
+    $script:attempt = 0
+    $script:exitCodes = @(128, 128, 128)
+    $terminalError = $null
+    try {
+        Invoke-GitWithRetry -Operation 'Terminal clone' -Arguments $script:expectedArguments -ResetPath $resetPath -MaxAttempts 3 -RetryDelaySeconds 0
+    } catch {
+        $terminalError = $_
+    }
+    if ($null -eq $terminalError -or $terminalError.Exception.Message -notmatch 'failed after 3 attempts') {
+        throw 'Terminal clone failure was not surfaced after the configured retry limit.'
+    }
+    if ($script:attempt -ne 3 -or (Test-Path -LiteralPath $resetPath)) {
+        throw 'Terminal clone retry did not clean the final partial checkout.'
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $testRoot) {
+        Remove-Item -LiteralPath $testRoot -Recurse -Force
+    }
+}

--- a/PowerForge.Tests/Scripts/Test-GitWithRetry.ps1
+++ b/PowerForge.Tests/Scripts/Test-GitWithRetry.ps1
@@ -40,9 +40,7 @@ function git {
     }
 
     $exitCode = $script:exitCodes[$script:attempt - 1]
-    if ($exitCode -ne 0) {
-        New-Item -ItemType Directory -Path $resetPath | Out-Null
-    }
+    New-Item -ItemType Directory -Path $resetPath | Out-Null
     $global:LASTEXITCODE = $exitCode
 }
 
@@ -51,11 +49,10 @@ try {
     $script:attempt = 0
     $script:exitCodes = @(128, 128, 0)
     Invoke-GitWithRetry -Operation 'Transient clone' -Arguments $script:expectedArguments -ResetPath $resetPath -MaxAttempts 3 -RetryDelaySeconds 0
-    if ($script:attempt -ne 3 -or (Test-Path -LiteralPath $resetPath)) {
-        throw 'Transient clone retry did not recover cleanly on the third attempt.'
+    if ($script:attempt -ne 3 -or -not (Test-Path -LiteralPath $resetPath)) {
+        throw 'Transient clone retry did not preserve the successful checkout from the third attempt.'
     }
 
-    New-Item -ItemType Directory -Path $resetPath -Force | Out-Null
     $script:attempt = 0
     $script:exitCodes = @(128, 128, 128)
     $terminalError = $null
@@ -69,6 +66,89 @@ try {
     }
     if ($script:attempt -ne 3 -or (Test-Path -LiteralPath $resetPath)) {
         throw 'Terminal clone retry did not clean the final partial checkout.'
+    }
+
+    Remove-Item Function:\git
+    $remote = Join-Path $testRoot 'remote.git'
+    $seed = Join-Path $testRoot 'seed'
+    $workerA = Join-Path $testRoot 'worker-a'
+    $workerB = Join-Path $testRoot 'worker-b'
+    $workerC = Join-Path $testRoot 'worker-c'
+
+    function Invoke-TestGit {
+        param([Parameter(ValueFromRemainingArguments)][object[]] $GitArguments)
+
+        & git @GitArguments | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "Test Git command failed with exit code ${LASTEXITCODE}: git $GitArguments"
+        }
+    }
+
+    Invoke-TestGit init --bare $remote
+    Invoke-TestGit init $seed
+    Invoke-TestGit -C $seed checkout -b main
+    Invoke-TestGit -C $seed config user.name PowerForgeTest
+    Invoke-TestGit -C $seed config user.email powerforge-test@example.invalid
+    Set-Content -LiteralPath (Join-Path $seed 'base.txt') -Value base -Encoding utf8NoBOM
+    Invoke-TestGit -C $seed add base.txt
+    Invoke-TestGit -C $seed commit -m base
+    Invoke-TestGit -C $seed remote add origin $remote
+    Invoke-TestGit -C $seed push -u origin main
+
+    $remoteUri = ([Uri]$remote).AbsoluteUri
+    $cloneArguments = @('clone', '--depth', '1', '--no-tags', '--single-branch', '--branch', 'main', $remoteUri, $workerA)
+    Invoke-GitWithRetry -Operation 'Shallow worker A clone' -Arguments $cloneArguments -ResetPath $workerA -RetryDelaySeconds 0
+    Invoke-TestGit clone --depth 1 --no-tags --single-branch --branch main $remoteUri $workerB
+    foreach ($worker in @($workerA, $workerB)) {
+        Invoke-TestGit -C $worker config user.name PowerForgeTest
+        Invoke-TestGit -C $worker config user.email powerforge-test@example.invalid
+    }
+
+    Set-Content -LiteralPath (Join-Path $workerA 'worker-a.txt') -Value worker-a -Encoding utf8NoBOM
+    Invoke-TestGit -C $workerA add worker-a.txt
+    Invoke-TestGit -C $workerA commit -m worker-a
+
+    Set-Content -LiteralPath (Join-Path $workerB 'worker-b.txt') -Value worker-b -Encoding utf8NoBOM
+    Invoke-TestGit -C $workerB add worker-b.txt
+    Invoke-TestGit -C $workerB commit -m worker-b
+    Invoke-TestGit -C $workerB push origin HEAD:main
+    $workerBHead = (& git -C $workerB rev-parse HEAD).Trim()
+    Invoke-TestGit -C $workerB rev-parse HEAD
+
+    $fetchArguments = @('-C', $workerA, 'fetch', '--no-tags', 'origin', '+refs/heads/main:refs/remotes/origin/main')
+    Invoke-GitWithRetry -Operation 'Advance shallow origin/main' -Arguments $fetchArguments -RetryDelaySeconds 0
+    $workerAOrigin = (& git -C $workerA rev-parse origin/main).Trim()
+    if ($LASTEXITCODE -ne 0 -or $workerAOrigin -ne $workerBHead) {
+        throw 'Exact shallow fetch did not advance origin/main to the competing commit.'
+    }
+    Invoke-TestGit -C $workerA rebase origin/main
+
+    Invoke-TestGit clone --depth 1 --no-tags --single-branch --branch main $remoteUri $workerC
+    Invoke-TestGit -C $workerC config user.name PowerForgeTest
+    Invoke-TestGit -C $workerC config user.email powerforge-test@example.invalid
+    Set-Content -LiteralPath (Join-Path $workerC 'worker-c.txt') -Value worker-c -Encoding utf8NoBOM
+    Invoke-TestGit -C $workerC add worker-c.txt
+    Invoke-TestGit -C $workerC commit -m worker-c
+    Invoke-TestGit -C $workerC push origin HEAD:main
+
+    & git -C $workerA push origin HEAD:main 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        throw 'The first worker A push unexpectedly ignored the competing publication.'
+    }
+
+    Invoke-GitWithRetry -Operation 'Refresh after rejected push' -Arguments $fetchArguments -RetryDelaySeconds 0
+    Invoke-TestGit -C $workerA rebase origin/main
+    Invoke-TestGit -C $workerA push origin HEAD:main
+    $remoteHead = (& git --git-dir=$remote rev-parse main).Trim()
+    $workerAHead = (& git -C $workerA rev-parse HEAD).Trim()
+    if ($LASTEXITCODE -ne 0 -or $remoteHead -ne $workerAHead) {
+        throw 'Fetch, rebase, and retry did not publish the local backup commit.'
+    }
+    foreach ($requiredPath in @('worker-a.txt', 'worker-b.txt', 'worker-c.txt')) {
+        & git --git-dir=$remote cat-file -e "main:$requiredPath"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Published history does not retain $requiredPath."
+        }
     }
 }
 finally {


### PR DESCRIPTION
## Summary

- retry transient private-backup clone and fetch failures with bounded backoff
- use a shallow, tag-free clone and update the exact remote-tracking ref consumed by rebase
- remove partial clone state between attempts and after terminal failure
- cover transient recovery, terminal cleanup, shallow remote advancement, and competing publication with offline behavioral tests

## Why

A scheduled encrypted backup in EvotecIT/CasaRay completed its server capture but lost the run when the private backup repository clone ended with an early EOF. The backup repository is small and the unchanged rerun succeeded, so this hardens the shared transport boundary instead of adding a consumer-specific workaround.

Consumers pinned to an older PowerForge workflow commit will need a normal owner-first repin after this change merges.

## Validation

- focused `GitHubServerBackupActionTests` and protected-environment action tests
- hermetic PowerShell Git retry and concurrent publication scenario
- PowerShell parser and diff checks
