### PR TITLE
Fix benchmark handlers under strict callers

### DIFF
--- a/PowerForge.Tests/BenchmarkServicesTests.InlineSettingsClosure.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.InlineSettingsClosure.cs
@@ -35,4 +35,45 @@ Invoke-BenchmarkSuite -Settings $settings -Plan
         var item = Assert.IsType<PowerShellBenchmarkWorkItem>(Assert.Single(plan).BaseObject);
         Assert.Equal("FromClosure", item.Values["Probe"]);
     }
+
+    [Fact]
+    public void InvokeBenchmarkSuiteCommand_RunsInlineSettingsFromStrictCallerWithoutDslAliases()
+    {
+        var initialSessionState = InitialSessionState.CreateDefault();
+        initialSessionState.Commands.Add(new SessionStateCmdletEntry("Invoke-BenchmarkSuite", typeof(PSPublishModule.InvokeBenchmarkSuiteCommand), helpFileName: null));
+        using var runspace = RunspaceFactory.CreateRunspace(initialSessionState);
+        runspace.Open();
+        ImportBenchmarkDslCommands(runspace);
+        using var ps = PowerShell.Create(runspace);
+        ps.AddScript("""
+Set-StrictMode -Version Latest
+$outputRoot = Join-Path ([IO.Path]::GetTempPath()) ('powerforge-benchmark-strict-' + [Guid]::NewGuid().ToString('N'))
+try {
+    $settings = {
+        New-BenchmarkSuite 'strict-caller' {
+            Set-BenchmarkPolicy -Warmup 0 -Iterations 1
+            Add-BenchmarkCases { Add-BenchmarkCase Default @{} }
+            Add-BenchmarkAxis Operation Run
+            Add-BenchmarkAxis Engine Managed
+            Add-BenchmarkEngine Managed {
+                Add-BenchmarkOperation Run { param($case, $run) $run.Value = 42 }
+            }
+            Add-BenchmarkValidation {
+                param($case, $run)
+                if ($run.Value -ne 42) { throw 'Operation result was not retained.' }
+            }
+        }
+    }
+    (Invoke-BenchmarkSuite -Settings $settings -OutputRoot $outputRoot).Samples[0].Status.ToString()
+}
+finally {
+    if (Test-Path -LiteralPath $outputRoot) { Remove-Item -LiteralPath $outputRoot -Recurse -Force }
+}
+""");
+
+        var output = ps.Invoke();
+
+        Assert.Empty(ps.Streams.Error);
+        Assert.Equal("Succeeded", Assert.Single(output).BaseObject);
+    }
 }

--- a/PowerForge.Tests/BenchmarkServicesTests.InlineSettingsClosure.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.InlineSettingsClosure.cs
@@ -56,14 +56,15 @@ try {
             Add-BenchmarkAxis Operation Run
             Add-BenchmarkAxis Engine Managed
             Add-BenchmarkEngine Managed {
-                Add-BenchmarkOperation Run { param($case, $run) $run.Value = 42 }
+                Add-BenchmarkOperation Run { param($case, $run) $run.Value = $Error.Count }
             }
             Add-BenchmarkValidation {
                 param($case, $run)
-                if ($run.Value -ne 42) { throw 'Operation result was not retained.' }
+                if ($run.Value -ne 0) { throw 'Optional alias discovery polluted the automatic error collection.' }
             }
         }
     }
+    $Error.Clear()
     (Invoke-BenchmarkSuite -Settings $settings -OutputRoot $outputRoot).Samples[0].Status.ToString()
 }
 finally {

--- a/PowerForge/Scripts/Benchmarks/Invoke-NativeExitAwareBlock.ps1
+++ b/PowerForge/Scripts/Benchmarks/Invoke-NativeExitAwareBlock.ps1
@@ -21,8 +21,10 @@ if ($null -eq $installNativeExitTracker) {
 $nativeExitTracker = $installNativeExitTracker.Invoke($null, @($ExecutionContext.SessionState))
 $benchmarkDslCommandAliasNames = [System.Collections.Generic.List[string]]::new()
 try {
-    if ($null -ne $PowerForgeBenchmarkDslCommandAliases) {
-        foreach ($entry in @($PowerForgeBenchmarkDslCommandAliases.GetEnumerator())) {
+    $dslCommandAliasesVariable = Get-Variable -Name PowerForgeBenchmarkDslCommandAliases -ErrorAction SilentlyContinue
+    $dslCommandAliases = if ($null -eq $dslCommandAliasesVariable) { $null } else { $dslCommandAliasesVariable.Value }
+    if ($null -ne $dslCommandAliases) {
+        foreach ($entry in @($dslCommandAliases.GetEnumerator())) {
             Set-Alias -Name $entry.Key -Value $entry.Value -Scope Local -Force
             $benchmarkDslCommandAliasNames.Add([string] $entry.Key)
         }

--- a/PowerForge/Scripts/Benchmarks/Invoke-NativeExitAwareBlock.ps1
+++ b/PowerForge/Scripts/Benchmarks/Invoke-NativeExitAwareBlock.ps1
@@ -21,7 +21,7 @@ if ($null -eq $installNativeExitTracker) {
 $nativeExitTracker = $installNativeExitTracker.Invoke($null, @($ExecutionContext.SessionState))
 $benchmarkDslCommandAliasNames = [System.Collections.Generic.List[string]]::new()
 try {
-    $dslCommandAliasesVariable = Get-Variable -Name PowerForgeBenchmarkDslCommandAliases -ErrorAction SilentlyContinue
+    $dslCommandAliasesVariable = Get-Variable -Name PowerForgeBenchmarkDslCommandAliases -ErrorAction Ignore
     $dslCommandAliases = if ($null -eq $dslCommandAliasesVariable) { $null } else { $dslCommandAliasesVariable.Value }
     if ($null -ne $dslCommandAliases) {
         foreach ($entry in @($dslCommandAliases.GetEnumerator())) {


### PR DESCRIPTION
## Summary

- make the native exit-aware benchmark wrapper safe when its caller enables strict mode
- treat the optional benchmark DSL alias table as genuinely optional
- cover an inline benchmark settings block that runs from a strict caller without DSL aliases

## Why

PowerForge owns the reusable benchmark runner used by [OfficeIMO](https://github.com/EvotecIT/OfficeIMO) and other repositories. A strict caller could previously fail before the benchmark started when no alias table was installed. The wrapper now discovers the optional variable without dereferencing an undefined name.

## Validation

- 12 focused benchmark service tests pass

## Related delivery

This helper change should land before the OCR work in [EvotecIT/OfficeIMO#2415](https://github.com/EvotecIT/OfficeIMO/pull/2415), which uses the reusable benchmark path. It does not publish or change any package by itself.
