### PR TITLE
Harden module documentation and binary runtime targeting

### DIFF
--- a/PowerForge.PowerShell/Services/BinaryDependencyPreflightService.cs
+++ b/PowerForge.PowerShell/Services/BinaryDependencyPreflightService.cs
@@ -183,7 +183,7 @@ public sealed class BinaryDependencyPreflightService
             foreach (var reference in ReadAssemblyReferences(assemblyPath))
             {
                 if (string.IsNullOrWhiteSpace(reference.Name)) continue;
-                if (IsHostProvidedAssemblyReference(providedByHost, reference.Name)) continue;
+                if (IsHostProvidedAssemblyReference(providedByHost, reference)) continue;
 
                 var key = assemblyFileName + "->" + reference.Name;
                 if (!seen.Add(key)) continue;
@@ -264,7 +264,7 @@ public sealed class BinaryDependencyPreflightService
                     continue;
                 }
 
-                if (IsHostProvidedAssemblyReference(providedByHost, reference.Name)) continue;
+                if (IsHostProvidedAssemblyReference(providedByHost, reference)) continue;
 
                 var key = assemblyFileName + "->" + reference.Name;
                 if (!seenIssues.Add(key)) continue;
@@ -712,13 +712,17 @@ public sealed class BinaryDependencyPreflightService
         return set;
     }
 
-    private static bool IsHostProvidedAssemblyReference(ISet<string> providedByHost, string assemblyName)
+    private static bool IsHostProvidedAssemblyReference(ISet<string> providedByHost, AssemblyReferenceInfo reference)
     {
-        if (providedByHost.Contains(assemblyName))
+        if (providedByHost.Contains(reference.Name))
             return true;
 
-        return Path.DirectorySeparatorChar == '\\' && IsWindowsRuntimeContractAssemblyName(assemblyName);
+        return Path.DirectorySeparatorChar == '\\' && IsWindowsRuntimeContractReference(reference.Name, reference.Flags);
     }
+
+    internal static bool IsWindowsRuntimeContractReference(string? assemblyName, AssemblyFlags flags)
+        => IsWindowsRuntimeContractAssemblyName(assemblyName) &&
+           (flags & AssemblyFlags.ContentTypeMask) == AssemblyFlags.WindowsRuntime;
 
     internal static bool IsWindowsRuntimeContractAssemblyName(string? assemblyName)
     {
@@ -809,7 +813,7 @@ public sealed class BinaryDependencyPreflightService
                 var reference = reader.GetAssemblyReference(handle);
                 var name = reader.GetString(reference.Name);
                 if (string.IsNullOrWhiteSpace(name)) continue;
-                list.Add(new AssemblyReferenceInfo(name, reference.Version));
+                list.Add(new AssemblyReferenceInfo(name, reference.Version, reference.Flags));
             }
 
             return list;
@@ -824,11 +828,13 @@ public sealed class BinaryDependencyPreflightService
     {
         public string Name { get; }
         public Version? Version { get; }
+        public AssemblyFlags Flags { get; }
 
-        public AssemblyReferenceInfo(string name, Version? version)
+        public AssemblyReferenceInfo(string name, Version? version, AssemblyFlags flags)
         {
             Name = name;
             Version = version;
+            Flags = flags;
         }
     }
 

--- a/PowerForge.PowerShell/Services/BinaryDependencyPreflightService.cs
+++ b/PowerForge.PowerShell/Services/BinaryDependencyPreflightService.cs
@@ -183,7 +183,7 @@ public sealed class BinaryDependencyPreflightService
             foreach (var reference in ReadAssemblyReferences(assemblyPath))
             {
                 if (string.IsNullOrWhiteSpace(reference.Name)) continue;
-                if (providedByHost.Contains(reference.Name)) continue;
+                if (IsHostProvidedAssemblyReference(providedByHost, reference.Name)) continue;
 
                 var key = assemblyFileName + "->" + reference.Name;
                 if (!seen.Add(key)) continue;
@@ -264,7 +264,7 @@ public sealed class BinaryDependencyPreflightService
                     continue;
                 }
 
-                if (providedByHost.Contains(reference.Name)) continue;
+                if (IsHostProvidedAssemblyReference(providedByHost, reference.Name)) continue;
 
                 var key = assemblyFileName + "->" + reference.Name;
                 if (!seenIssues.Add(key)) continue;
@@ -693,6 +693,10 @@ public sealed class BinaryDependencyPreflightService
                     set,
                     Path.Combine(windir, "Microsoft.NET", "assembly"),
                     "System.Management.Automation.dll");
+                AddSpecificAssemblyIfPresent(
+                    set,
+                    Path.Combine(windir, "Microsoft.NET", "assembly"),
+                    "System.Runtime.WindowsRuntime.dll");
             }
 
             return set;
@@ -706,6 +710,23 @@ public sealed class BinaryDependencyPreflightService
         AddAssembliesFromDirectory(set, Path.GetDirectoryName(typeof(PSObject).Assembly.Location));
 
         return set;
+    }
+
+    private static bool IsHostProvidedAssemblyReference(ISet<string> providedByHost, string assemblyName)
+    {
+        if (providedByHost.Contains(assemblyName))
+            return true;
+
+        return Path.DirectorySeparatorChar == '\\' && IsWindowsRuntimeContractAssemblyName(assemblyName);
+    }
+
+    internal static bool IsWindowsRuntimeContractAssemblyName(string? assemblyName)
+    {
+        if (string.IsNullOrWhiteSpace(assemblyName))
+            return false;
+
+        return assemblyName!.StartsWith("Windows.", StringComparison.OrdinalIgnoreCase) &&
+               assemblyName.EndsWith("Contract", StringComparison.OrdinalIgnoreCase);
     }
 
     private static IEnumerable<string> GetDesktopReferenceAssemblyDirectories()

--- a/PowerForge.Tests/BinaryDependencyPreflightServiceTests.cs
+++ b/PowerForge.Tests/BinaryDependencyPreflightServiceTests.cs
@@ -431,6 +431,35 @@ public sealed class BinaryDependencyPreflightServiceTests
             Assert.DoesNotContain(hostAssemblies, name => string.Equals(name, assemblyName, StringComparison.OrdinalIgnoreCase));
     }
 
+    [Theory]
+    [InlineData("Windows.Foundation.FoundationContract")]
+    [InlineData("Windows.Foundation.UniversalApiContract")]
+    [InlineData("Windows.Networking.Connectivity.WwanContract")]
+    public void WindowsRuntimeContractNames_AreRecognizedAsHostContracts(string assemblyName)
+    {
+        Assert.True(BinaryDependencyPreflightService.IsWindowsRuntimeContractAssemblyName(assemblyName));
+    }
+
+    [Theory]
+    [InlineData("WindowsBase")]
+    [InlineData("Windows.Foundation")]
+    [InlineData("Contoso.Foundation.UniversalApiContract")]
+    public void NonContractAssemblyNames_AreNotRecognizedAsWindowsRuntimeContracts(string assemblyName)
+    {
+        Assert.False(BinaryDependencyPreflightService.IsWindowsRuntimeContractAssemblyName(assemblyName));
+    }
+
+    [Fact]
+    public void DesktopHostBaseline_IncludesWindowsRuntimeFacadeOnWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var hostAssemblies = GetHostProvidedAssemblyNamesForTest("Desktop");
+
+        Assert.Contains(hostAssemblies, name => string.Equals(name, "System.Runtime.WindowsRuntime", StringComparison.OrdinalIgnoreCase));
+    }
+
     [Fact]
     public void CoreHostBaseline_IncludesKnownPowerShellRuntimeAssemblies()
     {

--- a/PowerForge.Tests/BinaryDependencyPreflightServiceTests.cs
+++ b/PowerForge.Tests/BinaryDependencyPreflightServiceTests.cs
@@ -450,6 +450,44 @@ public sealed class BinaryDependencyPreflightServiceTests
     }
 
     [Fact]
+    public void WindowsRuntimeContractReference_RequiresWindowsRuntimeMetadata()
+    {
+        const string assemblyName = "Windows.Contoso.UniversalApiContract";
+
+        Assert.False(BinaryDependencyPreflightService.IsWindowsRuntimeContractReference(
+            assemblyName,
+            (System.Reflection.AssemblyFlags)0));
+        Assert.True(BinaryDependencyPreflightService.IsWindowsRuntimeContractReference(
+            assemblyName,
+            System.Reflection.AssemblyFlags.WindowsRuntime));
+    }
+
+    [Fact]
+    public void Analyze_DoesNotSuppressManagedAssemblyThatOnlyLooksLikeAWindowsContract()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string dependencyName = "Windows.Contoso.UniversalApiContract";
+            var paths = CreateDependencyFixture(root.FullName, dependencyName);
+            BuildProject(paths.ConsumerProjectPath);
+
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module"));
+            var libCore = Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Lib", "Core"));
+            File.Copy(paths.ConsumerAssemblyPath, Path.Combine(libCore.FullName, "Consumer.dll"), overwrite: true);
+
+            var result = new BinaryDependencyPreflightService(new NullLogger()).Analyze(moduleRoot.FullName, "Core");
+
+            Assert.Contains(result.Issues, issue =>
+                string.Equals(issue.MissingDependencyName, dependencyName, StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void DesktopHostBaseline_IncludesWindowsRuntimeFacadeOnWindows()
     {
         if (!OperatingSystem.IsWindows())
@@ -490,17 +528,18 @@ public sealed class BinaryDependencyPreflightServiceTests
         return (System.Collections.Generic.IReadOnlyCollection<string>)field.GetValue(null)!;
     }
 
-    private static DependencyFixture CreateDependencyFixture(string rootPath)
+    private static DependencyFixture CreateDependencyFixture(string rootPath, string dependencyAssemblyName = "Dependency")
     {
         var dependencyRoot = Directory.CreateDirectory(Path.Combine(rootPath, "Dependency"));
         var consumerRoot = Directory.CreateDirectory(Path.Combine(rootPath, "Consumer"));
 
-        File.WriteAllText(Path.Combine(dependencyRoot.FullName, "Dependency.csproj"), """
+        File.WriteAllText(Path.Combine(dependencyRoot.FullName, "Dependency.csproj"), $"""
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AssemblyName>{dependencyAssemblyName}</AssemblyName>
   </PropertyGroup>
 </Project>
 """);
@@ -538,7 +577,7 @@ public sealed class ConsumerMarker
         return new DependencyFixture(
             Path.Combine(consumerRoot.FullName, "Consumer.csproj"),
             Path.Combine(consumerRoot.FullName, "bin", "Release", "net8.0", "Consumer.dll"),
-            Path.Combine(dependencyRoot.FullName, "bin", "Release", "net8.0", "Dependency.dll"));
+            Path.Combine(dependencyRoot.FullName, "bin", "Release", "net8.0", dependencyAssemblyName + ".dll"));
     }
 
     private static DependencyFixture CreateTransitiveDependencyFixture(string rootPath)

--- a/PowerForge.Tests/DocumentationCollectorBuiltinIsolationTests.cs
+++ b/PowerForge.Tests/DocumentationCollectorBuiltinIsolationTests.cs
@@ -79,6 +79,62 @@ public sealed class DocumentationCollectorBuiltinIsolationTests
 
     [Theory]
     [MemberData(nameof(PowerShellHosts))]
+    public void CollectorParameterDiscovery_HandlesParameterNamedKeys(string host)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-doc-parameter-keys-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            const string moduleName = "ParameterKeysFixture";
+            File.WriteAllText(
+                Path.Combine(root, moduleName + ".psm1"),
+                "function Get-ParameterKeysFixture { [CmdletBinding()] param([string]$Keys) }" + Environment.NewLine +
+                "Export-ModuleMember -Function Get-ParameterKeysFixture",
+                new UTF8Encoding(false));
+            File.WriteAllText(
+                Path.Combine(root, moduleName + ".psd1"),
+                "@{" + Environment.NewLine +
+                "RootModule = 'ParameterKeysFixture.psm1'" + Environment.NewLine +
+                "ModuleVersion = '1.0.0'" + Environment.NewLine +
+                "GUID = '60606060-6060-6060-6060-606060606060'" + Environment.NewLine +
+                "FunctionsToExport = @('Get-ParameterKeysFixture')" + Environment.NewLine +
+                "CmdletsToExport = @()" + Environment.NewLine +
+                "AliasesToExport = @()" + Environment.NewLine +
+                "VariablesToExport = @()" + Environment.NewLine +
+                "}",
+                new UTF8Encoding(false));
+
+            var scriptPath = Path.Combine(root, "ValidateParameterKeys.ps1");
+            var outputPath = Path.Combine(root, "parameters.txt");
+            File.WriteAllText(
+                scriptPath,
+                "param([string]$ManifestPath, [string]$OutputPath)" + Environment.NewLine +
+                EmbeddedScripts.Load("Scripts/Documentation/Export-HelpJson.Protocol.ps1") +
+                Environment.NewLine + "try {" + Environment.NewLine +
+                "$getParameterNames = (Microsoft.PowerShell.Core\\Get-Command GetDocumentationParameterNames -CommandType Function).ScriptBlock" + Environment.NewLine +
+                "$module = Microsoft.PowerShell.Core\\Import-Module -Name $ManifestPath -Force -PassThru -Function '*' -Cmdlet '*' -Alias '__none__' -Variable '__none__'" + Environment.NewLine +
+                "$command = Microsoft.PowerShell.Core\\Get-Command Get-ParameterKeysFixture -CommandType Function" + Environment.NewLine +
+                "$names = @(& $getParameterNames $command @())" + Environment.NewLine +
+                "[System.IO.File]::WriteAllLines($OutputPath, $names, [System.Text.UTF8Encoding]::new($false))" + Environment.NewLine +
+                "} finally { if ($module) { Microsoft.PowerShell.Core\\Remove-Module $module -Force -ErrorAction SilentlyContinue } }",
+                new UTF8Encoding(false));
+
+            var run = new ExecutablePowerShellRunner(host, root).Run(
+                new PowerShellRunRequest(
+                    scriptPath,
+                    new[] { Path.Combine(root, moduleName + ".psd1"), outputPath },
+                    TimeSpan.FromSeconds(20)));
+            Assert.Equal(0, run.ExitCode);
+            Assert.Equal(new[] { "Keys" }, File.ReadAllLines(outputPath));
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(PowerShellHosts))]
     public void RuntimeValueHelpers_IsolateBuiltinCmdletsFromTargetExports(string host)
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-doc-helper-isolation-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -81,7 +81,10 @@ public partial class ModuleBootstrapperGeneratorTests
         var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-lib-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(Path.Combine(root, "Lib", "Core"));
         Directory.CreateDirectory(Path.Combine(root, "Public"));
-        File.WriteAllText(Path.Combine(root, "Lib", "Core", "DemoModule.dll"), string.Empty);
+        File.Copy(
+            typeof(ModuleBootstrapperGeneratorTests).Assembly.Location,
+            Path.Combine(root, "Lib", "Core", "DemoModule.dll"),
+            overwrite: true);
         File.WriteAllText(Path.Combine(root, "Public", "Get-Demo.ps1"), "function Get-Demo { 'demo' }");
 
         try
@@ -98,7 +101,7 @@ public partial class ModuleBootstrapperGeneratorTests
             Assert.Contains("# DemoModule.Libraries.ps1", libraries);
             Assert.Contains("Lib\\Core\\DemoModule.dll", libraries);
             Assert.Contains("$L -split '[\\\\/]'", libraries);
-            Assert.Contains("[System.Reflection.AssemblyName]::GetAssemblyName($LibraryPath)", libraries);
+            Assert.Contains("Add-Type -Path $LibraryPath -ErrorAction Stop", libraries);
 
             var bootstrapper = File.ReadAllText(bootstrapperPath);
             Assert.Contains("# DemoModule bootstrapper", bootstrapper);
@@ -144,8 +147,14 @@ public partial class ModuleBootstrapperGeneratorTests
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-ignore-native-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(Path.Combine(root, "Lib", "Default"));
-        File.WriteAllText(Path.Combine(root, "Lib", "Default", "DemoModule.dll"), string.Empty);
-        File.WriteAllText(Path.Combine(root, "Lib", "Default", "Dependency.dll"), string.Empty);
+        File.Copy(
+            typeof(ModuleBootstrapperGeneratorTests).Assembly.Location,
+            Path.Combine(root, "Lib", "Default", "DemoModule.dll"),
+            overwrite: true);
+        File.Copy(
+            typeof(ModuleBootstrapperGeneratorTests).Assembly.Location,
+            Path.Combine(root, "Lib", "Default", "Dependency.dll"),
+            overwrite: true);
         File.WriteAllText(Path.Combine(root, "Lib", "Default", "libgcc_s_seh-1.dll"), string.Empty);
 
         try
@@ -417,9 +426,18 @@ public partial class ModuleBootstrapperGeneratorTests
         Directory.CreateDirectory(Path.Combine(root, "Lib", "Core"));
         Directory.CreateDirectory(Path.Combine(root, "Lib", "Core-net10.0"));
         Directory.CreateDirectory(Path.Combine(root, "Lib", "Default"));
-        File.WriteAllText(Path.Combine(root, "Lib", "Core", "DemoModule.dll"), string.Empty);
-        File.WriteAllText(Path.Combine(root, "Lib", "Core-net10.0", "DemoModule.dll"), string.Empty);
-        File.WriteAllText(Path.Combine(root, "Lib", "Default", "DemoModule.dll"), string.Empty);
+        File.Copy(
+            typeof(ModuleBootstrapperGeneratorTests).Assembly.Location,
+            Path.Combine(root, "Lib", "Core", "DemoModule.dll"),
+            overwrite: true);
+        File.Copy(
+            typeof(ModuleBootstrapperGeneratorTests).Assembly.Location,
+            Path.Combine(root, "Lib", "Core-net10.0", "DemoModule.dll"),
+            overwrite: true);
+        File.Copy(
+            typeof(ModuleBootstrapperGeneratorTests).Assembly.Location,
+            Path.Combine(root, "Lib", "Default", "DemoModule.dll"),
+            overwrite: true);
 
         try
         {

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -363,10 +363,12 @@ public partial class ModuleBootstrapperGeneratorTests
     }
 
     [Theory]
-    [InlineData("Core")]
-    [InlineData("Standard")]
-    [InlineData("Default")]
-    public void ResolveAssemblyLoadContextTargetFrameworkForPayloads_GenericFolderKeepsDeclaredRuntime(string folderName)
+    [InlineData("Core", "net8.0")]
+    [InlineData("Standard", "netcoreapp3.1")]
+    [InlineData("Default", "net8.0")]
+    public void ResolveAssemblyLoadContextTargetFrameworkForPayloads_UsesGenericFolderCompatibilityContract(
+        string folderName,
+        string expectedFramework)
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-alc-generic-" + Guid.NewGuid().ToString("N"));
         var payload = Directory.CreateDirectory(Path.Combine(root, folderName)).FullName;
@@ -377,7 +379,7 @@ public partial class ModuleBootstrapperGeneratorTests
                 "net8.0",
                 new[] { payload });
 
-            Assert.Equal("net8.0", framework);
+            Assert.Equal(expectedFramework, framework);
         }
         finally
         {
@@ -726,7 +728,7 @@ public partial class ModuleBootstrapperGeneratorTests
 
     [Fact]
     [Trait("Category", "Integration")]
-    public void Generate_WithAssemblyLoadContextAndUnmarkedPayloads_UsesDeclaredModernLoaderFramework()
+    public void Generate_WithAssemblyLoadContextAndUnmarkedPayloads_WritesPerPayloadCompatibleLoaders()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-alc-standard-" + Guid.NewGuid().ToString("N"));
         var libStandard = Directory.CreateDirectory(Path.Combine(root, "Lib", "Standard")).FullName;
@@ -745,20 +747,18 @@ public partial class ModuleBootstrapperGeneratorTests
                 useAssemblyLoadContext: true,
                 targetFrameworks: new[] { "netstandard2.0", "net8.0" });
 
-            foreach (var loaderPath in new[]
-                     {
-                         Path.Combine(libStandard, "DemoModule.ModuleLoadContext.dll"),
-                         Path.Combine(libCore, "DemoModule.ModuleLoadContext.dll")
-                     })
-            {
-                Assert.True(File.Exists(loaderPath));
-                var targetFramework = System.Reflection.Assembly.Load(File.ReadAllBytes(loaderPath))
-                    .GetCustomAttributesData()
-                    .Single(attribute => attribute.AttributeType == typeof(System.Runtime.Versioning.TargetFrameworkAttribute))
-                    .ConstructorArguments[0]
-                    .Value as string;
-                Assert.Equal(".NETCoreApp,Version=v8.0", targetFramework);
-            }
+            var standardLoaderPath = Path.Combine(libStandard, "DemoModule.ModuleLoadContext.dll");
+            var coreLoaderPath = Path.Combine(libCore, "DemoModule.ModuleLoadContext.dll");
+            Assert.True(File.Exists(standardLoaderPath));
+            Assert.True(File.Exists(coreLoaderPath));
+            Assert.Contains(
+                ".NETCoreApp,Version=v3.1",
+                System.Text.Encoding.UTF8.GetString(File.ReadAllBytes(standardLoaderPath)),
+                StringComparison.Ordinal);
+            Assert.Contains(
+                ".NETCoreApp,Version=v8.0",
+                System.Text.Encoding.UTF8.GetString(File.ReadAllBytes(coreLoaderPath)),
+                StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -353,6 +353,30 @@ public partial class ModuleBootstrapperGeneratorTests
         }
     }
 
+    [Theory]
+    [InlineData("Core")]
+    [InlineData("Standard")]
+    [InlineData("Default")]
+    public void ResolveAssemblyLoadContextTargetFrameworkForPayloads_GenericFolderKeepsDeclaredRuntime(string folderName)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-alc-generic-" + Guid.NewGuid().ToString("N"));
+        var payload = Directory.CreateDirectory(Path.Combine(root, folderName)).FullName;
+
+        try
+        {
+            var framework = ModuleBootstrapperGenerator.ResolveAssemblyLoadContextTargetFrameworkForPayloads(
+                "net8.0",
+                new[] { payload });
+
+            Assert.Equal("net8.0", framework);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
     [Fact]
     public void ResolveAssemblyLoadContextTargetFrameworkForPayloads_InfersPrebuiltCompatibleFloors()
     {
@@ -590,7 +614,7 @@ public partial class ModuleBootstrapperGeneratorTests
                 .Single(attribute => attribute.AttributeType == typeof(System.Runtime.Versioning.TargetFrameworkAttribute))
                 .ConstructorArguments[0]
                 .Value as string;
-            Assert.Equal(".NETCoreApp,Version=v3.1", coreLoaderTargetFramework);
+            Assert.Equal(".NETCoreApp,Version=v8.0", coreLoaderTargetFramework);
             Assert.True(File.Exists(Path.Combine(root, "DemoModule.Libraries.ps1")));
 
             var libraries = File.ReadAllText(Path.Combine(root, "DemoModule.Libraries.ps1"));
@@ -684,7 +708,7 @@ public partial class ModuleBootstrapperGeneratorTests
 
     [Fact]
     [Trait("Category", "Integration")]
-    public void Generate_WithAssemblyLoadContextAndStandardFallback_BuildsPowerShell70CompatibleLoader()
+    public void Generate_WithAssemblyLoadContextAndUnmarkedPayloads_UsesDeclaredModernLoaderFramework()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-alc-standard-" + Guid.NewGuid().ToString("N"));
         var libStandard = Directory.CreateDirectory(Path.Combine(root, "Lib", "Standard")).FullName;
@@ -715,7 +739,7 @@ public partial class ModuleBootstrapperGeneratorTests
                     .Single(attribute => attribute.AttributeType == typeof(System.Runtime.Versioning.TargetFrameworkAttribute))
                     .ConstructorArguments[0]
                     .Value as string;
-                Assert.Equal(".NETCoreApp,Version=v3.1", targetFramework);
+                Assert.Equal(".NETCoreApp,Version=v8.0", targetFramework);
             }
         }
         finally

--- a/PowerForge/Scripts/Documentation/Export-HelpJson.Protocol.ps1
+++ b/PowerForge/Scripts/Documentation/Export-HelpJson.Protocol.ps1
@@ -184,7 +184,13 @@ function GetDocumentationParameterNames(
     'InformationAction','InformationVariable','OutVariable','OutBuffer','PipelineVariable',
     'WhatIf','Confirm','ProgressAction')
   $names = @()
-  try { $names = @($command.Parameters.Keys) } catch { $names = @() }
+  try {
+    $names = @(
+      foreach ($entry in $command.Parameters.GetEnumerator()) {
+        [string]$entry.Key
+      }
+    )
+  } catch { $names = @() }
   foreach ($helpParameter in @($helpParameters)) {
     try { $names += [string]$helpParameter.Name } catch { }
   }

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -435,46 +435,60 @@ internal static partial class ModuleBootstrapperGenerator
 
         EnsureDotNetSdkAvailable(moduleRoot);
 
-        targetFramework = ResolveAssemblyLoadContextTargetFrameworkForPayloads(targetFramework, targetDirectories);
-
         var buildRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "module-load-context", identity.AssemblyName + "_" + Guid.NewGuid().ToString("N"));
-        var outputRoot = Path.Combine(buildRoot, "out");
 
         try
         {
             Directory.CreateDirectory(buildRoot);
-            Directory.CreateDirectory(outputRoot);
 
-            var projectPath = Path.Combine(buildRoot, identity.AssemblyName + ".csproj");
-            File.WriteAllText(projectPath, BuildAssemblyLoadContextProject(identity, targetFramework), Encoding.UTF8);
-            File.WriteAllText(Path.Combine(buildRoot, "ModuleAssemblyLoadContext.cs"), BuildAssemblyLoadContextSource(identity), Encoding.UTF8);
+            var targetGroups = targetDirectories
+                .Select(directory => new
+                {
+                    Directory = directory,
+                    TargetFramework = ResolveAssemblyLoadContextTargetFrameworkForPayload(targetFramework, directory)
+                })
+                .GroupBy(static target => target.TargetFramework, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
 
-            log?.Invoke($"Building module-scoped AssemblyLoadContext loader '{identity.AssemblyName}' for {targetFramework}.");
-            var result = RunProcess(
-                "dotnet",
-                buildRoot,
-                // Disable MSBuild node reuse so short-lived helper builds exit cleanly in CI and tests.
-                new[] { "build", projectPath, "-c", "Release", "-o", outputRoot, "-nologo", "-v:minimal", "-nr:false" },
-                AssemblyLoadContextLoaderBuildTimeout);
-            if (result.ExitCode != 0)
+            for (var groupIndex = 0; groupIndex < targetGroups.Length; groupIndex++)
             {
-                var message = string.Join(
-                    Environment.NewLine,
-                    new[]
-                    {
-                        $"Failed to build module-scoped AssemblyLoadContext loader '{identity.AssemblyName}' (exit {result.ExitCode}).",
-                        result.StdOut,
-                        result.StdErr
-                    }.Where(static line => !string.IsNullOrWhiteSpace(line)));
-                throw new InvalidOperationException(message);
+                var targetGroup = targetGroups[groupIndex];
+                var groupRoot = Path.Combine(buildRoot, "target-" + groupIndex);
+                var outputRoot = Path.Combine(groupRoot, "out");
+                Directory.CreateDirectory(groupRoot);
+                Directory.CreateDirectory(outputRoot);
+
+                var projectPath = Path.Combine(groupRoot, identity.AssemblyName + ".csproj");
+                File.WriteAllText(projectPath, BuildAssemblyLoadContextProject(identity, targetGroup.Key), Encoding.UTF8);
+                File.WriteAllText(Path.Combine(groupRoot, "ModuleAssemblyLoadContext.cs"), BuildAssemblyLoadContextSource(identity), Encoding.UTF8);
+
+                log?.Invoke($"Building module-scoped AssemblyLoadContext loader '{identity.AssemblyName}' for {targetGroup.Key}.");
+                var result = RunProcess(
+                    "dotnet",
+                    groupRoot,
+                    // Disable MSBuild node reuse so short-lived helper builds exit cleanly in CI and tests.
+                    new[] { "build", projectPath, "-c", "Release", "-o", outputRoot, "-nologo", "-v:minimal", "-nr:false" },
+                    AssemblyLoadContextLoaderBuildTimeout);
+                if (result.ExitCode != 0)
+                {
+                    var message = string.Join(
+                        Environment.NewLine,
+                        new[]
+                        {
+                            $"Failed to build module-scoped AssemblyLoadContext loader '{identity.AssemblyName}' for {targetGroup.Key} (exit {result.ExitCode}).",
+                            result.StdOut,
+                            result.StdErr
+                        }.Where(static line => !string.IsNullOrWhiteSpace(line)));
+                    throw new InvalidOperationException(message);
+                }
+
+                var loaderPath = Path.Combine(outputRoot, identity.AssemblyName + ".dll");
+                if (!File.Exists(loaderPath))
+                    throw new FileNotFoundException("Module-scoped AssemblyLoadContext loader build did not produce the expected DLL.", loaderPath);
+
+                foreach (var target in targetGroup)
+                    File.Copy(loaderPath, Path.Combine(target.Directory, identity.AssemblyName + ".dll"), overwrite: true);
             }
-
-            var loaderPath = Path.Combine(outputRoot, identity.AssemblyName + ".dll");
-            if (!File.Exists(loaderPath))
-                throw new FileNotFoundException("Module-scoped AssemblyLoadContext loader build did not produce the expected DLL.", loaderPath);
-
-            foreach (var directory in targetDirectories)
-                File.Copy(loaderPath, Path.Combine(directory, identity.AssemblyName + ".dll"), overwrite: true);
         }
         finally
         {
@@ -609,14 +623,32 @@ internal static partial class ModuleBootstrapperGenerator
         string targetFramework,
         IReadOnlyList<string>? targetDirectories)
     {
-        var candidates = new[] { targetFramework }
-            .Concat((targetDirectories ?? Array.Empty<string>()).Select(ResolvePayloadAssemblyLoadContextTargetFramework))
-            .Where(static framework => !string.IsNullOrWhiteSpace(framework))
-            .Select(static framework => framework!)
+        var candidates = (targetDirectories ?? Array.Empty<string>())
+            .Select(directory => ResolveAssemblyLoadContextTargetFrameworkForPayload(targetFramework, directory))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(static framework => GetNetTfmVersion(framework), Comparer<Version>.Create(static (left, right) => left.CompareTo(right)))
             .ToArray();
         return candidates.FirstOrDefault() ?? targetFramework;
+    }
+
+    internal static string ResolveAssemblyLoadContextTargetFrameworkForPayload(string targetFramework, string directory)
+    {
+        var payloadFramework = ResolvePayloadAssemblyLoadContextTargetFramework(directory);
+        if (!string.IsNullOrWhiteSpace(payloadFramework))
+        {
+            // The helper only needs to meet the lower of the module's declared runtime floor and
+            // the payload floor. This also keeps future-TFM payload folders buildable by today's SDK.
+            return new[] { targetFramework, payloadFramework! }
+                .OrderBy(static framework => GetNetTfmVersion(framework), Comparer<Version>.Create(static (left, right) => left.CompareTo(right)))
+                .First();
+        }
+
+        // The generic Standard folder is the compatibility fallback selected by older PowerShell 7
+        // hosts when a generic Core payload cannot be proven compatible. Keep its loader at the
+        // PowerShell 7.0 runtime floor while allowing modern Core payloads to use their declared TFM.
+        return string.Equals(Path.GetFileName(directory), "Standard", StringComparison.OrdinalIgnoreCase)
+            ? PowerShell70AssemblyLoadContextTargetFramework
+            : targetFramework;
     }
 
     private static string? ResolvePayloadAssemblyLoadContextTargetFramework(string directory)
@@ -643,9 +675,7 @@ internal static partial class ModuleBootstrapperGenerator
                 return NormalizePayloadAssemblyLoadContextTargetFramework(folderName.Substring(prefix.Length));
         }
 
-        // Generic payload folder names describe selection behavior, not a target-framework floor.
-        // Keep the framework already resolved from the module's declared TFMs unless the payload
-        // carries an explicit marker or a framework-qualified folder name.
+        // Generic payload folder names are resolved against their selection contract by the caller.
         return null;
     }
 

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -643,11 +643,10 @@ internal static partial class ModuleBootstrapperGenerator
                 return NormalizePayloadAssemblyLoadContextTargetFramework(folderName.Substring(prefix.Length));
         }
 
-        return folderName.Equals("Core", StringComparison.OrdinalIgnoreCase) ||
-               folderName.Equals("Standard", StringComparison.OrdinalIgnoreCase) ||
-               folderName.Equals("Default", StringComparison.OrdinalIgnoreCase)
-            ? PowerShell70AssemblyLoadContextTargetFramework
-            : null;
+        // Generic payload folder names describe selection behavior, not a target-framework floor.
+        // Keep the framework already resolved from the module's declared TFMs unless the payload
+        // carries an explicit marker or a framework-qualified folder name.
+        return null;
     }
 
     private static string? NormalizePayloadAssemblyLoadContextTargetFramework(string? framework)


### PR DESCRIPTION
## Summary

- enumerate command parameter metadata safely when a command exposes a parameter named `Keys`
- suppress Windows Runtime contract dependencies only when their assembly-reference metadata identifies them as Windows Runtime components
- build module-scoped AssemblyLoadContext helpers per payload compatibility floor: modern Core payloads use the declared runtime, while the legacy Standard fallback remains compatible with PowerShell 7.0
- use real managed assemblies in module payload tests so fixtures match the current binary-preload contract

## Why

A DesktopManager module build exposed three reusable packaging-owner problems: documentation extraction could time out on a `Keys` parameter, Desktop dependency preflight could reject Windows Runtime contracts supplied by the host, and one shared loader target could either force modern payloads down to .NET Core 3.1 or make a legacy Standard fallback unloadable on older PowerShell 7 hosts.

This fixes those contracts in PowerForge/PSPublishModule without adding downstream compatibility branches. Managed assemblies whose names merely resemble Windows contracts remain subject to normal dependency validation.

## Downstream and release order

This is the shared owner fix needed by [EvotecIT/PowerBGInfo#72](https://github.com/EvotecIT/PowerBGInfo/pull/72) through its DesktopManager dependency.

1. Merge this PR and publish PSPublishModule 3.0.129.
2. Build and publish DesktopManager 3.6.4.
3. Re-run PowerBGInfo #72 against the public package chain.

Explicit target-framework markers and framework-qualified payload folders remain supported. Future payload folders are clamped to the module's declared runtime floor so today's SDK can still generate the compatible helper.