### PR TITLE
Speed up exact-source Apple deployment plans

### DIFF
--- a/PowerForge.Tests/AppleLocalBuildSourceTrustTests.cs
+++ b/PowerForge.Tests/AppleLocalBuildSourceTrustTests.cs
@@ -236,6 +236,72 @@ public sealed class AppleLocalBuildSourceTrustTests
     }
 
     [Fact]
+    public void ValidateLocalBuildInputContainment_checks_directory_filters_before_path_aware_hashing()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests.LocalAppleTrust",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(
+                root.FullName,
+                "CasaRay.xcodeproj"));
+            File.WriteAllText(
+                Path.Combine(project.FullName, "project.pbxproj"),
+                """
+                {
+                    objects = {
+                        AA0000000000000000000001 = {
+                            isa = PBXBuildFile;
+                            fileRef = AA0000000000000000000002;
+                        };
+                        AA0000000000000000000002 = {
+                            isa = PBXFileReference;
+                            lastKnownFileType = folder;
+                            path = Assets;
+                            sourceTree = "<group>";
+                        };
+                    };
+                }
+                """);
+            var schemeRoot = Directory.CreateDirectory(Path.Combine(
+                project.FullName,
+                "xcshareddata",
+                "xcschemes"));
+            File.WriteAllText(
+                Path.Combine(schemeRoot.FullName, "CasaRay.xcscheme"),
+                "<Scheme />");
+            var assets = Directory.CreateDirectory(Path.Combine(
+                root.FullName,
+                "Assets"));
+            var trackedAsset = Path.Combine(assets.FullName, "tracked.txt");
+            File.WriteAllText(trackedAsset, "tracked\n");
+            InitializeGitRepository(root.FullName, writeInputs: null);
+            var infoRoot = Path.Combine(root.FullName, ".git", "info");
+            Directory.CreateDirectory(infoRoot);
+            File.WriteAllText(
+                Path.Combine(infoRoot, "attributes"),
+                "Assets/tracked.txt filter=malicious\n");
+            File.WriteAllText(trackedAsset, "changed\n");
+
+            var error = Assert.Throws<InvalidOperationException>(() =>
+                new AppleReleaseSourceTrustService()
+                    .ValidateLocalBuildInputContainment(
+                        root.FullName,
+                        project.FullName,
+                        "CasaRay"));
+
+            Assert.Contains("custom Git filter", error.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Assets/tracked.txt", error.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void ValidateLocalBuildInputContainment_inspects_locked_remote_package_execution_features()
     {
         var root = Directory.CreateDirectory(Path.Combine(

--- a/PowerForge.Tests/AppleReleaseSourceTrustPerformanceTests.cs
+++ b/PowerForge.Tests/AppleReleaseSourceTrustPerformanceTests.cs
@@ -106,8 +106,9 @@ public sealed class AppleReleaseSourceTrustPerformanceTests
         try
         {
             var paths = Enumerable.Range(0, 600)
-                .Select(index => Path.Combine(root, $"Source{index:D4}.swift"))
+                .Select(index => Path.Combine(root, "Sources", $"Source{index:D4}.swift"))
                 .ToArray();
+            Directory.CreateDirectory(Path.Combine(root, "Sources"));
             foreach (var path in paths)
                 File.WriteAllText(path, "struct Source { }\n");
             RunGit(root, "init", "--quiet");
@@ -128,11 +129,13 @@ public sealed class AppleReleaseSourceTrustPerformanceTests
                 service.EnsureTrackedFile(root, path, "Swift source input");
             service.ValidatePendingGitFilters();
 
-            Assert.InRange(runner.Requests.Count, 1, 8);
+            Assert.InRange(runner.Requests.Count, 1, 16);
             Assert.Single(runner.Requests, request =>
-                request.Arguments.Contains("ls-tree", StringComparer.Ordinal));
+                request.Arguments.Contains("ls-tree", StringComparer.Ordinal) &&
+                request.Arguments.Contains("Sources", StringComparer.Ordinal));
             Assert.Single(runner.Requests, request =>
-                request.Arguments.Contains("--stage", StringComparer.Ordinal));
+                request.Arguments.Contains("--stage", StringComparer.Ordinal) &&
+                request.Arguments.Contains("Sources", StringComparer.Ordinal));
             Assert.Equal(3, runner.Requests.Count(request =>
                 request.Arguments.Contains("check-attr", StringComparer.Ordinal)));
 
@@ -183,6 +186,13 @@ public sealed class AppleReleaseSourceTrustPerformanceTests
             service.ValidatePendingGitFilters();
 
             Assert.InRange(runner.Requests.Count, 1, 5);
+            var proofRequests = runner.Requests.Where(request =>
+                request.Arguments.Contains("ls-tree", StringComparer.Ordinal) ||
+                request.Arguments.Contains("--stage", StringComparer.Ordinal));
+            Assert.Equal(2, proofRequests.Count());
+            Assert.All(proofRequests, request =>
+                Assert.Contains(request.Arguments, argument =>
+                    argument.EndsWith("Source0511.swift", StringComparison.Ordinal)));
             var filterRequest = Assert.Single(runner.Requests, request =>
                 request.Arguments.Contains("check-attr", StringComparer.Ordinal));
             Assert.Single(filterRequest.Arguments, argument =>

--- a/PowerForge.Tests/AppleReleaseSourceTrustPerformanceTests.cs
+++ b/PowerForge.Tests/AppleReleaseSourceTrustPerformanceTests.cs
@@ -95,6 +95,60 @@ public sealed class AppleReleaseSourceTrustPerformanceTests
         }
     }
 
+    [Fact]
+    public void EnsureTrackedFile_batches_repository_proof_for_many_distinct_inputs()
+    {
+        var temporaryRoot = Path.GetTempPath();
+        if (OperatingSystem.IsMacOS() && temporaryRoot.StartsWith("/var/", StringComparison.Ordinal))
+            temporaryRoot = "/private" + temporaryRoot;
+        var root = Path.Combine(temporaryRoot, "PowerForge.TrackedFileBatchTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var paths = Enumerable.Range(0, 600)
+                .Select(index => Path.Combine(root, $"Source{index:D4}.swift"))
+                .ToArray();
+            foreach (var path in paths)
+                File.WriteAllText(path, "struct Source { }\n");
+            RunGit(root, "init", "--quiet");
+            RunGit(root, "add", ".");
+            RunGit(
+                root,
+                "-c", "user.name=PowerForge Tests",
+                "-c", "user.email=powerforge-tests@example.invalid",
+                "commit", "--quiet", "-m", "fixture");
+
+            var runner = new CountingProcessRunner();
+            var git = new GitClient(runner, defaultTimeout: TimeSpan.FromSeconds(30));
+            var service = new AppleReleaseSourceTrustService(
+                new HomeAssistantReleaseGitService(git, runner),
+                git);
+
+            foreach (var path in paths)
+                service.EnsureTrackedFile(root, path, "Swift source input");
+
+            Assert.InRange(runner.Requests.Count, 1, 8);
+            Assert.Single(runner.Requests, request =>
+                request.Arguments.Contains("ls-tree", StringComparer.Ordinal));
+            Assert.Single(runner.Requests, request =>
+                request.Arguments.Contains("--stage", StringComparer.Ordinal));
+            Assert.Equal(3, runner.Requests.Count(request =>
+                request.Arguments.Contains("check-attr", StringComparer.Ordinal)));
+
+            var requestCount = runner.Requests.Count;
+            File.WriteAllText(paths[511], "struct ChangedSource { }\n");
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                service.EnsureTrackedFile(root, paths[511], "Swift source input"));
+            Assert.Contains("changed after it was validated", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(requestCount, runner.Requests.Count);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
     private static void RunGit(string root, params string[] arguments)
     {
         var result = new ProcessRunner().RunAsync(new ProcessRunRequest(

--- a/PowerForge.Tests/AppleReleaseSourceTrustPerformanceTests.cs
+++ b/PowerForge.Tests/AppleReleaseSourceTrustPerformanceTests.cs
@@ -126,6 +126,7 @@ public sealed class AppleReleaseSourceTrustPerformanceTests
 
             foreach (var path in paths)
                 service.EnsureTrackedFile(root, path, "Swift source input");
+            service.ValidatePendingGitFilters();
 
             Assert.InRange(runner.Requests.Count, 1, 8);
             Assert.Single(runner.Requests, request =>
@@ -141,6 +142,93 @@ public sealed class AppleReleaseSourceTrustPerformanceTests
                 service.EnsureTrackedFile(root, paths[511], "Swift source input"));
             Assert.Contains("changed after it was validated", exception.Message, StringComparison.OrdinalIgnoreCase);
             Assert.Equal(requestCount, runner.Requests.Count);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void EnsureTrackedFile_batches_only_consumed_inputs_in_large_repositories()
+    {
+        var temporaryRoot = Path.GetTempPath();
+        if (OperatingSystem.IsMacOS() && temporaryRoot.StartsWith("/var/", StringComparison.Ordinal))
+            temporaryRoot = "/private" + temporaryRoot;
+        var root = Path.Combine(temporaryRoot, "PowerForge.TrackedFileScopeTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var paths = Enumerable.Range(0, 600)
+                .Select(index => Path.Combine(root, $"Source{index:D4}.swift"))
+                .ToArray();
+            foreach (var path in paths)
+                File.WriteAllText(path, "struct Source { }\n");
+            RunGit(root, "init", "--quiet");
+            RunGit(root, "add", ".");
+            RunGit(
+                root,
+                "-c", "user.name=PowerForge Tests",
+                "-c", "user.email=powerforge-tests@example.invalid",
+                "commit", "--quiet", "-m", "fixture");
+
+            var runner = new CountingProcessRunner();
+            var git = new GitClient(runner, defaultTimeout: TimeSpan.FromSeconds(30));
+            var service = new AppleReleaseSourceTrustService(
+                new HomeAssistantReleaseGitService(git, runner),
+                git);
+
+            service.EnsureTrackedFile(root, paths[511], "Swift source input");
+            service.ValidatePendingGitFilters();
+
+            Assert.InRange(runner.Requests.Count, 1, 5);
+            var filterRequest = Assert.Single(runner.Requests, request =>
+                request.Arguments.Contains("check-attr", StringComparer.Ordinal));
+            Assert.Single(filterRequest.Arguments, argument =>
+                argument.EndsWith("Source0511.swift", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void EnsureTrackedFile_rechecks_filter_metadata_before_path_aware_hashing()
+    {
+        var temporaryRoot = Path.GetTempPath();
+        if (OperatingSystem.IsMacOS() && temporaryRoot.StartsWith("/var/", StringComparison.Ordinal))
+            temporaryRoot = "/private" + temporaryRoot;
+        var root = Path.Combine(temporaryRoot, "PowerForge.TrackedFileFilterRaceTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var first = Path.Combine(root, "First.txt");
+            var second = Path.Combine(root, "Second.txt");
+            File.WriteAllText(first, "first\n");
+            File.WriteAllText(second, "second\n");
+            RunGit(root, "init", "--quiet");
+            RunGit(root, "add", ".");
+            RunGit(
+                root,
+                "-c", "user.name=PowerForge Tests",
+                "-c", "user.email=powerforge-tests@example.invalid",
+                "commit", "--quiet", "-m", "fixture");
+
+            var service = new AppleReleaseSourceTrustService();
+            service.EnsureTrackedFile(root, first, "first input");
+            var infoRoot = Path.Combine(root, ".git", "info");
+            Directory.CreateDirectory(infoRoot);
+            File.WriteAllText(Path.Combine(infoRoot, "attributes"), "Second.txt filter=malicious\n");
+            File.WriteAllText(second, "changed\n");
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                service.EnsureTrackedFile(root, second, "second input"));
+
+            Assert.Contains("custom Git filter", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Second.txt", exception.Message, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge/Services/AppleReleaseSourceTrustService.GitBlobs.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.GitBlobs.cs
@@ -2,8 +2,49 @@ namespace PowerForge;
 
 internal sealed partial class AppleReleaseSourceTrustService
 {
+    private sealed class TrackedRepositoryProof
+    {
+        internal TrackedRepositoryProof(
+            Dictionary<string, TrackedIndexEntry> indexEntries,
+            Dictionary<string, string> headBlobIds,
+            Dictionary<string, string> filterAttributes)
+        {
+            IndexEntries = indexEntries;
+            HeadBlobIds = headBlobIds;
+            FilterAttributes = filterAttributes;
+        }
+
+        internal Dictionary<string, TrackedIndexEntry> IndexEntries { get; }
+
+        internal Dictionary<string, string> HeadBlobIds { get; }
+
+        internal Dictionary<string, string> FilterAttributes { get; }
+    }
+
+    private sealed class TrackedIndexEntry
+    {
+        internal TrackedIndexEntry(string fullPath, string relativePath, string tag)
+        {
+            FullPath = fullPath;
+            RelativePath = relativePath;
+            Tag = tag;
+        }
+
+        internal string FullPath { get; }
+
+        internal string RelativePath { get; }
+
+        internal string Tag { get; }
+    }
+
     private void EnsureNoCustomGitFilter(string repositoryRoot, string relativePath, string name)
         => EnsureNoCustomGitFilters(repositoryRoot, new[] { relativePath }, name);
+
+    private static void EnsureNoCustomGitFilter(
+        TrackedRepositoryProof repositoryProof,
+        string relativePath,
+        string name)
+        => EnsureNoCustomGitFilters(repositoryProof, new[] { relativePath }, name);
 
     internal void EnsureNoCustomGitFilters(
         string repositoryRoot,
@@ -51,6 +92,125 @@ internal sealed partial class AppleReleaseSourceTrustService
                 }
             }
         }
+    }
+
+    private static void EnsureNoCustomGitFilters(
+        TrackedRepositoryProof repositoryProof,
+        IEnumerable<string> relativePaths,
+        string name)
+    {
+        foreach (var relativePath in relativePaths.Distinct(GetPathComparer()))
+        {
+            if (!repositoryProof.FilterAttributes.TryGetValue(relativePath, out var value))
+            {
+                throw new InvalidOperationException(
+                    $"{name} Git filter attributes did not include exact-source path: {relativePath}.");
+            }
+            if (!value.Equals("unspecified", StringComparison.Ordinal) &&
+                !value.Equals("unset", StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"{name} uses custom Git filter '{value}' and cannot be attested to the exact source commit: {relativePath}. " +
+                    "Exact Apple source inputs may use Git text/EOL normalization but not repository-configuration-dependent clean or smudge filters.");
+            }
+        }
+    }
+
+    private TrackedRepositoryProof ReadTrackedRepositoryProof(string repositoryRoot)
+    {
+        var root = Path.GetFullPath(repositoryRoot);
+        if (_trackedRepositoryProofs.TryGetValue(root, out var cached))
+            return cached;
+
+        var comparer = GetPathComparer();
+        var indexEntries = new Dictionary<string, TrackedIndexEntry>(comparer);
+        var relativePaths = new List<string>();
+        var stagedEntries = RunGit(root, "ls-files", "--stage", "-v", "-z")
+            .StdOut.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var stagedEntry in stagedEntries)
+        {
+            var tab = stagedEntry.IndexOf('\t');
+            var metadata = tab > 2
+                ? stagedEntry.Substring(2, tab - 2).Split(
+                    new[] { ' ' },
+                    StringSplitOptions.RemoveEmptyEntries)
+                : Array.Empty<string>();
+            if (stagedEntry.Length < 3 || stagedEntry[1] != ' ' ||
+                metadata.Length != 3 || !metadata[2].Equals("0", StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    "Tracked Apple source inputs contain an unexpected or unmerged Git index entry.");
+            }
+
+            var relativePath = stagedEntry.Substring(tab + 1);
+            var fullPath = Path.GetFullPath(Path.Combine(root, relativePath));
+            if (!indexEntries.TryAdd(
+                    fullPath,
+                    new TrackedIndexEntry(fullPath, relativePath, stagedEntry.Substring(0, 1))))
+            {
+                throw new InvalidOperationException(
+                    $"Tracked Apple source inputs contain duplicate Git index entries for: {relativePath}");
+            }
+            relativePaths.Add(relativePath);
+        }
+
+        var headBlobIds = new Dictionary<string, string>(comparer);
+        var headEntries = RunGit(root, "ls-tree", "-r", "-z", "HEAD")
+            .StdOut.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var headEntry in headEntries)
+        {
+            var tab = headEntry.IndexOf('\t');
+            if (tab < 0)
+                continue;
+            var metadata = headEntry.Substring(0, tab).Split(' ');
+            if (metadata.Length != 3 || !metadata[1].Equals("blob", StringComparison.Ordinal))
+                continue;
+            var fullPath = Path.GetFullPath(Path.Combine(root, headEntry.Substring(tab + 1)));
+            headBlobIds[fullPath] = metadata[2];
+        }
+
+        var filterAttributes = ReadGitFilterAttributes(root, relativePaths);
+        var proof = new TrackedRepositoryProof(indexEntries, headBlobIds, filterAttributes);
+        _trackedRepositoryProofs[root] = proof;
+        return proof;
+    }
+
+    private Dictionary<string, string> ReadGitFilterAttributes(
+        string repositoryRoot,
+        IReadOnlyList<string> relativePaths)
+    {
+        const int maximumPathsPerInvocation = 256;
+        var result = new Dictionary<string, string>(GetPathComparer());
+        for (var offset = 0; offset < relativePaths.Count; offset += maximumPathsPerInvocation)
+        {
+            var batch = relativePaths.Skip(offset).Take(maximumPathsPerInvocation).ToArray();
+            var arguments = new List<string> { "check-attr", "-z", "filter", "--" };
+            arguments.AddRange(batch);
+            var attributes = RunGit(repositoryRoot, arguments.ToArray())
+                .StdOut.Split(new[] { '\0' }, StringSplitOptions.None);
+            var valueCount = attributes.Length > 0 && attributes[attributes.Length - 1].Length == 0
+                ? attributes.Length - 1
+                : attributes.Length;
+            if (valueCount != batch.Length * 3)
+            {
+                throw new InvalidOperationException(
+                    $"Git filter attributes could not be parsed safely for {batch.Length} tracked Apple source input(s).");
+            }
+            for (var index = 0; index < valueCount; index += 3)
+            {
+                var path = attributes[index];
+                var attribute = attributes[index + 1];
+                var value = attributes[index + 2];
+                if (!attribute.Equals("filter", StringComparison.Ordinal) ||
+                    !batch.Contains(path, GetPathComparer()))
+                {
+                    throw new InvalidOperationException(
+                        $"Git filter attributes returned an unexpected tracked Apple source path: {path}.");
+                }
+                result[path] = value;
+            }
+        }
+        return result;
     }
 
     private string ComputeRawGitBlobId(string repositoryRoot, string filePath)

--- a/PowerForge/Services/AppleReleaseSourceTrustService.GitBlobs.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.GitBlobs.cs
@@ -6,19 +6,16 @@ internal sealed partial class AppleReleaseSourceTrustService
     {
         internal TrackedRepositoryProof(
             Dictionary<string, TrackedIndexEntry> indexEntries,
-            Dictionary<string, string> headBlobIds,
-            Dictionary<string, string> filterAttributes)
+            Dictionary<string, string> headBlobIds)
         {
             IndexEntries = indexEntries;
             HeadBlobIds = headBlobIds;
-            FilterAttributes = filterAttributes;
         }
 
         internal Dictionary<string, TrackedIndexEntry> IndexEntries { get; }
 
         internal Dictionary<string, string> HeadBlobIds { get; }
 
-        internal Dictionary<string, string> FilterAttributes { get; }
     }
 
     private sealed class TrackedIndexEntry
@@ -39,12 +36,6 @@ internal sealed partial class AppleReleaseSourceTrustService
 
     private void EnsureNoCustomGitFilter(string repositoryRoot, string relativePath, string name)
         => EnsureNoCustomGitFilters(repositoryRoot, new[] { relativePath }, name);
-
-    private static void EnsureNoCustomGitFilter(
-        TrackedRepositoryProof repositoryProof,
-        string relativePath,
-        string name)
-        => EnsureNoCustomGitFilters(repositoryProof, new[] { relativePath }, name);
 
     internal void EnsureNoCustomGitFilters(
         string repositoryRoot,
@@ -94,26 +85,35 @@ internal sealed partial class AppleReleaseSourceTrustService
         }
     }
 
-    private static void EnsureNoCustomGitFilters(
-        TrackedRepositoryProof repositoryProof,
-        IEnumerable<string> relativePaths,
-        string name)
+    private void TrackGitFilterPath(string repositoryRoot, string relativePath)
+        => TrackGitFilterPaths(repositoryRoot, new[] { relativePath });
+
+    private void TrackGitFilterPaths(
+        string repositoryRoot,
+        IEnumerable<string> relativePaths)
     {
-        foreach (var relativePath in relativePaths.Distinct(GetPathComparer()))
+        var root = Path.GetFullPath(repositoryRoot);
+        if (!_pendingGitFilterPaths.TryGetValue(root, out var pending))
         {
-            if (!repositoryProof.FilterAttributes.TryGetValue(relativePath, out var value))
-            {
-                throw new InvalidOperationException(
-                    $"{name} Git filter attributes did not include exact-source path: {relativePath}.");
-            }
-            if (!value.Equals("unspecified", StringComparison.Ordinal) &&
-                !value.Equals("unset", StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"{name} uses custom Git filter '{value}' and cannot be attested to the exact source commit: {relativePath}. " +
-                    "Exact Apple source inputs may use Git text/EOL normalization but not repository-configuration-dependent clean or smudge filters.");
-            }
+            pending = new HashSet<string>(GetPathComparer());
+            _pendingGitFilterPaths.Add(root, pending);
         }
+        pending.UnionWith(relativePaths.Where(static path => !string.IsNullOrWhiteSpace(path)));
+    }
+
+    internal void ValidatePendingGitFilters()
+    {
+        foreach (var repositoryRoot in _pendingGitFilterPaths.Keys.ToArray())
+            ValidatePendingGitFilters(repositoryRoot);
+    }
+
+    private void ValidatePendingGitFilters(string repositoryRoot)
+    {
+        var root = Path.GetFullPath(repositoryRoot);
+        if (!_pendingGitFilterPaths.TryGetValue(root, out var pending))
+            return;
+        EnsureNoCustomGitFilters(root, pending.ToArray(), "Apple exact-source input");
+        _pendingGitFilterPaths.Remove(root);
     }
 
     private TrackedRepositoryProof ReadTrackedRepositoryProof(string repositoryRoot)
@@ -124,7 +124,6 @@ internal sealed partial class AppleReleaseSourceTrustService
 
         var comparer = GetPathComparer();
         var indexEntries = new Dictionary<string, TrackedIndexEntry>(comparer);
-        var relativePaths = new List<string>();
         var stagedEntries = RunGit(root, "ls-files", "--stage", "-v", "-z")
             .StdOut.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
         foreach (var stagedEntry in stagedEntries)
@@ -144,14 +143,14 @@ internal sealed partial class AppleReleaseSourceTrustService
 
             var relativePath = stagedEntry.Substring(tab + 1);
             var fullPath = Path.GetFullPath(Path.Combine(root, relativePath));
-            if (!indexEntries.TryAdd(
-                    fullPath,
-                    new TrackedIndexEntry(fullPath, relativePath, stagedEntry.Substring(0, 1))))
+            if (indexEntries.ContainsKey(fullPath))
             {
                 throw new InvalidOperationException(
                     $"Tracked Apple source inputs contain duplicate Git index entries for: {relativePath}");
             }
-            relativePaths.Add(relativePath);
+            indexEntries.Add(
+                fullPath,
+                new TrackedIndexEntry(fullPath, relativePath, stagedEntry.Substring(0, 1)));
         }
 
         var headBlobIds = new Dictionary<string, string>(comparer);
@@ -169,48 +168,9 @@ internal sealed partial class AppleReleaseSourceTrustService
             headBlobIds[fullPath] = metadata[2];
         }
 
-        var filterAttributes = ReadGitFilterAttributes(root, relativePaths);
-        var proof = new TrackedRepositoryProof(indexEntries, headBlobIds, filterAttributes);
+        var proof = new TrackedRepositoryProof(indexEntries, headBlobIds);
         _trackedRepositoryProofs[root] = proof;
         return proof;
-    }
-
-    private Dictionary<string, string> ReadGitFilterAttributes(
-        string repositoryRoot,
-        IReadOnlyList<string> relativePaths)
-    {
-        const int maximumPathsPerInvocation = 256;
-        var result = new Dictionary<string, string>(GetPathComparer());
-        for (var offset = 0; offset < relativePaths.Count; offset += maximumPathsPerInvocation)
-        {
-            var batch = relativePaths.Skip(offset).Take(maximumPathsPerInvocation).ToArray();
-            var arguments = new List<string> { "check-attr", "-z", "filter", "--" };
-            arguments.AddRange(batch);
-            var attributes = RunGit(repositoryRoot, arguments.ToArray())
-                .StdOut.Split(new[] { '\0' }, StringSplitOptions.None);
-            var valueCount = attributes.Length > 0 && attributes[attributes.Length - 1].Length == 0
-                ? attributes.Length - 1
-                : attributes.Length;
-            if (valueCount != batch.Length * 3)
-            {
-                throw new InvalidOperationException(
-                    $"Git filter attributes could not be parsed safely for {batch.Length} tracked Apple source input(s).");
-            }
-            for (var index = 0; index < valueCount; index += 3)
-            {
-                var path = attributes[index];
-                var attribute = attributes[index + 1];
-                var value = attributes[index + 2];
-                if (!attribute.Equals("filter", StringComparison.Ordinal) ||
-                    !batch.Contains(path, GetPathComparer()))
-                {
-                    throw new InvalidOperationException(
-                        $"Git filter attributes returned an unexpected tracked Apple source path: {path}.");
-                }
-                result[path] = value;
-            }
-        }
-        return result;
     }
 
     private string ComputeRawGitBlobId(string repositoryRoot, string filePath)

--- a/PowerForge/Services/AppleReleaseSourceTrustService.GitBlobs.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.GitBlobs.cs
@@ -15,7 +15,6 @@ internal sealed partial class AppleReleaseSourceTrustService
         internal Dictionary<string, TrackedIndexEntry> IndexEntries { get; }
 
         internal Dictionary<string, string> HeadBlobIds { get; }
-
     }
 
     private sealed class TrackedIndexEntry

--- a/PowerForge/Services/AppleReleaseSourceTrustService.GitBlobs.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.GitBlobs.cs
@@ -4,17 +4,24 @@ internal sealed partial class AppleReleaseSourceTrustService
 {
     private sealed class TrackedRepositoryProof
     {
-        internal TrackedRepositoryProof(
-            Dictionary<string, TrackedIndexEntry> indexEntries,
-            Dictionary<string, string> headBlobIds)
+        internal TrackedRepositoryProof(IEqualityComparer<string> comparer)
         {
-            IndexEntries = indexEntries;
-            HeadBlobIds = headBlobIds;
+            IndexEntries = new Dictionary<string, TrackedIndexEntry>(comparer);
+            HeadBlobIds = new Dictionary<string, string>(comparer);
+            LoadedFilePaths = new HashSet<string>(comparer);
+            LoadedDirectoryPaths = new HashSet<string>(comparer);
+            FileProbeCountsByDirectory = new Dictionary<string, int>(comparer);
         }
 
         internal Dictionary<string, TrackedIndexEntry> IndexEntries { get; }
 
         internal Dictionary<string, string> HeadBlobIds { get; }
+
+        internal HashSet<string> LoadedFilePaths { get; }
+
+        internal HashSet<string> LoadedDirectoryPaths { get; }
+
+        internal Dictionary<string, int> FileProbeCountsByDirectory { get; }
     }
 
     private sealed class TrackedIndexEntry
@@ -115,16 +122,50 @@ internal sealed partial class AppleReleaseSourceTrustService
         _pendingGitFilterPaths.Remove(root);
     }
 
-    private TrackedRepositoryProof ReadTrackedRepositoryProof(string repositoryRoot)
+    private TrackedRepositoryProof ReadTrackedRepositoryProof(
+        string repositoryRoot,
+        string requestedPath,
+        bool recursive)
     {
+        const int directoryExpansionThreshold = 4;
         var root = Path.GetFullPath(repositoryRoot);
-        if (_trackedRepositoryProofs.TryGetValue(root, out var cached))
-            return cached;
-
         var comparer = GetPathComparer();
-        var indexEntries = new Dictionary<string, TrackedIndexEntry>(comparer);
-        var stagedEntries = RunGit(root, "ls-files", "--stage", "-v", "-z")
+        if (!_trackedRepositoryProofs.TryGetValue(root, out var proof))
+        {
+            proof = new TrackedRepositoryProof(comparer);
+            _trackedRepositoryProofs.Add(root, proof);
+        }
+
+        var requested = Path.GetFullPath(requestedPath);
+        if (proof.LoadedDirectoryPaths.Any(directory => IsPathAtOrWithin(requested, directory)) ||
+            (!recursive && proof.LoadedFilePaths.Contains(requested)))
+        {
+            return proof;
+        }
+
+        var scope = requested;
+        var loadDirectory = recursive;
+        if (!recursive)
+        {
+            var directory = Path.GetDirectoryName(requested) ?? root;
+            proof.FileProbeCountsByDirectory.TryGetValue(directory, out var probes);
+            probes++;
+            proof.FileProbeCountsByDirectory[directory] = probes;
+            // Keep small graphs exact-path scoped, then amortize repeated sibling
+            // lookups without ever expanding root-level files to the whole repository.
+            if (!comparer.Equals(directory, root) && probes >= directoryExpansionThreshold)
+            {
+                scope = directory;
+                loadDirectory = true;
+            }
+        }
+
+        var relativeScope = FrameworkCompatibility.GetRelativePath(root, scope).Replace('\\', '/');
+        if (string.IsNullOrWhiteSpace(relativeScope))
+            relativeScope = ".";
+        var stagedEntries = RunGit(root, "--literal-pathspecs", "ls-files", "--stage", "-v", "-z", "--", relativeScope)
             .StdOut.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
+        var seenIndexEntries = new HashSet<string>(comparer);
         foreach (var stagedEntry in stagedEntries)
         {
             var tab = stagedEntry.IndexOf('\t');
@@ -142,18 +183,16 @@ internal sealed partial class AppleReleaseSourceTrustService
 
             var relativePath = stagedEntry.Substring(tab + 1);
             var fullPath = Path.GetFullPath(Path.Combine(root, relativePath));
-            if (indexEntries.ContainsKey(fullPath))
+            if (!seenIndexEntries.Add(fullPath))
             {
                 throw new InvalidOperationException(
                     $"Tracked Apple source inputs contain duplicate Git index entries for: {relativePath}");
             }
-            indexEntries.Add(
-                fullPath,
-                new TrackedIndexEntry(fullPath, relativePath, stagedEntry.Substring(0, 1)));
+            proof.IndexEntries[fullPath] =
+                new TrackedIndexEntry(fullPath, relativePath, stagedEntry.Substring(0, 1));
         }
 
-        var headBlobIds = new Dictionary<string, string>(comparer);
-        var headEntries = RunGit(root, "ls-tree", "-r", "-z", "HEAD")
+        var headEntries = RunGit(root, "--literal-pathspecs", "ls-tree", "-r", "-z", "HEAD", "--", relativeScope)
             .StdOut.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
         foreach (var headEntry in headEntries)
         {
@@ -164,11 +203,13 @@ internal sealed partial class AppleReleaseSourceTrustService
             if (metadata.Length != 3 || !metadata[1].Equals("blob", StringComparison.Ordinal))
                 continue;
             var fullPath = Path.GetFullPath(Path.Combine(root, headEntry.Substring(tab + 1)));
-            headBlobIds[fullPath] = metadata[2];
+            proof.HeadBlobIds[fullPath] = metadata[2];
         }
 
-        var proof = new TrackedRepositoryProof(indexEntries, headBlobIds);
-        _trackedRepositoryProofs[root] = proof;
+        if (loadDirectory)
+            proof.LoadedDirectoryPaths.Add(scope);
+        else
+            proof.LoadedFilePaths.Add(requested);
         return proof;
     }
 

--- a/PowerForge/Services/AppleReleaseSourceTrustService.LocalBuild.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.LocalBuild.cs
@@ -70,7 +70,9 @@ internal sealed partial class AppleReleaseSourceTrustService
                             localPackageRoots);
                     }
                 }
-                return ReadApprovedTrackedPackageRevisions(root, packageLocks);
+                var revisions = ReadApprovedTrackedPackageRevisions(root, packageLocks);
+                ValidatePendingGitFilters();
+                return revisions;
             }
             finally
             {
@@ -135,6 +137,7 @@ internal sealed partial class AppleReleaseSourceTrustService
                         metadataPaths,
                         Array.Empty<string>());
                 }
+                ValidatePendingGitFilters();
             }
             finally
             {

--- a/PowerForge/Services/AppleReleaseSourceTrustService.RemotePackages.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.RemotePackages.cs
@@ -106,6 +106,7 @@ internal sealed partial class AppleReleaseSourceTrustService
             locks,
             new HashSet<string>(GetPathComparer()),
             validateRemoteDependencies);
+        ValidatePendingGitFilters(checkoutPath);
         _git.EnsureClean(checkoutPath);
         var headAfter = RunGit(checkoutPath, "rev-parse", "HEAD").StdOut.Trim();
         if (!headAfter.Equals(revision, StringComparison.OrdinalIgnoreCase))

--- a/PowerForge/Services/AppleReleaseSourceTrustService.Xcode.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.Xcode.cs
@@ -570,14 +570,17 @@ internal sealed partial class AppleReleaseSourceTrustService
                         $"{name} differs from the exact source commit: " +
                         relativePath);
                 }
-                if (!expectedBlob.Equals(worktreeBlob, StringComparison.OrdinalIgnoreCase) &&
-                    !expectedBlob.Equals(
-                        ComputePathAwareGitBlobId(repositoryRoot, fullPath, relativePath),
-                        StringComparison.OrdinalIgnoreCase))
+                if (!expectedBlob.Equals(worktreeBlob, StringComparison.OrdinalIgnoreCase))
                 {
-                    throw new InvalidOperationException(
-                        $"{name} differs from the exact source commit: " +
-                        relativePath);
+                    EnsureNoCustomGitFilter(repositoryRoot, relativePath, name);
+                    if (!expectedBlob.Equals(
+                            ComputePathAwareGitBlobId(repositoryRoot, fullPath, relativePath),
+                            StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException(
+                            $"{name} differs from the exact source commit: " +
+                            relativePath);
+                    }
                 }
                 _validatedTrackedFileBlobs[fullPath] = worktreeBlob;
                 ValidateSourceLevelIncludes(

--- a/PowerForge/Services/AppleReleaseSourceTrustService.Xcode.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.Xcode.cs
@@ -544,12 +544,11 @@ internal sealed partial class AppleReleaseSourceTrustService
             .Where(File.Exists)
             .Select(Path.GetFullPath)
             .ToArray();
-        EnsureNoCustomGitFilters(
-            repositoryProof,
+        TrackGitFilterPaths(
+            repositoryRoot,
             trackedFiles.Select(file => FrameworkCompatibility
                 .GetRelativePath(repositoryRoot, file)
-                .Replace('\\', '/')),
-            name);
+                .Replace('\\', '/')));
         foreach (var entry in entries)
         {
             if ((File.GetAttributes(entry) & FileAttributes.ReparsePoint) != 0)

--- a/PowerForge/Services/AppleReleaseSourceTrustService.Xcode.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.Xcode.cs
@@ -499,7 +499,7 @@ internal sealed partial class AppleReleaseSourceTrustService
         string? assemblerWorkingDirectory = null)
     {
         EnsureDirectoryWithinRepository(repositoryRoot, path, name);
-        var repositoryProof = ReadTrackedRepositoryProof(repositoryRoot);
+        var repositoryProof = ReadTrackedRepositoryProof(repositoryRoot, path, recursive: true);
         var indexEntries = repositoryProof.IndexEntries.Values
             .Where(entry => IsPathAtOrWithin(entry.FullPath, path))
             .ToArray();

--- a/PowerForge/Services/AppleReleaseSourceTrustService.Xcode.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.Xcode.cs
@@ -499,20 +499,20 @@ internal sealed partial class AppleReleaseSourceTrustService
         string? assemblerWorkingDirectory = null)
     {
         EnsureDirectoryWithinRepository(repositoryRoot, path, name);
-        var relativeRoot = FrameworkCompatibility.GetRelativePath(repositoryRoot, path).Replace('\\', '/');
-        var indexEntries = RunGit(repositoryRoot, "ls-files", "-v", "-z", "--", relativeRoot)
-            .StdOut.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
-        var hiddenEntry = indexEntries.FirstOrDefault(HasHiddenGitIndexState);
+        var repositoryProof = ReadTrackedRepositoryProof(repositoryRoot);
+        var indexEntries = repositoryProof.IndexEntries.Values
+            .Where(entry => IsPathAtOrWithin(entry.FullPath, path))
+            .ToArray();
+        var hiddenEntry = indexEntries.FirstOrDefault(entry => HasHiddenGitIndexState(entry.Tag));
         if (hiddenEntry is not null)
         {
             throw new InvalidOperationException(
-                $"{name} contains a skip-worktree or assume-unchanged Git index entry and cannot be attested: {hiddenEntry.Substring(2)}");
+                $"{name} contains a skip-worktree or assume-unchanged Git index entry and cannot be attested: {hiddenEntry.RelativePath}");
         }
         var tracked = indexEntries
-            .Where(static entry => entry.Length > 2 && entry[1] == ' ')
-            .Select(entry => Path.GetFullPath(Path.Combine(repositoryRoot, entry.Substring(2))))
+            .Select(static entry => entry.FullPath)
             .ToHashSet(GetPathComparer());
-        var headBlobs = ReadHeadTreeBlobIds(repositoryRoot, relativeRoot);
+        var headBlobs = repositoryProof.HeadBlobIds;
         var entries = EnumerateTreeWithoutLinks(path, name);
         var impliedDirectories = new HashSet<string>(GetPathComparer());
         foreach (var trackedPath in tracked.Where(File.Exists))
@@ -545,10 +545,10 @@ internal sealed partial class AppleReleaseSourceTrustService
             .Select(Path.GetFullPath)
             .ToArray();
         EnsureNoCustomGitFilters(
-            repositoryRoot,
-            trackedFiles
-                .Select(file => FrameworkCompatibility.GetRelativePath(repositoryRoot, file).Replace('\\', '/'))
-                .ToArray(),
+            repositoryProof,
+            trackedFiles.Select(file => FrameworkCompatibility
+                .GetRelativePath(repositoryRoot, file)
+                .Replace('\\', '/')),
             name);
         foreach (var entry in entries)
         {

--- a/PowerForge/Services/AppleReleaseSourceTrustService.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.cs
@@ -588,7 +588,7 @@ internal sealed partial class AppleReleaseSourceTrustService
         }
 
         var relative = FrameworkCompatibility.GetRelativePath(repositoryRoot, candidate).Replace('\\', '/');
-        var repositoryProof = ReadTrackedRepositoryProof(repositoryRoot);
+        var repositoryProof = ReadTrackedRepositoryProof(repositoryRoot, candidate, recursive: false);
         if (!repositoryProof.IndexEntries.TryGetValue(candidate, out var tracked))
             throw new InvalidOperationException($"{name} must be tracked at the exact source commit: {relative}");
         if (HasHiddenGitIndexState(tracked.Tag))

--- a/PowerForge/Services/AppleReleaseSourceTrustService.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.cs
@@ -30,6 +30,7 @@ internal sealed partial class AppleReleaseSourceTrustService
     private readonly HashSet<string> _remotePackagesUnderValidation = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _validatedRemotePackages = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, string> _validatedTrackedFileBlobs = new(GetPathComparer());
+    private readonly Dictionary<string, TrackedRepositoryProof> _trackedRepositoryProofs = new(GetPathComparer());
     private readonly HashSet<string> _validatedSourceIncludeFiles = new(GetPathComparer());
     private readonly HashSet<string> _validatedAssemblerInputFiles = new(GetPathComparer());
     private readonly HashSet<string> _validatedSourceSemanticInputs = new(StringComparer.Ordinal);
@@ -175,6 +176,7 @@ internal sealed partial class AppleReleaseSourceTrustService
         _remotePackagesUnderValidation.Clear();
         _validatedRemotePackages.Clear();
         _validatedTrackedFileBlobs.Clear();
+        _trackedRepositoryProofs.Clear();
         _validatedSourceIncludeFiles.Clear();
         _validatedAssemblerInputFiles.Clear();
         _validatedSourceSemanticInputs.Clear();
@@ -582,23 +584,19 @@ internal sealed partial class AppleReleaseSourceTrustService
         }
 
         var relative = FrameworkCompatibility.GetRelativePath(repositoryRoot, candidate).Replace('\\', '/');
-        var tracked = RunGitAllowFailure(repositoryRoot, "ls-files", "-v", "--error-unmatch", "--", relative);
-        if (!tracked.Succeeded)
+        var repositoryProof = ReadTrackedRepositoryProof(repositoryRoot);
+        if (!repositoryProof.IndexEntries.TryGetValue(candidate, out var tracked))
             throw new InvalidOperationException($"{name} must be tracked at the exact source commit: {relative}");
-        var indexEntry = tracked.StdOut
-            .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-            .FirstOrDefault();
-        if (HasHiddenGitIndexState(indexEntry))
+        if (HasHiddenGitIndexState(tracked.Tag))
         {
             throw new InvalidOperationException(
                 $"{name} uses a skip-worktree or assume-unchanged Git index flag and cannot be attested to the exact source commit: {relative}");
         }
-        var headBlob = RunGitAllowFailure(repositoryRoot, "rev-parse", "--verify", $"HEAD:{relative}");
-        if (!headBlob.Succeeded || string.IsNullOrWhiteSpace(headBlob.StdOut))
+        if (!repositoryProof.HeadBlobIds.TryGetValue(candidate, out var expectedBlob) ||
+            string.IsNullOrWhiteSpace(expectedBlob))
             throw new InvalidOperationException($"{name} is not present in the exact source commit: {relative}");
-        EnsureNoCustomGitFilter(repositoryRoot, relative, name);
+        EnsureNoCustomGitFilter(repositoryProof, relative, name);
         var worktreeBlob = capturedWorktreeBlob ?? ComputeRawGitBlobId(repositoryRoot, candidate);
-        var expectedBlob = headBlob.StdOut.Trim();
         if (!expectedBlob.Equals(worktreeBlob, StringComparison.OrdinalIgnoreCase))
         {
             var filteredWorktreeBlob = capturedWorktreeBytes is null
@@ -624,30 +622,8 @@ internal sealed partial class AppleReleaseSourceTrustService
         return reader.ReadToEnd();
     }
 
-    private Dictionary<string, string> ReadHeadTreeBlobIds(string repositoryRoot, string relativeRoot)
-    {
-        var comparer = GetPathComparer();
-        var result = new Dictionary<string, string>(comparer);
-        var entries = RunGit(repositoryRoot, "ls-tree", "-r", "-z", "HEAD", "--", relativeRoot)
-            .StdOut.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
-        foreach (var entry in entries)
-        {
-            var tab = entry.IndexOf('\t');
-            if (tab < 0)
-                continue;
-            var header = entry.Substring(0, tab).Split(' ');
-            if (header.Length != 3 || !header[1].Equals("blob", StringComparison.Ordinal))
-                continue;
-            var fullPath = Path.GetFullPath(Path.Combine(repositoryRoot, entry.Substring(tab + 1)));
-            result[fullPath] = header[2];
-        }
-        return result;
-    }
-
     private static bool HasHiddenGitIndexState(string? entry)
         => !string.IsNullOrWhiteSpace(entry) &&
-           entry!.Length > 2 &&
-           entry[1] == ' ' &&
            (entry[0] == 'S' || char.IsLower(entry[0]));
 
     private static void EnsureDirectoryWithinRepository(string repositoryRoot, string path, string name)

--- a/PowerForge/Services/AppleReleaseSourceTrustService.cs
+++ b/PowerForge/Services/AppleReleaseSourceTrustService.cs
@@ -31,6 +31,7 @@ internal sealed partial class AppleReleaseSourceTrustService
     private readonly HashSet<string> _validatedRemotePackages = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, string> _validatedTrackedFileBlobs = new(GetPathComparer());
     private readonly Dictionary<string, TrackedRepositoryProof> _trackedRepositoryProofs = new(GetPathComparer());
+    private readonly Dictionary<string, HashSet<string>> _pendingGitFilterPaths = new(GetPathComparer());
     private readonly HashSet<string> _validatedSourceIncludeFiles = new(GetPathComparer());
     private readonly HashSet<string> _validatedAssemblerInputFiles = new(GetPathComparer());
     private readonly HashSet<string> _validatedSourceSemanticInputs = new(StringComparer.Ordinal);
@@ -95,6 +96,7 @@ internal sealed partial class AppleReleaseSourceTrustService
             ?? throw new InvalidOperationException("The release configuration does not contain an AppleApps contract.");
         var generatedOutputs = ResolveGeneratedOutputPaths(releaseConfigPath, options);
         ValidateAppleInputs(root, releaseConfigPath, options, generatedOutputs);
+        ValidatePendingGitFilters();
 
         EnsureNoGitReplacementRefs(root);
         _git.EnsureClean(root);
@@ -162,6 +164,7 @@ internal sealed partial class AppleReleaseSourceTrustService
         }
 
         ValidateAppleInputs(root, releaseConfigPath, options, generatedOutputs);
+        ValidatePendingGitFilters();
         EnsureNoGitReplacementRefs(root);
         EnsureNoUnexpectedWorktreeChanges(root, generatedOutputs);
         if (!ReadExactHead(root).Equals(snapshot.SourceCommit, StringComparison.OrdinalIgnoreCase))
@@ -177,6 +180,7 @@ internal sealed partial class AppleReleaseSourceTrustService
         _validatedRemotePackages.Clear();
         _validatedTrackedFileBlobs.Clear();
         _trackedRepositoryProofs.Clear();
+        _pendingGitFilterPaths.Clear();
         _validatedSourceIncludeFiles.Clear();
         _validatedAssemblerInputFiles.Clear();
         _validatedSourceSemanticInputs.Clear();
@@ -595,10 +599,11 @@ internal sealed partial class AppleReleaseSourceTrustService
         if (!repositoryProof.HeadBlobIds.TryGetValue(candidate, out var expectedBlob) ||
             string.IsNullOrWhiteSpace(expectedBlob))
             throw new InvalidOperationException($"{name} is not present in the exact source commit: {relative}");
-        EnsureNoCustomGitFilter(repositoryProof, relative, name);
+        TrackGitFilterPath(repositoryRoot, relative);
         var worktreeBlob = capturedWorktreeBlob ?? ComputeRawGitBlobId(repositoryRoot, candidate);
         if (!expectedBlob.Equals(worktreeBlob, StringComparison.OrdinalIgnoreCase))
         {
+            EnsureNoCustomGitFilter(repositoryRoot, relative, name);
             var filteredWorktreeBlob = capturedWorktreeBytes is null
                 ? ComputePathAwareGitBlobId(repositoryRoot, candidate, relative)
                 : ComputePathAwareGitBlobId(repositoryRoot, capturedWorktreeBytes, relative);
@@ -624,7 +629,7 @@ internal sealed partial class AppleReleaseSourceTrustService
 
     private static bool HasHiddenGitIndexState(string? entry)
         => !string.IsNullOrWhiteSpace(entry) &&
-           (entry[0] == 'S' || char.IsLower(entry[0]));
+           (entry![0] == 'S' || char.IsLower(entry[0]));
 
     private static void EnsureDirectoryWithinRepository(string repositoryRoot, string path, string name)
     {


### PR DESCRIPTION
## Summary

- batch exact-source Git index and HEAD proofs across Apple build inputs instead of spawning several Git processes per file
- scope small build graphs to literal consumed paths, then adaptively cache only repeated sibling directories instead of materializing an entire monorepo
- validate custom Git filters only for inputs the selected build graph actually consumes, while keeping checks adjacent to filter-aware hashing
- finalize filter proof before temporary Swift package checkouts are removed, including concurrent plan runs
- preserve PowerForge net472, net8.0, and net10.0 targets

## User impact

powerforge apple-deploy --plan no longer appears to hang while inspecting a normal Xcode graph. CasaRay iOS and Mac Catalyst plans complete in tens of seconds, including when run concurrently, while retaining exact-source, hidden-index, custom-filter, and source-mutation protections. Small projects inside large monorepos no longer pay repository-wide index and HEAD materialization costs.

## Validation

- 47 Apple source-trust, provenance, and local-build contracts pass
- all PowerForge target frameworks build with zero warnings and errors
- clean CasaRay iOS Plus and Mac Catalyst Plus plans pass concurrently on the final candidate