### PR TITLE
Harden coordinated release payload promotion

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.FileSystemRetries.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.FileSystemRetries.cs
@@ -1,0 +1,121 @@
+using System;
+using System.IO;
+
+namespace PowerForge;
+
+public sealed partial class ModulePipelineRunner
+{
+    /// <summary>
+    /// Moves a release directory atomically while tolerating short-lived filesystem locks.
+    /// </summary>
+    /// <param name="sourcePath">Completed temporary directory to promote.</param>
+    /// <param name="destinationPath">Final durable directory path.</param>
+    /// <param name="failureDescription">Release-specific guidance added when all attempts fail.</param>
+    /// <param name="moveDirectory">Optional filesystem boundary used by focused tests.</param>
+    /// <param name="delay">Optional retry delay boundary used by focused tests.</param>
+    /// <param name="maximumAttempts">Maximum number of move attempts.</param>
+    /// <param name="initialDelayMs">Initial retry delay in milliseconds.</param>
+    internal static void MoveDirectoryWithRetries(
+        string sourcePath,
+        string destinationPath,
+        string failureDescription,
+        Action<string, string>? moveDirectory = null,
+        Action<int>? delay = null,
+        int maximumAttempts = 6,
+        int initialDelayMs = 50)
+    {
+        if (string.IsNullOrWhiteSpace(sourcePath))
+            throw new ArgumentException("Source path is required.", nameof(sourcePath));
+        if (string.IsNullOrWhiteSpace(destinationPath))
+            throw new ArgumentException("Destination path is required.", nameof(destinationPath));
+
+        var move = moveDirectory ?? Directory.Move;
+        RunFileSystemOperationWithRetries(
+            () => move(sourcePath, destinationPath),
+            failureDescription,
+            $"moving '{sourcePath}' to '{destinationPath}'",
+            delay,
+            maximumAttempts,
+            initialDelayMs);
+    }
+
+    /// <summary>
+    /// Executes a release filesystem operation with bounded retries for transient Windows locks.
+    /// </summary>
+    /// <param name="operation">Filesystem operation to execute.</param>
+    /// <param name="failureDescription">Release-specific guidance added when all attempts fail.</param>
+    /// <param name="operationDescription">Concrete operation description added to diagnostics.</param>
+    /// <param name="delay">Optional retry delay boundary used by focused tests.</param>
+    /// <param name="maximumAttempts">Maximum number of operation attempts.</param>
+    /// <param name="initialDelayMs">Initial retry delay in milliseconds.</param>
+    internal static void RunFileSystemOperationWithRetries(
+        Action operation,
+        string failureDescription,
+        string operationDescription,
+        Action<int>? delay = null,
+        int maximumAttempts = 6,
+        int initialDelayMs = 50)
+    {
+        if (operation is null)
+            throw new ArgumentNullException(nameof(operation));
+        if (string.IsNullOrWhiteSpace(failureDescription))
+            throw new ArgumentException("Failure description is required.", nameof(failureDescription));
+        if (string.IsNullOrWhiteSpace(operationDescription))
+            throw new ArgumentException("Operation description is required.", nameof(operationDescription));
+
+        var wait = delay ?? System.Threading.Thread.Sleep;
+        maximumAttempts = Math.Max(1, maximumAttempts);
+        var delayMs = Math.Min(Math.Max(0, initialDelayMs), 2000);
+        Exception? last = null;
+
+        for (var attempt = 1; attempt <= maximumAttempts; attempt++)
+        {
+            try
+            {
+                operation();
+                return;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                last = ex;
+            }
+
+            if (attempt >= maximumAttempts)
+            {
+                throw new InvalidOperationException(
+                    $"{failureDescription} Failed after {maximumAttempts} attempts while {operationDescription}.",
+                    last);
+            }
+
+            if (delayMs > 0)
+                wait(delayMs);
+            delayMs = Math.Min(delayMs * 2, 2000);
+        }
+    }
+
+    /// <summary>
+    /// Cleans a temporary release path without hiding an operation failure already in flight.
+    /// </summary>
+    /// <param name="temporaryPath">Temporary path to clean.</param>
+    /// <param name="operationFailure">Primary operation failure, when cleanup runs during exception unwinding.</param>
+    /// <param name="cleanup">Cleanup action.</param>
+    internal static void CleanupTemporaryPath(
+        string temporaryPath,
+        Exception? operationFailure,
+        Action cleanup)
+    {
+        if (cleanup is null)
+            throw new ArgumentNullException(nameof(cleanup));
+
+        try
+        {
+            cleanup();
+        }
+        catch (Exception cleanupFailure) when (operationFailure is not null)
+        {
+            throw new InvalidOperationException(
+                $"{operationFailure.Message} Cleanup also failed for temporary path '{temporaryPath}'; release its filesystem lock and remove the retained temporary path before retrying.",
+                new AggregateException(operationFailure, cleanupFailure));
+        }
+    }
+}

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleasePayloadFingerprint.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleasePayloadFingerprint.cs
@@ -7,6 +7,12 @@ namespace PowerForge;
 
 public sealed partial class ModulePipelineRunner
 {
+    private const string PayloadCachePromotionFailure =
+        "The exact signed coordinated release payload could not be committed to its durable cache before any remote publish attempt. Resolve the local filesystem lock and retry; the release checkpoint will resume without duplicating publication.";
+
+    private const string PayloadRestoreFailure =
+        "The exact signed coordinated release payload could not be restored from its durable cache. Resolve the local filesystem lock and retry the incomplete release.";
+
     private ModuleBuildResult BindSynchronizedReleasePayload(
         ModulePipelinePlan plan,
         ModuleBuildResult buildResult,
@@ -247,6 +253,7 @@ public sealed partial class ModulePipelineRunner
         ModulePipelineRunState state)
     {
         var temporaryPath = cachePath + ".tmp-" + Guid.NewGuid().ToString("N");
+        Exception? operationFailure = null;
         try
         {
             CopySynchronizedReleaseDirectory(buildResult.StagingPath, Path.Combine(temporaryPath, "module"));
@@ -304,13 +311,37 @@ public sealed partial class ModulePipelineRunner
             }
 
             if (Directory.Exists(cachePath))
-                DeleteDirectoryWithRetries(cachePath);
-            Directory.Move(temporaryPath, cachePath);
+            {
+                try
+                {
+                    DeleteDirectoryWithRetries(cachePath);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    throw new InvalidOperationException(
+                        $"{PayloadCachePromotionFailure} Failed while deleting the previous cache '{cachePath}'.",
+                        ex);
+                }
+            }
+            MoveDirectoryWithRetries(
+                temporaryPath,
+                cachePath,
+                PayloadCachePromotionFailure);
+        }
+        catch (Exception ex)
+        {
+            operationFailure = ex;
+            throw;
         }
         finally
         {
             if (Directory.Exists(temporaryPath))
-                DeleteDirectoryWithRetries(temporaryPath);
+            {
+                CleanupTemporaryPath(
+                    temporaryPath,
+                    operationFailure,
+                    () => DeleteDirectoryWithRetries(temporaryPath));
+            }
         }
     }
 
@@ -527,17 +558,42 @@ public sealed partial class ModulePipelineRunner
     {
         DeleteStaleSynchronizedReleaseRestorePaths(destinationPath);
         var temporaryPath = destinationPath + ".restore-" + Guid.NewGuid().ToString("N");
+        Exception? operationFailure = null;
         try
         {
             CopySynchronizedReleaseDirectory(sourcePath, temporaryPath);
             if (Directory.Exists(destinationPath))
-                DeleteDirectoryWithRetries(destinationPath);
-            Directory.Move(temporaryPath, destinationPath);
+            {
+                try
+                {
+                    DeleteDirectoryWithRetries(destinationPath);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    throw new InvalidOperationException(
+                        $"{PayloadRestoreFailure} Failed while deleting the previous destination '{destinationPath}'.",
+                        ex);
+                }
+            }
+            MoveDirectoryWithRetries(
+                temporaryPath,
+                destinationPath,
+                PayloadRestoreFailure);
+        }
+        catch (Exception ex)
+        {
+            operationFailure = ex;
+            throw;
         }
         finally
         {
             if (Directory.Exists(temporaryPath))
-                DeleteDirectoryWithRetries(temporaryPath);
+            {
+                CleanupTemporaryPath(
+                    temporaryPath,
+                    operationFailure,
+                    () => DeleteDirectoryWithRetries(temporaryPath));
+            }
         }
     }
 
@@ -553,17 +609,42 @@ public sealed partial class ModulePipelineRunner
         Directory.CreateDirectory(destinationDirectory);
         DeleteStaleSynchronizedReleaseRestorePaths(destinationPath);
         var temporaryPath = destinationPath + ".restore-" + Guid.NewGuid().ToString("N");
+        Exception? operationFailure = null;
         try
         {
-            File.Copy(sourcePath, temporaryPath, overwrite: true);
+            RunFileSystemOperationWithRetries(
+                () => File.Copy(sourcePath, temporaryPath, overwrite: true),
+                PayloadRestoreFailure,
+                $"copying cached file '{sourcePath}' to temporary path '{temporaryPath}'");
             if (File.Exists(destinationPath))
-                File.Delete(destinationPath);
-            File.Move(temporaryPath, destinationPath);
+            {
+                RunFileSystemOperationWithRetries(
+                    () => File.Delete(destinationPath),
+                    PayloadRestoreFailure,
+                    $"deleting previous destination file '{destinationPath}'");
+            }
+            RunFileSystemOperationWithRetries(
+                () => File.Move(temporaryPath, destinationPath),
+                PayloadRestoreFailure,
+                $"moving temporary file '{temporaryPath}' to '{destinationPath}'");
+        }
+        catch (Exception ex)
+        {
+            operationFailure = ex;
+            throw;
         }
         finally
         {
             if (File.Exists(temporaryPath))
-                File.Delete(temporaryPath);
+            {
+                CleanupTemporaryPath(
+                    temporaryPath,
+                    operationFailure,
+                    () => RunFileSystemOperationWithRetries(
+                        () => File.Delete(temporaryPath),
+                        PayloadRestoreFailure,
+                        $"deleting temporary file '{temporaryPath}'"));
+            }
         }
     }
 

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseDirectoryRetryTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseDirectoryRetryTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class ModulePipelineUnifiedReleaseTests
+{
+    [Fact]
+    public void MoveDirectoryWithRetries_PromotesPayloadAfterTransientWindowsFailures()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            var sourcePath = Path.Combine(root.FullName, "payload.tmp");
+            var destinationPath = Path.Combine(root.FullName, "payload");
+            Directory.CreateDirectory(sourcePath);
+            File.WriteAllText(Path.Combine(sourcePath, "signed.bin"), "signed-payload");
+
+            var attempts = 0;
+            var delays = new List<int>();
+            ModulePipelineRunner.MoveDirectoryWithRetries(
+                sourcePath,
+                destinationPath,
+                "Payload promotion failed.",
+                moveDirectory: (source, destination) =>
+                {
+                    attempts++;
+                    if (attempts == 1)
+                        throw new UnauthorizedAccessException("Simulated scanner lock.");
+                    if (attempts == 2)
+                        throw new IOException("Simulated indexing lock.");
+                    Directory.Move(source, destination);
+                },
+                delay: delays.Add);
+
+            Assert.Equal(3, attempts);
+            Assert.Equal(new[] { 50, 100 }, delays);
+            Assert.False(Directory.Exists(sourcePath));
+            Assert.Equal("signed-payload", File.ReadAllText(Path.Combine(destinationPath, "signed.bin")));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void MoveDirectoryWithRetries_ExplainsSafeRetryWhenPromotionRemainsLocked()
+    {
+        var sourcePath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", "payload.tmp");
+        var destinationPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", "payload");
+        var attempts = 0;
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            ModulePipelineRunner.MoveDirectoryWithRetries(
+                sourcePath,
+                destinationPath,
+                "No remote publish attempt began; retry the checkpoint safely.",
+                moveDirectory: (_, _) =>
+                {
+                    attempts++;
+                    throw new UnauthorizedAccessException("Persistent scanner lock.");
+                },
+                delay: _ => { },
+                maximumAttempts: 3,
+                initialDelayMs: 1));
+
+        Assert.Equal(3, attempts);
+        Assert.Contains("No remote publish attempt began", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Failed after 3 attempts", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(sourcePath, exception.Message, StringComparison.Ordinal);
+        Assert.Contains(destinationPath, exception.Message, StringComparison.Ordinal);
+        Assert.IsType<UnauthorizedAccessException>(exception.InnerException);
+    }
+
+    [Fact]
+    public void RunFileSystemOperationWithRetries_RestoresFileAfterTransientLock()
+    {
+        var attempts = 0;
+        var delays = new List<int>();
+
+        ModulePipelineRunner.RunFileSystemOperationWithRetries(
+            operation: () =>
+            {
+                attempts++;
+                if (attempts < 3)
+                    throw new UnauthorizedAccessException("Simulated scanner lock.");
+            },
+            failureDescription: "Payload restoration failed.",
+            operationDescription: "moving a cached package file",
+            delay: delays.Add);
+
+        Assert.Equal(3, attempts);
+        Assert.Equal(new[] { 50, 100 }, delays);
+    }
+
+    [Fact]
+    public void CleanupTemporaryPath_PreservesPrimarySafeResumeFailure()
+    {
+        var primary = new InvalidOperationException(
+            "No remote publish attempt began; retry the checkpoint safely.");
+        var cleanup = new UnauthorizedAccessException("Persistent scanner lock.");
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            ModulePipelineRunner.CleanupTemporaryPath(
+                "payload.tmp",
+                primary,
+                () => throw cleanup));
+
+        Assert.Contains(primary.Message, exception.Message, StringComparison.Ordinal);
+        Assert.Contains("retained temporary path", exception.Message, StringComparison.Ordinal);
+        var aggregate = Assert.IsType<AggregateException>(exception.InnerException);
+        Assert.Same(primary, aggregate.InnerExceptions[0]);
+        Assert.Same(cleanup, aggregate.InnerExceptions[1]);
+    }
+}


### PR DESCRIPTION
## Summary

- Retry transient Windows filesystem locks while caching and restoring exact coordinated-release payloads.
- Preserve atomic directory and file promotion while adding bounded, release-specific safe-resume diagnostics.
- Keep primary failures visible when temporary-path cleanup also fails.

## Why

[Transferetto](https://github.com/EvotecIT/Transferetto) completed its local 2.0.1 build and signing work but stopped before any remote publication when Windows denied the temporary payload-cache promotion. The fix belongs in PSPublishModule/PowerForge so publishing consumers retain thin build wrappers.

## Validation

- Focused retry, cleanup, cached-payload resume, and stable-identity rebind tests pass.
- PowerForge.PowerShell builds for `net8.0` and `net472` pass.
- A rebuilt local PSPublishModule completed Transferetto's non-publish build gate.
- The broader coordinated-release test class remains at 98 passes and one exact-base pre-existing version-pattern failure.
