### PR TITLE
Fix exact-source Apple device deployment

### DIFF
--- a/PowerForge.Cli/Program.Command.AppleDeploy.cs
+++ b/PowerForge.Cli/Program.Command.AppleDeploy.cs
@@ -247,12 +247,10 @@ internal static partial class Program
             cliResult.Success = deployment.Succeeded;
             cliResult.Warning = deployment.Install?.Warning;
             cliResult.Diagnostic = ResolveAppleDeployDiagnostic(
+                CollectAppleDeployCredentialMetadata(apple, authentication, projectRoot),
                 deployment.Build.ProcessResult,
                 deployment.Install?.ProcessResult,
                 deployment.Launch?.ProcessResult);
-            cliResult.Diagnostic = RedactAppleDeployDiagnostic(
-                cliResult.Diagnostic,
-                CollectAppleDeployCredentialMetadata(apple, authentication, projectRoot));
             return;
         }
 
@@ -292,12 +290,10 @@ internal static partial class Program
         cliResult.DeviceLocked = deviceDeployment.Launch?.DeviceLocked ?? false;
         cliResult.Success = deviceDeployment.RequestedStagesSucceeded;
         cliResult.Diagnostic = ResolveAppleDeployDiagnostic(
+            CollectAppleDeployCredentialMetadata(apple, authentication, projectRoot),
             deviceDeployment.Build.ProcessResult,
             deviceDeployment.Install?.ProcessResult,
             deviceDeployment.Launch?.ProcessResult);
-        cliResult.Diagnostic = RedactAppleDeployDiagnostic(
-            cliResult.Diagnostic,
-            CollectAppleDeployCredentialMetadata(apple, authentication, projectRoot));
     }
 
     private static AppleAppConfiguration SelectAppleDeployTarget(
@@ -440,13 +436,6 @@ internal static partial class Program
     private static string? FirstNonEmptyAppleDeploy(params string?[] values)
         => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
 
-    private static string? RedactAppleDeployDiagnostic(
-        string? diagnostic,
-        IEnumerable<string> sensitiveValues)
-        => diagnostic is null
-            ? null
-            : RedactReleaseCredentialText(diagnostic, sensitiveValues);
-
     private static ApplePlatform ParseAppleDeployPlatform(string? value, ApplePlatform fallback)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -542,7 +531,9 @@ internal static partial class Program
     private static string FormatAppleDeployTargetSuffix(string? target)
         => string.IsNullOrWhiteSpace(target) ? string.Empty : $" and target '{target}'";
 
-    private static string? ResolveAppleDeployDiagnostic(params ProcessRunResult?[] stages)
+    private static string? ResolveAppleDeployDiagnostic(
+        IEnumerable<string> sensitiveValues,
+        params ProcessRunResult?[] stages)
     {
         var failed = stages.FirstOrDefault(static stage => stage is not null && !stage.Succeeded);
         if (failed is null)
@@ -550,7 +541,7 @@ internal static partial class Program
         var text = string.IsNullOrWhiteSpace(failed.StdErr) ? failed.StdOut : failed.StdErr;
         if (string.IsNullOrWhiteSpace(text))
             return $"{failed.Executable} exited with code {failed.ExitCode}.";
-        var compact = text.Trim();
+        var compact = RedactReleaseCredentialText(text, sensitiveValues).Trim();
         return compact.Length <= 2000 ? compact : compact[^2000..];
     }
 

--- a/PowerForge.Cli/Program.Command.AppleDeploy.cs
+++ b/PowerForge.Cli/Program.Command.AppleDeploy.cs
@@ -16,6 +16,9 @@ internal static partial class Program
     {
         var argv = filteredArgs.Skip(1).ToArray();
         var outputJson = IsJsonOutput(argv);
+        PowerForgeAppleReleaseOptions? appleForRedaction = null;
+        string? projectRootForRedaction = null;
+        AppleDeployAuthentication? authenticationForRedaction = null;
         if (argv.Any(static value => value.Equals("-h", StringComparison.OrdinalIgnoreCase) || value.Equals("--help", StringComparison.OrdinalIgnoreCase)))
         {
             if (outputJson)
@@ -45,6 +48,7 @@ internal static partial class Program
 
             var (release, fullConfigPath) = LoadPowerForgeReleaseSpecWithPath(configPath);
             var apple = release.AppleApps ?? throw new InvalidOperationException("Release config has no AppleApps section.");
+            appleForRedaction = apple;
             var local = apple.LocalDeployment;
             var requestedPlatform = ParseAppleDeployPlatform(TryGetOptionValue(argv, "--platform"), local.DefaultPlatform);
             var selectedTarget = SelectAppleDeployTarget(
@@ -57,6 +61,9 @@ internal static partial class Program
 
             var configDirectory = Path.GetDirectoryName(fullConfigPath) ?? Directory.GetCurrentDirectory();
             var projectRoot = ResolvePathFromBase(configDirectory, string.IsNullOrWhiteSpace(apple.ProjectRoot) ? "." : apple.ProjectRoot!);
+            projectRootForRedaction = projectRoot;
+            var authentication = ResolveAppleDeployAuthentication(apple, projectRoot);
+            authenticationForRedaction = authentication;
             var projectPath = ResolvePathFromBase(projectRoot, selectedTarget.ProjectPath);
             if (!Directory.Exists(projectPath) && !File.Exists(projectPath))
                 throw new FileNotFoundException("Xcode project or workspace was not found.", projectPath);
@@ -158,7 +165,15 @@ internal static partial class Program
             if (!planOnly)
             {
                 using var deploymentLock = AppleLocalDeploymentLock.Acquire(localRoot, $"build cache '{localRoot}'");
-                ExecuteAppleDeploy(cliResult, apple, selectedTarget, projectRoot, profile, device, deviceIdentifier);
+                ExecuteAppleDeploy(
+                    cliResult,
+                    apple,
+                    selectedTarget,
+                    projectRoot,
+                    profile,
+                    device,
+                    deviceIdentifier,
+                    authentication);
             }
             else
                 cliResult.Success = true;
@@ -167,7 +182,17 @@ internal static partial class Program
         }
         catch (Exception exception)
         {
-            return WriteReleaseError(outputJson, "apple-deploy", 1, exception.Message, logger);
+            return WriteReleaseError(
+                outputJson,
+                "apple-deploy",
+                1,
+                RedactReleaseCredentialText(
+                    exception.Message,
+                    CollectAppleDeployCredentialMetadata(
+                        appleForRedaction,
+                        authenticationForRedaction,
+                        projectRootForRedaction)),
+                logger);
         }
     }
 
@@ -178,7 +203,8 @@ internal static partial class Program
         string projectRoot,
         PowerForgeAppleLocalDeploymentProfile? profile,
         string? device,
-        string? deviceIdentifier)
+        string? deviceIdentifier,
+        AppleDeployAuthentication authentication)
     {
         var environment = profile is null
             ? new Dictionary<string, string>(StringComparer.Ordinal)
@@ -200,6 +226,9 @@ internal static partial class Program
                 DerivedDataPath = cliResult.DerivedDataPath,
                 XcodeBuildExecutable = apple.XcodeBuildExecutable,
                 AllowProvisioningUpdates = apple.AllowProvisioningUpdates,
+                AppStoreConnectApiKeyPath = authentication.KeyPath,
+                AppStoreConnectApiKeyId = authentication.KeyId,
+                AppStoreConnectApiIssuerId = authentication.IssuerId,
                 UseBuildMirror = cliResult.UseBuildMirror,
                 BuildRoot = projectRoot,
                 BuildMirrorPath = cliResult.BuildMirrorPath,
@@ -221,6 +250,9 @@ internal static partial class Program
                 deployment.Build.ProcessResult,
                 deployment.Install?.ProcessResult,
                 deployment.Launch?.ProcessResult);
+            cliResult.Diagnostic = RedactAppleDeployDiagnostic(
+                cliResult.Diagnostic,
+                CollectAppleDeployCredentialMetadata(apple, authentication, projectRoot));
             return;
         }
 
@@ -243,6 +275,9 @@ internal static partial class Program
             DerivedDataPath = cliResult.DerivedDataPath,
             XcodeBuildExecutable = apple.XcodeBuildExecutable,
             AllowProvisioningUpdates = apple.AllowProvisioningUpdates,
+            AppStoreConnectApiKeyPath = authentication.KeyPath,
+            AppStoreConnectApiKeyId = authentication.KeyId,
+            AppStoreConnectApiIssuerId = authentication.IssuerId,
             UseBuildMirror = cliResult.UseBuildMirror,
             BuildRoot = projectRoot,
             BuildMirrorPath = cliResult.BuildMirrorPath
@@ -260,6 +295,9 @@ internal static partial class Program
             deviceDeployment.Build.ProcessResult,
             deviceDeployment.Install?.ProcessResult,
             deviceDeployment.Launch?.ProcessResult);
+        cliResult.Diagnostic = RedactAppleDeployDiagnostic(
+            cliResult.Diagnostic,
+            CollectAppleDeployCredentialMetadata(apple, authentication, projectRoot));
     }
 
     private static AppleAppConfiguration SelectAppleDeployTarget(
@@ -305,6 +343,109 @@ internal static partial class Program
             throw new InvalidOperationException($"Local deployment profile '{name}' is not configured exactly once.");
         return matches[0];
     }
+
+    private static AppleDeployAuthentication ResolveAppleDeployAuthentication(
+        PowerForgeAppleReleaseOptions apple,
+        string projectRoot)
+    {
+        var configuredCount =
+            (string.IsNullOrWhiteSpace(apple.AppStoreConnectApiKeyPath) ? 0 : 1) +
+            (string.IsNullOrWhiteSpace(apple.AppStoreConnectApiKeyId) ? 0 : 1) +
+            (string.IsNullOrWhiteSpace(apple.AppStoreConnectApiIssuerId) ? 0 : 1);
+        var useEnvironment = configuredCount == 0;
+        var configuredKeyPath = useEnvironment
+            ? FirstNonEmptyAppleDeploy(
+                Environment.GetEnvironmentVariable("APP_STORE_CONNECT_PRIVATE_KEY_PATH"),
+                Environment.GetEnvironmentVariable("ASC_PRIVATE_KEY_PATH"))
+            : apple.AppStoreConnectApiKeyPath;
+        var keyId = useEnvironment
+            ? FirstNonEmptyAppleDeploy(
+                Environment.GetEnvironmentVariable("APP_STORE_CONNECT_KEY_ID"),
+                Environment.GetEnvironmentVariable("ASC_KEY_ID"))
+            : apple.AppStoreConnectApiKeyId;
+        var issuerId = useEnvironment
+            ? FirstNonEmptyAppleDeploy(
+                Environment.GetEnvironmentVariable("APP_STORE_CONNECT_ISSUER_ID"),
+                Environment.GetEnvironmentVariable("ASC_ISSUER_ID"))
+            : apple.AppStoreConnectApiIssuerId;
+        string? keyPath = null;
+        try
+        {
+            keyPath = string.IsNullOrWhiteSpace(configuredKeyPath)
+                ? null
+                : ResolvePathFromBase(projectRoot, configuredKeyPath!);
+
+            AppleXcodeAuthentication.AddArguments(
+                keyPath,
+                keyId,
+                issuerId,
+                apple.AllowProvisioningUpdates,
+                new List<string>());
+        }
+        catch (Exception exception)
+        {
+            throw new InvalidOperationException(
+                RedactReleaseCredentialText(
+                    exception.Message,
+                    new[] { configuredKeyPath, keyPath, keyId, issuerId }
+                        .Where(static value => !string.IsNullOrWhiteSpace(value))
+                        .Select(static value => value!.Trim())),
+                exception);
+        }
+        return new AppleDeployAuthentication(
+            keyPath,
+            string.IsNullOrWhiteSpace(keyId) ? null : keyId.Trim(),
+            string.IsNullOrWhiteSpace(issuerId) ? null : issuerId.Trim());
+    }
+
+    private static string[] CollectAppleDeployCredentialMetadata(
+        PowerForgeAppleReleaseOptions? apple,
+        AppleDeployAuthentication? authentication,
+        string? projectRoot)
+    {
+        var values = new List<string?>
+        {
+            apple?.AppStoreConnectApiKeyPath,
+            apple?.AppStoreConnectApiKeyId,
+            apple?.AppStoreConnectApiIssuerId,
+            authentication?.KeyPath,
+            authentication?.KeyId,
+            authentication?.IssuerId
+        };
+        values.AddRange(CollectReleaseCredentialMetadata(null, null));
+
+        if (!string.IsNullOrWhiteSpace(projectRoot) &&
+            !string.IsNullOrWhiteSpace(apple?.AppStoreConnectApiKeyPath))
+        {
+            try
+            {
+                values.Add(ResolvePathFromBase(
+                    projectRoot!,
+                    apple!.AppStoreConnectApiKeyPath!));
+            }
+            catch
+            {
+                // Error reporting must not repeat a malformed-path failure.
+            }
+        }
+
+        return values
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value!.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .OrderByDescending(static value => value.Length)
+            .ToArray();
+    }
+
+    private static string? FirstNonEmptyAppleDeploy(params string?[] values)
+        => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
+
+    private static string? RedactAppleDeployDiagnostic(
+        string? diagnostic,
+        IEnumerable<string> sensitiveValues)
+        => diagnostic is null
+            ? null
+            : RedactReleaseCredentialText(diagnostic, sensitiveValues);
 
     private static ApplePlatform ParseAppleDeployPlatform(string? value, ApplePlatform fallback)
     {
@@ -412,4 +553,9 @@ internal static partial class Program
         var compact = text.Trim();
         return compact.Length <= 2000 ? compact : compact[^2000..];
     }
+
+    private sealed record AppleDeployAuthentication(
+        string? KeyPath,
+        string? KeyId,
+        string? IssuerId);
 }

--- a/PowerForge.Tests/AppleDeploymentTestFixture.cs
+++ b/PowerForge.Tests/AppleDeploymentTestFixture.cs
@@ -4,12 +4,10 @@ internal static class AppleDeploymentTestFixture
 {
     internal static void MaterializeConfiguredBuildProduct(ProcessRunRequest request)
     {
-        var outputSetting = request.Arguments.FirstOrDefault(argument =>
-            argument.StartsWith("CONFIGURATION_BUILD_DIR=", StringComparison.Ordinal));
-        if (outputSetting is null)
+        var outputRoot = TryResolveConfiguredBuildProductDirectory(request);
+        if (outputRoot is null)
             return;
 
-        var outputRoot = outputSetting.Substring("CONFIGURATION_BUILD_DIR=".Length);
         Directory.CreateDirectory(outputRoot);
         if (Directory.EnumerateDirectories(outputRoot, "*.app", SearchOption.TopDirectoryOnly).Any())
             return;
@@ -42,6 +40,49 @@ internal static class AppleDeploymentTestFixture
             : "AppleApp";
         var app = Directory.CreateDirectory(Path.Combine(outputRoot, scheme + ".app"));
         File.WriteAllText(Path.Combine(app.FullName, "payload"), "test product");
+    }
+
+    internal static string? TryResolvePrivateProductRoot(ProcessRunRequest request)
+    {
+        var outputSetting = request.Arguments.FirstOrDefault(argument =>
+            argument.StartsWith("SYMROOT=", StringComparison.Ordinal));
+        return outputSetting?.Substring("SYMROOT=".Length);
+    }
+
+    internal static string? TryResolveConfiguredBuildProductDirectory(
+        ProcessRunRequest request)
+    {
+        var productRoot = TryResolvePrivateProductRoot(request);
+        if (productRoot is null)
+            return null;
+
+        var arguments = request.Arguments.ToArray();
+        var configurationIndex = Array.IndexOf(arguments, "-configuration");
+        var configuration = configurationIndex >= 0 &&
+                            configurationIndex + 1 < arguments.Length
+            ? arguments[configurationIndex + 1]
+            : "Debug";
+        var destinationIndex = Array.IndexOf(arguments, "-destination");
+        var destination = destinationIndex >= 0 &&
+                          destinationIndex + 1 < arguments.Length
+            ? arguments[destinationIndex + 1]
+            : string.Empty;
+        var productDirectory = destination.Contains(
+                "platform=macOS",
+                StringComparison.OrdinalIgnoreCase)
+            ? destination.Contains(
+                    "variant=Mac Catalyst",
+                    StringComparison.OrdinalIgnoreCase)
+                ? configuration + "-maccatalyst"
+                : configuration
+            : destination.Contains("watchOS", StringComparison.OrdinalIgnoreCase)
+                ? configuration + "-watchos"
+                : destination.Contains("tvOS", StringComparison.OrdinalIgnoreCase)
+                    ? configuration + "-appletvos"
+                    : destination.Contains("visionOS", StringComparison.OrdinalIgnoreCase)
+                        ? configuration + "-xros"
+                        : configuration + "-iphoneos";
+        return Path.Combine(productRoot, productDirectory);
     }
 
     internal static void WriteSharedSchemes(

--- a/PowerForge.Tests/AppleDeviceDeploymentServiceTests.PackageSnapshotWave.cs
+++ b/PowerForge.Tests/AppleDeviceDeploymentServiceTests.PackageSnapshotWave.cs
@@ -90,14 +90,110 @@ public sealed partial class AppleDeviceDeploymentServiceTests
             Assert.Equal(
                 ReadArgumentValue(resolve, "-clonedSourcePackagesDirPath"),
                 ReadArgumentValue(build, "-clonedSourcePackagesDirPath"));
-            var productRoot = build.Arguments.Single(argument =>
-                    argument.StartsWith("CONFIGURATION_BUILD_DIR=", StringComparison.Ordinal))
-                .Substring("CONFIGURATION_BUILD_DIR=".Length);
+            Assert.DoesNotContain(
+                build.Arguments,
+                argument => argument.StartsWith(
+                    "CONFIGURATION_BUILD_DIR=",
+                    StringComparison.Ordinal));
+            var productRoot = AppleDeploymentTestFixture
+                .TryResolvePrivateProductRoot(build);
+            Assert.NotNull(productRoot);
+            var productDirectory = AppleDeploymentTestFixture
+                .TryResolveConfiguredBuildProductDirectory(build)
+                ?? throw new InvalidOperationException("Private build product directory was not configured.");
+            Assert.EndsWith(
+                Path.Combine("Debug-iphoneos"),
+                productDirectory,
+                StringComparison.Ordinal);
             Assert.False(Directory.Exists(productRoot));
             Assert.False(Directory.Exists(runner.SourcePackagesRoot));
         }
         finally
         {
+            fixture.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Materialized_package_validation_accepts_an_owned_mirror_through_a_path_alias()
+    {
+        if (Path.DirectorySeparatorChar == '\\')
+            return;
+
+        var fixture = CreateLocalPackageBuildFixture();
+        var snapshotRoot = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests.PackageMirrorSnapshot",
+            Guid.NewGuid().ToString("N")));
+        var aliasRoot = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests.PackageMirrorAlias",
+            Guid.NewGuid().ToString("N")));
+        var sourcePackages = Directory.CreateDirectory(Path.Combine(
+            snapshotRoot.FullName,
+            "SourcePackages"));
+        var aliasPath = Path.Combine(aliasRoot.FullName, "SourcePackages");
+        try
+        {
+            var repositories = Directory.CreateDirectory(Path.Combine(
+                sourcePackages.FullName,
+                "repositories"));
+            var mirror = Path.Combine(repositories.FullName, "Shared-96812fe1");
+            RunGit(
+                repositories.FullName,
+                "clone",
+                "--mirror",
+                "--quiet",
+                "--no-hardlinks",
+                fixture.RemoteRoot,
+                mirror);
+            RunGit(mirror, "remote", "set-url", "origin", fixture.RemoteUrl);
+
+            Directory.CreateSymbolicLink(aliasPath, sourcePackages.FullName);
+            var checkouts = Directory.CreateDirectory(Path.Combine(
+                sourcePackages.FullName,
+                "checkouts"));
+            var checkout = Path.Combine(checkouts.FullName, "Shared");
+            var aliasedMirror = Path.Combine(
+                aliasPath,
+                "repositories",
+                Path.GetFileName(mirror));
+            RunGit(
+                checkouts.FullName,
+                "clone",
+                "--quiet",
+                "--no-hardlinks",
+                aliasedMirror,
+                checkout);
+
+            var materializedOrigin = ReadGit(
+                checkout,
+                "remote",
+                "get-url",
+                "origin").Trim();
+            Assert.StartsWith(aliasPath, materializedOrigin, StringComparison.Ordinal);
+            var revision = ReadGit(checkout, "rev-parse", "HEAD").Trim();
+
+            new AppleReleaseSourceTrustService().ValidateMaterializedPackageCheckouts(
+                sourcePackages.FullName,
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [fixture.RemoteUrl[..^4]] = revision
+                });
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(aliasPath))
+                    Directory.Delete(aliasPath);
+            }
+            catch
+            {
+                // Best effort fixture cleanup.
+            }
+            try { aliasRoot.Delete(recursive: true); } catch { /* best effort */ }
+            try { snapshotRoot.Delete(recursive: true); } catch { /* best effort */ }
             fixture.Dispose();
         }
     }

--- a/PowerForge.Tests/AppleDeviceDeploymentServiceTests.PackageSnapshotWave.cs
+++ b/PowerForge.Tests/AppleDeviceDeploymentServiceTests.PackageSnapshotWave.cs
@@ -90,11 +90,9 @@ public sealed partial class AppleDeviceDeploymentServiceTests
             Assert.Equal(
                 ReadArgumentValue(resolve, "-clonedSourcePackagesDirPath"),
                 ReadArgumentValue(build, "-clonedSourcePackagesDirPath"));
-            Assert.DoesNotContain(
-                build.Arguments,
-                argument => argument.StartsWith(
-                    "CONFIGURATION_BUILD_DIR=",
-                    StringComparison.Ordinal));
+            Assert.Contains(
+                "CONFIGURATION_BUILD_DIR=$(SYMROOT)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
+                build.Arguments);
             var productRoot = AppleDeploymentTestFixture
                 .TryResolvePrivateProductRoot(build);
             Assert.NotNull(productRoot);
@@ -132,7 +130,7 @@ public sealed partial class AppleDeviceDeploymentServiceTests
         var sourcePackages = Directory.CreateDirectory(Path.Combine(
             snapshotRoot.FullName,
             "SourcePackages"));
-        var aliasPath = Path.Combine(aliasRoot.FullName, "SourcePackages");
+        var aliasPath = Path.Combine(aliasRoot.FullName, "SnapshotAlias");
         try
         {
             var repositories = Directory.CreateDirectory(Path.Combine(
@@ -149,13 +147,14 @@ public sealed partial class AppleDeviceDeploymentServiceTests
                 mirror);
             RunGit(mirror, "remote", "set-url", "origin", fixture.RemoteUrl);
 
-            Directory.CreateSymbolicLink(aliasPath, sourcePackages.FullName);
+            Directory.CreateSymbolicLink(aliasPath, snapshotRoot.FullName);
             var checkouts = Directory.CreateDirectory(Path.Combine(
                 sourcePackages.FullName,
                 "checkouts"));
             var checkout = Path.Combine(checkouts.FullName, "Shared");
             var aliasedMirror = Path.Combine(
                 aliasPath,
+                "SourcePackages",
                 "repositories",
                 Path.GetFileName(mirror));
             RunGit(
@@ -193,6 +192,153 @@ public sealed partial class AppleDeviceDeploymentServiceTests
                 // Best effort fixture cleanup.
             }
             try { aliasRoot.Delete(recursive: true); } catch { /* best effort */ }
+            try { snapshotRoot.Delete(recursive: true); } catch { /* best effort */ }
+            fixture.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Materialized_package_validation_rejects_a_linked_repositories_directory()
+    {
+        if (Path.DirectorySeparatorChar == '\\')
+            return;
+
+        var fixture = CreateLocalPackageBuildFixture();
+        var snapshotRoot = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests.LinkedPackageRepositories",
+            Guid.NewGuid().ToString("N")));
+        var externalRepositories = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests.ExternalPackageRepositories",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            var sourcePackages = Directory.CreateDirectory(Path.Combine(
+                snapshotRoot.FullName,
+                "SourcePackages"));
+            var linkedRepositories = Path.Combine(
+                sourcePackages.FullName,
+                "repositories");
+            Directory.CreateSymbolicLink(
+                linkedRepositories,
+                externalRepositories.FullName);
+            var mirror = Path.Combine(
+                linkedRepositories,
+                "Shared-96812fe1");
+            RunGit(
+                linkedRepositories,
+                "clone",
+                "--mirror",
+                "--quiet",
+                "--no-hardlinks",
+                fixture.RemoteRoot,
+                mirror);
+            RunGit(mirror, "remote", "set-url", "origin", fixture.RemoteUrl);
+
+            var checkouts = Directory.CreateDirectory(Path.Combine(
+                sourcePackages.FullName,
+                "checkouts"));
+            var checkout = Path.Combine(checkouts.FullName, "Shared");
+            RunGit(
+                checkouts.FullName,
+                "clone",
+                "--quiet",
+                "--no-hardlinks",
+                mirror,
+                checkout);
+            var revision = ReadGit(checkout, "rev-parse", "HEAD").Trim();
+
+            var error = Assert.Throws<InvalidOperationException>(() =>
+                new AppleReleaseSourceTrustService().ValidateMaterializedPackageCheckouts(
+                    sourcePackages.FullName,
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [fixture.RemoteUrl[..^4]] = revision
+                    }));
+
+            Assert.Contains(
+                "must not traverse a symbolic link or reparse point",
+                error.Message,
+                StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { snapshotRoot.Delete(recursive: true); } catch { /* best effort */ }
+            try { externalRepositories.Delete(recursive: true); } catch { /* best effort */ }
+            fixture.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Materialized_package_validation_rejects_a_linked_mirror_entry()
+    {
+        if (Path.DirectorySeparatorChar == '\\')
+            return;
+
+        var fixture = CreateLocalPackageBuildFixture();
+        var snapshotRoot = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests.LinkedPackageMirror",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            var sourcePackages = Directory.CreateDirectory(Path.Combine(
+                snapshotRoot.FullName,
+                "SourcePackages"));
+            var repositories = Directory.CreateDirectory(Path.Combine(
+                sourcePackages.FullName,
+                "repositories"));
+            var physicalMirror = Path.Combine(
+                repositories.FullName,
+                "Physical-96812fe1");
+            RunGit(
+                repositories.FullName,
+                "clone",
+                "--mirror",
+                "--quiet",
+                "--no-hardlinks",
+                fixture.RemoteRoot,
+                physicalMirror);
+            RunGit(
+                physicalMirror,
+                "remote",
+                "set-url",
+                "origin",
+                fixture.RemoteUrl);
+            var linkedMirror = Path.Combine(
+                repositories.FullName,
+                "Shared-96812fe1");
+            Directory.CreateSymbolicLink(linkedMirror, physicalMirror);
+
+            var checkouts = Directory.CreateDirectory(Path.Combine(
+                sourcePackages.FullName,
+                "checkouts"));
+            var checkout = Path.Combine(checkouts.FullName, "Shared");
+            RunGit(
+                checkouts.FullName,
+                "clone",
+                "--quiet",
+                "--no-hardlinks",
+                linkedMirror,
+                checkout);
+            var revision = ReadGit(checkout, "rev-parse", "HEAD").Trim();
+
+            var error = Assert.Throws<InvalidOperationException>(() =>
+                new AppleReleaseSourceTrustService().ValidateMaterializedPackageCheckouts(
+                    sourcePackages.FullName,
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [fixture.RemoteUrl[..^4]] = revision
+                    }));
+
+            Assert.Contains(
+                "must not traverse a symbolic link or reparse point",
+                error.Message,
+                StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
             try { snapshotRoot.Delete(recursive: true); } catch { /* best effort */ }
             fixture.Dispose();
         }

--- a/PowerForge.Tests/AppleDeviceDeploymentServiceTests.ProductBoundaryWave.cs
+++ b/PowerForge.Tests/AppleDeviceDeploymentServiceTests.ProductBoundaryWave.cs
@@ -5,6 +5,55 @@ namespace PowerForge.Tests;
 public sealed partial class AppleDeviceDeploymentServiceTests
 {
     [Fact]
+    public async Task BuildForDeploymentAsync_overrides_a_project_product_directory_inside_the_private_platform_root()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(
+                root.FullName,
+                "CasaRay.xcodeproj"));
+            File.WriteAllText(
+                Path.Combine(project.FullName, "project.pbxproj"),
+                "CONFIGURATION_BUILD_DIR = $(SRCROOT)/CustomProducts;");
+            InitializeGitRepository(root.FullName);
+            var runner = new CapturingProcessRunner(_ => Success("ok"));
+
+            using var operation = await new AppleDeviceDeploymentService(runner)
+                .BuildForDeploymentAsync(new AppleAppBuildRequest
+                {
+                    ProjectPath = project.FullName,
+                    Scheme = "CasaRay",
+                    Platform = ApplePlatform.iOS,
+                    Destination = "platform=iOS,id=device-1",
+                    DerivedDataPath = ExternalOutputPath(root, "DerivedData"),
+                    XcodeBuildExecutable = "/usr/bin/xcodebuild"
+                });
+
+            Assert.True(operation.Result.Succeeded);
+            var request = Assert.Single(runner.Requests);
+            Assert.Contains(
+                "CONFIGURATION_BUILD_DIR=$(SYMROOT)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
+                request.Arguments);
+            Assert.Contains(
+                Path.Combine("Debug-iphoneos", "CasaRay.app"),
+                operation.Result.AppPath,
+                StringComparison.Ordinal);
+            Assert.False(Directory.Exists(Path.Combine(
+                project.FullName,
+                "CustomProducts")));
+        }
+        finally
+        {
+            DeleteExternalOutputs(root);
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public async Task BuildAsync_preserves_a_standalone_app_path_outside_private_DerivedData()
     {
         var root = Directory.CreateDirectory(Path.Combine(

--- a/PowerForge.Tests/AppleDeviceDeploymentServiceTests.ProductBoundaryWave.cs
+++ b/PowerForge.Tests/AppleDeviceDeploymentServiceTests.ProductBoundaryWave.cs
@@ -180,11 +180,10 @@ public sealed partial class AppleDeviceDeploymentServiceTests
             Requests.Add(request);
             request.InvokePreStartBoundary();
             request.InvokeStartBoundary();
-            var productRoot = request.Arguments.Single(argument =>
-                    argument.StartsWith(
-                        "CONFIGURATION_BUILD_DIR=",
-                        StringComparison.Ordinal))
-                .Substring("CONFIGURATION_BUILD_DIR=".Length);
+            var productRoot = AppleDeploymentTestFixture
+                .TryResolveConfiguredBuildProductDirectory(request)
+                ?? throw new InvalidOperationException("Private build product directory was not configured.");
+            Directory.CreateDirectory(productRoot);
             Directory.CreateSymbolicLink(
                 Path.Combine(productRoot, "CasaRay.app"),
                 _redirectedApp);

--- a/PowerForge.Tests/AppleDeviceDeploymentServiceTests.SourceIntegrityWave.cs
+++ b/PowerForge.Tests/AppleDeviceDeploymentServiceTests.SourceIntegrityWave.cs
@@ -666,11 +666,9 @@ public sealed partial class AppleDeviceDeploymentServiceTests
             CancellationToken cancellationToken = default)
         {
             Requests.Add(request);
-            var productRoot = request.Arguments.Single(argument =>
-                    argument.StartsWith(
-                        "CONFIGURATION_BUILD_DIR=",
-                        StringComparison.Ordinal))
-                .Substring("CONFIGURATION_BUILD_DIR=".Length);
+            var productRoot = AppleDeploymentTestFixture
+                .TryResolvePrivateProductRoot(request)
+                ?? throw new InvalidOperationException("Private product root was not configured.");
             ProductRoot = productRoot;
             Directory.Delete(productRoot, recursive: true);
             Directory.CreateSymbolicLink(productRoot, _redirectRoot);

--- a/PowerForge.Tests/AppleDeviceDeploymentServiceTests.cs
+++ b/PowerForge.Tests/AppleDeviceDeploymentServiceTests.cs
@@ -1296,11 +1296,9 @@ App installed:
                 runner.Requests[0],
                 "-derivedDataPath");
             Assert.False(Directory.Exists(privateDerivedDataRoot));
-            Assert.DoesNotContain(
-                runner.Requests[0].Arguments,
-                argument => argument.StartsWith(
-                    "CONFIGURATION_BUILD_DIR=",
-                    StringComparison.Ordinal));
+            Assert.Contains(
+                "CONFIGURATION_BUILD_DIR=$(SYMROOT)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
+                runner.Requests[0].Arguments);
             var privateProductRoot = AppleDeploymentTestFixture
                 .TryResolvePrivateProductRoot(runner.Requests[0]);
             Assert.NotNull(privateProductRoot);
@@ -1315,7 +1313,7 @@ App installed:
     }
 
     [Fact]
-    public async Task DeployAsync_reuses_id_destination_for_install_and_launch()
+    public async Task DeployAsync_reuses_composite_id_destination_for_install_and_launch()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
@@ -1340,7 +1338,7 @@ App installed:
                 ProjectPath = project.FullName,
                 Scheme = "Tactra",
                 DerivedDataPath = derived,
-                Destination = "id=device-1",
+                Destination = "platform=iOS,id=device-1",
                 BundleIdentifier = "com.evotecit.tactra",
                 Launch = true,
                 XcodeBuildExecutable = "/usr/bin/xcodebuild",

--- a/PowerForge.Tests/AppleDeviceDeploymentServiceTests.cs
+++ b/PowerForge.Tests/AppleDeviceDeploymentServiceTests.cs
@@ -40,6 +40,27 @@ OldPhone   OldPhone.coredevice.local   11111111-1111-1111-1111-111111111111   un
     }
 
     [Fact]
+    public async Task GetDevicesAsync_matches_normal_spaces_to_a_nonbreaking_space_device_name()
+    {
+        var output = """
+Name                       Hostname                                 Identifier                             State                Model
+------------------------   --------------------------------------   ------------------------------------   ------------------   -------------------------------
+Apple Watch (Przemyslaw)   AppleWatch-Przemyslaw.coredevice.local   CF0D62D9-4A80-5701-A87E-516D71556A19   available (paired)   Apple Watch Ultra 3 (Watch7,12)
+""";
+        var runner = new CapturingProcessRunner(_ => Success(output));
+        var service = new AppleDeviceDeploymentService(runner);
+
+        var devices = await service.GetDevicesAsync(new AppleDeviceListRequest
+        {
+            XcrunExecutable = "xcrun-test",
+            Device = "Apple Watch (Przemyslaw)"
+        });
+
+        var device = Assert.Single(devices);
+        Assert.Equal("CF0D62D9-4A80-5701-A87E-516D71556A19", device.Identifier);
+    }
+
+    [Fact]
     public async Task GetDevicesAsync_throws_when_devicectl_fails()
     {
         var runner = new CapturingProcessRunner(_ => new ProcessRunResult(
@@ -106,9 +127,106 @@ OldPhone   OldPhone.coredevice.local   11111111-1111-1111-1111-111111111111   un
                 "-derivedDataPath",
                 result.DerivedDataPath,
                 "-allowProvisioningUpdates",
+                "-allowProvisioningDeviceRegistration",
                 "build",
                 $"POWERFORGE_SOURCE_REVISION={revision}"
             }, request.Arguments);
+        }
+        finally
+        {
+            DeleteExternalOutputs(root);
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task BuildAsync_passes_api_key_authentication_for_device_provisioning()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(
+                root.FullName,
+                "CasaRay.xcodeproj"));
+            File.WriteAllText(
+                Path.Combine(project.FullName, "project.pbxproj"),
+                string.Empty);
+            var derived = ExternalOutputPath(root, "DerivedData");
+            var keyPath = ExternalOutputPath(root, "AuthKey_TEST.p8");
+            Directory.CreateDirectory(Path.GetDirectoryName(keyPath)!);
+            await File.WriteAllTextAsync(keyPath, "private-key");
+            var runner = new CapturingProcessRunner(_ => Success("ok"));
+            InitializeGitRepository(root.FullName);
+
+            var result = await new AppleDeviceDeploymentService(runner).BuildAsync(
+                new AppleAppBuildRequest
+                {
+                    ProjectPath = project.FullName,
+                    Scheme = "CasaRay",
+                    DeviceIdentifier = "device-1",
+                    DerivedDataPath = derived,
+                    XcodeBuildExecutable = "/usr/bin/xcodebuild",
+                    AppStoreConnectApiKeyPath = keyPath,
+                    AppStoreConnectApiKeyId = "TESTKEY123",
+                    AppStoreConnectApiIssuerId = "issuer-id"
+                });
+
+            Assert.True(result.Succeeded);
+            var arguments = Assert.Single(runner.Requests).Arguments;
+            Assert.Contains("-allowProvisioningUpdates", arguments);
+            Assert.Contains("-allowProvisioningDeviceRegistration", arguments);
+            Assert.Contains("-authenticationKeyPath", arguments);
+            Assert.Contains(keyPath, arguments);
+            Assert.Contains("-authenticationKeyID", arguments);
+            Assert.Contains("TESTKEY123", arguments);
+            Assert.Contains("-authenticationKeyIssuerID", arguments);
+            Assert.Contains("issuer-id", arguments);
+        }
+        finally
+        {
+            DeleteExternalOutputs(root);
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task BuildAsync_rejects_api_key_authentication_without_provisioning_updates()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(
+                root.FullName,
+                "CasaRay.xcodeproj"));
+            File.WriteAllText(
+                Path.Combine(project.FullName, "project.pbxproj"),
+                string.Empty);
+            var keyPath = ExternalOutputPath(root, "AuthKey_TEST.p8");
+            Directory.CreateDirectory(Path.GetDirectoryName(keyPath)!);
+            await File.WriteAllTextAsync(keyPath, "private-key");
+            InitializeGitRepository(root.FullName);
+
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                new AppleDeviceDeploymentService(
+                    new CapturingProcessRunner(_ => Success("unexpected"))).BuildAsync(
+                    new AppleAppBuildRequest
+                    {
+                        ProjectPath = project.FullName,
+                        Scheme = "CasaRay",
+                        DeviceIdentifier = "device-1",
+                        DerivedDataPath = ExternalOutputPath(root, "DerivedData"),
+                        XcodeBuildExecutable = "/usr/bin/xcodebuild",
+                        AllowProvisioningUpdates = false,
+                        AppStoreConnectApiKeyPath = keyPath,
+                        AppStoreConnectApiKeyId = "TESTKEY123",
+                        AppStoreConnectApiIssuerId = "issuer-id"
+                    }));
         }
         finally
         {
@@ -1178,9 +1296,14 @@ App installed:
                 runner.Requests[0],
                 "-derivedDataPath");
             Assert.False(Directory.Exists(privateDerivedDataRoot));
-            var privateProductRoot = runner.Requests[0].Arguments.Single(argument =>
-                    argument.StartsWith("CONFIGURATION_BUILD_DIR=", StringComparison.Ordinal))
-                .Substring("CONFIGURATION_BUILD_DIR=".Length);
+            Assert.DoesNotContain(
+                runner.Requests[0].Arguments,
+                argument => argument.StartsWith(
+                    "CONFIGURATION_BUILD_DIR=",
+                    StringComparison.Ordinal));
+            var privateProductRoot = AppleDeploymentTestFixture
+                .TryResolvePrivateProductRoot(runner.Requests[0]);
+            Assert.NotNull(privateProductRoot);
             Assert.False(Directory.Exists(privateProductRoot));
             Assert.Equal(new[] { "devicectl", "device", "process", "launch", "--device", "device-1", "com.evotecit.tactra" }, runner.Requests[2].Arguments);
         }
@@ -1230,6 +1353,9 @@ App installed:
                 runner.Requests[1].Arguments.Take(6));
             Assert.EndsWith("Tactra.app", runner.Requests[1].Arguments[6], StringComparison.Ordinal);
             Assert.NotEqual(app.FullName, runner.Requests[1].Arguments[6]);
+            Assert.Contains(
+                "-allowProvisioningDeviceRegistration",
+                runner.Requests[0].Arguments);
             Assert.Equal(new[] { "devicectl", "device", "process", "launch", "--device", "device-1", "com.evotecit.tactra" }, runner.Requests[2].Arguments);
         }
         finally

--- a/PowerForge.Tests/AppleMacAppDeploymentServiceTests.cs
+++ b/PowerForge.Tests/AppleMacAppDeploymentServiceTests.cs
@@ -68,11 +68,10 @@ public sealed partial class AppleMacAppDeploymentServiceTests
                 result.Build.AppPath,
                 StringComparison.Ordinal);
             Assert.Equal(result.Build.AppPath, result.Install!.SourceAppPath);
-            var privateProductRoot = runner.Requests.Single(request =>
-                    request.FileName == "/usr/bin/xcodebuild")
-                .Arguments.Single(argument =>
-                    argument.StartsWith("CONFIGURATION_BUILD_DIR=", StringComparison.Ordinal))
-                .Substring("CONFIGURATION_BUILD_DIR=".Length);
+            var privateProductRoot = AppleDeploymentTestFixture
+                .TryResolvePrivateProductRoot(runner.Requests.Single(request =>
+                    request.FileName == "/usr/bin/xcodebuild"));
+            Assert.NotNull(privateProductRoot);
             Assert.False(Directory.Exists(privateProductRoot));
             Assert.Equal("new", File.ReadAllText(Path.Combine(installRoot.FullName, "CasaRay.app", "version.txt")));
             Assert.DoesNotContain(Directory.EnumerateDirectories(installRoot.FullName), path => path.Contains("powerforge-backup", StringComparison.Ordinal));
@@ -401,11 +400,9 @@ public sealed partial class AppleMacAppDeploymentServiceTests
         string version)
     {
         AppleDeploymentTestFixture.MaterializeConfiguredBuildProduct(request);
-        var productRoot = request.Arguments.Single(argument =>
-                argument.StartsWith(
-                    "CONFIGURATION_BUILD_DIR=",
-                    StringComparison.Ordinal))
-            .Substring("CONFIGURATION_BUILD_DIR=".Length);
+        var productRoot = AppleDeploymentTestFixture
+            .TryResolveConfiguredBuildProductDirectory(request)
+            ?? throw new InvalidOperationException("Private build product directory was not configured.");
         File.WriteAllText(
             Path.Combine(productRoot, "CasaRay.app", "version.txt"),
             version);

--- a/PowerForge.Tests/PowerForgeCliAppleDeployTests.cs
+++ b/PowerForge.Tests/PowerForgeCliAppleDeployTests.cs
@@ -6,6 +6,278 @@ namespace PowerForge.Tests;
 public sealed class PowerForgeCliAppleDeployTests
 {
     [Fact]
+    public async Task AppleDeploy_plan_uses_nonempty_alias_credentials_when_primary_environment_values_are_empty()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var tempRoot = Path.Combine(
+            Path.GetTempPath(),
+            "PowerForgeCliAppleDeploy-" + Guid.NewGuid().ToString("N"));
+        var credentialRoot = tempRoot + ".credentials";
+        Directory.CreateDirectory(tempRoot);
+        Directory.CreateDirectory(credentialRoot);
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(
+                tempRoot,
+                "Sample.xcodeproj"));
+            File.WriteAllText(
+                Path.Combine(project.FullName, "project.pbxproj"),
+                string.Empty);
+            var keyPath = Path.Combine(credentialRoot, "AuthKey_ALIAS.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var configPath = Path.Combine(tempRoot, "powerforge.release.json");
+            File.WriteAllText(configPath, """
+            {
+              "SchemaVersion": 1,
+              "AppleApps": {
+                "ProjectRoot": ".",
+                "LocalDeployment": {
+                  "DefaultPlatform": "iOS",
+                  "DefaultDevice": "EvoPhone"
+                },
+                "Apps": [
+                  {
+                    "Name": "Sample iOS",
+                    "BundleId": "com.example.sample",
+                    "Platform": "iOS",
+                    "ProjectPath": "Sample.xcodeproj",
+                    "Scheme": "Sample"
+                  }
+                ]
+              }
+            }
+            """);
+            InitializeGitRepository(tempRoot);
+
+            var result = await RunCliAsync(
+                repoRoot,
+                $"\"{GetCliPath(repoRoot)}\" apple-deploy --config \"{configPath}\" --plan --output json",
+                new Dictionary<string, string>
+                {
+                    ["APP_STORE_CONNECT_PRIVATE_KEY_PATH"] = "",
+                    ["APP_STORE_CONNECT_KEY_ID"] = "",
+                    ["APP_STORE_CONNECT_ISSUER_ID"] = "",
+                    ["ASC_PRIVATE_KEY_PATH"] = keyPath,
+                    ["ASC_KEY_ID"] = "ALIASKEY123",
+                    ["ASC_ISSUER_ID"] = "alias-issuer-id"
+                });
+
+            Assert.Equal(0, result.ExitCode);
+            using var document = JsonDocument.Parse(result.StdOut);
+            Assert.True(document.RootElement.GetProperty("success").GetBoolean());
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+            if (Directory.Exists(credentialRoot))
+                Directory.Delete(credentialRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task AppleDeploy_plan_redacts_configured_authentication_metadata_from_errors()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var tempRoot = Path.Combine(
+            Path.GetTempPath(),
+            "PowerForgeCliAppleDeploy-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(
+                tempRoot,
+                "Sample.xcodeproj"));
+            File.WriteAllText(
+                Path.Combine(project.FullName, "project.pbxproj"),
+                string.Empty);
+            var missingKeyPath = Path.Combine(
+                Path.GetTempPath(),
+                "private-signing",
+                "AuthKey_DO_NOT_PRINT.p8");
+            var keyId = "DO_NOT_PRINT_KEY_ID";
+            var issuerId = "do-not-print-issuer-id";
+            var configPath = Path.Combine(tempRoot, "powerforge.release.json");
+            File.WriteAllText(configPath, $$"""
+            {
+              "SchemaVersion": 1,
+              "AppleApps": {
+                "ProjectRoot": ".",
+                "AppStoreConnectApiKeyPath": "{{missingKeyPath}}",
+                "AppStoreConnectApiKeyId": "{{keyId}}",
+                "AppStoreConnectApiIssuerId": "{{issuerId}}",
+                "LocalDeployment": {
+                  "DefaultPlatform": "iOS",
+                  "DefaultDevice": "EvoPhone"
+                },
+                "Apps": [
+                  {
+                    "Name": "Sample iOS",
+                    "BundleId": "com.example.sample",
+                    "Platform": "iOS",
+                    "ProjectPath": "Sample.xcodeproj",
+                    "Scheme": "Sample"
+                  }
+                ]
+              }
+            }
+            """);
+            InitializeGitRepository(tempRoot);
+
+            var result = await RunCliAsync(
+                repoRoot,
+                $"\"{GetCliPath(repoRoot)}\" apple-deploy --config \"{configPath}\" --plan --output json");
+
+            Assert.Equal(1, result.ExitCode);
+            var output = result.StdOut + result.StdErr;
+            Assert.DoesNotContain(missingKeyPath, output, StringComparison.Ordinal);
+            Assert.DoesNotContain(keyId, output, StringComparison.Ordinal);
+            Assert.DoesNotContain(issuerId, output, StringComparison.Ordinal);
+            Assert.Contains("[REDACTED]", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task AppleDeploy_plan_redacts_resolved_relative_environment_key_paths()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var tempRoot = Path.Combine(
+            Path.GetTempPath(),
+            "PowerForgeCliAppleDeploy-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(
+                tempRoot,
+                "Sample.xcodeproj"));
+            File.WriteAllText(
+                Path.Combine(project.FullName, "project.pbxproj"),
+                string.Empty);
+            var configPath = Path.Combine(tempRoot, "powerforge.release.json");
+            File.WriteAllText(configPath, """
+            {
+              "SchemaVersion": 1,
+              "AppleApps": {
+                "ProjectRoot": ".",
+                "LocalDeployment": {
+                  "DefaultPlatform": "iOS",
+                  "DefaultDevice": "EvoPhone"
+                },
+                "Apps": [
+                  {
+                    "Name": "Sample iOS",
+                    "BundleId": "com.example.sample",
+                    "Platform": "iOS",
+                    "ProjectPath": "Sample.xcodeproj",
+                    "Scheme": "Sample"
+                  }
+                ]
+              }
+            }
+            """);
+            InitializeGitRepository(tempRoot);
+            const string relativeKeyPath = "../private-signing/AuthKey_ENV.p8";
+            var resolvedKeyPath = Path.GetFullPath(Path.Combine(
+                tempRoot,
+                relativeKeyPath));
+            const string keyId = "ENV_DO_NOT_PRINT_KEY_ID";
+            const string issuerId = "env-do-not-print-issuer-id";
+
+            var result = await RunCliAsync(
+                repoRoot,
+                $"\"{GetCliPath(repoRoot)}\" apple-deploy --config \"{configPath}\" --plan --output json",
+                new Dictionary<string, string>
+                {
+                    ["APP_STORE_CONNECT_PRIVATE_KEY_PATH"] = relativeKeyPath,
+                    ["APP_STORE_CONNECT_KEY_ID"] = keyId,
+                    ["APP_STORE_CONNECT_ISSUER_ID"] = issuerId,
+                    ["ASC_PRIVATE_KEY_PATH"] = "",
+                    ["ASC_KEY_ID"] = "",
+                    ["ASC_ISSUER_ID"] = ""
+                });
+
+            Assert.Equal(1, result.ExitCode);
+            var output = result.StdOut + result.StdErr;
+            Assert.DoesNotContain(relativeKeyPath, output, StringComparison.Ordinal);
+            Assert.DoesNotContain(resolvedKeyPath, output, StringComparison.Ordinal);
+            Assert.DoesNotContain(keyId, output, StringComparison.Ordinal);
+            Assert.DoesNotContain(issuerId, output, StringComparison.Ordinal);
+            Assert.Contains("[REDACTED]", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task AppleDeploy_plan_preserves_json_errors_for_malformed_credential_paths()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var tempRoot = Path.Combine(
+            Path.GetTempPath(),
+            "PowerForgeCliAppleDeploy-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(
+                tempRoot,
+                "Sample.xcodeproj"));
+            File.WriteAllText(
+                Path.Combine(project.FullName, "project.pbxproj"),
+                string.Empty);
+            var configPath = Path.Combine(tempRoot, "powerforge.release.json");
+            File.WriteAllText(configPath, """
+            {
+              "SchemaVersion": 1,
+              "AppleApps": {
+                "ProjectRoot": ".",
+                "AppStoreConnectApiKeyPath": "\u0000bad-path",
+                "AppStoreConnectApiKeyId": "MALFORMEDKEY",
+                "AppStoreConnectApiIssuerId": "malformed-issuer",
+                "LocalDeployment": {
+                  "DefaultPlatform": "iOS",
+                  "DefaultDevice": "EvoPhone"
+                },
+                "Apps": [
+                  {
+                    "Name": "Sample iOS",
+                    "BundleId": "com.example.sample",
+                    "Platform": "iOS",
+                    "ProjectPath": "Sample.xcodeproj",
+                    "Scheme": "Sample"
+                  }
+                ]
+              }
+            }
+            """);
+            InitializeGitRepository(tempRoot);
+
+            var result = await RunCliAsync(
+                repoRoot,
+                $"\"{GetCliPath(repoRoot)}\" apple-deploy --config \"{configPath}\" --plan --output json");
+
+            Assert.Equal(1, result.ExitCode);
+            using var document = JsonDocument.Parse(result.StdOut);
+            Assert.False(document.RootElement.GetProperty("success").GetBoolean());
+            Assert.Equal(1, document.RootElement.GetProperty("exitCode").GetInt32());
+            Assert.False(string.IsNullOrWhiteSpace(
+                document.RootElement.GetProperty("error").GetString()));
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task AppleDeploy_plan_rejects_a_configured_xcode_wrapper()
     {
         var repoRoot = FindRepositoryRoot();

--- a/PowerForge.Tests/PowerForgeCliAppleDeployTests.cs
+++ b/PowerForge.Tests/PowerForgeCliAppleDeployTests.cs
@@ -6,6 +6,44 @@ namespace PowerForge.Tests;
 public sealed class PowerForgeCliAppleDeployTests
 {
     [Fact]
+    public void AppleDeploy_diagnostic_redacts_credentials_before_truncation()
+    {
+        var cliAssembly = System.Reflection.Assembly.LoadFrom(
+            GetCliPath(FindRepositoryRoot()));
+        var program = cliAssembly.GetType("Program", throwOnError: true)!;
+        var formatter = program.GetMethod(
+            "ResolveAppleDeployDiagnostic",
+            System.Reflection.BindingFlags.NonPublic |
+            System.Reflection.BindingFlags.Static)
+            ?? throw new MissingMethodException(
+                "Program.ResolveAppleDeployDiagnostic was not found.");
+        const string credential = "credential-sensitive-value";
+        var failure = new ProcessRunResult(
+            1,
+            credential + new string('x', 1980),
+            string.Empty,
+            "xcodebuild",
+            TimeSpan.FromSeconds(1),
+            timedOut: false);
+
+        var diagnostic = (string?)formatter.Invoke(
+            null,
+            new object[]
+            {
+                new[] { credential },
+                new ProcessRunResult?[] { failure }
+            });
+
+        Assert.NotNull(diagnostic);
+        Assert.Contains("[REDACTED]", diagnostic, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "sensitive-value",
+            diagnostic,
+            StringComparison.Ordinal);
+        Assert.True(diagnostic.Length <= 2000);
+    }
+
+    [Fact]
     public async Task AppleDeploy_plan_uses_nonempty_alias_credentials_when_primary_environment_values_are_empty()
     {
         var repoRoot = FindRepositoryRoot();

--- a/PowerForge/Models/AppleDeviceDeploymentModels.cs
+++ b/PowerForge/Models/AppleDeviceDeploymentModels.cs
@@ -105,6 +105,15 @@ public class AppleAppBuildRequest
     /// <summary>Allows Xcode to create or update signing assets during build.</summary>
     public bool AllowProvisioningUpdates { get; set; } = true;
 
+    /// <summary>Path to an App Store Connect API private key used by xcodebuild provisioning authentication.</summary>
+    public string? AppStoreConnectApiKeyPath { get; set; }
+
+    /// <summary>App Store Connect API key identifier used by xcodebuild provisioning authentication.</summary>
+    public string? AppStoreConnectApiKeyId { get; set; }
+
+    /// <summary>App Store Connect API issuer identifier used by xcodebuild provisioning authentication.</summary>
+    public string? AppStoreConnectApiIssuerId { get; set; }
+
     /// <summary>Mirror the project root to a local folder before running xcodebuild.</summary>
     public bool UseBuildMirror { get; set; }
 

--- a/PowerForge/Services/AppleAppArchiveService.cs
+++ b/PowerForge/Services/AppleAppArchiveService.cs
@@ -71,7 +71,7 @@ public sealed partial class AppleAppArchiveService
         if (request.AllowProvisioningUpdates)
             args.Add("-allowProvisioningUpdates");
 
-        AddAppStoreConnectAuthenticationArguments(
+        AppleXcodeAuthentication.AddArguments(
             request.AppStoreConnectApiKeyPath,
             request.AppStoreConnectApiKeyId,
             request.AppStoreConnectApiIssuerId,
@@ -232,7 +232,7 @@ public sealed partial class AppleAppArchiveService
         if (request.AllowProvisioningUpdates)
             args.Add("-allowProvisioningUpdates");
 
-        AddAppStoreConnectAuthenticationArguments(
+        AppleXcodeAuthentication.AddArguments(
             request.AppStoreConnectApiKeyPath,
             request.AppStoreConnectApiKeyId,
             request.AppStoreConnectApiIssuerId,
@@ -347,36 +347,6 @@ public sealed partial class AppleAppArchiveService
         internal string? DistributionLogPath { get; }
 
         internal string? BuildUploadId { get; }
-    }
-
-    private static void AddAppStoreConnectAuthenticationArguments(
-        string? appStoreConnectApiKeyPath,
-        string? appStoreConnectApiKeyId,
-        string? appStoreConnectApiIssuerId,
-        bool allowProvisioningUpdates,
-        List<string> args)
-    {
-        var keyPath = string.IsNullOrWhiteSpace(appStoreConnectApiKeyPath)
-            ? null
-            : Path.GetFullPath(appStoreConnectApiKeyPath!);
-        var keyId = string.IsNullOrWhiteSpace(appStoreConnectApiKeyId) ? null : appStoreConnectApiKeyId!.Trim();
-        var issuerId = string.IsNullOrWhiteSpace(appStoreConnectApiIssuerId) ? null : appStoreConnectApiIssuerId!.Trim();
-        var configuredCount = (keyPath is null ? 0 : 1) + (keyId is null ? 0 : 1) + (issuerId is null ? 0 : 1);
-        if (configuredCount == 0)
-            return;
-        if (configuredCount != 3)
-            throw new ArgumentException("App Store Connect API-key authentication requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
-        if (!allowProvisioningUpdates)
-            throw new ArgumentException("App Store Connect API-key authentication requires AllowProvisioningUpdates=true so xcodebuild can use the credentials.");
-        if (!File.Exists(keyPath))
-            throw new FileNotFoundException($"App Store Connect API key file was not found: {keyPath}", keyPath);
-
-        args.Add("-authenticationKeyPath");
-        args.Add(keyPath!);
-        args.Add("-authenticationKeyID");
-        args.Add(keyId!);
-        args.Add("-authenticationKeyIssuerID");
-        args.Add(issuerId!);
     }
 
     /// <summary>

--- a/PowerForge/Services/AppleDeviceDeploymentService.cs
+++ b/PowerForge/Services/AppleDeviceDeploymentService.cs
@@ -391,10 +391,13 @@ public sealed partial class AppleDeviceDeploymentService
         {
             // SYMROOT keeps the exact-source product inside PowerForge's
             // private boundary while preserving Xcode's configuration- and
-            // SDK-specific subdirectories. CONFIGURATION_BUILD_DIR flattens
-            // embedded iOS/watchOS products and makes their package outputs
-            // collide.
+            // SDK-specific subdirectories. Override a project-level
+            // CONFIGURATION_BUILD_DIR with Xcode variables that remain
+            // target-specific so embedded iOS/watchOS products cannot collide
+            // or escape the private root.
             args.Add($"SYMROOT={deploymentProductRoot}");
+            args.Add(
+                "CONFIGURATION_BUILD_DIR=$(SYMROOT)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)");
         }
 
         args.Add("build");
@@ -816,13 +819,19 @@ public sealed partial class AppleDeviceDeploymentService
         if (string.IsNullOrWhiteSpace(destination))
             return null;
 
-        var trimmed = destination!.Trim();
         const string prefix = "id=";
-        if (!trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-            return null;
+        foreach (var field in destination!.Split(','))
+        {
+            var trimmed = field.Trim();
+            if (!trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                continue;
 
-        var value = trimmed.Substring(prefix.Length).Trim();
-        return string.IsNullOrWhiteSpace(value) ? null : value;
+            var value = trimmed.Substring(prefix.Length).Trim();
+            if (!string.IsNullOrWhiteSpace(value))
+                return value;
+        }
+
+        return null;
     }
 
     private static string? MatchValue(Regex regex, string output)

--- a/PowerForge/Services/AppleDeviceDeploymentService.cs
+++ b/PowerForge/Services/AppleDeviceDeploymentService.cs
@@ -128,11 +128,15 @@ public sealed partial class AppleDeviceDeploymentService
                 "apple-local-products",
                 Guid.NewGuid().ToString("N"))
             : null;
-        string productDirectory = deploymentProductRoot ?? Path.Combine(
-            derivedDataPath,
-            "Build",
-            "Products",
-            GetProductDirectory(request));
+        string productDirectory = deploymentProductRoot is null
+            ? Path.Combine(
+                derivedDataPath,
+                "Build",
+                "Products",
+                GetProductDirectory(request))
+            : Path.Combine(
+                deploymentProductRoot,
+                GetProductDirectory(request));
         string appPath = deploymentProductRoot is null
             ? ResolveAppPath(request, derivedDataPath)
             : Path.Combine(productDirectory, ResolveProductName(request) + ".app");
@@ -347,7 +351,9 @@ public sealed partial class AppleDeviceDeploymentService
                 "private Apple product directory",
                 sourcePathComparison);
             deploymentProductRoot = deploymentProductDirectory.Path;
-            productDirectory = deploymentProductDirectory.Path;
+            productDirectory = Path.Combine(
+                deploymentProductDirectory.Path,
+                GetProductDirectory(request));
             appPath = Path.Combine(
                 productDirectory,
                 ResolveProductName(request) + ".app");
@@ -368,9 +374,28 @@ public sealed partial class AppleDeviceDeploymentService
         };
 
         if (request.AllowProvisioningUpdates)
+        {
             args.Add("-allowProvisioningUpdates");
+            var provisioningDeviceIdentifier = deviceIdentifier ??
+                                               TryParseDestinationDeviceIdentifier(destination);
+            if (!string.IsNullOrWhiteSpace(provisioningDeviceIdentifier))
+                args.Add("-allowProvisioningDeviceRegistration");
+        }
+        AppleXcodeAuthentication.AddArguments(
+            request.AppStoreConnectApiKeyPath,
+            request.AppStoreConnectApiKeyId,
+            request.AppStoreConnectApiIssuerId,
+            request.AllowProvisioningUpdates,
+            args);
         if (deploymentProductRoot is not null)
-            args.Add($"CONFIGURATION_BUILD_DIR={deploymentProductRoot}");
+        {
+            // SYMROOT keeps the exact-source product inside PowerForge's
+            // private boundary while preserving Xcode's configuration- and
+            // SDK-specific subdirectories. CONFIGURATION_BUILD_DIR flattens
+            // embedded iOS/watchOS products and makes their package outputs
+            // collide.
+            args.Add($"SYMROOT={deploymentProductRoot}");
+        }
 
         args.Add("build");
         args.AddRange(AppleBuildProvenance.AppendXcodeBuildSetting(
@@ -765,9 +790,26 @@ public sealed partial class AppleDeviceDeploymentService
     }
 
     private static bool MatchesDevice(AppleDeviceInfo device, string filter)
-        => string.Equals(device.Identifier, filter, StringComparison.OrdinalIgnoreCase) ||
-           string.Equals(device.Name, filter, StringComparison.OrdinalIgnoreCase) ||
-           device.Model.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0;
+    {
+        if (string.Equals(device.Identifier, filter, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        var normalizedFilter = NormalizeDeviceMatchText(filter);
+        return string.Equals(
+                   NormalizeDeviceMatchText(device.Name),
+                   normalizedFilter,
+                   StringComparison.OrdinalIgnoreCase) ||
+               NormalizeDeviceMatchText(device.Model).IndexOf(
+                   normalizedFilter,
+                   StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static string NormalizeDeviceMatchText(string value)
+        => Regex.Replace(
+            value.Trim(),
+            @"\s+",
+            " ",
+            RegexOptions.CultureInvariant);
 
     private static string? TryParseDestinationDeviceIdentifier(string? destination)
     {

--- a/PowerForge/Services/AppleReleaseSourceTrustService.RemotePackages.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.RemotePackages.cs
@@ -173,18 +173,28 @@ internal sealed partial class AppleReleaseSourceTrustService
             ? Path.GetFullPath(origin)
             : Path.GetFullPath(Path.Combine(checkoutPath, origin));
         var repositories = Path.Combine(sourcePackagesRoot, "repositories");
-        var directMirror = Directory.Exists(repositories) &&
-                           Directory.Exists(resolvedOrigin) &&
-                           GetPathComparer().Equals(Path.GetDirectoryName(resolvedOrigin), repositories);
-        if (!directMirror)
+        if (!Directory.Exists(repositories) || !Directory.Exists(resolvedOrigin))
             return origin;
 
-        ValidateXcodeRepositoryMirrorMetadata(repositories, resolvedOrigin);
-        var canonicalOrigin = RunGitAllowFailure(resolvedOrigin, "remote", "get-url", "origin");
+        // Xcode can record the checkout origin through an existing path alias
+        // such as macOS's /var -> /private/var mapping. Compare the physical
+        // directories before deciding whether this is the owned repository
+        // mirror, then validate and inspect only that physical mirror.
+        var physicalRepositories = AppleReleaseArtifactService.ResolvePhysicalPath(repositories);
+        var physicalOrigin = AppleReleaseArtifactService.ResolvePhysicalPath(resolvedOrigin);
+        if (!GetPathComparer().Equals(
+                Path.GetDirectoryName(physicalOrigin),
+                physicalRepositories))
+        {
+            return origin;
+        }
+
+        ValidateXcodeRepositoryMirrorMetadata(physicalRepositories, physicalOrigin);
+        var canonicalOrigin = RunGitAllowFailure(physicalOrigin, "remote", "get-url", "origin");
         if (!canonicalOrigin.Succeeded || string.IsNullOrWhiteSpace(canonicalOrigin.StdOut))
         {
             throw new InvalidOperationException(
-                $"Xcode materialized Swift package repository mirror has no approved origin: {resolvedOrigin}");
+                $"Xcode materialized Swift package repository mirror has no approved origin: {physicalOrigin}");
         }
 
         return canonicalOrigin.StdOut.Trim();

--- a/PowerForge/Services/AppleReleaseSourceTrustService.RemotePackages.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.RemotePackages.cs
@@ -189,7 +189,17 @@ internal sealed partial class AppleReleaseSourceTrustService
             return origin;
         }
 
-        ValidateXcodeRepositoryMirrorMetadata(physicalRepositories, physicalOrigin);
+        // Preserve the lexical paths for link checks below the accepted
+        // repositories boundary. Only ancestor aliases are allowed; neither
+        // the repositories directory nor a mirror entry may itself be a link.
+        EnsureNoLinkedTraversal(
+            repositories,
+            repositories,
+            "Xcode materialized Swift package repository root");
+        var originRepositories = Path.GetDirectoryName(resolvedOrigin)
+            ?? throw new InvalidOperationException(
+                $"Xcode materialized Swift package repository mirror has no parent directory: {resolvedOrigin}");
+        ValidateXcodeRepositoryMirrorMetadata(originRepositories, resolvedOrigin);
         var canonicalOrigin = RunGitAllowFailure(physicalOrigin, "remote", "get-url", "origin");
         if (!canonicalOrigin.Succeeded || string.IsNullOrWhiteSpace(canonicalOrigin.StdOut))
         {

--- a/PowerForge/Services/AppleXcodeAuthentication.cs
+++ b/PowerForge/Services/AppleXcodeAuthentication.cs
@@ -1,0 +1,47 @@
+namespace PowerForge;
+
+internal static class AppleXcodeAuthentication
+{
+    internal static void AddArguments(
+        string? appStoreConnectApiKeyPath,
+        string? appStoreConnectApiKeyId,
+        string? appStoreConnectApiIssuerId,
+        bool allowProvisioningUpdates,
+        List<string> arguments)
+    {
+        var keyPath = string.IsNullOrWhiteSpace(appStoreConnectApiKeyPath)
+            ? null
+            : Path.GetFullPath(appStoreConnectApiKeyPath!);
+        var keyId = string.IsNullOrWhiteSpace(appStoreConnectApiKeyId)
+            ? null
+            : appStoreConnectApiKeyId!.Trim();
+        var issuerId = string.IsNullOrWhiteSpace(appStoreConnectApiIssuerId)
+            ? null
+            : appStoreConnectApiIssuerId!.Trim();
+        var configuredCount =
+            (keyPath is null ? 0 : 1) +
+            (keyId is null ? 0 : 1) +
+            (issuerId is null ? 0 : 1);
+        if (configuredCount == 0)
+            return;
+        if (configuredCount != 3)
+        {
+            throw new ArgumentException(
+                "App Store Connect API-key authentication requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
+        }
+        if (!allowProvisioningUpdates)
+        {
+            throw new ArgumentException(
+                "App Store Connect API-key authentication requires AllowProvisioningUpdates=true so xcodebuild can use the credentials.");
+        }
+        if (!File.Exists(keyPath))
+            throw new FileNotFoundException($"App Store Connect API key file was not found: {keyPath}", keyPath);
+
+        arguments.Add("-authenticationKeyPath");
+        arguments.Add(keyPath!);
+        arguments.Add("-authenticationKeyID");
+        arguments.Add(keyId!);
+        arguments.Add("-authenticationKeyIssuerID");
+        arguments.Add(issuerId!);
+    }
+}


### PR DESCRIPTION
## Summary

- accept Xcode-owned Swift package repository mirrors when macOS exposes the same path through an ancestor alias such as /var and /private/var, while still rejecting linked repository and mirror entries
- keep exact-source iOS and embedded watchOS build products in private, platform-specific directories, including projects with custom product output settings
- match Apple device names across Unicode whitespace and authenticate local provisioning with the existing App Store Connect configuration or environment convention
- allow physical-device registration for direct and composite destinations such as platform=iOS,id=UDID
- redact complete deployment output before diagnostics are shortened so credential fragments cannot survive truncation

## User impact

Local PowerForge Apple deployment can build and install mixed iOS/watchOS products from the exact reviewed source without package-mirror false positives, flattened product collisions, Watch-name mismatches, or manual Xcode account provisioning when App Store Connect credentials are configured.

The shared fix was exercised by the public CasaRay consumer: its exact merged source built, installed, and launched on iPhone; its Watch app and widget were provisioned for the paired physical Watch, signed, installed, and confirmed in device inventory.

## Validation

- PowerForge CLI Release build
- 124 Apple device deployment, Mac deployment, archive, package-integrity, product-boundary, and CLI tests
- exact-source CasaRay iPhone build, install, and launch after the review remediation
- exact-source CasaRay Watch build plus physical Watch install and inventory verification