### PR TITLE
Fix duplicate project content metadata

### DIFF
--- a/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
@@ -460,8 +460,16 @@ public class WebPipelineRunnerProjectCatalogTests
 
             var overview = File.ReadAllText(overviewPath);
             Assert.Contains("meta.project_content_mode: \"hybrid\"", overview, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(
+                1,
+                overview.Split("meta.project_content_mode:", StringSplitOptions.None).Length - 1);
             Assert.Contains("meta.project_surface_examples: true", overview, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("meta.project_artifact_examples: \"https://example.invalid/alpha-examples.zip\"", overview, StringComparison.OrdinalIgnoreCase);
+
+            var examplesSection = File.ReadAllText(examplesSectionPath);
+            Assert.Equal(
+                1,
+                examplesSection.Split("meta.project_content_mode:", StringSplitOptions.None).Length - 1);
         }
         finally
         {

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -2865,9 +2865,6 @@ internal static partial class WebPipelineRunner
         ProjectCatalogEntry project,
         bool includeProductPresentation)
     {
-        if (!string.IsNullOrWhiteSpace(project.ContentMode))
-            WriteMetaString(lines, "meta.project_content_mode", project.ContentMode);
-
         if (includeProductPresentation)
             AppendProductFrontMatterExtensions(lines, project);
 


### PR DESCRIPTION
## What changed

- Keep `meta.project_content_mode` owned by the project overview and section-page generators.
- Stop the shared frontmatter-extension helper from emitting a second copy of that key.
- Add focused coverage for both overview and generated section pages.

## Why

Generated project pages could contain duplicate YAML frontmatter keys. This was visible in the EvotecIT/Website PSWriteOffice routes and could make parsers disagree about which value was authoritative.

## Validation

- `WebPipelineRunnerProjectCatalogTests`: 8 passed
- Focused overview and generated-section regression test passed
- `git diff --check`

The full solution test run was also attempted. It exposed pre-existing failures in unrelated suites; the focused project-catalog tests covering this change are green, and repository CI remains the authoritative broad gate.

## Downstream

EvotecIT/Website regenerates project content from this owner. Its companion recovery/content PR should pin the merged commit from this PR before merge.
