### PR TITLE
Fix Windows runner cleanup for read-only files

### DIFF
--- a/PowerForge.Tests/RunnerHousekeepingServiceTests.cs
+++ b/PowerForge.Tests/RunnerHousekeepingServiceTests.cs
@@ -211,6 +211,57 @@ public sealed class RunnerHousekeepingServiceTests
     }
 
     [Fact]
+    public void Clean_Apply_DeletesWorkspaceContainingReadOnlyGitFiles()
+    {
+        var root = CreateSandbox();
+        var previousWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
+        try
+        {
+            var runnerRoot = Path.Combine(root, "runner");
+            var workRoot = Path.Combine(runnerRoot, "_work");
+            var runnerTemp = Path.Combine(workRoot, "_temp");
+            var oldWorkspace = Path.Combine(workRoot, "OldRepo");
+            var packRoot = Path.Combine(oldWorkspace, "OldRepo", ".git", "objects", "pack");
+            var readOnlyIndex = Path.Combine(packRoot, "pack-test.idx");
+
+            Directory.CreateDirectory(runnerTemp);
+            Directory.CreateDirectory(packRoot);
+            File.WriteAllText(readOnlyIndex, "x");
+            File.SetAttributes(readOnlyIndex, File.GetAttributes(readOnlyIndex) | FileAttributes.ReadOnly);
+            var staleTime = DateTime.UtcNow.AddDays(-10);
+            File.SetLastWriteTimeUtc(readOnlyIndex, staleTime);
+            foreach (var directory in Directory.EnumerateDirectories(oldWorkspace, "*", SearchOption.AllDirectories).OrderByDescending(static path => path.Length))
+                Directory.SetLastWriteTimeUtc(directory, staleTime);
+            Directory.SetLastWriteTimeUtc(oldWorkspace, staleTime);
+            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", null);
+
+            var service = new RunnerHousekeepingService(new NullLogger());
+            var result = service.Clean(new RunnerHousekeepingSpec
+            {
+                RunnerTempPath = runnerTemp,
+                RunnerRootPath = runnerRoot,
+                WorkRootPath = workRoot,
+                MinFreeGb = null,
+                DryRun = false,
+                Aggressive = false,
+                ClearDotNetCaches = false,
+                PruneDocker = false,
+                CleanRunnerTemp = false,
+                CleanWorkspaces = true
+            });
+
+            Assert.True(result.Success);
+            Assert.Contains(result.Steps, step => step.Id == "workspaces" && step.EntriesAffected == 1);
+            Assert.False(Directory.Exists(oldWorkspace));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Clean_Apply_UsesDescendantActivityForWorkspaceAge()
     {
         var root = CreateSandbox();
@@ -297,6 +348,19 @@ public sealed class RunnerHousekeepingServiceTests
         {
             TryDelete(root);
         }
+    }
+
+    [Fact]
+    public void DeleteSafety_RejectsReparsePointAttributes()
+    {
+        var method = typeof(RunnerHousekeepingService).GetMethod("EnsureNotReparsePoint", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        Assert.NotNull(method);
+
+        var exception = Assert.Throws<System.Reflection.TargetInvocationException>(() =>
+            method!.Invoke(null, new object?[] { "linked-workspace", FileAttributes.Directory | FileAttributes.ReparsePoint }));
+
+        Assert.IsType<InvalidOperationException>(exception.InnerException);
     }
 
     [Fact]

--- a/PowerForge/Services/RunnerHousekeepingService.FileSystem.cs
+++ b/PowerForge/Services/RunnerHousekeepingService.FileSystem.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace PowerForge;
+
+public sealed partial class RunnerHousekeepingService
+{
+    private static void ClearReadOnlyAttributesRecursively(string target, string? allowedRootPath)
+    {
+        EnsureDeleteTargetWithinRoot(target, allowedRootPath);
+
+        var targetAttributes = File.GetAttributes(target);
+        EnsureNotReparsePoint(target, targetAttributes);
+
+        var pending = new Stack<string>();
+        pending.Push(target);
+
+        while (pending.Count > 0)
+        {
+            var current = pending.Pop();
+            var currentAttributes = File.GetAttributes(current);
+            EnsureNotReparsePoint(current, currentAttributes);
+
+            foreach (var entry in Directory.EnumerateFileSystemEntries(current))
+            {
+                var attributes = File.GetAttributes(entry);
+                if ((attributes & FileAttributes.ReparsePoint) != 0)
+                    continue;
+
+                ClearReadOnlyAttribute(entry, attributes);
+                if ((attributes & FileAttributes.Directory) != 0)
+                    pending.Push(entry);
+            }
+        }
+
+        ClearReadOnlyAttribute(target, targetAttributes);
+    }
+
+    private static void EnsureNotReparsePoint(string path, FileAttributes attributes)
+    {
+        if ((attributes & FileAttributes.ReparsePoint) != 0)
+            throw new InvalidOperationException($"Refusing to traverse reparse-point cleanup path '{path}'.");
+    }
+
+    private static void ClearReadOnlyAttribute(string path, FileAttributes attributes)
+    {
+        if ((attributes & FileAttributes.ReadOnly) != 0)
+            File.SetAttributes(path, attributes & ~FileAttributes.ReadOnly);
+    }
+}

--- a/PowerForge/Services/RunnerHousekeepingService.cs
+++ b/PowerForge/Services/RunnerHousekeepingService.cs
@@ -470,6 +470,11 @@ public sealed partial class RunnerHousekeepingService
             if (File.Exists(target))
                 File.Delete(target);
         }
+        catch (UnauthorizedAccessException) when (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Directory.Exists(target))
+        {
+            ClearReadOnlyAttributesRecursively(target, allowedRootPath);
+            Directory.Delete(target, recursive: true);
+        }
         catch when (allowSudo && CanUseSudo() && (isDirectory == true || Directory.Exists(target)))
         {
             RunSudoDelete(target, allowedRootPath);


### PR DESCRIPTION
## What changed

- retry Windows workspace deletion after clearing read-only attributes from runner-owned files and directories
- keep attribute traversal inside the supplied cleanup root
- refuse top-level reparse points and skip nested reparse entries instead of traversing them
- add regression coverage for read-only Git pack indexes and the reparse-point refusal rule

## Why

Runner housekeeping could identify stale Windows workspaces but fail to remove them when Git object or pack-index files carried the read-only attribute. The failed cleanup left disk space below the configured minimum even though all targets were stale and the runner was idle.

The fallback runs only after a Windows `UnauthorizedAccessException`. Normal deletion behavior is unchanged on other platforms, and unsafe reparse-point cleanup fails closed.

## Validation

- `dotnet test PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~RunnerHousekeepingServiceTests" --configuration Release --no-restore` — 28 passed
- `dotnet build PowerForge\PowerForge.csproj --framework net472 --configuration Release --no-restore` — succeeded with 0 warnings and 0 errors
- independent local review found and confirmed fixes for .NET Framework compatibility and reparse-point containment
- live housekeeping rerun on `GITHUBRUNNERX5` removed 25 stale workspaces and restored free space above the 20 GiB floor
