### PR TITLE
Fix repository-local project API artifact sync

### DIFF
--- a/PowerForge.Tests/WebPipelineRunnerProjectDocsSyncTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectDocsSyncTests.cs
@@ -289,6 +289,69 @@ public sealed class WebPipelineRunnerProjectDocsSyncTests
     }
 
     [Fact]
+    public void RunPipeline_ProjectDocsSync_OnlyLocalLinksIncludesRepositoryLocalDotNetApiArtifact()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-project-docs-sync-local-dotnet-api-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var catalogPath = Path.Combine(root, "data", "projects", "catalog.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(catalogPath)!);
+            File.WriteAllText(catalogPath,
+                """
+                {
+                  "projects": [
+                    {
+                      "slug": "dotnetonly",
+                      "surfaces": { "apiDotNet": true, "apiPowerShell": false },
+                      "artifacts": { "api": "WebsiteArtifacts/apidocs" }
+                    }
+                  ]
+                }
+                """);
+
+            var sourceApi = Path.Combine(root, "projects-sources", "dotnetonly", "WebsiteArtifacts", "apidocs");
+            Directory.CreateDirectory(sourceApi);
+            File.WriteAllText(Path.Combine(sourceApi, "Library.xml"), "<doc />");
+
+            var pipelinePath = Path.Combine(root, "pipeline.json");
+            File.WriteAllText(pipelinePath,
+                """
+                {
+                  "steps": [
+                    {
+                      "task": "project-docs-sync",
+                      "catalog": "./data/projects/catalog.json",
+                      "sourcesRoot": "./projects-sources",
+                      "contentRoot": "./content/docs",
+                      "syncDocs": false,
+                      "syncApi": true,
+                      "apiRoot": "./data/apidocs",
+                      "sourceApiPaths": ["WebsiteArtifacts/apidocs"],
+                      "syncExamples": false,
+                      "onlyLocalLinks": true,
+                      "failOnMissingApiSource": true
+                    }
+                  ]
+                }
+                """);
+
+            var result = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
+
+            Assert.True(result.Success);
+            Assert.Single(result.Steps);
+            Assert.True(result.Steps[0].Success);
+            Assert.Contains("api=1/1", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.Exists(Path.Combine(root, "data", "apidocs", "dotnetonly", "Library.xml")));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void RunPipeline_ProjectDocsSync_FailsWhenMissingApiSourceAndFailOnMissingApiSourceEnabled()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-project-docs-sync-fail-missing-api-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebPipelineRunnerProjectDocsSyncTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectDocsSyncTests.cs
@@ -305,7 +305,14 @@ public sealed class WebPipelineRunnerProjectDocsSyncTests
                     {
                       "slug": "dotnetonly",
                       "surfaces": { "apiDotNet": true, "apiPowerShell": false },
+                      "links": { "apiDotNet": "https://example.invalid/dotnetonly/api/" },
                       "artifacts": { "api": "WebsiteArtifacts/apidocs" }
+                    },
+                    {
+                      "slug": "traversal",
+                      "surfaces": { "apiDotNet": true },
+                      "links": { "apiDotNet": "https://example.invalid/traversal/api/" },
+                      "artifacts": { "api": "../outside-api" }
                     }
                   ]
                 }
@@ -314,6 +321,10 @@ public sealed class WebPipelineRunnerProjectDocsSyncTests
             var sourceApi = Path.Combine(root, "projects-sources", "dotnetonly", "WebsiteArtifacts", "apidocs");
             Directory.CreateDirectory(sourceApi);
             File.WriteAllText(Path.Combine(sourceApi, "Library.xml"), "<doc />");
+
+            var outsideApi = Path.Combine(root, "projects-sources", "outside-api");
+            Directory.CreateDirectory(outsideApi);
+            File.WriteAllText(Path.Combine(outsideApi, "Secret.xml"), "<doc />");
 
             var pipelinePath = Path.Combine(root, "pipeline.json");
             File.WriteAllText(pipelinePath,
@@ -328,7 +339,6 @@ public sealed class WebPipelineRunnerProjectDocsSyncTests
                       "syncDocs": false,
                       "syncApi": true,
                       "apiRoot": "./data/apidocs",
-                      "sourceApiPaths": ["WebsiteArtifacts/apidocs"],
                       "syncExamples": false,
                       "onlyLocalLinks": true,
                       "failOnMissingApiSource": true
@@ -339,11 +349,12 @@ public sealed class WebPipelineRunnerProjectDocsSyncTests
 
             var result = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
 
-            Assert.True(result.Success);
+            Assert.True(result.Success, result.Steps[0].Message);
             Assert.Single(result.Steps);
             Assert.True(result.Steps[0].Success);
             Assert.Contains("api=1/1", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
             Assert.True(File.Exists(Path.Combine(root, "data", "apidocs", "dotnetonly", "Library.xml")));
+            Assert.False(File.Exists(Path.Combine(root, "data", "apidocs", "traversal", "Secret.xml")));
         }
         finally
         {

--- a/PowerForge.Tests/WebPipelineRunnerProjectDocsSyncTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectDocsSyncTests.cs
@@ -313,6 +313,12 @@ public sealed class WebPipelineRunnerProjectDocsSyncTests
                       "surfaces": { "apiDotNet": true },
                       "links": { "apiDotNet": "https://example.invalid/traversal/api/" },
                       "artifacts": { "api": "../outside-api" }
+                    },
+                    {
+                      "slug": "backslash-rooted",
+                      "surfaces": { "apiDotNet": true },
+                      "links": { "apiDotNet": "https://example.invalid/backslash-rooted/api/" },
+                      "artifacts": { "api": "\\\\outside-api" }
                     }
                   ]
                 }
@@ -339,6 +345,7 @@ public sealed class WebPipelineRunnerProjectDocsSyncTests
                       "syncDocs": false,
                       "syncApi": true,
                       "apiRoot": "./data/apidocs",
+                      "sourceApiPaths": ["websiteartifacts/apidocs"],
                       "syncExamples": false,
                       "onlyLocalLinks": true,
                       "failOnMissingApiSource": true
@@ -355,6 +362,7 @@ public sealed class WebPipelineRunnerProjectDocsSyncTests
             Assert.Contains("api=1/1", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
             Assert.True(File.Exists(Path.Combine(root, "data", "apidocs", "dotnetonly", "Library.xml")));
             Assert.False(File.Exists(Path.Combine(root, "data", "apidocs", "traversal", "Secret.xml")));
+            Assert.False(Directory.Exists(Path.Combine(root, "data", "apidocs", "backslash-rooted")));
         }
         finally
         {
@@ -563,7 +571,7 @@ public sealed class WebPipelineRunnerProjectDocsSyncTests
     }
 
     [Fact]
-    public void RunPipeline_ProjectDocsSync_UsesRawExamplesFolderWhenExplicitlyConfigured()
+    public void RunPipeline_ProjectDocsSync_UsesDeclaredExamplesArtifactPath()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-project-docs-sync-examples-explicit-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
@@ -576,12 +584,16 @@ public sealed class WebPipelineRunnerProjectDocsSyncTests
                 """
                 {
                   "projects": [
-                    { "slug": "alpha", "surfaces": { "docs": false, "examples": true } }
+                    {
+                      "slug": "alpha",
+                      "surfaces": { "docs": false, "examples": true },
+                      "artifacts": { "examples": "WebsiteArtifacts/examples" }
+                    }
                   ]
                 }
                 """);
 
-            var rawExamples = Path.Combine(root, "projects-sources", "alpha", "Examples");
+            var rawExamples = Path.Combine(root, "projects-sources", "alpha", "WebsiteArtifacts", "examples");
             Directory.CreateDirectory(rawExamples);
             File.WriteAllText(Path.Combine(rawExamples, "Invoke-Alpha.ps1"), "Invoke-Alpha -Name Demo");
 
@@ -611,7 +623,6 @@ public sealed class WebPipelineRunnerProjectDocsSyncTests
                       "syncDocs": false,
                       "syncExamples": true,
                       "examplesRoot": "./content/project-examples",
-                      "sourceExamplesPaths": ["Examples"],
                       "summaryPath": "./Build/sync-project-docs-summary.json"
                     }
                   ]
@@ -633,7 +644,7 @@ public sealed class WebPipelineRunnerProjectDocsSyncTests
             var markdown = File.ReadAllText(generatedMarkdown);
             Assert.Contains("meta.generated_by: \"powerforge.project-docs-sync\"", markdown, StringComparison.Ordinal);
             Assert.Contains("meta.project_base_slug: \"alpha\"", markdown, StringComparison.Ordinal);
-            Assert.Contains("meta.project_artifact_examples: \"Examples\"", File.ReadAllText(Path.Combine(root, "content", "projects", "alpha.md")), StringComparison.Ordinal);
+            Assert.Contains("meta.project_artifact_examples: \"WebsiteArtifacts/examples\"", File.ReadAllText(Path.Combine(root, "content", "projects", "alpha.md")), StringComparison.Ordinal);
             Assert.Contains("```powershell", markdown, StringComparison.Ordinal);
             Assert.Contains("Invoke-Alpha -Name Demo", markdown, StringComparison.Ordinal);
         }
@@ -707,6 +718,80 @@ public sealed class WebPipelineRunnerProjectDocsSyncTests
             Assert.Contains("examples=1/1", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
             Assert.False(File.Exists(staleTarget));
             Assert.True(File.Exists(Path.Combine(root, "content", "project-examples", "alpha", "examples", "current-example.md")));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void RunPipeline_ProjectDocsSync_HydratesDeclaredApiPathFromLinkedZipArtifact()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-project-docs-sync-declared-api-artifact-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var artifactZip = Path.Combine(root, "api-artifact.zip");
+            using (var archive = ZipFile.Open(artifactZip, ZipArchiveMode.Create))
+            {
+                var apiEntry = archive.CreateEntry("bundle/WebsiteArtifacts/apidocs/Library.xml");
+                using var writer = new StreamWriter(apiEntry.Open());
+                writer.Write("<doc />");
+            }
+
+            var catalogPath = Path.Combine(root, "data", "projects", "catalog.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(catalogPath)!);
+            File.WriteAllText(catalogPath,
+                $$"""
+                {
+                  "projects": [
+                    {
+                      "slug": "dotnetonly",
+                      "surfaces": { "apiDotNet": true },
+                      "links": {
+                        "apiDotNet": "{{artifactZip.Replace("\\", "\\\\", StringComparison.Ordinal)}}"
+                      },
+                      "artifacts": { "api": "WebsiteArtifacts/apidocs" }
+                    }
+                  ]
+                }
+                """);
+
+            var pipelinePath = Path.Combine(root, "pipeline.json");
+            File.WriteAllText(pipelinePath,
+                """
+                {
+                  "steps": [
+                    {
+                      "task": "project-docs-sync",
+                      "catalog": "./data/projects/catalog.json",
+                      "sourcesRoot": "./projects-sources",
+                      "contentRoot": "./content/docs",
+                      "syncDocs": false,
+                      "syncApi": true,
+                      "apiRoot": "./data/apidocs",
+                      "syncExamples": false,
+                      "hydrateFromArtifacts": true,
+                      "failOnMissingApiSource": true,
+                      "summaryPath": "./Build/sync-project-docs-summary.json",
+                      "strict": true
+                    }
+                  ]
+                }
+                """);
+
+            var result = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
+
+            Assert.True(result.Success, result.Steps[0].Message);
+            Assert.Single(result.Steps);
+            Assert.True(result.Steps[0].Success);
+            Assert.Contains("api=1/1", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.Exists(Path.Combine(root, "data", "apidocs", "dotnetonly", "Library.xml")));
+
+            using var summary = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, "Build", "sync-project-docs-summary.json")));
+            Assert.Equal(1, summary.RootElement.GetProperty("apiHydrated").GetInt32());
         }
         finally
         {

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectDocsSync.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectDocsSync.cs
@@ -450,7 +450,7 @@ internal static partial class WebPipelineRunner
                     copiedExampleFiles++;
                 }
 
-                var matchedExamplesCandidate = TryGetMatchedSourceCandidate(sourcesRoot, slug, sourceExamplesRoot, examplesSourceCandidates);
+                var matchedExamplesCandidate = TryGetMatchedSourceCandidate(sourcesRoot, slug, sourceExamplesRoot, projectExamplesSourceCandidates);
                 if (!string.IsNullOrWhiteSpace(matchedExamplesCandidate))
                     examplesArtifactSources[slug] = matchedExamplesCandidate;
 
@@ -1378,12 +1378,13 @@ internal static partial class WebPipelineRunner
             var slug = project.Slug.Trim().ToLowerInvariant();
             if (project.HasDocsSurface)
             {
+                var projectDocsSourceCandidates = GetProjectSourceCandidates(project.ArtifactDocs, docsSourceCandidates);
                 HydrateProjectArtifactSurface(
                     project,
                     ProjectDocsSurfaceType.Docs,
                     slug,
                     sourcesRoot,
-                    docsSourceCandidates,
+                    projectDocsSourceCandidates,
                     artifactWorkRoot,
                     timeoutSeconds,
                     artifactToken,
@@ -1394,12 +1395,13 @@ internal static partial class WebPipelineRunner
 
             if (syncApi && project.HasApiSurface)
             {
+                var projectApiSourceCandidates = GetProjectSourceCandidates(project.ArtifactApi, apiSourceCandidates);
                 HydrateProjectArtifactSurface(
                     project,
                     ProjectDocsSurfaceType.Api,
                     slug,
                     sourcesRoot,
-                    apiSourceCandidates,
+                    projectApiSourceCandidates,
                     artifactWorkRoot,
                     timeoutSeconds,
                     artifactToken,
@@ -1410,12 +1412,13 @@ internal static partial class WebPipelineRunner
 
             if (syncExamples && project.HasExamplesSurface)
             {
+                var projectExamplesSourceCandidates = GetProjectSourceCandidates(project.ArtifactExamples, examplesSourceCandidates);
                 HydrateProjectArtifactSurface(
                     project,
                     ProjectDocsSurfaceType.Examples,
                     slug,
                     sourcesRoot,
-                    examplesSourceCandidates,
+                    projectExamplesSourceCandidates,
                     artifactWorkRoot,
                     timeoutSeconds,
                     artifactToken,
@@ -1554,7 +1557,8 @@ internal static partial class WebPipelineRunner
         var value = source.Trim();
         if (IsZipArtifactSource(value) ||
             Path.IsPathRooted(value) ||
-            value.StartsWith("//", StringComparison.Ordinal) ||
+            value.StartsWith("/", StringComparison.Ordinal) ||
+            value.StartsWith("\\", StringComparison.Ordinal) ||
             Uri.TryCreate(value, UriKind.Absolute, out _))
             return false;
 
@@ -1571,7 +1575,7 @@ internal static partial class WebPipelineRunner
             return configuredCandidates;
 
         var localArtifactPath = declaredArtifactPath!.Trim();
-        if (configuredCandidates.Contains(localArtifactPath, StringComparer.OrdinalIgnoreCase))
+        if (configuredCandidates.Contains(localArtifactPath, StringComparer.Ordinal))
             return configuredCandidates;
 
         var candidates = new List<string>(configuredCandidates.Count + 1) { localArtifactPath };

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectDocsSync.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectDocsSync.cs
@@ -1257,19 +1257,29 @@ internal static partial class WebPipelineRunner
 
             if (onlyLocalLinks)
             {
-                if (hasDocsSurface && !IsLocalSurfaceLink(docsLink) && !IsZipArtifactSource(artifactDocs))
+                if (hasDocsSurface &&
+                    !IsLocalSurfaceLink(docsLink) &&
+                    !IsLocalProjectArtifactPath(artifactDocs) &&
+                    !IsZipArtifactSource(artifactDocs))
                     hasDocsSurface = false;
 
-                if (hasApiDotNetSurface && !IsLocalSurfaceLink(apiDotNetLink) && !IsZipArtifactSource(artifactApi))
+                if (hasApiDotNetSurface &&
+                    !IsLocalSurfaceLink(apiDotNetLink) &&
+                    !IsLocalProjectArtifactPath(artifactApi) &&
+                    !IsZipArtifactSource(artifactApi))
                     hasApiDotNetSurface = false;
 
                 if (hasApiPowerShellSurface &&
                     !IsLocalSurfaceLink(apiPowerShellLink) &&
+                    !IsLocalProjectArtifactPath(artifactApi) &&
                     !IsZipArtifactSource(artifactApi) &&
                     !HasPowerShellGalleryPackage(powerShellGalleryPackageId, powerShellGalleryPackageVersion))
                     hasApiPowerShellSurface = false;
 
-                if (hasExamplesSurface && !IsLocalSurfaceLink(examplesLink) && !IsZipArtifactSource(artifactExamples))
+                if (hasExamplesSurface &&
+                    !IsLocalSurfaceLink(examplesLink) &&
+                    !IsLocalProjectArtifactPath(artifactExamples) &&
+                    !IsZipArtifactSource(artifactExamples))
                     hasExamplesSurface = false;
             }
 
@@ -1531,6 +1541,18 @@ internal static partial class WebPipelineRunner
         }
 
         return value.EndsWith(".zip", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsLocalProjectArtifactPath(string? source)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+            return false;
+
+        var value = source.Trim();
+        if (Path.IsPathRooted(value) || value.StartsWith("//", StringComparison.Ordinal))
+            return false;
+
+        return !Uri.TryCreate(value, UriKind.Absolute, out _);
     }
 
     private static bool TryExtractArtifactZip(

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectDocsSync.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectDocsSync.cs
@@ -292,13 +292,14 @@ internal static partial class WebPipelineRunner
                 continue;
 
             var slug = project.Slug.Trim().ToLowerInvariant();
-            var sourceDocsRoot = ResolveExistingProjectSourcePath(sourcesRoot, slug, docsSourceCandidates);
+            var projectDocsSourceCandidates = GetProjectSourceCandidates(project.ArtifactDocs, docsSourceCandidates);
+            var sourceDocsRoot = ResolveExistingProjectSourcePath(sourcesRoot, slug, projectDocsSourceCandidates);
             if (!Directory.Exists(sourceDocsRoot))
             {
                 skipped++;
-                missingSources.Add(GetExpectedProjectSourcePath(sourcesRoot, slug, docsSourceCandidates));
+                missingSources.Add(GetExpectedProjectSourcePath(sourcesRoot, slug, projectDocsSourceCandidates));
                 if (failOnMissingSource)
-                    throw new InvalidOperationException($"project-docs-sync source docs path not found for '{slug}': {GetExpectedProjectSourcePath(sourcesRoot, slug, docsSourceCandidates)}");
+                    throw new InvalidOperationException($"project-docs-sync source docs path not found for '{slug}': {GetExpectedProjectSourcePath(sourcesRoot, slug, projectDocsSourceCandidates)}");
                 continue;
             }
 
@@ -365,13 +366,14 @@ internal static partial class WebPipelineRunner
                     continue;
 
                 var slug = project.Slug.Trim().ToLowerInvariant();
-                var sourceApiRoot = ResolveExistingProjectSourcePath(sourcesRoot, slug, apiSourceCandidates);
+                var projectApiSourceCandidates = GetProjectSourceCandidates(project.ArtifactApi, apiSourceCandidates);
+                var sourceApiRoot = ResolveExistingProjectSourcePath(sourcesRoot, slug, projectApiSourceCandidates);
                 if (!Directory.Exists(sourceApiRoot))
                 {
                     skippedApi++;
-                    missingApiSources.Add(GetExpectedProjectSourcePath(sourcesRoot, slug, apiSourceCandidates));
+                    missingApiSources.Add(GetExpectedProjectSourcePath(sourcesRoot, slug, projectApiSourceCandidates));
                     if (failOnMissingApiSource)
-                        throw new InvalidOperationException($"project-docs-sync source api path not found for '{slug}': {GetExpectedProjectSourcePath(sourcesRoot, slug, apiSourceCandidates)}");
+                        throw new InvalidOperationException($"project-docs-sync source api path not found for '{slug}': {GetExpectedProjectSourcePath(sourcesRoot, slug, projectApiSourceCandidates)}");
                     continue;
                 }
 
@@ -412,13 +414,14 @@ internal static partial class WebPipelineRunner
                     continue;
 
                 var slug = project.Slug.Trim().ToLowerInvariant();
-                var sourceExamplesRoot = ResolveExistingProjectSourcePath(sourcesRoot, slug, examplesSourceCandidates);
+                var projectExamplesSourceCandidates = GetProjectSourceCandidates(project.ArtifactExamples, examplesSourceCandidates);
+                var sourceExamplesRoot = ResolveExistingProjectSourcePath(sourcesRoot, slug, projectExamplesSourceCandidates);
                 if (!Directory.Exists(sourceExamplesRoot))
                 {
                     skippedExamples++;
-                    missingExampleSources.Add(GetExpectedProjectSourcePath(sourcesRoot, slug, examplesSourceCandidates));
+                    missingExampleSources.Add(GetExpectedProjectSourcePath(sourcesRoot, slug, projectExamplesSourceCandidates));
                     if (failOnMissingExamplesSource)
-                        throw new InvalidOperationException($"project-docs-sync source examples path not found for '{slug}': {GetExpectedProjectSourcePath(sourcesRoot, slug, examplesSourceCandidates)}");
+                        throw new InvalidOperationException($"project-docs-sync source examples path not found for '{slug}': {GetExpectedProjectSourcePath(sourcesRoot, slug, projectExamplesSourceCandidates)}");
                     continue;
                 }
 
@@ -1549,10 +1552,31 @@ internal static partial class WebPipelineRunner
             return false;
 
         var value = source.Trim();
-        if (Path.IsPathRooted(value) || value.StartsWith("//", StringComparison.Ordinal))
+        if (IsZipArtifactSource(value) ||
+            Path.IsPathRooted(value) ||
+            value.StartsWith("//", StringComparison.Ordinal) ||
+            Uri.TryCreate(value, UriKind.Absolute, out _))
             return false;
 
-        return !Uri.TryCreate(value, UriKind.Absolute, out _);
+        return !value
+            .Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries)
+            .Any(segment => segment.Equals("..", StringComparison.Ordinal));
+    }
+
+    private static IReadOnlyList<string> GetProjectSourceCandidates(
+        string? declaredArtifactPath,
+        IReadOnlyList<string> configuredCandidates)
+    {
+        if (!IsLocalProjectArtifactPath(declaredArtifactPath))
+            return configuredCandidates;
+
+        var localArtifactPath = declaredArtifactPath!.Trim();
+        if (configuredCandidates.Contains(localArtifactPath, StringComparer.OrdinalIgnoreCase))
+            return configuredCandidates;
+
+        var candidates = new List<string>(configuredCandidates.Count + 1) { localArtifactPath };
+        candidates.AddRange(configuredCandidates);
+        return candidates;
     }
 
     private static bool TryExtractArtifactZip(


### PR DESCRIPTION
## Summary

- keep repository-local project artifact paths eligible when project-docs-sync runs with onlyLocalLinks enabled
- resolve each declared local docs, API, or examples artifact path directly before configured fallbacks and preserve its exact casing
- use project-specific candidates consistently for direct copy, examples metadata, and ZIP/package hydration
- reject rooted, URI, archive, parent-traversal, and Unix backslash-root escape values from repository-local path resolution

## Why

The [EvotecIT Website](https://github.com/EvotecIT/Website) deploy pipeline consumes project API artifacts through PowerForge. A .NET-only project such as [ChartForgeX](https://github.com/EvotecIT/ChartForgeX) can provide a repository-local API artifact while intentionally omitting a local PowerShell API link. PowerForge previously removed that surface before inspecting the cloned artifact, which left the downstream API documentation build without its required source.

## Validation

- Windows: dotnet test PowerForge.Tests/PowerForge.Tests.csproj -c Release --filter FullyQualifiedName~WebPipelineRunnerProjectDocsSync — 14 passed
- WSL/Linux: the same .NET 10 test slice — 14 passed
- live Linux reproduction synchronized the Website project API set from 6/6 to 7/7 and rendered both 7-project API suites, including 663 ChartForgeX types