### PR TITLE
Preserve tracked inputs in Apple build mirrors

### DIFF
--- a/PowerForge.Tests/AppleBuildProvenanceTests.cs
+++ b/PowerForge.Tests/AppleBuildProvenanceTests.cs
@@ -403,6 +403,34 @@ public sealed class AppleBuildProvenanceTests
     }
 
     [Fact]
+    public void RejectIgnoredBuildInputs_rejects_ignored_outputs_beside_tracked_generated_root_inputs()
+    {
+        var root = CreateRepository();
+        try
+        {
+            var build = Directory.CreateDirectory(Path.Combine(root.FullName, "build"));
+            File.WriteAllText(Path.Combine(build.FullName, "build.sh"), "#!/bin/sh\n");
+            RunGit(root.FullName, "add", "build/build.sh");
+            RunGit(root.FullName, "commit", "-m", "track build helper");
+            File.WriteAllText(Path.Combine(root.FullName, ".gitignore"), "build/*\n");
+            RunGit(root.FullName, "add", ".gitignore");
+            RunGit(root.FullName, "commit", "-m", "ignore build outputs");
+            File.WriteAllText(Path.Combine(build.FullName, "generated.xcconfig"), "SETTING = local");
+
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => AppleBuildProvenance.RejectIgnoredBuildInputs(
+                    root.FullName,
+                    excludesGeneratedDirectories: true));
+
+            Assert.Contains("build/generated.xcconfig", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void RejectIgnoredBuildInputs_rejects_nested_generated_named_directories_for_mirrors()
     {
         var root = CreateRepository();

--- a/PowerForge.Tests/AppleDeviceDeploymentServiceTests.PackageSnapshotWave.cs
+++ b/PowerForge.Tests/AppleDeviceDeploymentServiceTests.PackageSnapshotWave.cs
@@ -113,6 +113,68 @@ public sealed partial class AppleDeviceDeploymentServiceTests
     }
 
     [Fact]
+    public async Task DeployAsync_resolves_packages_from_the_build_mirror()
+    {
+        if (!File.Exists("/usr/bin/rsync"))
+            return;
+
+        var fixture = CreateLocalPackageBuildFixture();
+        var mirrorPath = ExternalOutputPath(
+            new DirectoryInfo(fixture.RootPath),
+            "BuildMirror");
+        try
+        {
+            var runner = new LocalPackageBuildRunner(
+                fixture.RemoteRoot,
+                fixture.RemoteUrl,
+                mutateDuringBuild: false,
+                executeRsync: true);
+
+            var result = await new AppleDeviceDeploymentService(runner).DeployAsync(
+                new AppleAppDeviceDeploymentRequest
+                {
+                    ProjectPath = fixture.ProjectPath,
+                    BuildRoot = fixture.RootPath,
+                    BuildMirrorPath = mirrorPath,
+                    UseBuildMirror = true,
+                    RsyncExecutable = "/usr/bin/rsync",
+                    Scheme = "CasaRay",
+                    ProductName = "CasaRay",
+                    DerivedDataPath = fixture.DerivedDataPath,
+                    DeviceIdentifier = "device-1",
+                    BundleIdentifier = "com.evotecit.casaray",
+                    Launch = false,
+                    XcodeBuildExecutable = "/usr/bin/xcodebuild",
+                    XcrunExecutable = "/usr/bin/xcrun"
+                });
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(4, runner.Requests.Count);
+            var resolve = runner.Requests[1];
+            var build = runner.Requests[2];
+            var mirroredProjectPath = Path.Combine(
+                mirrorPath,
+                Path.GetRelativePath(fixture.RootPath, fixture.ProjectPath));
+            Assert.Equal(
+                AppleReleaseArtifactService.ResolvePhysicalPath(mirroredProjectPath),
+                AppleReleaseArtifactService.ResolvePhysicalPath(
+                    ReadArgumentValue(resolve, "-project")));
+            Assert.Equal(
+                AppleReleaseArtifactService.ResolvePhysicalPath(mirroredProjectPath),
+                AppleReleaseArtifactService.ResolvePhysicalPath(
+                    ReadArgumentValue(build, "-project")));
+            Assert.NotEqual(
+                AppleReleaseArtifactService.ResolvePhysicalPath(fixture.ProjectPath),
+                AppleReleaseArtifactService.ResolvePhysicalPath(
+                    ReadArgumentValue(resolve, "-project")));
+        }
+        finally
+        {
+            fixture.Dispose();
+        }
+    }
+
+    [Fact]
     public void Materialized_package_validation_accepts_an_owned_mirror_through_a_path_alias()
     {
         if (Path.DirectorySeparatorChar == '\\')
@@ -619,17 +681,20 @@ public sealed partial class AppleDeviceDeploymentServiceTests
         private readonly string _remoteUrl;
         private readonly bool _mutateDuringBuild;
         private readonly bool _replaceSnapshotRootDuringBuild;
+        private readonly bool _executeRsync;
 
         internal LocalPackageBuildRunner(
             string remoteRoot,
             string remoteUrl,
             bool mutateDuringBuild,
-            bool replaceSnapshotRootDuringBuild = false)
+            bool replaceSnapshotRootDuringBuild = false,
+            bool executeRsync = false)
         {
             _remoteRoot = remoteRoot;
             _remoteUrl = remoteUrl;
             _mutateDuringBuild = mutateDuringBuild;
             _replaceSnapshotRootDuringBuild = replaceSnapshotRootDuringBuild;
+            _executeRsync = executeRsync;
         }
 
         internal List<ProcessRunRequest> Requests { get; } = new();
@@ -641,6 +706,12 @@ public sealed partial class AppleDeviceDeploymentServiceTests
             CancellationToken cancellationToken = default)
         {
             Requests.Add(request);
+            if (_executeRsync &&
+                request.FileName.Equals("/usr/bin/rsync", StringComparison.Ordinal))
+            {
+                return new ProcessRunner().RunAsync(request, cancellationToken);
+            }
+
             request.InvokePreStartBoundary();
             request.InvokeStartBoundary();
             if (request.Arguments.Contains("-resolvePackageDependencies"))

--- a/PowerForge.Tests/AppleDeviceDeploymentServiceTests.SourceIntegrityWave.cs
+++ b/PowerForge.Tests/AppleDeviceDeploymentServiceTests.SourceIntegrityWave.cs
@@ -215,7 +215,7 @@ public sealed partial class AppleDeviceDeploymentServiceTests
     }
 
     [Fact]
-    public async Task BuildAsync_rejects_tracked_inputs_hidden_by_root_mirror_exclusions()
+    public async Task BuildAsync_preserves_tracked_inputs_under_generated_named_roots()
     {
         var root = Directory.CreateDirectory(Path.Combine(
             Path.GetTempPath(),
@@ -230,7 +230,70 @@ public sealed partial class AppleDeviceDeploymentServiceTests
             var build = Directory.CreateDirectory(Path.Combine(root.FullName, "build"));
             File.WriteAllText(Path.Combine(build.FullName, "schema.json"), "{}");
             InitializeGitRepository(root.FullName);
-            var runner = new CapturingProcessRunner(_ => Success("unexpected"));
+            var runner = new CapturingProcessRunner(request =>
+            {
+                if (request.FileName.Equals("/usr/bin/xcodebuild", StringComparison.Ordinal))
+                {
+                    Directory.CreateDirectory(Path.Combine(
+                        request.WorkingDirectory,
+                        ".swiftpm",
+                        "xcode",
+                        "xcuserdata"));
+                }
+                return Success("ok");
+            });
+
+            var result = await new AppleDeviceDeploymentService(runner).BuildAsync(
+                new AppleAppBuildRequest
+                {
+                    ProjectPath = project.FullName,
+                    BuildRoot = root.FullName,
+                    Scheme = "CasaRay",
+                    Destination = "id=device-1",
+                    DerivedDataPath = ExternalOutputPath(root, "DerivedData"),
+                    UseBuildMirror = true
+                });
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(2, runner.Requests.Count);
+            Assert.Equal("/usr/bin/rsync", runner.Requests[0].FileName);
+            Assert.DoesNotContain("/build", runner.Requests[0].Arguments);
+            Assert.Contains("/.build", runner.Requests[0].Arguments);
+            Assert.Contains("/.swiftpm", runner.Requests[0].Arguments);
+            Assert.Contains("/DerivedData", runner.Requests[0].Arguments);
+        }
+        finally
+        {
+            DeleteExternalOutputs(root);
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task BuildAsync_rejects_file_injection_under_an_excluded_generated_mirror_root()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(root.FullName, "CasaRay.xcodeproj"));
+            File.WriteAllText(Path.Combine(project.FullName, "project.pbxproj"), string.Empty);
+            InitializeGitRepository(root.FullName);
+            var runner = new CapturingProcessRunner(request =>
+            {
+                if (request.FileName.Equals("/usr/bin/xcodebuild", StringComparison.Ordinal))
+                {
+                    var swiftPackageState = Directory.CreateDirectory(Path.Combine(
+                        request.WorkingDirectory,
+                        ".swiftpm"));
+                    File.WriteAllText(
+                        Path.Combine(swiftPackageState.FullName, "configuration.json"),
+                        "{}");
+                }
+                return Success("ok");
+            });
 
             var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
                 new AppleDeviceDeploymentService(runner).BuildAsync(new AppleAppBuildRequest
@@ -243,9 +306,113 @@ public sealed partial class AppleDeviceDeploymentServiceTests
                     UseBuildMirror = true
                 }));
 
-            Assert.Contains("build/schema.json", error.Message, StringComparison.Ordinal);
-            Assert.Contains("disable the build mirror", error.Message, StringComparison.OrdinalIgnoreCase);
-            Assert.Empty(runner.Requests);
+            Assert.Contains("local Apple build mirror changed", error.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(".swiftpm", error.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteExternalOutputs(root);
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task BuildAsync_rejects_a_generated_mirror_root_symlink_injection()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        var outside = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests.Outside",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(root.FullName, "CasaRay.xcodeproj"));
+            File.WriteAllText(Path.Combine(project.FullName, "project.pbxproj"), string.Empty);
+            InitializeGitRepository(root.FullName);
+            var runner = new CapturingProcessRunner(request =>
+            {
+                if (request.FileName.Equals("/usr/bin/xcodebuild", StringComparison.Ordinal))
+                {
+                    Directory.CreateSymbolicLink(
+                        Path.Combine(request.WorkingDirectory, ".swiftpm"),
+                        outside.FullName);
+                }
+                return Success("ok");
+            });
+
+            var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                new AppleDeviceDeploymentService(runner).BuildAsync(new AppleAppBuildRequest
+                {
+                    ProjectPath = project.FullName,
+                    BuildRoot = root.FullName,
+                    Scheme = "CasaRay",
+                    Destination = "id=device-1",
+                    DerivedDataPath = ExternalOutputPath(root, "DerivedData"),
+                    UseBuildMirror = true
+                }));
+
+            Assert.Contains("local Apple build mirror changed", error.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(".swiftpm", error.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteExternalOutputs(root);
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+            try { outside.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task BuildAsync_does_not_ignore_case_aliases_of_excluded_generated_roots()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            if (FrameworkCompatibility.GetPathStringComparisonForPath(root.FullName) !=
+                StringComparison.OrdinalIgnoreCase)
+            {
+                return;
+            }
+
+            var project = Directory.CreateDirectory(Path.Combine(root.FullName, "CasaRay.xcodeproj"));
+            File.WriteAllText(Path.Combine(project.FullName, "project.pbxproj"), string.Empty);
+            var build = Directory.CreateDirectory(Path.Combine(root.FullName, "Build"));
+            File.WriteAllText(Path.Combine(build.FullName, "schema.json"), "{}");
+            InitializeGitRepository(root.FullName);
+            var runner = new CapturingProcessRunner(request =>
+            {
+                if (request.FileName.Equals("/usr/bin/xcodebuild", StringComparison.Ordinal))
+                {
+                    Directory.CreateDirectory(Path.Combine(request.WorkingDirectory, "Build"));
+                    File.WriteAllText(
+                        Path.Combine(request.WorkingDirectory, "Build", "schema.json"),
+                        "changed");
+                }
+                return Success("ok");
+            });
+
+            var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                new AppleDeviceDeploymentService(runner).BuildAsync(new AppleAppBuildRequest
+                {
+                    ProjectPath = project.FullName,
+                    BuildRoot = root.FullName,
+                    Scheme = "CasaRay",
+                    Destination = "id=device-1",
+                    DerivedDataPath = ExternalOutputPath(root, "DerivedData"),
+                    UseBuildMirror = true
+                }));
+
+            Assert.Contains("local Apple build mirror changed", error.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Build", error.Message, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge/Services/AppleBuildProvenance.cs
+++ b/PowerForge/Services/AppleBuildProvenance.cs
@@ -7,6 +7,8 @@ namespace PowerForge;
 internal static class AppleBuildProvenance
 {
     internal const string XcodeBuildSetting = "POWERFORGE_SOURCE_REVISION";
+    private static readonly string[] GeneratedRootPaths =
+        [".build", ".swiftpm", "build", "DerivedData"];
 
     internal sealed class Snapshot
     {
@@ -18,6 +20,7 @@ internal static class AppleBuildProvenance
             RootPath = rootPath;
             Revision = revision;
             TrackedFileMutationIdentities = trackedFileMutationIdentities;
+            MirrorExcludedRootPaths = Array.Empty<string>();
         }
 
         internal string RootPath { get; }
@@ -26,6 +29,8 @@ internal static class AppleBuildProvenance
 
         internal IReadOnlyDictionary<string, string>
             TrackedFileMutationIdentities { get; }
+
+        internal IReadOnlyCollection<string> MirrorExcludedRootPaths { get; set; }
     }
 
     internal static string? ResolveLocalSourceRevision(string projectRoot)
@@ -92,9 +97,17 @@ internal static class AppleBuildProvenance
     {
         var snapshot = Capture(sourceRoot);
         if (excludesGeneratedDirectories)
-            RejectTrackedMirrorExclusions(sourceRoot);
-        RejectIgnoredBuildInputs(sourceRoot, excludesGeneratedDirectories);
-        RejectSymbolicLinkBuildInputs(sourceRoot, excludesGeneratedDirectories);
+        {
+            snapshot.MirrorExcludedRootPaths = ResolveMirrorExcludedRootPaths(sourceRoot);
+        }
+        RejectIgnoredBuildInputs(
+            sourceRoot,
+            excludesGeneratedDirectories,
+            snapshot.MirrorExcludedRootPaths);
+        RejectSymbolicLinkBuildInputs(
+            sourceRoot,
+            excludesGeneratedDirectories,
+            snapshot.MirrorExcludedRootPaths);
         return snapshot;
     }
 
@@ -149,41 +162,48 @@ internal static class AppleBuildProvenance
             "Declare build inputs in tracked Xcode project or workspace metadata instead.");
     }
 
-    private static void RejectTrackedMirrorExclusions(string sourceRoot)
+    private static IReadOnlyCollection<string> ResolveMirrorExcludedRootPaths(string sourceRoot)
     {
         var root = Path.GetFullPath(sourceRoot);
         var git = GitClient.CreateTrustedSystemClient(
             defaultTimeout: TimeSpan.FromSeconds(10));
         var tracked = git.RunRawAsync(
                 root,
-                ["ls-files", "-z", "--", ".build", ".swiftpm", "build", "DerivedData"])
+                ["ls-files", "-z", "--", .. GeneratedRootPaths])
             .GetAwaiter()
             .GetResult();
         if (!tracked.Succeeded)
         {
             throw new InvalidOperationException(
-                "Unable to verify tracked Apple build-mirror exclusions. " +
+                "Unable to resolve safe Apple build-mirror exclusions. " +
                 (string.IsNullOrWhiteSpace(tracked.StdErr)
                     ? "git ls-files failed."
                     : tracked.StdErr.Trim()));
         }
 
-        var excluded = tracked.StdOut
+        var trackedRoots = tracked.StdOut
             .Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries)
-            .Take(5)
+            .Select(GetRootPathSegment)
+            .ToHashSet(StringComparer.Ordinal);
+        return GeneratedRootPaths
+            .Where(path => !trackedRoots.Contains(path))
             .ToArray();
-        if (excluded.Length == 0)
-            return;
-
-        throw new InvalidOperationException(
-            "Apple build-mirror exclusions contain tracked source inputs: " +
-            string.Join(", ", excluded) +
-            ". Relocate those tracked inputs or disable the build mirror so xcodebuild consumes the complete attested source tree.");
     }
 
     internal static void RejectIgnoredBuildInputs(
         string sourceRoot,
         bool excludesGeneratedDirectories)
+        => RejectIgnoredBuildInputs(
+            sourceRoot,
+            excludesGeneratedDirectories,
+            excludesGeneratedDirectories
+                ? ResolveMirrorExcludedRootPaths(sourceRoot)
+                : Array.Empty<string>());
+
+    private static void RejectIgnoredBuildInputs(
+        string sourceRoot,
+        bool excludesGeneratedDirectories,
+        IReadOnlyCollection<string> excludedRootPaths)
     {
         var root = Path.GetFullPath(sourceRoot);
         var git = GitClient.CreateTrustedSystemClient(
@@ -204,7 +224,8 @@ internal static class AppleBuildProvenance
 
         var unexpected = ignored.StdOut
             .Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries)
-            .Where(path => !excludesGeneratedDirectories || !IsExcludedGeneratedPath(path))
+            .Where(path => !excludesGeneratedDirectories ||
+                           !IsExcludedGeneratedPath(path, excludedRootPaths))
             .Take(5)
             .ToArray();
         if (unexpected.Length == 0)
@@ -219,6 +240,17 @@ internal static class AppleBuildProvenance
     internal static void RejectSymbolicLinkBuildInputs(
         string sourceRoot,
         bool excludesGeneratedDirectories)
+        => RejectSymbolicLinkBuildInputs(
+            sourceRoot,
+            excludesGeneratedDirectories,
+            excludesGeneratedDirectories
+                ? ResolveMirrorExcludedRootPaths(sourceRoot)
+                : Array.Empty<string>());
+
+    private static void RejectSymbolicLinkBuildInputs(
+        string sourceRoot,
+        bool excludesGeneratedDirectories,
+        IReadOnlyCollection<string> excludedRootPaths)
     {
         var root = Path.GetFullPath(sourceRoot);
         var pendingDirectories = new Stack<string>();
@@ -234,7 +266,8 @@ internal static class AppleBuildProvenance
                     .Replace('\\', '/');
                 if (relativePath.Equals(".git", StringComparison.Ordinal) ||
                     relativePath.StartsWith(".git/", StringComparison.Ordinal) ||
-                    excludesGeneratedDirectories && IsExcludedGeneratedPath(relativePath))
+                    excludesGeneratedDirectories &&
+                    IsExcludedGeneratedPath(relativePath, excludedRootPaths))
                 {
                     continue;
                 }
@@ -599,16 +632,18 @@ internal static class AppleBuildProvenance
         }
     }
 
-    private static bool IsExcludedGeneratedPath(string path)
+    private static bool IsExcludedGeneratedPath(
+        string path,
+        IReadOnlyCollection<string> excludedRootPaths)
+    {
+        var rootSegment = GetRootPathSegment(path);
+        return excludedRootPaths.Contains(rootSegment, StringComparer.Ordinal);
+    }
+
+    private static string GetRootPathSegment(string path)
     {
         var normalized = path.Replace('\\', '/').TrimStart('/');
         var separator = normalized.IndexOf('/');
-        var rootSegment = separator < 0
-            ? normalized
-            : normalized.Substring(0, separator);
-        return rootSegment.Equals(".build", StringComparison.Ordinal) ||
-               rootSegment.Equals(".swiftpm", StringComparison.Ordinal) ||
-               rootSegment.Equals("build", StringComparison.Ordinal) ||
-               rootSegment.Equals("DerivedData", StringComparison.Ordinal);
+        return separator < 0 ? normalized : normalized.Substring(0, separator);
     }
 }

--- a/PowerForge/Services/AppleDeviceDeploymentService.Mirror.cs
+++ b/PowerForge/Services/AppleDeviceDeploymentService.Mirror.cs
@@ -7,6 +7,7 @@ public sealed partial class AppleDeviceDeploymentService
         AppleAppBuildRequest request,
         string rsyncExecutable,
         StringComparison sourcePathComparison,
+        IReadOnlyCollection<string> excludedGeneratedRootPaths,
         CancellationToken cancellationToken)
     {
         var sourceRoot = ResolveBuildRoot(projectPath, request.BuildRoot);
@@ -41,7 +42,11 @@ public sealed partial class AppleDeviceDeploymentService
             "local Apple build mirror",
             "xcodebuild",
             "Discard the product and rebuild the mirror.",
-            enableImmediately: false);
+            enableImmediately: false,
+            ignoredMutation: args => IsExpectedGeneratedMirrorDirectoryMutation(
+                args,
+                mirrorPath,
+                excludedGeneratedRootPaths));
 
         try
         {
@@ -52,17 +57,14 @@ public sealed partial class AppleDeviceDeploymentService
                 "--delete-excluded",
                 "--exclude",
                 "/.git",
-                "--exclude",
-                "/.build",
-                "--exclude",
-                "/.swiftpm",
-                "--exclude",
-                "/build",
-                "--exclude",
-                "/DerivedData",
-                normalizedSourceRoot,
-                normalizedMirrorPath
             };
+            foreach (var excludedRootPath in excludedGeneratedRootPaths)
+            {
+                args.Add("--exclude");
+                args.Add("/" + excludedRootPath);
+            }
+            args.Add(normalizedSourceRoot);
+            args.Add(normalizedMirrorPath);
 
             var processRequest = AppleTrustedExecutionEnvironment.CreateProcessRequest(
                 rsyncExecutable,
@@ -146,6 +148,36 @@ public sealed partial class AppleDeviceDeploymentService
             fullCandidate.StartsWith(
                 EnsureTrailingDirectorySeparator(fullRoot),
                 comparison);
+    }
+
+    private static bool IsExpectedGeneratedMirrorDirectoryMutation(
+        FileSystemEventArgs args,
+        string mirrorPath,
+        IReadOnlyCollection<string> excludedGeneratedRootPaths)
+    {
+        if (args.ChangeType != WatcherChangeTypes.Created &&
+            args.ChangeType != WatcherChangeTypes.Changed)
+            return false;
+        if (!excludedGeneratedRootPaths.Any(rootPath =>
+                IsSameOrDescendant(
+                    args.FullPath,
+                    Path.Combine(mirrorPath, rootPath),
+                    StringComparison.Ordinal)))
+        {
+            return false;
+        }
+
+        try
+        {
+            var attributes = File.GetAttributes(args.FullPath);
+            return (attributes & FileAttributes.Directory) != 0 &&
+                   (attributes & FileAttributes.ReparsePoint) == 0;
+        }
+        catch
+        {
+            // If the event target disappeared or cannot be inspected, fail closed.
+            return false;
+        }
     }
 
     private static void ValidatePhysicalMirrorBoundary(

--- a/PowerForge/Services/AppleDeviceDeploymentService.cs
+++ b/PowerForge/Services/AppleDeviceDeploymentService.cs
@@ -213,6 +213,7 @@ public sealed partial class AppleDeviceDeploymentService
                     request,
                     rsyncExecutable!,
                     sourcePathComparison,
+                    sourceSnapshot.MirrorExcludedRootPaths,
                     cancellationToken).ConfigureAwait(false);
                 if (!mirror.ProcessResult.Succeeded)
                 {
@@ -418,7 +419,7 @@ public sealed partial class AppleDeviceDeploymentService
                 packageSnapshot = await AppleSwiftPackageBuildSnapshot.CreateAsync(
                         _processRunner,
                         xcodeBuildExecutable,
-                        projectPath,
+                        buildProjectPath,
                         request.IsWorkspace,
                         request.Scheme.Trim(),
                         approvedPackageRevisions,


### PR DESCRIPTION
## Summary

Apple build mirrors now preserve legitimate tracked inputs even when they live under conventional generated-directory names such as `build`. PowerForge excludes only generated roots that contain no tracked source, while still rejecting ignored files and symbolic links beside copied tracked inputs.

Mirror monitoring now permits only ordinary generated-directory creation inside excluded roots. File injection, symbolic links, deletes, renames, disappearing paths, and case-alias mutations remain build-stopping integrity failures.

Swift package dependency resolution now uses the same attested build mirror as compilation. Approved package declarations continue to come from the original exact source checkout.

## User impact

Repositories such as CasaRay can keep tracked build helpers under `build/` and let Xcode create `.swiftpm` state without disabling exact-source enforcement or modifying the live checkout during local device deployment.

## Validation

- 30 focused Apple provenance, mirror, and package-snapshot tests passed
- PowerForge builds passed for .NET Framework 4.7.2, .NET 8, and .NET 10 with no warnings
- A clean detached CasaRay checkout built and installed CasaRay 2.0 (18) on EvoPhone through the mirror; automatic launch alone was denied because the phone was locked
- The full test suite exposed two assertions that fail identically on current `main`, plus a macOS PowerShell host crash while enumerating mount points; these are unrelated to this change
- One independent read-only review found two mirror-monitoring issues; both were fixed, and its targeted confirmation found no remaining issue in that scope