### PR TITLE
Speed up publish provenance validation

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave88.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave88.cs
@@ -190,23 +190,10 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
             using DotNetPublishPipelineRunner.TrustedDotNetInstallationSnapshot snapshot =
                 DotNetPublishPipelineRunner.TrustedDotNetInstallationSnapshot.Create(executablePath, root);
 
-            File.WriteAllText(sdkAssembly, "replaced-sdk");
+            File.AppendAllText(sdkAssembly, "-replaced");
 
-            bool rejected = SpinWait.SpinUntil(
-                () =>
-                {
-                    try
-                    {
-                        snapshot.ValidateUnchanged(verifyHashes: false);
-                        return false;
-                    }
-                    catch (InvalidOperationException)
-                    {
-                        return true;
-                    }
-                },
-                TimeSpan.FromSeconds(5));
-            Assert.True(rejected, "The SDK mutation watcher did not reject the replacement.");
+            Assert.Throws<InvalidOperationException>(() =>
+                snapshot.ValidateUnchanged(verifyHashes: false));
         }
         finally
         {

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave88.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave88.cs
@@ -273,6 +273,158 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
         }
     }
 
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void SourceProvenance_RejectsNewUntrackedSourceAtCachedCheckpoint()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string projectDirectory = Directory.CreateDirectory(Path.Combine(root, "src", "App")).FullName;
+            string projectPath = Path.Combine(projectDirectory, "App.csproj");
+            File.WriteAllText(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>");
+            File.WriteAllText(Path.Combine(projectDirectory, "Program.cs"), "internal static class Program { }");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source\"");
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(
+                    root,
+                    buildProjectPaths: [projectPath],
+                    buildConfiguration: "Release");
+            Assert.False(provenance.Dirty);
+
+            File.WriteAllText(
+                Path.Combine(projectDirectory, "NewSource.cs"),
+                "internal static class NewSource { }");
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+                provenance.ValidateCurrentSource);
+            Assert.Contains("NewSource.cs", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void SourceProvenance_RejectsHeadAdvanceAtCachedCheckpoint()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string sourcePath = Path.Combine(root, "Program.cs");
+            File.WriteAllText(sourcePath, "internal static class Program { }");
+            RunGit(root, "add Program.cs");
+            RunGit(root, "commit -m \"approved source\"");
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(root, sourceRootPaths: [root]);
+            Assert.False(provenance.Dirty);
+
+            File.AppendAllText(sourcePath, Environment.NewLine + "// later commit");
+            RunGit(root, "add Program.cs");
+            RunGit(root, "commit -m \"later source\"");
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+                provenance.ValidateCurrentSource);
+            Assert.Contains("revision changed", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void SourceProvenance_AllowsNewGeneratedOutputAtCachedCheckpoint()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            File.WriteAllText(Path.Combine(root, "Program.cs"), "internal static class Program { }");
+            RunGit(root, "add Program.cs");
+            RunGit(root, "commit -m \"approved source\"");
+            string outputDirectory = Path.Combine(root, "Artifacts", "Publish");
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(
+                    root,
+                    generatedPaths: [outputDirectory],
+                    sourceRootPaths: [root]);
+            Assert.False(provenance.Dirty);
+
+            Directory.CreateDirectory(outputDirectory);
+            File.WriteAllText(Path.Combine(outputDirectory, "App.dll"), "published");
+
+            provenance.ValidateCurrentSource();
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void TryBuildManifestProvenance_PreservesSharedCachedCheckpoint()
+    {
+        int validationCount = 0;
+        var shared = new DotNetPublishPipelineRunner.SourceProvenance(
+            "approved-revision",
+            dirty: false,
+            validateCurrentSource: () => validationCount++);
+        DotNetPublishArtefactResult[] artefacts =
+        [
+            CreatePublishArtefact("win-x64"),
+            CreatePublishArtefact("linux-x64")
+        ];
+        var provenances = new Dictionary<string, DotNetPublishPipelineRunner.SourceProvenance>(
+            StringComparer.OrdinalIgnoreCase)
+        {
+            ["App|net8.0|win-x64|PortableCompat"] = shared,
+            ["App|net8.0|linux-x64|PortableCompat"] = shared
+        };
+
+        DotNetPublishPipelineRunner.SourceProvenance? result =
+            DotNetPublishPipelineRunner.TryBuildManifestProvenance(artefacts, provenances);
+
+        Assert.Same(shared, result);
+        result!.ValidateCurrentSource();
+        Assert.Equal(1, validationCount);
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void NormalizeBuildInputPathRoot_PreservesFileSystemRoot()
+    {
+        string root = Path.GetPathRoot(Path.GetFullPath(Path.GetTempPath()))!;
+
+        string normalized = DotNetPublishPipelineRunner.NormalizeBuildInputPathRoot(root);
+
+        Assert.Equal(root, normalized);
+    }
+
+    private static DotNetPublishArtefactResult CreatePublishArtefact(string runtime)
+        => new()
+        {
+            Category = DotNetPublishArtefactCategory.Publish,
+            Target = "App",
+            Framework = "net8.0",
+            Runtime = runtime,
+            Style = DotNetPublishStyle.PortableCompat
+        };
+
     private static string CreateFixtureFile(string root, params string[] parts)
     {
         string path = parts.Aggregate(root, Path.Combine);

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave88.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave88.cs
@@ -1,10 +1,120 @@
 using PowerForge;
+using System.Reflection;
+using System.Text.Json;
 using Xunit;
 
 namespace PowerForge.Tests;
 
 public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
 {
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void VerifiedPackageCatalog_InheritsOnlyArchivesVerifiedByChildLock()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string packageRoot = Directory.CreateDirectory(Path.Combine(root, "packages")).FullName;
+            string sharedArchive = Path.Combine(packageRoot, "shared.nupkg");
+            string rootOnlyArchive = Path.Combine(packageRoot, "root-only.nupkg");
+            Type runnerType = typeof(DotNetPublishPipelineRunner);
+            Type catalogType = runnerType.GetNestedType(
+                "VerifiedPackageInputCatalog",
+                BindingFlags.NonPublic)!;
+            Type cacheType = runnerType.GetNestedType(
+                "VerifiedPackageArchiveCache",
+                BindingFlags.NonPublic)!;
+            object cache = Activator.CreateInstance(cacheType, nonPublic: true)!;
+            try
+            {
+                ConstructorInfo constructor = Assert.Single(
+                    catalogType.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic));
+                object catalog = constructor.Invoke(
+                [
+                    new[] { packageRoot },
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+                    cache,
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Shared.Package/1.0.0"] = sharedArchive
+                    },
+                    Array.Empty<string>()
+                ]);
+                catalogType.GetMethod(
+                        "InheritSdkManagedArchivePaths",
+                        BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .Invoke(catalog, [new[] { sharedArchive, rootOnlyArchive }]);
+
+                var inherited = Assert.IsAssignableFrom<IEnumerable<string>>(
+                    catalogType.GetProperty(
+                            "SdkManagedArchivePaths",
+                            BindingFlags.Instance | BindingFlags.NonPublic)!
+                        .GetValue(catalog));
+                Assert.Equal(Path.GetFullPath(sharedArchive), Assert.Single(inherited));
+            }
+            finally
+            {
+                (cache as IDisposable)?.Dispose();
+            }
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void WriteManifestsWithProvenance_UsesConfirmedPublishProvenance()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string outputDirectory = Directory.CreateDirectory(Path.Combine(root, "publish")).FullName;
+            File.WriteAllText(Path.Combine(outputDirectory, "App.dll"), "payload");
+            string manifestPath = Path.Combine(root, "manifest.json");
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Outputs = new DotNetPublishOutputs { ManifestJsonPath = manifestPath }
+            };
+            var artefacts = new List<DotNetPublishArtefactResult>
+            {
+                new()
+                {
+                    Category = DotNetPublishArtefactCategory.Publish,
+                    Target = "App",
+                    Framework = "net8.0",
+                    Runtime = "win-x64",
+                    Style = DotNetPublishStyle.PortableCompat,
+                    PublishDir = outputDirectory,
+                    OutputDir = outputDirectory,
+                    Files = 1,
+                    TotalBytes = 7
+                }
+            };
+            var confirmed = new DotNetPublishPipelineRunner.SourceProvenance(
+                "confirmed-revision",
+                dirty: false);
+
+            DotNetPublishPipelineRunner.WriteManifestsWithProvenance(
+                plan,
+                artefacts,
+                new List<DotNetPublishStorePackageResult>(),
+                new List<DotNetPublishMsiBuildResult>(),
+                verifiedSourceProvenance: confirmed);
+
+            using JsonDocument manifest = JsonDocument.Parse(File.ReadAllText(manifestPath));
+            JsonElement entry = Assert.Single(manifest.RootElement.EnumerateArray());
+            Assert.Equal("confirmed-revision", entry.GetProperty("SourceRevision").GetString());
+            Assert.False(entry.GetProperty("SourceDirty").GetBoolean());
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
     [Fact]
     [Trait("Category", "DotNetPublishPrGate")]
     public void Run_NoBuildPublishKeepsPublicDefiningProjectMetadataBeforeSnapshotCopyBinding()
@@ -58,6 +168,45 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
             Assert.True(snapshot.AffectsCapturedClosureForTest(packFile));
             Assert.True(snapshot.AffectsCapturedClosureForTest(manifestFile));
             Assert.True(snapshot.AffectsCapturedClosureForTest(workloadFile));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void TrustedDotNetInstallationSnapshot_IntermediateValidationRejectsObservedSdkReplacement()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string executablePath = Path.Combine(root, OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet");
+            string sdkDirectory = Directory.CreateDirectory(Path.Combine(root, "sdk", "10.0.100")).FullName;
+            string sdkAssembly = Path.Combine(sdkDirectory, "MSBuild.dll");
+            File.WriteAllText(executablePath, "trusted-host");
+            File.WriteAllText(sdkAssembly, "trusted-sdk");
+            using DotNetPublishPipelineRunner.TrustedDotNetInstallationSnapshot snapshot =
+                DotNetPublishPipelineRunner.TrustedDotNetInstallationSnapshot.Create(executablePath, root);
+
+            File.WriteAllText(sdkAssembly, "replaced-sdk");
+
+            bool rejected = SpinWait.SpinUntil(
+                () =>
+                {
+                    try
+                    {
+                        snapshot.ValidateUnchanged(verifyHashes: false);
+                        return false;
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        return true;
+                    }
+                },
+                TimeSpan.FromSeconds(5));
+            Assert.True(rejected, "The SDK mutation watcher did not reject the replacement.");
         }
         finally
         {

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave89.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave89.cs
@@ -8,7 +8,7 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
 {
     [Fact]
     [Trait("Category", "DotNetPublishPrGate")]
-    public void ResolvePlannedPublishOutputDirectories_ExcludesEveryPublishCombinationFromCachedSourceChecks()
+    public void ResolvePlannedPublishGeneratedPaths_ExcludesEveryPublishDirectoryAndZipFromCachedSourceChecks()
     {
         string root = Directory.CreateTempSubdirectory().FullName;
         try
@@ -32,7 +32,21 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
                         {
                             Framework = "net8.0",
                             Style = DotNetPublishStyle.FrameworkDependent,
-                            OutputPath = "Artifacts/{target}/{rid}/{framework}/{style}"
+                            OutputPath = "Artifacts/{target}/{rid}/{framework}/{style}",
+                            Zip = true
+                        }
+                    },
+                    new DotNetPublishTargetPlan
+                    {
+                        Name = "Tool",
+                        ProjectPath = Path.Combine(root, "Tool.csproj"),
+                        Publish = new DotNetPublishPublishOptions
+                        {
+                            Framework = "net8.0",
+                            Style = DotNetPublishStyle.FrameworkDependent,
+                            OutputPath = "Artifacts/{target}/{rid}/{framework}/{style}",
+                            Zip = true,
+                            ZipPath = "Artifacts/Archives/{rid}/tool.zip"
                         }
                     }
                 ],
@@ -53,11 +67,28 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
                         Framework = "net8.0",
                         Runtime = "linux-x64",
                         Style = DotNetPublishStyle.FrameworkDependent
+                    },
+                    new DotNetPublishStep
+                    {
+                        Kind = DotNetPublishStepKind.Publish,
+                        TargetName = "Tool",
+                        Framework = "net8.0",
+                        Runtime = "win-x64",
+                        Style = DotNetPublishStyle.FrameworkDependent
                     }
                 ]
             };
-            string[] outputs = DotNetPublishPipelineRunner.ResolvePlannedPublishOutputDirectories(plan);
-            Assert.Equal(2, outputs.Length);
+            string[] outputs = DotNetPublishPipelineRunner.ResolvePlannedPublishGeneratedPaths(plan);
+            Assert.Equal(6, outputs.Length);
+            Assert.Contains(outputs, path => path.EndsWith(
+                "App-net8.0-win-x64-FrameworkDependent.zip",
+                StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(outputs, path => path.EndsWith(
+                "App-net8.0-linux-x64-FrameworkDependent.zip",
+                StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(outputs, path => path.Replace('\\', '/').EndsWith(
+                "Artifacts/Archives/win-x64/tool.zip",
+                StringComparison.OrdinalIgnoreCase));
             DotNetPublishPipelineRunner.SourceProvenance provenance =
                 DotNetPublishPipelineRunner.ReadSourceProvenance(
                     root,
@@ -67,8 +98,16 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
 
             foreach (string output in outputs)
             {
-                Directory.CreateDirectory(output);
-                File.WriteAllText(Path.Combine(output, "App.dll"), "published");
+                if (output.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(output)!);
+                    File.WriteAllText(output, "archive");
+                }
+                else
+                {
+                    Directory.CreateDirectory(output);
+                    File.WriteAllText(Path.Combine(output, "App.dll"), "published");
+                }
             }
 
             provenance.ValidateCurrentSource();

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave89.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave89.cs
@@ -1,0 +1,210 @@
+using PowerForge;
+using System.Reflection;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
+{
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void ResolvePlannedPublishOutputDirectories_ExcludesEveryPublishCombinationFromCachedSourceChecks()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            File.WriteAllText(Path.Combine(root, "Program.cs"), "internal static class Program { }");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source\"");
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Targets =
+                [
+                    new DotNetPublishTargetPlan
+                    {
+                        Name = "App",
+                        ProjectPath = Path.Combine(root, "App.csproj"),
+                        Publish = new DotNetPublishPublishOptions
+                        {
+                            Framework = "net8.0",
+                            Style = DotNetPublishStyle.FrameworkDependent,
+                            OutputPath = "Artifacts/{target}/{rid}/{framework}/{style}"
+                        }
+                    }
+                ],
+                Steps =
+                [
+                    new DotNetPublishStep
+                    {
+                        Kind = DotNetPublishStepKind.Publish,
+                        TargetName = "App",
+                        Framework = "net8.0",
+                        Runtime = "win-x64",
+                        Style = DotNetPublishStyle.FrameworkDependent
+                    },
+                    new DotNetPublishStep
+                    {
+                        Kind = DotNetPublishStepKind.Publish,
+                        TargetName = "App",
+                        Framework = "net8.0",
+                        Runtime = "linux-x64",
+                        Style = DotNetPublishStyle.FrameworkDependent
+                    }
+                ]
+            };
+            string[] outputs = DotNetPublishPipelineRunner.ResolvePlannedPublishOutputDirectories(plan);
+            Assert.Equal(2, outputs.Length);
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(
+                    root,
+                    generatedPaths: outputs,
+                    sourceRootPaths: [root]);
+            Assert.False(provenance.Dirty);
+
+            foreach (string output in outputs)
+            {
+                Directory.CreateDirectory(output);
+                File.WriteAllText(Path.Combine(output, "App.dll"), "published");
+            }
+
+            provenance.ValidateCurrentSource();
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void ProjectEvaluationRequest_RequiresSdkPackageEvidenceForReferencedProject()
+    {
+        Type runnerType = typeof(DotNetPublishPipelineRunner);
+        Type requestType = runnerType.GetNestedType("ProjectEvaluationRequest", BindingFlags.NonPublic)!;
+        Type referenceType = runnerType.GetNestedType("EvaluatedProjectReference", BindingFlags.NonPublic)!;
+        ConstructorInfo requestConstructor = Assert.Single(
+            requestType.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic));
+        ConstructorInfo referenceConstructor = Assert.Single(
+            referenceType.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic));
+        object request = requestConstructor.Invoke(
+        [
+            Path.GetFullPath("App.csproj"),
+            "net8.0",
+            "Release",
+            null,
+            null,
+            null,
+            true
+        ]);
+        object projectReference = referenceConstructor.Invoke(
+        [
+            Path.GetFullPath("Library.csproj"),
+            "net8.0",
+            null,
+            null
+        ]);
+
+        object childRequest = requestType.GetMethod(
+                "ForProject",
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                binder: null,
+                types: [referenceType],
+                modifiers: null)!
+            .Invoke(request, [projectReference])!;
+
+        Assert.True((bool)requestType.GetProperty(
+                "RequiresSdkPackageEvidence",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(childRequest)!);
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void SourceProvenance_AllowsAuthorizedTrackedGeneratedPathAtCachedCheckpoint()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string statePath = Path.Combine(root, "version-state.json");
+            File.WriteAllText(statePath, "{\"version\":1}");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved state\"");
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(root, sourceRootPaths: [root]);
+            Assert.False(provenance.Dirty);
+
+            File.WriteAllText(statePath, "{\"version\":2}");
+
+            Assert.Throws<InvalidOperationException>(provenance.ValidateCurrentSource);
+            provenance.ValidateCurrentSource([statePath]);
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void ReadPortableInventorySourceProvenance_RefreshRejectsNewIgnoredEvaluatedInput()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string projectPath = Path.Combine(root, "App.csproj");
+            File.WriteAllText(
+                projectPath,
+                "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup><ItemGroup><AdditionalFiles Include=\"ignored/*.json\" /></ItemGroup></Project>");
+            File.WriteAllText(Path.Combine(root, "Program.cs"), "internal static class Program { }");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\nignored/\n");
+            RunDotNet(root, $"restore \"{projectPath}\" --use-lock-file --nologo");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source\"");
+            string revision = RunGit(root, "rev-parse HEAD").Trim();
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                SourceRevision = revision,
+                Configuration = "Release",
+                NoRestoreInPublish = true,
+                Targets =
+                [
+                    new DotNetPublishTargetPlan
+                    {
+                        Name = "App",
+                        ProjectPath = projectPath,
+                        Publish = new DotNetPublishPublishOptions
+                        {
+                            Framework = "net8.0",
+                            Style = DotNetPublishStyle.FrameworkDependent
+                        }
+                    }
+                ]
+            };
+            DotNetPublishPipelineRunner.SourceProvenance checkpoint =
+                DotNetPublishPipelineRunner.ReadPortableInventorySourceProvenance(plan);
+
+            string ignoredDirectory = Directory.CreateDirectory(Path.Combine(root, "ignored")).FullName;
+            File.WriteAllText(Path.Combine(ignoredDirectory, "rules.json"), "{}");
+            checkpoint.ValidateCurrentSource();
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                DotNetPublishPipelineRunner.ReadPortableInventorySourceProvenance(plan));
+            Assert.Contains("untrusted evaluated build input", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+}

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave91.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave91.cs
@@ -1,0 +1,175 @@
+using PowerForge;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
+{
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void CachedProvenance_AllowsTrackedManifestOutputsWrittenByThePipeline()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string manifestJson = Path.Combine(root, "manifest.json");
+            string manifestText = Path.Combine(root, "manifest.txt");
+            string checksums = Path.Combine(root, "SHA256SUMS.txt");
+            File.WriteAllText(manifestJson, "old json");
+            File.WriteAllText(manifestText, "old text");
+            File.WriteAllText(checksums, "old checksums");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source\"");
+
+            IReadOnlyDictionary<string, string> cleanState =
+                DotNetPublishPipelineRunner.CaptureCleanTrackedGeneratedProvenanceState(
+                    root,
+                    [manifestJson, manifestText, checksums]);
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(root, sourceRootPaths: [root]);
+
+            File.WriteAllText(manifestJson, "new json");
+            File.WriteAllText(manifestText, "new text");
+            File.WriteAllText(checksums, "new checksums");
+            IReadOnlyDictionary<string, string> writtenState =
+                DotNetPublishPipelineRunner.CaptureTrackedManifestOutputState(
+                    root,
+                    cleanState,
+                    manifestJson,
+                    manifestText,
+                    checksums);
+
+            Assert.Equal(3, writtenState.Count);
+            provenance.ValidateCurrentSource(writtenState.Keys);
+            DotNetPublishPipelineRunner.ValidateTrackedManifestOutputState(writtenState);
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void CachedProvenance_AllowsADeclaredHookOutputCreatedAfterTheCheckpoint()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            File.WriteAllText(Path.Combine(root, "Program.cs"), "internal static class Program { }");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "Generated/\n");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source\"");
+            string revision = RunGit(root, "rev-parse HEAD").Trim();
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                SourceRevision = revision,
+                Steps =
+                [
+                    new DotNetPublishStep
+                    {
+                        Kind = DotNetPublishStepKind.CommandHook,
+                        HookId = "generate",
+                        HookGeneratedOutputs = ["Generated/later.txt"]
+                    }
+                ]
+            };
+
+            DotNetPublishPipelineRunner.SourceProvenance checkpoint =
+                DotNetPublishPipelineRunner.ReadPortableInventorySourceProvenance(plan);
+            string output = Path.Combine(root, "Generated", "later.txt");
+            Directory.CreateDirectory(Path.GetDirectoryName(output)!);
+            File.WriteAllText(output, "generated later");
+
+            checkpoint.ValidateCurrentSource();
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void ReadSourceProvenance_UsesImportedFrameworkForOrdinaryProjectReference()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string appDirectory = Directory.CreateDirectory(Path.Combine(root, "src", "App")).FullName;
+            string libraryDirectory = Directory.CreateDirectory(Path.Combine(root, "src", "Library")).FullName;
+            string inputDirectory = Directory.CreateDirectory(Path.Combine(root, "inputs")).FullName;
+            string appProject = Path.Combine(appDirectory, "App.csproj");
+            string libraryProject = Path.Combine(libraryDirectory, "Library.csproj");
+            string selectedInput = Path.Combine(inputDirectory, "net8.json");
+            string unselectedInput = Path.Combine(inputDirectory, "net10.json");
+            File.WriteAllText(appProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+                  <ItemGroup><ProjectReference Include="../Library/Library.csproj" /></ItemGroup>
+                </Project>
+                """);
+            File.WriteAllText(Path.Combine(appDirectory, "Program.cs"), "internal static class Program { private static void Main() { } }");
+            File.WriteAllText(Path.Combine(libraryDirectory, "Directory.Build.props"), """
+                <Project>
+                  <PropertyGroup><TargetFrameworks>net8.0;net10.0</TargetFrameworks></PropertyGroup>
+                </Project>
+                """);
+            File.WriteAllText(libraryProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+                    <AdditionalFiles Include="../../inputs/net8.json" />
+                  </ItemGroup>
+                  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+                    <AdditionalFiles Include="../../inputs/net10.json" />
+                  </ItemGroup>
+                </Project>
+                """);
+            File.WriteAllText(Path.Combine(libraryDirectory, "Library.cs"), "public static class Library { }");
+            File.WriteAllText(selectedInput, "approved");
+            File.WriteAllText(unselectedInput, "approved");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
+            RunDotNet(root, $"restore \"{appProject}\" --use-lock-file --nologo");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source\"");
+            File.WriteAllText(unselectedInput, "changed");
+
+            DotNetPublishPipelineRunner.SourceProvenance unselectedProvenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(
+                    root,
+                    buildProjectPaths: [appProject],
+                    buildConfiguration: "Release");
+
+            Assert.False(
+                unselectedProvenance.Dirty,
+                string.Join(Environment.NewLine, unselectedProvenance.DirtyReasons));
+            File.WriteAllText(unselectedInput, "approved");
+            File.WriteAllText(selectedInput, "changed");
+
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(
+                    root,
+                    buildProjectPaths: [appProject],
+                    buildConfiguration: "Release");
+
+            Assert.True(provenance.Dirty, string.Join(Environment.NewLine, provenance.DirtyReasons));
+            Assert.Contains(
+                provenance.DirtyPaths,
+                path => path.Replace('\\', '/').EndsWith("inputs/net8.json", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+}

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave92.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave92.cs
@@ -1,0 +1,107 @@
+using PowerForge;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
+{
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void Run_NoBuildPublishReacquiresProvenanceAfterEachMatrixBuild()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string projectPath = Path.Combine(root, "App.csproj");
+            File.WriteAllText(
+                projectPath,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+                  </PropertyGroup>
+                </Project>
+                """);
+            File.WriteAllText(Path.Combine(root, "Program.cs"), "System.Console.WriteLine(\"matrix\");");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\nArtifacts/\n");
+            RunDotNet(root, $"restore \"{projectPath}\" -r win-x64 --use-lock-file --nologo");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source\"");
+
+            string revision = RunGit(root, "rev-parse HEAD").Trim();
+            var target = new DotNetPublishTargetPlan
+            {
+                Name = "app",
+                ProjectPath = projectPath,
+                Publish = new DotNetPublishPublishOptions
+                {
+                    Framework = "net8.0",
+                    Runtimes = ["win-x64"],
+                    Style = DotNetPublishStyle.FrameworkDependent,
+                    OutputPath = "Artifacts/{framework}",
+                    UseStaging = false
+                },
+                Combinations =
+                [
+                    new DotNetPublishTargetCombination
+                    {
+                        Framework = "net8.0",
+                        Runtime = "win-x64",
+                        Style = DotNetPublishStyle.FrameworkDependent
+                    },
+                    new DotNetPublishTargetCombination
+                    {
+                        Framework = "net10.0",
+                        Runtime = "win-x64",
+                        Style = DotNetPublishStyle.FrameworkDependent
+                    }
+                ]
+            };
+            var runner = new DotNetPublishPipelineRunner(new NullLogger());
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Configuration = "Release",
+                SourceRevision = revision,
+                Restore = true,
+                Build = true,
+                NoBuildInPublish = true,
+                NoRestoreInPublish = true,
+                Targets = [target],
+                Steps =
+                [
+                    CreateCombinationStep(DotNetPublishStepKind.Build, "net8.0"),
+                    CreateCombinationStep(DotNetPublishStepKind.Publish, "net8.0"),
+                    CreateCombinationStep(DotNetPublishStepKind.Build, "net10.0"),
+                    CreateCombinationStep(DotNetPublishStepKind.Publish, "net10.0")
+                ]
+            };
+
+            DotNetPublishResult result = runner.Run(plan, progress: null);
+
+            Assert.True(result.Succeeded, result.ErrorMessage);
+            Assert.Equal(2, result.Artefacts.Length);
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    private static DotNetPublishStep CreateCombinationStep(
+        DotNetPublishStepKind kind,
+        string framework)
+        => new()
+        {
+            Key = $"{kind}:{framework}",
+            Kind = kind,
+            TargetName = "app",
+            Framework = framework,
+            Runtime = "win-x64",
+            Style = DotNetPublishStyle.FrameworkDependent
+        };
+}

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ToolchainSnapshot.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ToolchainSnapshot.cs
@@ -111,6 +111,9 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             if (Volatile.Read(ref _changed) != 0)
                 ThrowChanged();
+            if (!verifyHashes)
+                return;
+
             string[] currentFiles = EnumerateCapturedFiles(_capturedRoots).ToArray();
             if (currentFiles.Length != _files.Count || currentFiles.Any(path => !_files.ContainsKey(path)))
                 ThrowChanged();
@@ -121,8 +124,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 if (!info.Exists ||
                     info.Length != expected.Length ||
                     info.LastWriteTimeUtc != expected.LastWriteTimeUtc ||
-                    (verifyHashes &&
-                     !string.Equals(ComputeFileSha256(path), expected.Sha256, StringComparison.OrdinalIgnoreCase)))
+                    !string.Equals(ComputeFileSha256(path), expected.Sha256, StringComparison.OrdinalIgnoreCase))
                 {
                     ThrowChanged();
                 }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ToolchainSnapshot.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.ToolchainSnapshot.cs
@@ -111,8 +111,6 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             if (Volatile.Read(ref _changed) != 0)
                 ThrowChanged();
-            if (!verifyHashes)
-                return;
 
             string[] currentFiles = EnumerateCapturedFiles(_capturedRoots).ToArray();
             if (currentFiles.Length != _files.Count || currentFiles.Any(path => !_files.ContainsKey(path)))
@@ -124,7 +122,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 if (!info.Exists ||
                     info.Length != expected.Length ||
                     info.LastWriteTimeUtc != expected.LastWriteTimeUtc ||
-                    !string.Equals(ComputeFileSha256(path), expected.Sha256, StringComparison.OrdinalIgnoreCase))
+                    (verifyHashes &&
+                     !string.Equals(ComputeFileSha256(path), expected.Sha256, StringComparison.OrdinalIgnoreCase)))
                 {
                     ThrowChanged();
                 }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
@@ -548,7 +548,10 @@ public sealed partial class DotNetPublishPipelineRunner
         return current;
     }
 
-    private static string NormalizeBuildInputPathRoot(string path)
+    /// <summary>
+    /// Normalizes a build-input root without trimming a filesystem root into an empty or drive-relative path.
+    /// </summary>
+    internal static string NormalizeBuildInputPathRoot(string path)
     {
         string fullPath = Path.GetFullPath(path);
         string trimmed = fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
@@ -676,7 +676,8 @@ public sealed partial class DotNetPublishPipelineRunner
             string? configuration,
             IReadOnlyDictionary<string, string>? globalProperties,
             IReadOnlyDictionary<string, string?>? environmentVariables,
-            IReadOnlyCollection<string>? controlledBuildEnvironmentVariableNames = null)
+            IReadOnlyCollection<string>? controlledBuildEnvironmentVariableNames = null,
+            bool requiresSdkPackageEvidence = true)
         {
             ProjectPath = projectPath;
             TargetFramework = targetFramework;
@@ -689,6 +690,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
                 .ToArray() ?? Array.Empty<string>();
+            RequiresSdkPackageEvidence = requiresSdkPackageEvidence;
         }
 
         internal string ProjectPath { get; }
@@ -698,6 +700,7 @@ public sealed partial class DotNetPublishPipelineRunner
         internal IReadOnlyDictionary<string, string> GlobalProperties { get; }
         internal IReadOnlyDictionary<string, string?> EnvironmentVariables { get; }
         internal IReadOnlyCollection<string> ControlledBuildEnvironmentVariableNames { get; }
+        internal bool RequiresSdkPackageEvidence { get; }
 
         internal IReadOnlyDictionary<string, string> ReadEffectiveGlobalProperties()
         {
@@ -726,7 +729,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 Configuration,
                 GlobalProperties,
                 EnvironmentVariables,
-                ControlledBuildEnvironmentVariableNames);
+                ControlledBuildEnvironmentVariableNames,
+                RequiresSdkPackageEvidence);
 
         internal ProjectEvaluationRequest ForProject(EvaluatedProjectReference projectReference)
         {
@@ -751,7 +755,12 @@ public sealed partial class DotNetPublishPipelineRunner
                     : Configuration;
             string? targetFramework = undefinesTargetFramework
                 ? null
-                : projectReference.TargetFramework;
+                : projectReference.TargetFramework ??
+                  (string.IsNullOrWhiteSpace(TargetFramework)
+                      ? null
+                      : ResolveNearestDeclaredTargetFrameworkUnconditionally(
+                          projectReference.ProjectPath,
+                          TargetFramework!));
             properties.Remove("Configuration");
             properties.Remove("TargetFramework");
             return new ProjectEvaluationRequest(
@@ -760,7 +769,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 configuration,
                 properties,
                 EnvironmentVariables,
-                ControlledBuildEnvironmentVariableNames);
+                ControlledBuildEnvironmentVariableNames,
+                requiresSdkPackageEvidence: false);
         }
 
         internal string BuildVisitKey()
@@ -797,6 +807,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 AppendProjectReferenceKeySegment(key, "ControlledEnvironment");
                 AppendProjectReferenceKeySegment(key, NormalizeEnvironmentIdentityName(name));
             }
+            AppendProjectReferenceKeySegment(key, "SdkPackageEvidence");
+            AppendProjectReferenceKeySegment(key, RequiresSdkPackageEvidence ? "Required" : "Inherited");
             return key.ToString();
         }
     }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
@@ -773,7 +773,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 properties,
                 EnvironmentVariables,
                 ControlledBuildEnvironmentVariableNames,
-                requiresSdkPackageEvidence: false);
+                requiresSdkPackageEvidence: true);
         }
 
         internal string BuildVisitKey()

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ControlledProjectReferences.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ControlledProjectReferences.cs
@@ -354,6 +354,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 // Temporary controlled-reference cleanup is best effort.
             }
         }
+
     }
 
     private static bool TryMapControlledResolutionItems(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
@@ -330,6 +330,7 @@ public sealed partial class DotNetPublishPipelineRunner
         var evaluationsByEvaluation = new Dictionary<string, EvaluatedProjectInputs>(StringComparer.Ordinal);
         var trustedBuildInfrastructureRootsByEvaluation =
             new Dictionary<string, string[]>(StringComparer.Ordinal);
+        var sdkManagedArchivePaths = new HashSet<string>(comparison);
         var generatedProjectReferenceOutputs = new List<(ProjectEvaluationRequest Request, GeneratedProjectReferenceOutput Output)>();
         var evaluatedPublishInputs = new List<(string EvaluationKey, EvaluatedPublishInput Input)>();
         using var verifiedPackageArchives = new VerifiedPackageArchiveCache();
@@ -364,12 +365,12 @@ public sealed partial class DotNetPublishPipelineRunner
                 if (!TryReadEvaluatedProjectInputs(
                         request,
                         verifiedPackageArchives,
+                        sdkManagedArchivePaths,
                         out EvaluatedProjectInputs? evaluation) || evaluation is null)
                 {
                     projectDirectories = directories.ToArray();
                     return false;
                 }
-
                 foreach (string input in evaluation.BuildInputs)
                     buildInputs.Add(input);
                 foreach (string input in evaluation.SourceInputs)
@@ -722,6 +723,7 @@ public sealed partial class DotNetPublishPipelineRunner
     private static bool TryReadEvaluatedProjectInputs(
         ProjectEvaluationRequest request,
         VerifiedPackageArchiveCache verifiedPackageArchives,
+        HashSet<string> knownSdkManagedArchivePaths,
         out EvaluatedProjectInputs? evaluation)
     {
         evaluation = null;
@@ -883,9 +885,17 @@ public sealed partial class DotNetPublishPipelineRunner
                         verifiedPackageArchives,
                         request.ReadEffectiveGlobalProperties(),
                         request.EnvironmentVariables,
+                        request.RequiresSdkPackageEvidence,
                         out verifiedPackages))
                 {
                     return false;
+                }
+                if (verifiedPackages is not null)
+                {
+                    if (request.RequiresSdkPackageEvidence)
+                        knownSdkManagedArchivePaths.UnionWith(verifiedPackages.SdkManagedArchivePaths);
+                    else
+                        verifiedPackages.InheritSdkManagedArchivePaths(knownSdkManagedArchivePaths);
                 }
                 trustedBuildInfrastructureRoots = ReadTrustedBuildInfrastructureRoots(
                     properties,
@@ -1100,16 +1110,9 @@ public sealed partial class DotNetPublishPipelineRunner
                 foreach (EvaluatedProjectReference projectReference in rawReferences.Values)
                     references[BuildEvaluatedProjectReferenceKey(projectReference)] = projectReference;
             }
-            else if (rawReferences.Count > 0 ||
-                     projectReferenceDeclarations.Any(declaration =>
-                         declaration.IsTargetTime &&
-                         !IsTrustedExternalBuildInfrastructurePath(
-                             declaration.DefiningProjectPath,
-                             trustedBuildInfrastructureRoots) &&
-                         declaration.Element.Attributes().Any(attribute =>
-                             attribute.Name.LocalName.Equals(
-                                 "Include",
-                                 StringComparison.OrdinalIgnoreCase))) ||
+            else if (RequiresControlledProjectReferenceResolution(
+                         projectReferenceDeclarations,
+                         trustedBuildInfrastructureRoots) ||
                      hasDynamicProjectReferenceTaskOutputs)
             {
                 if (!TryReadControlledResolvedProjectReferences(
@@ -1162,6 +1165,11 @@ public sealed partial class DotNetPublishPipelineRunner
                     return false;
                 }
             }
+            else
+            {
+                foreach (EvaluatedProjectReference projectReference in rawReferences.Values)
+                    references[BuildEvaluatedProjectReferenceKey(projectReference)] = projectReference;
+            }
 
             evaluation = new EvaluatedProjectInputs(
                 inputs.ToArray(),
@@ -1189,6 +1197,32 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             return false;
         }
+    }
+
+    private static bool RequiresControlledProjectReferenceResolution(
+        IEnumerable<PreprocessedProjectReferenceDeclaration> declarations,
+        IReadOnlyCollection<string> trustedBuildInfrastructureRoots)
+    {
+        string[] outputShapingMetadata =
+        [
+            "OutputItemType",
+            "ReferenceOutputAssembly",
+            "Targets",
+            "BuildReference"
+        ];
+        return declarations.Any(declaration =>
+            !IsTrustedExternalBuildInfrastructurePath(
+                declaration.DefiningProjectPath,
+                trustedBuildInfrastructureRoots) &&
+            (declaration.IsTargetTime ||
+             declaration.Element.Attributes().Any(attribute =>
+                 outputShapingMetadata.Contains(
+                     attribute.Name.LocalName,
+                     StringComparer.OrdinalIgnoreCase)) ||
+             declaration.Element.Elements().Any(element =>
+                 outputShapingMetadata.Contains(
+                     element.Name.LocalName,
+                     StringComparer.OrdinalIgnoreCase))));
     }
 
     private static string? ResolveExistingCustomAfterTargets(string? value, string projectDirectory)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
@@ -1113,6 +1113,9 @@ public sealed partial class DotNetPublishPipelineRunner
             else if (RequiresControlledProjectReferenceResolution(
                          projectReferenceDeclarations,
                          trustedBuildInfrastructureRoots) ||
+                     RequiresControlledProjectReferenceFrameworkResolution(
+                         request,
+                         rawReferences.Values) ||
                      hasDynamicProjectReferenceTaskOutputs)
             {
                 if (!TryReadControlledResolvedProjectReferences(
@@ -1223,6 +1226,23 @@ public sealed partial class DotNetPublishPipelineRunner
                  outputShapingMetadata.Contains(
                      element.Name.LocalName,
                      StringComparer.OrdinalIgnoreCase))));
+    }
+
+    private static bool RequiresControlledProjectReferenceFrameworkResolution(
+        ProjectEvaluationRequest request,
+        IEnumerable<EvaluatedProjectReference> references)
+    {
+        if (string.IsNullOrWhiteSpace(request.TargetFramework))
+            return false;
+
+        return references.Any(reference =>
+            !reference.UndefineProperties.Contains(
+                "TargetFramework",
+                StringComparer.OrdinalIgnoreCase) &&
+            string.IsNullOrWhiteSpace(reference.TargetFramework) &&
+            string.IsNullOrWhiteSpace(ResolveNearestDeclaredTargetFrameworkUnconditionally(
+                reference.ProjectPath,
+                request.TargetFramework!)));
     }
 
     private static string? ResolveExistingCustomAfterTargets(string? value, string projectDirectory)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
@@ -325,7 +325,8 @@ public sealed partial class DotNetPublishPipelineRunner
         List<DotNetPublishMsiBuildResult>? msiBuilds,
         IEnumerable<string>? cleanTrackedGeneratedPaths = null,
         IReadOnlyDictionary<string, string>? cleanTrackedGeneratedProvenanceState = null,
-        string? msiReservationOwner = null)
+        string? msiReservationOwner = null,
+        SourceProvenance? verifiedSourceProvenance = null)
     {
         ValidateGeneratedConfigurationInputs(plan);
         var orderedArtefacts = (artefacts ?? new List<DotNetPublishArtefactResult>())
@@ -349,7 +350,7 @@ public sealed partial class DotNetPublishPipelineRunner
             .ThenBy(a => a.Style.ToString(), StringComparer.OrdinalIgnoreCase)
             .ThenBy(a => a.InstallerId, StringComparer.OrdinalIgnoreCase)
             .ToList();
-        var provenance = ReadSourceProvenance(
+        var provenance = verifiedSourceProvenance ?? ReadSourceProvenance(
             plan.ProjectRoot,
             EnumerateGeneratedProvenancePaths(
                 plan,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.HookOutputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.HookOutputProvenance.cs
@@ -22,7 +22,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 ? Array.Empty<string>()
                 : new[] { outputDirectory! })
             .Concat(additionalGeneratedPaths ?? Array.Empty<string>())
-            .Concat(hookGeneratedOutputs);
+            .Concat(hookDeclaredOutputs);
         SourceProvenance provenance = ReadSourceProvenance(
             plan.ProjectRoot,
             generatedPaths,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.GitIgnoredInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.GitIgnoredInputs.cs
@@ -81,10 +81,8 @@ public sealed partial class DotNetPublishPipelineRunner
         out string repositoryRoot)
     {
         repositoryRoot = string.Empty;
-        string current = Path.GetFullPath(inputDirectory)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        string outerRoot = Path.GetFullPath(outerGitRoot)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        string current = NormalizeBuildInputPathRoot(inputDirectory);
+        string outerRoot = NormalizeBuildInputPathRoot(outerGitRoot);
         StringComparison comparison = IsWindows()
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
@@ -115,8 +113,7 @@ public sealed partial class DotNetPublishPipelineRunner
                     return false;
                 }
 
-                resolvedRoot = Path.GetFullPath(resolvedRoot!)
-                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                resolvedRoot = NormalizeBuildInputPathRoot(resolvedRoot!);
                 if (!string.Equals(resolvedRoot, current, comparison))
                 {
                     CacheBuildInputRepositoryDirectories(repositoryByDirectory, traversed, null);

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.GitIgnoredInputs.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.GitIgnoredInputs.cs
@@ -14,22 +14,24 @@ public sealed partial class DotNetPublishPipelineRunner
         string fullGitRoot = Path.GetFullPath(gitRoot);
         var inputsByRepository = new Dictionary<string, HashSet<string>>(comparer);
         var repositoryByDirectory = new Dictionary<string, string?>(comparer);
+        var verifiedRepositories = new HashSet<string>(comparer);
         foreach (string input in buildInputs)
         {
             string fullInput = Path.GetFullPath(input);
             string inputDirectory = Path.GetDirectoryName(fullInput)!;
-            if (!repositoryByDirectory.TryGetValue(inputDirectory, out string? repositoryRoot))
-            {
-                repositoryRoot = ReadGitText(inputDirectory, "rev-parse --show-toplevel");
-                repositoryByDirectory[inputDirectory] = repositoryRoot;
-            }
-            if (string.IsNullOrWhiteSpace(repositoryRoot))
+            if (!TryResolveBuildInputRepository(
+                    inputDirectory,
+                    fullGitRoot,
+                    repositoryByDirectory,
+                    out string repositoryRoot))
                 return null;
 
-            repositoryRoot = Path.GetFullPath(repositoryRoot!);
+            bool verifyRepository = verifiedRepositories.Add(repositoryRoot);
             if (!IsSameOrBelowBuildInputPath(repositoryRoot, fullGitRoot) ||
                 !IsSameOrBelowBuildInputPath(fullInput, repositoryRoot) ||
-                !IsRecordedNestedGitRepository(repositoryRoot, fullGitRoot))
+                (verifyRepository &&
+                 !comparer.Equals(repositoryRoot, fullGitRoot) &&
+                 !IsRecordedNestedGitRepository(repositoryRoot, fullGitRoot)))
             {
                 return null;
             }
@@ -72,6 +74,92 @@ public sealed partial class DotNetPublishPipelineRunner
         return ignoredInputs.ToArray();
     }
 
+    private static bool TryResolveBuildInputRepository(
+        string inputDirectory,
+        string outerGitRoot,
+        Dictionary<string, string?> repositoryByDirectory,
+        out string repositoryRoot)
+    {
+        repositoryRoot = string.Empty;
+        string current = Path.GetFullPath(inputDirectory)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        string outerRoot = Path.GetFullPath(outerGitRoot)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        StringComparison comparison = IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        var traversed = new List<string>();
+
+        while (IsSameOrBelowBuildInputPath(current, outerRoot))
+        {
+            if (repositoryByDirectory.TryGetValue(current, out string? cachedRoot))
+            {
+                if (string.IsNullOrWhiteSpace(cachedRoot))
+                    return false;
+                repositoryRoot = cachedRoot!;
+                CacheBuildInputRepositoryDirectories(
+                    repositoryByDirectory,
+                    traversed,
+                    repositoryRoot);
+                return true;
+            }
+
+            traversed.Add(current);
+            string gitMarker = Path.Combine(current, ".git");
+            if (File.Exists(gitMarker) || Directory.Exists(gitMarker))
+            {
+                string? resolvedRoot = ReadGitText(current, "rev-parse --show-toplevel");
+                if (string.IsNullOrWhiteSpace(resolvedRoot))
+                {
+                    CacheBuildInputRepositoryDirectories(repositoryByDirectory, traversed, null);
+                    return false;
+                }
+
+                resolvedRoot = Path.GetFullPath(resolvedRoot!)
+                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                if (!string.Equals(resolvedRoot, current, comparison))
+                {
+                    CacheBuildInputRepositoryDirectories(repositoryByDirectory, traversed, null);
+                    return false;
+                }
+
+                repositoryRoot = resolvedRoot;
+                CacheBuildInputRepositoryDirectories(
+                    repositoryByDirectory,
+                    traversed,
+                    repositoryRoot);
+                return true;
+            }
+
+            if (string.Equals(current, outerRoot, comparison))
+            {
+                repositoryRoot = outerRoot;
+                CacheBuildInputRepositoryDirectories(
+                    repositoryByDirectory,
+                    traversed,
+                    repositoryRoot);
+                return true;
+            }
+
+            string? parent = Path.GetDirectoryName(current);
+            if (string.IsNullOrWhiteSpace(parent) || string.Equals(parent, current, comparison))
+                break;
+            current = parent;
+        }
+
+        CacheBuildInputRepositoryDirectories(repositoryByDirectory, traversed, null);
+        return false;
+    }
+
+    private static void CacheBuildInputRepositoryDirectories(
+        Dictionary<string, string?> repositoryByDirectory,
+        IEnumerable<string> directories,
+        string? repositoryRoot)
+    {
+        foreach (string directory in directories)
+            repositoryByDirectory[directory] = repositoryRoot;
+    }
+
     private static string? ReadIgnoredGitPaths(string gitRoot, IReadOnlyCollection<string> paths)
     {
         if (paths.Count == 0)
@@ -79,8 +167,7 @@ public sealed partial class DotNetPublishPipelineRunner
 
         try
         {
-            if (!TryResolveTrustedBuildTool("git", out string gitPath))
-                return null;
+            string gitPath = ResolveGitChildExecutable("git");
             using var process = new Process
             {
                 StartInfo = new ProcessStartInfo

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
@@ -289,14 +289,16 @@ public sealed partial class DotNetPublishPipelineRunner
             dirtyReasons.ToArray(),
             dirtyScope.NoBuildPublishInputs,
             publishInputFiles,
-            () => ValidateCurrentSourceProvenance(
-                projectRoot,
-                gitRoot!,
-                postEvaluationRevision!,
-                postEvaluationUntrackedOutput!,
-                allGeneratedPaths,
-                trackedGeneratedPathArray,
-                dirtyScope));
+            validateCurrentSourceWithTrackedGeneratedPaths: additionalTrackedGeneratedPaths =>
+                ValidateCurrentSourceProvenance(
+                    projectRoot,
+                    gitRoot!,
+                    postEvaluationRevision!,
+                    postEvaluationUntrackedOutput!,
+                    allGeneratedPaths,
+                    trackedGeneratedPathArray.Concat(
+                        additionalTrackedGeneratedPaths ?? Array.Empty<string>()),
+                    dirtyScope));
     }
 
     private static bool HasGeneratedOutputInputOverlap(
@@ -981,7 +983,8 @@ public sealed partial class DotNetPublishPipelineRunner
             string[]? dirtyReasons = null,
             NoBuildPublishInput[]? noBuildPublishInputs = null,
             string[]? publishInputFiles = null,
-            Action? validateCurrentSource = null)
+            Action? validateCurrentSource = null,
+            Action<IEnumerable<string>?>? validateCurrentSourceWithTrackedGeneratedPaths = null)
         {
             Revision = revision;
             Dirty = dirty;
@@ -990,6 +993,8 @@ public sealed partial class DotNetPublishPipelineRunner
             NoBuildPublishInputs = noBuildPublishInputs ?? Array.Empty<NoBuildPublishInput>();
             PublishInputFiles = publishInputFiles ?? Array.Empty<string>();
             _validateCurrentSource = validateCurrentSource;
+            _validateCurrentSourceWithTrackedGeneratedPaths =
+                validateCurrentSourceWithTrackedGeneratedPaths;
         }
 
         public string? Revision { get; }
@@ -1006,8 +1011,20 @@ public sealed partial class DotNetPublishPipelineRunner
 
         private readonly Action? _validateCurrentSource;
 
+        private readonly Action<IEnumerable<string>?>? _validateCurrentSourceWithTrackedGeneratedPaths;
+
         internal void ValidateCurrentSource()
-            => _validateCurrentSource?.Invoke();
+            => ValidateCurrentSource(additionalTrackedGeneratedPaths: null);
+
+        internal void ValidateCurrentSource(IEnumerable<string>? additionalTrackedGeneratedPaths)
+        {
+            if (_validateCurrentSourceWithTrackedGeneratedPaths is not null)
+            {
+                _validateCurrentSourceWithTrackedGeneratedPaths(additionalTrackedGeneratedPaths);
+                return;
+            }
+            _validateCurrentSource?.Invoke();
+        }
     }
 
     private sealed class MsiVersionStateWrite

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
@@ -166,8 +166,13 @@ public sealed partial class DotNetPublishPipelineRunner
                 path,
                 hookDeclaredOutputs,
                 hookGeneratedOutputs));
-        IEnumerable<string> allGeneratedPaths = (generatedPaths ?? Array.Empty<string>())
-            .Concat(hookGeneratedOutputs);
+        string[] allGeneratedPaths = (generatedPaths ?? Array.Empty<string>())
+            .Concat(hookGeneratedOutputs)
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .ToArray();
+        string[] trackedGeneratedPathArray = (trackedGeneratedPaths ?? Array.Empty<string>())
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .ToArray();
         SourceDirtyScope dirtyScope = BuildSourceDirtyScope(
             projectRoot,
             gitRoot!,
@@ -194,7 +199,7 @@ public sealed partial class DotNetPublishPipelineRunner
             projectRoot,
             gitRoot!,
             postEvaluationTrackedStatus,
-            trackedGeneratedPaths,
+            trackedGeneratedPathArray,
             dirtyScope);
         string[] untrackedSourceFiles = FindUntrackedSourceFiles(
             projectRoot,
@@ -283,7 +288,15 @@ public sealed partial class DotNetPublishPipelineRunner
                 .ToArray(),
             dirtyReasons.ToArray(),
             dirtyScope.NoBuildPublishInputs,
-            publishInputFiles);
+            publishInputFiles,
+            () => ValidateCurrentSourceProvenance(
+                projectRoot,
+                gitRoot!,
+                postEvaluationRevision!,
+                postEvaluationUntrackedOutput!,
+                allGeneratedPaths,
+                trackedGeneratedPathArray,
+                dirtyScope));
     }
 
     private static bool HasGeneratedOutputInputOverlap(
@@ -967,7 +980,8 @@ public sealed partial class DotNetPublishPipelineRunner
             string[]? dirtyPaths = null,
             string[]? dirtyReasons = null,
             NoBuildPublishInput[]? noBuildPublishInputs = null,
-            string[]? publishInputFiles = null)
+            string[]? publishInputFiles = null,
+            Action? validateCurrentSource = null)
         {
             Revision = revision;
             Dirty = dirty;
@@ -975,6 +989,7 @@ public sealed partial class DotNetPublishPipelineRunner
             DirtyReasons = dirtyReasons ?? Array.Empty<string>();
             NoBuildPublishInputs = noBuildPublishInputs ?? Array.Empty<NoBuildPublishInput>();
             PublishInputFiles = publishInputFiles ?? Array.Empty<string>();
+            _validateCurrentSource = validateCurrentSource;
         }
 
         public string? Revision { get; }
@@ -988,6 +1003,11 @@ public sealed partial class DotNetPublishPipelineRunner
         internal NoBuildPublishInput[] NoBuildPublishInputs { get; }
 
         internal string[] PublishInputFiles { get; }
+
+        private readonly Action? _validateCurrentSource;
+
+        internal void ValidateCurrentSource()
+            => _validateCurrentSource?.Invoke();
     }
 
     private sealed class MsiVersionStateWrite

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
@@ -572,6 +572,10 @@ public sealed partial class DotNetPublishPipelineRunner
         DotNetPublishPlan plan,
         IEnumerable<DotNetPublishMsiBuildResult> msiBuilds)
     {
+        yield return plan.Outputs.ManifestJsonPath ?? string.Empty;
+        yield return plan.Outputs.ManifestTextPath ?? string.Empty;
+        yield return plan.Outputs.ChecksumsPath ?? string.Empty;
+
         foreach (var statePath in EnumeratePlannedMsiVersionStatePaths(plan))
             yield return statePath;
 

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
@@ -2,6 +2,7 @@ using System.IO.Compression;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Xml.Linq;
+using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Signing;
 using NuGet.Versioning;
@@ -104,6 +105,46 @@ public sealed partial class DotNetPublishPipelineRunner
         catch
         {
             return false;
+        }
+    }
+
+    private static string? ResolveNearestDeclaredTargetFrameworkUnconditionally(
+        string projectPath,
+        string requestedFramework)
+    {
+        try
+        {
+            NuGetFramework requested = NuGetFramework.ParseFolder(requestedFramework);
+            if (requested.IsUnsupported)
+                return null;
+            (string Text, NuGetFramework Framework)[] declared = XDocument.Load(projectPath, LoadOptions.None)
+                .Descendants()
+                .Where(element =>
+                    (element.Name.LocalName.Equals("TargetFramework", StringComparison.OrdinalIgnoreCase) ||
+                     element.Name.LocalName.Equals("TargetFrameworks", StringComparison.OrdinalIgnoreCase)) &&
+                    !string.IsNullOrWhiteSpace(element.Value) &&
+                    !element.AncestorsAndSelf().Any(candidate => candidate.Attributes().Any(attribute =>
+                        attribute.Name.LocalName.Equals("Condition", StringComparison.OrdinalIgnoreCase) &&
+                        !string.IsNullOrWhiteSpace(attribute.Value))))
+                .SelectMany(element => element.Value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+                .Select(value => value.Trim())
+                .Where(value => value.Length > 0 && !value.Contains("$(", StringComparison.Ordinal))
+                .Select(value => (Text: value, Framework: NuGetFramework.ParseFolder(value)))
+                .Where(candidate => !candidate.Framework.IsUnsupported)
+                .ToArray();
+            if (declared.Length == 0)
+                return null;
+
+            NuGetFramework? nearest = new FrameworkReducer().GetNearest(
+                requested,
+                declared.Select(candidate => candidate.Framework));
+            return nearest is null
+                ? null
+                : declared.First(candidate => candidate.Framework.Equals(nearest)).Text;
+        }
+        catch
+        {
+            return null;
         }
     }
 
@@ -385,6 +426,8 @@ public sealed partial class DotNetPublishPipelineRunner
         private readonly Dictionary<string, HashSet<string>> _controlledBuildInputsByArchive = new(
             IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
 
+        internal IEnumerable<string> SdkManagedArchivePaths => _sdkManagedArchivePaths;
+
         private VerifiedPackageInputCatalog(
             IEnumerable<string> packageRoots,
             IReadOnlyDictionary<string, string> lockedPackageHashes,
@@ -403,6 +446,15 @@ public sealed partial class DotNetPublishPipelineRunner
                 sdkManagedPackageKeys.Where(archivePathsByPackageKey.ContainsKey)
                     .Select(packageKey => archivePathsByPackageKey[packageKey]),
                 IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+        }
+
+        internal void InheritSdkManagedArchivePaths(IEnumerable<string> archivePaths)
+        {
+            var verifiedArchivePaths = new HashSet<string>(
+                _archivePathsByPackageKey.Values.Select(Path.GetFullPath),
+                IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+            _sdkManagedArchivePaths.UnionWith(
+                archivePaths.Select(Path.GetFullPath).Where(verifiedArchivePaths.Contains));
         }
 
         internal static bool TryCreate(
@@ -427,6 +479,25 @@ public sealed partial class DotNetPublishPipelineRunner
             VerifiedPackageArchiveCache archives,
             IReadOnlyDictionary<string, string>? effectiveGlobalProperties,
             IReadOnlyDictionary<string, string?>? environmentVariables,
+            out VerifiedPackageInputCatalog? catalog)
+            => TryCreateForEvaluation(
+                projectPath,
+                properties,
+                packageRoots,
+                archives,
+                effectiveGlobalProperties,
+                environmentVariables,
+                includeSdkPackageEvidence: true,
+                out catalog);
+
+        internal static bool TryCreateForEvaluation(
+            string projectPath,
+            JsonElement properties,
+            IEnumerable<string> packageRoots,
+            VerifiedPackageArchiveCache archives,
+            IReadOnlyDictionary<string, string>? effectiveGlobalProperties,
+            IReadOnlyDictionary<string, string?>? environmentVariables,
+            bool includeSdkPackageEvidence,
             out VerifiedPackageInputCatalog? catalog)
         {
             catalog = null;
@@ -477,7 +548,9 @@ public sealed partial class DotNetPublishPipelineRunner
                 StringComparer.OrdinalIgnoreCase);
             var sdkDownloadPackageHashes = new Dictionary<string, string>(
                 StringComparer.OrdinalIgnoreCase);
-            var sdkManagedPackageKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var sdkManagedPackageKeys = new HashSet<string>(
+                sdkPackageLockHashes.Keys,
+                StringComparer.OrdinalIgnoreCase);
             if (!TryPrimeLockedPackageArchives(
                     allRoots,
                     committedPackageHashes,
@@ -486,16 +559,18 @@ public sealed partial class DotNetPublishPipelineRunner
             {
                 return false;
             }
-            string? sdkEvidenceRoot = AddSdkManagedPackageHashes(
-                projectPath,
-                properties,
-                allRoots,
-                sdkDownloadPackageHashes,
-                sdkManagedPackageKeys,
-                effectiveGlobalProperties,
-                environmentVariables,
-                archivePathsByPackageKey,
-                archives);
+            string? sdkEvidenceRoot = includeSdkPackageEvidence
+                ? AddSdkManagedPackageHashes(
+                    projectPath,
+                    properties,
+                    allRoots,
+                    sdkDownloadPackageHashes,
+                    sdkManagedPackageKeys,
+                    effectiveGlobalProperties,
+                    environmentVariables,
+                    archivePathsByPackageKey,
+                    archives)
+                : null;
             try
             {
                 if (allRoots.Count == 0)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PortableEvidenceFinalization.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PortableEvidenceFinalization.cs
@@ -6,7 +6,8 @@ public sealed partial class DotNetPublishPipelineRunner
 {
     internal void FinalizePortableEvidence(
         DotNetPublishPlan plan,
-        IReadOnlyList<DotNetPublishArtefactResult> artefacts)
+        IReadOnlyList<DotNetPublishArtefactResult> artefacts,
+        IReadOnlyDictionary<string, SourceProvenance>? verifiedProvenanceByArtifact = null)
     {
         if (plan is null) throw new ArgumentNullException(nameof(plan));
         if (artefacts is null) throw new ArgumentNullException(nameof(artefacts));
@@ -74,10 +75,15 @@ public sealed partial class DotNetPublishPipelineRunner
                 artefact.BundleId,
                 archivePayload,
                 sign);
-            SourceProvenance provenance = ReadPortableInventorySourceProvenance(
-                plan,
-                outputDirectory,
-                EnumerateBundleGeneratedArtefactPaths(artefacts));
+            SourceProvenance provenance = verifiedProvenanceByArtifact is not null &&
+                                          verifiedProvenanceByArtifact.TryGetValue(
+                                              BuildArtifactProvenanceKey(artefact),
+                                              out SourceProvenance? verifiedProvenance)
+                ? verifiedProvenance
+                : ReadPortableInventorySourceProvenance(
+                    plan,
+                    outputDirectory,
+                    EnumerateBundleGeneratedArtefactPaths(artefacts));
             string portableVersion = FirstText(versionInfo.ProductVersion, versionInfo.FileVersion);
             PowerForgePortablePayloadInventory inventory = archivePayload
                 ? PowerForgePortablePayloadInventoryCms.CreateFromArchive(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PublishLayout.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PublishLayout.cs
@@ -235,20 +235,7 @@ public sealed partial class DotNetPublishPipelineRunner
     {
         try
         {
-            var nameTemplate = string.IsNullOrWhiteSpace(target.Publish.ZipNameTemplate)
-                ? "{target}-{framework}-{rid}-{style}.zip"
-                : target.Publish.ZipNameTemplate!;
-
-            var zipName = ApplyTemplate(nameTemplate, tokens);
-            if (!zipName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
-                zipName += ".zip";
-
-            var zipPath = string.IsNullOrWhiteSpace(target.Publish.ZipPath)
-                ? Path.Combine(Path.GetDirectoryName(outputDir)!, zipName)
-                : ResolvePath(plan.ProjectRoot, ApplyTemplate(target.Publish.ZipPath!, tokens));
-
-            if (!plan.AllowOutputOutsideProjectRoot)
-                EnsurePathWithinRoot(plan.ProjectRoot, zipPath, $"Target '{target.Name}' zip path");
+            string zipPath = ResolvePublishZipPath(outputDir, plan, target, tokens);
 
             Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(zipPath))!);
             if (File.Exists(zipPath)) File.Delete(zipPath);

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PublishOutputPaths.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PublishOutputPaths.cs
@@ -2,32 +2,42 @@ namespace PowerForge;
 
 public sealed partial class DotNetPublishPipelineRunner
 {
-    internal static string[] ResolvePlannedPublishOutputDirectories(DotNetPublishPlan plan)
+    internal static string[] ResolvePlannedPublishGeneratedPaths(DotNetPublishPlan plan)
     {
         StringComparer comparer = IsWindows()
             ? StringComparer.OrdinalIgnoreCase
             : StringComparer.Ordinal;
-        return (plan.Steps ?? Array.Empty<DotNetPublishStep>())
-            .Where(static step => step is not null && step.Kind == DotNetPublishStepKind.Publish)
-            .Select(step =>
-            {
-                DotNetPublishTargetPlan target = (plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
-                    .First(candidate => candidate.Name.Equals(
-                        step.TargetName,
-                        StringComparison.OrdinalIgnoreCase));
-                string framework = string.IsNullOrWhiteSpace(step.Framework)
-                    ? target.Publish.Framework
-                    : step.Framework!.Trim();
-                DotNetPublishStyle style = step.Style ?? target.Publish.Style;
-                return ResolvePublishOutputDirectory(
-                    plan,
-                    target,
-                    framework,
-                    step.Runtime ?? string.Empty,
-                    style);
-            })
-            .Distinct(comparer)
-            .ToArray();
+        var paths = new HashSet<string>(comparer);
+        foreach (DotNetPublishStep step in (plan.Steps ?? Array.Empty<DotNetPublishStep>())
+                     .Where(static step => step is not null && step.Kind == DotNetPublishStepKind.Publish))
+        {
+            DotNetPublishTargetPlan target = (plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
+                .First(candidate => candidate.Name.Equals(
+                    step.TargetName,
+                    StringComparison.OrdinalIgnoreCase));
+            string framework = string.IsNullOrWhiteSpace(step.Framework)
+                ? target.Publish.Framework
+                : step.Framework!.Trim();
+            string runtime = step.Runtime ?? string.Empty;
+            DotNetPublishStyle style = step.Style ?? target.Publish.Style;
+            IReadOnlyDictionary<string, string> tokens = BuildPublishOutputTokens(
+                plan,
+                target,
+                framework,
+                runtime,
+                style);
+            string outputDirectory = ResolvePublishOutputDirectory(
+                plan,
+                target,
+                framework,
+                runtime,
+                style);
+            paths.Add(outputDirectory);
+            if (target.Publish.Zip)
+                paths.Add(ResolvePublishZipPath(outputDirectory, plan, target, tokens));
+        }
+
+        return paths.OrderBy(path => path, comparer).ToArray();
     }
 
     private static string ResolvePublishOutputDirectory(
@@ -74,4 +84,25 @@ public sealed partial class DotNetPublishPipelineRunner
                 runtime,
                 style) ?? string.Empty
         };
+
+    private static string ResolvePublishZipPath(
+        string outputDirectory,
+        DotNetPublishPlan plan,
+        DotNetPublishTargetPlan target,
+        IReadOnlyDictionary<string, string> tokens)
+    {
+        string nameTemplate = string.IsNullOrWhiteSpace(target.Publish.ZipNameTemplate)
+            ? "{target}-{framework}-{rid}-{style}.zip"
+            : target.Publish.ZipNameTemplate!;
+        string zipName = ApplyTemplate(nameTemplate, tokens);
+        if (!zipName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+            zipName += ".zip";
+
+        string zipPath = string.IsNullOrWhiteSpace(target.Publish.ZipPath)
+            ? Path.Combine(Path.GetDirectoryName(outputDirectory)!, zipName)
+            : ResolvePath(plan.ProjectRoot, ApplyTemplate(target.Publish.ZipPath!, tokens));
+        if (!plan.AllowOutputOutsideProjectRoot)
+            EnsurePathWithinRoot(plan.ProjectRoot, zipPath, $"Target '{target.Name}' zip path");
+        return Path.GetFullPath(zipPath);
+    }
 }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PublishOutputPaths.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PublishOutputPaths.cs
@@ -1,0 +1,77 @@
+namespace PowerForge;
+
+public sealed partial class DotNetPublishPipelineRunner
+{
+    internal static string[] ResolvePlannedPublishOutputDirectories(DotNetPublishPlan plan)
+    {
+        StringComparer comparer = IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+        return (plan.Steps ?? Array.Empty<DotNetPublishStep>())
+            .Where(static step => step is not null && step.Kind == DotNetPublishStepKind.Publish)
+            .Select(step =>
+            {
+                DotNetPublishTargetPlan target = (plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
+                    .First(candidate => candidate.Name.Equals(
+                        step.TargetName,
+                        StringComparison.OrdinalIgnoreCase));
+                string framework = string.IsNullOrWhiteSpace(step.Framework)
+                    ? target.Publish.Framework
+                    : step.Framework!.Trim();
+                DotNetPublishStyle style = step.Style ?? target.Publish.Style;
+                return ResolvePublishOutputDirectory(
+                    plan,
+                    target,
+                    framework,
+                    step.Runtime ?? string.Empty,
+                    style);
+            })
+            .Distinct(comparer)
+            .ToArray();
+    }
+
+    private static string ResolvePublishOutputDirectory(
+        DotNetPublishPlan plan,
+        DotNetPublishTargetPlan target,
+        string framework,
+        string runtime,
+        DotNetPublishStyle style)
+    {
+        IReadOnlyDictionary<string, string> tokens = BuildPublishOutputTokens(
+            plan,
+            target,
+            framework,
+            runtime,
+            style);
+        string outputDirTemplate = string.IsNullOrWhiteSpace(target.Publish.OutputPath)
+            ? Path.Combine("Artifacts", "DotNetPublish", "{target}", "{rid}", "{framework}", "{style}")
+            : target.Publish.OutputPath!;
+        string outputDir = ResolvePath(
+            plan.ProjectRoot,
+            ApplyTemplate(outputDirTemplate, tokens));
+        if (!plan.AllowOutputOutsideProjectRoot)
+            EnsurePathWithinRoot(plan.ProjectRoot, outputDir, $"Target '{target.Name}' output path");
+        return outputDir;
+    }
+
+    private static IReadOnlyDictionary<string, string> BuildPublishOutputTokens(
+        DotNetPublishPlan plan,
+        DotNetPublishTargetPlan target,
+        string framework,
+        string runtime,
+        DotNetPublishStyle style)
+        => new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["target"] = target.Name,
+            ["rid"] = runtime,
+            ["framework"] = framework,
+            ["style"] = style.ToString(),
+            ["configuration"] = plan.Configuration,
+            ["version"] = ResolvePublishReleaseVersion(
+                plan,
+                target.Name,
+                framework,
+                runtime,
+                style) ?? string.Empty
+        };
+}

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
@@ -63,7 +63,8 @@ public sealed partial class DotNetPublishPipelineRunner
         var benchmarkGates = new List<DotNetPublishBenchmarkGateResult>();
         var benchmarkExtracts = new Dictionary<string, DotNetPublishBenchmarkExtractionResult>(StringComparer.OrdinalIgnoreCase);
         var stepReports = new List<DotNetPublishRunReportStep>();
-        var manifestProvenanceLeases = new List<PublishProvenanceLease>();
+        PublishProvenanceLease? manifestProvenanceLease = null;
+        SourceProvenance? sharedPublishProvenance = null;
         var publishProvenanceByArtifact = new Dictionary<string, SourceProvenance>(StringComparer.OrdinalIgnoreCase);
         IReadOnlyDictionary<string, string> cleanTrackedGeneratedProvenanceState =
             new Dictionary<string, string>();
@@ -133,62 +134,69 @@ public sealed partial class DotNetPublishPipelineRunner
                                     target.Publish?.Sign?.Enabled == true);
                             SourceProvenance? publishProvenance = null;
                             PublishProvenanceLease? provenanceLease = null;
-                            bool retainProvenanceLease = false;
                             if (requiresPublishProvenance)
                             {
-                                publishProvenance = ReadPortableInventorySourceProvenance(plan);
-                                provenanceLease = PublishProvenanceLease.Create(
-                                    PublishProvenanceLease.BuildGuardedPaths(
-                                        publishProvenance.PublishInputFiles,
-                                        publishProvenance.NoBuildPublishInputs));
-                                retainProvenanceLease = true;
-                                SourceProvenance confirmedProvenance =
-                                    ReadPortableInventorySourceProvenance(plan);
-                                provenanceLease.EnsureCovers(PublishProvenanceLease.BuildGuardedPaths(
-                                    confirmedProvenance.PublishInputFiles,
-                                    confirmedProvenance.NoBuildPublishInputs));
-                                provenanceLease.ValidateUnchanged();
-                                publishProvenance = confirmedProvenance;
+                                if (sharedPublishProvenance is null)
+                                {
+                                    SourceProvenance initialProvenance =
+                                        ReadPortableInventorySourceProvenance(plan);
+                                    PublishProvenanceLease candidateLease = PublishProvenanceLease.Create(
+                                        PublishProvenanceLease.BuildGuardedPaths(
+                                            initialProvenance.PublishInputFiles,
+                                            initialProvenance.NoBuildPublishInputs));
+                                    try
+                                    {
+                                        SourceProvenance confirmedProvenance =
+                                            ReadPortableInventorySourceProvenance(plan);
+                                        candidateLease.EnsureCovers(PublishProvenanceLease.BuildGuardedPaths(
+                                            confirmedProvenance.PublishInputFiles,
+                                            confirmedProvenance.NoBuildPublishInputs));
+                                        candidateLease.ValidateUnchanged();
+                                        confirmedProvenance.ValidateCurrentSource();
+                                        manifestProvenanceLease = candidateLease;
+                                        sharedPublishProvenance = confirmedProvenance;
+                                    }
+                                    catch
+                                    {
+                                        candidateLease.Dispose();
+                                        throw;
+                                    }
+                                }
+                                else
+                                {
+                                    manifestProvenanceLease!.ValidateUnchanged();
+                                    sharedPublishProvenance.ValidateCurrentSource();
+                                }
+
+                                publishProvenance = sharedPublishProvenance;
+                                provenanceLease = manifestProvenanceLease;
                             }
-                            try
+                            using NoBuildPublishInputSnapshot? inputSnapshot =
+                                requiresPublishProvenance
+                                    ? CreateNoBuildPublishInputSnapshot(
+                                        plan,
+                                        step.TargetName!,
+                                        step.Framework ?? string.Empty,
+                                        step.Runtime!,
+                                        step.Style,
+                                        publishProvenance!)
+                                    : null;
+                            DotNetPublishArtefactResult publishedArtefact = Publish(
+                                plan,
+                                step.TargetName!,
+                                step.Framework ?? string.Empty,
+                                step.Runtime!,
+                                step.Style,
+                                msiReservationOwner,
+                                inputSnapshot,
+                                provenanceLease,
+                                publishProvenance);
+                            artefacts.Add(publishedArtefact);
+                            if (publishProvenance is not null)
                             {
-                                using NoBuildPublishInputSnapshot? inputSnapshot =
-                                    requiresPublishProvenance
-                                        ? CreateNoBuildPublishInputSnapshot(
-                                            plan,
-                                            step.TargetName!,
-                                            step.Framework ?? string.Empty,
-                                            step.Runtime!,
-                                            step.Style,
-                                            publishProvenance!)
-                                        : null;
-                                DotNetPublishArtefactResult publishedArtefact = Publish(
-                                    plan,
-                                    step.TargetName!,
-                                    step.Framework ?? string.Empty,
-                                    step.Runtime!,
-                                    step.Style,
-                                    msiReservationOwner,
-                                    inputSnapshot,
-                                    provenanceLease,
+                                publishProvenanceByArtifact.Add(
+                                    BuildArtifactProvenanceKey(publishedArtefact),
                                     publishProvenance);
-                                artefacts.Add(publishedArtefact);
-                                if (publishProvenance is not null)
-                                {
-                                    publishProvenanceByArtifact.Add(
-                                        BuildArtifactProvenanceKey(publishedArtefact),
-                                        publishProvenance);
-                                }
-                                if (retainProvenanceLease)
-                                {
-                                    manifestProvenanceLeases.Add(provenanceLease!);
-                                    retainProvenanceLease = false;
-                                }
-                            }
-                            finally
-                            {
-                                if (retainProvenanceLease)
-                                    provenanceLease?.Dispose();
                             }
                             break;
                         }
@@ -218,9 +226,13 @@ public sealed partial class DotNetPublishPipelineRunner
                             break;
                         case DotNetPublishStepKind.Manifest:
                         {
-                            ValidateManifestProvenanceLeases(manifestProvenanceLeases);
+                            ValidateManifestProvenance(
+                                manifestProvenanceLease,
+                                sharedPublishProvenance);
                             FinalizePortableEvidence(plan, artefacts, publishProvenanceByArtifact);
-                            ValidateManifestProvenanceLeases(manifestProvenanceLeases);
+                            ValidateManifestProvenance(
+                                manifestProvenanceLease,
+                                sharedPublishProvenance);
                             (manifestJson, manifestText, checksumsPath) = WriteManifestsWithProvenance(
                                 plan,
                                 artefacts,
@@ -233,7 +245,9 @@ public sealed partial class DotNetPublishPipelineRunner
                                     msiReservationOwner,
                                 verifiedSourceProvenance:
                                     TryBuildManifestProvenance(artefacts, publishProvenanceByArtifact));
-                            ValidateManifestProvenanceLeases(manifestProvenanceLeases);
+                            ValidateManifestProvenance(
+                                manifestProvenanceLease,
+                                sharedPublishProvenance);
                             break;
                         }
                     }
@@ -344,8 +358,7 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             try
             {
-                foreach (PublishProvenanceLease provenanceLease in manifestProvenanceLeases)
-                    provenanceLease.Dispose();
+                manifestProvenanceLease?.Dispose();
                 foreach (var version in plan.MsiVersions.Values)
                 {
                     if (!ReleaseMsiVersionStateReservation(version, msiReservationOwner))
@@ -436,11 +449,12 @@ public sealed partial class DotNetPublishPipelineRunner
             artefact.Runtime,
             artefact.Style.ToString());
 
-    private static void ValidateManifestProvenanceLeases(
-        IEnumerable<PublishProvenanceLease> provenanceLeases)
+    private static void ValidateManifestProvenance(
+        PublishProvenanceLease? provenanceLease,
+        SourceProvenance? provenance)
     {
-        foreach (PublishProvenanceLease provenanceLease in provenanceLeases)
-            provenanceLease.ValidateUnchanged();
+        provenanceLease?.ValidateUnchanged();
+        provenance?.ValidateCurrentSource();
     }
 
     internal static SourceProvenance? TryBuildManifestProvenance(
@@ -459,6 +473,10 @@ public sealed partial class DotNetPublishPipelineRunner
         SourceProvenance[] provenances = publishArtefacts
             .Select(artefact => publishProvenanceByArtifact[BuildArtifactProvenanceKey(artefact)])
             .ToArray();
+        SourceProvenance sharedProvenance = provenances[0];
+        if (provenances.All(provenance => ReferenceEquals(provenance, sharedProvenance)))
+            return sharedProvenance;
+
         string?[] revisions = provenances
             .Select(static provenance => provenance.Revision)
             .Distinct(StringComparer.OrdinalIgnoreCase)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
@@ -39,6 +39,7 @@ public sealed partial class DotNetPublishPipelineRunner
         TrustedNativeAotPathSnapshot? previousNativeAotPathSnapshot = ActiveNativeAotPathSnapshot.Value;
         string? previousGitExecutablePath = ActiveGitExecutablePath.Value;
         string? previousGitExecutableSha256 = ActiveGitExecutableSha256.Value;
+        PublishProvenanceLease? previousGitExecutableLease = ActiveGitExecutableLease.Value;
         bool previousNativeAotPublish = ActiveNativeAotPublish.Value;
         bool previousStrictDotNetEnvironment = ActiveStrictDotNetEnvironment.Value;
         bool previousToolSnapshotScope = ActiveToolSnapshotScope.Value;
@@ -48,6 +49,7 @@ public sealed partial class DotNetPublishPipelineRunner
         ActiveNativeAotPathSnapshot.Value = null;
         ActiveGitExecutablePath.Value = null;
         ActiveGitExecutableSha256.Value = null;
+        ActiveGitExecutableLease.Value = null;
         ActiveToolSnapshotScope.Value = true;
         _cancellationToken.Value = cancellationToken;
         progress ??= NullDotNetPublishProgressReporter.Instance;
@@ -61,6 +63,8 @@ public sealed partial class DotNetPublishPipelineRunner
         var benchmarkGates = new List<DotNetPublishBenchmarkGateResult>();
         var benchmarkExtracts = new Dictionary<string, DotNetPublishBenchmarkExtractionResult>(StringComparer.OrdinalIgnoreCase);
         var stepReports = new List<DotNetPublishRunReportStep>();
+        var manifestProvenanceLeases = new List<PublishProvenanceLease>();
+        var publishProvenanceByArtifact = new Dictionary<string, SourceProvenance>(StringComparer.OrdinalIgnoreCase);
         IReadOnlyDictionary<string, string> cleanTrackedGeneratedProvenanceState =
             new Dictionary<string, string>();
         string? manifestJson = null;
@@ -127,16 +131,17 @@ public sealed partial class DotNetPublishPipelineRunner
                                     target is not null &&
                                     target.Name.Equals(step.TargetName, StringComparison.OrdinalIgnoreCase) &&
                                     target.Publish?.Sign?.Enabled == true);
-                            SourceProvenance? publishProvenance = requiresPublishProvenance
-                                ? ReadPortableInventorySourceProvenance(plan)
-                                : null;
-                            using PublishProvenanceLease? provenanceLease = requiresPublishProvenance
-                                ? PublishProvenanceLease.Create(PublishProvenanceLease.BuildGuardedPaths(
-                                    publishProvenance!.PublishInputFiles,
-                                    publishProvenance.NoBuildPublishInputs))
-                                : null;
-                            if (provenanceLease is not null)
+                            SourceProvenance? publishProvenance = null;
+                            PublishProvenanceLease? provenanceLease = null;
+                            bool retainProvenanceLease = false;
+                            if (requiresPublishProvenance)
                             {
+                                publishProvenance = ReadPortableInventorySourceProvenance(plan);
+                                provenanceLease = PublishProvenanceLease.Create(
+                                    PublishProvenanceLease.BuildGuardedPaths(
+                                        publishProvenance.PublishInputFiles,
+                                        publishProvenance.NoBuildPublishInputs));
+                                retainProvenanceLease = true;
                                 SourceProvenance confirmedProvenance =
                                     ReadPortableInventorySourceProvenance(plan);
                                 provenanceLease.EnsureCovers(PublishProvenanceLease.BuildGuardedPaths(
@@ -145,25 +150,46 @@ public sealed partial class DotNetPublishPipelineRunner
                                 provenanceLease.ValidateUnchanged();
                                 publishProvenance = confirmedProvenance;
                             }
-                            using NoBuildPublishInputSnapshot? inputSnapshot =
-                                requiresPublishProvenance
-                                    ? CreateNoBuildPublishInputSnapshot(
-                                        plan,
-                                        step.TargetName!,
-                                        step.Framework ?? string.Empty,
-                                        step.Runtime!,
-                                        step.Style,
-                                        publishProvenance!)
-                                    : null;
-                            artefacts.Add(Publish(
-                                plan,
-                                step.TargetName!,
-                                step.Framework ?? string.Empty,
-                                step.Runtime!,
-                                step.Style,
-                                msiReservationOwner,
-                                inputSnapshot,
-                                provenanceLease));
+                            try
+                            {
+                                using NoBuildPublishInputSnapshot? inputSnapshot =
+                                    requiresPublishProvenance
+                                        ? CreateNoBuildPublishInputSnapshot(
+                                            plan,
+                                            step.TargetName!,
+                                            step.Framework ?? string.Empty,
+                                            step.Runtime!,
+                                            step.Style,
+                                            publishProvenance!)
+                                        : null;
+                                DotNetPublishArtefactResult publishedArtefact = Publish(
+                                    plan,
+                                    step.TargetName!,
+                                    step.Framework ?? string.Empty,
+                                    step.Runtime!,
+                                    step.Style,
+                                    msiReservationOwner,
+                                    inputSnapshot,
+                                    provenanceLease,
+                                    publishProvenance);
+                                artefacts.Add(publishedArtefact);
+                                if (publishProvenance is not null)
+                                {
+                                    publishProvenanceByArtifact.Add(
+                                        BuildArtifactProvenanceKey(publishedArtefact),
+                                        publishProvenance);
+                                }
+                                if (retainProvenanceLease)
+                                {
+                                    manifestProvenanceLeases.Add(provenanceLease!);
+                                    retainProvenanceLease = false;
+                                }
+                            }
+                            finally
+                            {
+                                if (retainProvenanceLease)
+                                    provenanceLease?.Dispose();
+                            }
                             break;
                         }
                         case DotNetPublishStepKind.Bundle:
@@ -192,7 +218,9 @@ public sealed partial class DotNetPublishPipelineRunner
                             break;
                         case DotNetPublishStepKind.Manifest:
                         {
-                            FinalizePortableEvidence(plan, artefacts);
+                            ValidateManifestProvenanceLeases(manifestProvenanceLeases);
+                            FinalizePortableEvidence(plan, artefacts, publishProvenanceByArtifact);
+                            ValidateManifestProvenanceLeases(manifestProvenanceLeases);
                             (manifestJson, manifestText, checksumsPath) = WriteManifestsWithProvenance(
                                 plan,
                                 artefacts,
@@ -202,7 +230,10 @@ public sealed partial class DotNetPublishPipelineRunner
                                 cleanTrackedGeneratedProvenanceState:
                                     cleanTrackedGeneratedProvenanceState,
                                 msiReservationOwner:
-                                    msiReservationOwner);
+                                    msiReservationOwner,
+                                verifiedSourceProvenance:
+                                    TryBuildManifestProvenance(artefacts, publishProvenanceByArtifact));
+                            ValidateManifestProvenanceLeases(manifestProvenanceLeases);
                             break;
                         }
                     }
@@ -313,6 +344,8 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             try
             {
+                foreach (PublishProvenanceLease provenanceLease in manifestProvenanceLeases)
+                    provenanceLease.Dispose();
                 foreach (var version in plan.MsiVersions.Values)
                 {
                     if (!ReleaseMsiVersionStateReservation(version, msiReservationOwner))
@@ -327,6 +360,7 @@ public sealed partial class DotNetPublishPipelineRunner
             {
                 TrustedDotNetInstallationSnapshot? dotNetInstallationSnapshot = ActiveDotNetInstallationSnapshot.Value;
                 TrustedNativeAotPathSnapshot? nativeAotPathSnapshot = ActiveNativeAotPathSnapshot.Value;
+                PublishProvenanceLease? gitExecutableLease = ActiveGitExecutableLease.Value;
                 try
                 {
                     try
@@ -360,20 +394,101 @@ public sealed partial class DotNetPublishPipelineRunner
                 }
                 finally
                 {
-                    ClearMsiVersionStateWrites(msiReservationOwner);
-                    _cancellationToken.Value = previousCancellationToken;
-                    ActiveDotNetExecutablePath.Value = previousDotNetExecutablePath;
-                    ActiveDotNetExecutableSha256.Value = previousDotNetExecutableSha256;
-                    ActiveDotNetInstallationSnapshot.Value = previousDotNetInstallationSnapshot;
-                    ActiveNativeAotPathSnapshot.Value = previousNativeAotPathSnapshot;
-                    ActiveGitExecutablePath.Value = previousGitExecutablePath;
-                    ActiveGitExecutableSha256.Value = previousGitExecutableSha256;
-                    ActiveNativeAotPublish.Value = previousNativeAotPublish;
-                    ActiveStrictDotNetEnvironment.Value = previousStrictDotNetEnvironment;
-                    ActiveToolSnapshotScope.Value = previousToolSnapshotScope;
+                    try
+                    {
+                        if (gitExecutableLease is not null)
+                        {
+                            try
+                            {
+                                gitExecutableLease.ValidateUnchanged();
+                            }
+                            finally
+                            {
+                                gitExecutableLease.Dispose();
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        ClearMsiVersionStateWrites(msiReservationOwner);
+                        _cancellationToken.Value = previousCancellationToken;
+                        ActiveDotNetExecutablePath.Value = previousDotNetExecutablePath;
+                        ActiveDotNetExecutableSha256.Value = previousDotNetExecutableSha256;
+                        ActiveDotNetInstallationSnapshot.Value = previousDotNetInstallationSnapshot;
+                        ActiveNativeAotPathSnapshot.Value = previousNativeAotPathSnapshot;
+                        ActiveGitExecutablePath.Value = previousGitExecutablePath;
+                        ActiveGitExecutableSha256.Value = previousGitExecutableSha256;
+                        ActiveGitExecutableLease.Value = previousGitExecutableLease;
+                        ActiveNativeAotPublish.Value = previousNativeAotPublish;
+                        ActiveStrictDotNetEnvironment.Value = previousStrictDotNetEnvironment;
+                        ActiveToolSnapshotScope.Value = previousToolSnapshotScope;
+                    }
                 }
             }
         }
+    }
+
+    private static string BuildArtifactProvenanceKey(DotNetPublishArtefactResult artefact)
+        => string.Join(
+            "|",
+            artefact.Target,
+            artefact.Framework,
+            artefact.Runtime,
+            artefact.Style.ToString());
+
+    private static void ValidateManifestProvenanceLeases(
+        IEnumerable<PublishProvenanceLease> provenanceLeases)
+    {
+        foreach (PublishProvenanceLease provenanceLease in provenanceLeases)
+            provenanceLease.ValidateUnchanged();
+    }
+
+    internal static SourceProvenance? TryBuildManifestProvenance(
+        IReadOnlyCollection<DotNetPublishArtefactResult> artefacts,
+        IReadOnlyDictionary<string, SourceProvenance> publishProvenanceByArtifact)
+    {
+        DotNetPublishArtefactResult[] publishArtefacts = artefacts
+            .Where(static artefact => artefact.Category == DotNetPublishArtefactCategory.Publish)
+            .ToArray();
+        if (publishArtefacts.Length == 0 || publishArtefacts.Any(artefact =>
+                !publishProvenanceByArtifact.ContainsKey(BuildArtifactProvenanceKey(artefact))))
+        {
+            return null;
+        }
+
+        SourceProvenance[] provenances = publishArtefacts
+            .Select(artefact => publishProvenanceByArtifact[BuildArtifactProvenanceKey(artefact)])
+            .ToArray();
+        string?[] revisions = provenances
+            .Select(static provenance => provenance.Revision)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (revisions.Length > 1)
+            throw new InvalidOperationException("Published artifacts do not share one verified source revision.");
+
+        bool? dirty = provenances.Any(static provenance => provenance.Dirty == true)
+            ? true
+            : provenances.All(static provenance => provenance.Dirty == false)
+                ? false
+                : null;
+        return new SourceProvenance(
+            revisions.SingleOrDefault(),
+            dirty,
+            provenances.SelectMany(static provenance => provenance.DirtyPaths)
+                .Distinct(IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
+                .ToArray(),
+            provenances.SelectMany(static provenance => provenance.DirtyReasons)
+                .Distinct(StringComparer.Ordinal)
+                .ToArray(),
+            provenances.SelectMany(static provenance => provenance.NoBuildPublishInputs)
+                .GroupBy(
+                    static input => input.EvaluationKey + "\n" + input.FullPath,
+                    StringComparer.Ordinal)
+                .Select(static group => group.First())
+                .ToArray(),
+            provenances.SelectMany(static provenance => provenance.PublishInputFiles)
+                .Distinct(IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
+                .ToArray());
     }
 
 }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
@@ -66,7 +66,7 @@ public sealed partial class DotNetPublishPipelineRunner
         PublishProvenanceLease? manifestProvenanceLease = null;
         SourceProvenance? sharedPublishProvenance = null;
         var publishProvenanceByArtifact = new Dictionary<string, SourceProvenance>(StringComparer.OrdinalIgnoreCase);
-        string[] plannedPublishOutputDirectories = Array.Empty<string>();
+        string[] plannedPublishGeneratedPaths = Array.Empty<string>();
         IReadOnlyDictionary<string, string> cleanTrackedGeneratedProvenanceState =
             new Dictionary<string, string>();
         string? manifestJson = null;
@@ -77,7 +77,7 @@ public sealed partial class DotNetPublishPipelineRunner
 
         try
         {
-            plannedPublishOutputDirectories = ResolvePlannedPublishOutputDirectories(plan);
+            plannedPublishGeneratedPaths = ResolvePlannedPublishGeneratedPaths(plan);
             ValidateExplicitDotNetEnvironmentVariables(plan.EnvironmentVariables);
             ValidateNativeAotEnvironmentVariables(plan);
             ValidateTrackedGeneratedProvenancePaths(plan);
@@ -143,7 +143,7 @@ public sealed partial class DotNetPublishPipelineRunner
                                     SourceProvenance initialProvenance =
                                         ReadPortableInventorySourceProvenance(
                                             plan,
-                                            additionalGeneratedPaths: plannedPublishOutputDirectories);
+                                            additionalGeneratedPaths: plannedPublishGeneratedPaths);
                                     PublishProvenanceLease candidateLease = PublishProvenanceLease.Create(
                                         PublishProvenanceLease.BuildGuardedPaths(
                                             initialProvenance.PublishInputFiles,
@@ -153,7 +153,7 @@ public sealed partial class DotNetPublishPipelineRunner
                                         SourceProvenance confirmedProvenance =
                                             ReadPortableInventorySourceProvenance(
                                                 plan,
-                                                additionalGeneratedPaths: plannedPublishOutputDirectories);
+                                                additionalGeneratedPaths: plannedPublishGeneratedPaths);
                                         candidateLease.EnsureCovers(PublishProvenanceLease.BuildGuardedPaths(
                                             confirmedProvenance.PublishInputFiles,
                                             confirmedProvenance.NoBuildPublishInputs));
@@ -197,7 +197,7 @@ public sealed partial class DotNetPublishPipelineRunner
                                 inputSnapshot,
                                 provenanceLease,
                                 publishProvenance,
-                                plannedPublishOutputDirectories,
+                                plannedPublishGeneratedPaths,
                                 out SourceProvenance? finalPublishProvenance);
                             artefacts.Add(publishedArtefact);
                             if (finalPublishProvenance is not null)
@@ -261,13 +261,22 @@ public sealed partial class DotNetPublishPipelineRunner
                                     msiReservationOwner,
                                 verifiedSourceProvenance:
                                     TryBuildManifestProvenance(artefacts, publishProvenanceByArtifact));
+                            IReadOnlyDictionary<string, string> trackedManifestOutputState =
+                                CaptureTrackedManifestOutputState(
+                                    plan.ProjectRoot,
+                                    cleanTrackedGeneratedProvenanceState,
+                                    manifestJson,
+                                    manifestText,
+                                    checksumsPath);
                             ValidateManifestProvenance(
                                 manifestProvenanceLease,
                                 sharedPublishProvenance,
                                 GetVerifiedMsiVersionStateWrites(
                                     plan.ProjectRoot,
                                     cleanTrackedGeneratedProvenanceState,
-                                    msiReservationOwner));
+                                    msiReservationOwner)
+                                .Concat(trackedManifestOutputState.Keys));
+                            ValidateTrackedManifestOutputState(trackedManifestOutputState);
                             break;
                         }
                     }
@@ -476,6 +485,48 @@ public sealed partial class DotNetPublishPipelineRunner
     {
         provenanceLease?.ValidateUnchanged();
         provenance?.ValidateCurrentSource(additionalTrackedGeneratedPaths);
+    }
+
+    internal static IReadOnlyDictionary<string, string> CaptureTrackedManifestOutputState(
+        string projectRoot,
+        IReadOnlyDictionary<string, string> cleanTrackedGeneratedProvenanceState,
+        params string?[] outputPaths)
+    {
+        StringComparer comparer = IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+        var outputState = new Dictionary<string, string>(comparer);
+        foreach (string outputPath in outputPaths
+                     .Where(static path => !string.IsNullOrWhiteSpace(path))
+                     .Select(path => Path.GetFullPath(
+                         Path.IsPathRooted(path)
+                             ? path!
+                             : Path.Combine(projectRoot, path!)))
+                     .Distinct(comparer))
+        {
+            if (!cleanTrackedGeneratedProvenanceState.ContainsKey(outputPath) || !File.Exists(outputPath))
+                continue;
+            using Stream stream = File.OpenRead(outputPath);
+            outputState[outputPath] = ComputeSha256Hex(stream);
+        }
+
+        return outputState;
+    }
+
+    internal static void ValidateTrackedManifestOutputState(
+        IReadOnlyDictionary<string, string> outputState)
+    {
+        foreach (KeyValuePair<string, string> output in outputState)
+        {
+            if (!File.Exists(output.Key))
+                throw new InvalidOperationException($"Generated manifest output disappeared during provenance validation: {output.Key}");
+            using Stream stream = File.OpenRead(output.Key);
+            if (!string.Equals(ComputeSha256Hex(stream), output.Value, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Generated manifest output changed during provenance validation: {output.Key}");
+            }
+        }
     }
 
     internal static SourceProvenance? TryBuildManifestProvenance(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
@@ -117,6 +117,18 @@ public sealed partial class DotNetPublishPipelineRunner
                             Clean(plan);
                             break;
                         case DotNetPublishStepKind.Build:
+                            if (manifestProvenanceLease is not null)
+                            {
+                                // A per-combination build is allowed to replace the previous combination's
+                                // generated bin/obj inputs. Validate the completed publish boundary, then
+                                // release and reacquire provenance after this build for the next publish.
+                                manifestProvenanceLease.ValidateUnchanged();
+                                sharedPublishProvenance?.ValidateCurrentSource();
+                                manifestProvenanceLease.Dispose();
+                                manifestProvenanceLease = null;
+                                sharedPublishProvenance = null;
+                            }
+
                             if ((plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
                                 .Any(static target => target?.Publish?.Sign?.Enabled == true))
                             {

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
@@ -66,6 +66,7 @@ public sealed partial class DotNetPublishPipelineRunner
         PublishProvenanceLease? manifestProvenanceLease = null;
         SourceProvenance? sharedPublishProvenance = null;
         var publishProvenanceByArtifact = new Dictionary<string, SourceProvenance>(StringComparer.OrdinalIgnoreCase);
+        string[] plannedPublishOutputDirectories = Array.Empty<string>();
         IReadOnlyDictionary<string, string> cleanTrackedGeneratedProvenanceState =
             new Dictionary<string, string>();
         string? manifestJson = null;
@@ -76,6 +77,7 @@ public sealed partial class DotNetPublishPipelineRunner
 
         try
         {
+            plannedPublishOutputDirectories = ResolvePlannedPublishOutputDirectories(plan);
             ValidateExplicitDotNetEnvironmentVariables(plan.EnvironmentVariables);
             ValidateNativeAotEnvironmentVariables(plan);
             ValidateTrackedGeneratedProvenancePaths(plan);
@@ -139,7 +141,9 @@ public sealed partial class DotNetPublishPipelineRunner
                                 if (sharedPublishProvenance is null)
                                 {
                                     SourceProvenance initialProvenance =
-                                        ReadPortableInventorySourceProvenance(plan);
+                                        ReadPortableInventorySourceProvenance(
+                                            plan,
+                                            additionalGeneratedPaths: plannedPublishOutputDirectories);
                                     PublishProvenanceLease candidateLease = PublishProvenanceLease.Create(
                                         PublishProvenanceLease.BuildGuardedPaths(
                                             initialProvenance.PublishInputFiles,
@@ -147,7 +151,9 @@ public sealed partial class DotNetPublishPipelineRunner
                                     try
                                     {
                                         SourceProvenance confirmedProvenance =
-                                            ReadPortableInventorySourceProvenance(plan);
+                                            ReadPortableInventorySourceProvenance(
+                                                plan,
+                                                additionalGeneratedPaths: plannedPublishOutputDirectories);
                                         candidateLease.EnsureCovers(PublishProvenanceLease.BuildGuardedPaths(
                                             confirmedProvenance.PublishInputFiles,
                                             confirmedProvenance.NoBuildPublishInputs));
@@ -190,13 +196,15 @@ public sealed partial class DotNetPublishPipelineRunner
                                 msiReservationOwner,
                                 inputSnapshot,
                                 provenanceLease,
-                                publishProvenance);
+                                publishProvenance,
+                                plannedPublishOutputDirectories,
+                                out SourceProvenance? finalPublishProvenance);
                             artefacts.Add(publishedArtefact);
-                            if (publishProvenance is not null)
+                            if (finalPublishProvenance is not null)
                             {
                                 publishProvenanceByArtifact.Add(
                                     BuildArtifactProvenanceKey(publishedArtefact),
-                                    publishProvenance);
+                                    finalPublishProvenance);
                             }
                             break;
                         }
@@ -228,11 +236,19 @@ public sealed partial class DotNetPublishPipelineRunner
                         {
                             ValidateManifestProvenance(
                                 manifestProvenanceLease,
-                                sharedPublishProvenance);
+                                sharedPublishProvenance,
+                                GetVerifiedMsiVersionStateWrites(
+                                    plan.ProjectRoot,
+                                    cleanTrackedGeneratedProvenanceState,
+                                    msiReservationOwner));
                             FinalizePortableEvidence(plan, artefacts, publishProvenanceByArtifact);
                             ValidateManifestProvenance(
                                 manifestProvenanceLease,
-                                sharedPublishProvenance);
+                                sharedPublishProvenance,
+                                GetVerifiedMsiVersionStateWrites(
+                                    plan.ProjectRoot,
+                                    cleanTrackedGeneratedProvenanceState,
+                                    msiReservationOwner));
                             (manifestJson, manifestText, checksumsPath) = WriteManifestsWithProvenance(
                                 plan,
                                 artefacts,
@@ -247,7 +263,11 @@ public sealed partial class DotNetPublishPipelineRunner
                                     TryBuildManifestProvenance(artefacts, publishProvenanceByArtifact));
                             ValidateManifestProvenance(
                                 manifestProvenanceLease,
-                                sharedPublishProvenance);
+                                sharedPublishProvenance,
+                                GetVerifiedMsiVersionStateWrites(
+                                    plan.ProjectRoot,
+                                    cleanTrackedGeneratedProvenanceState,
+                                    msiReservationOwner));
                             break;
                         }
                     }
@@ -451,10 +471,11 @@ public sealed partial class DotNetPublishPipelineRunner
 
     private static void ValidateManifestProvenance(
         PublishProvenanceLease? provenanceLease,
-        SourceProvenance? provenance)
+        SourceProvenance? provenance,
+        IEnumerable<string>? additionalTrackedGeneratedPaths = null)
     {
         provenanceLease?.ValidateUnchanged();
-        provenance?.ValidateCurrentSource();
+        provenance?.ValidateCurrentSource(additionalTrackedGeneratedPaths);
     }
 
     internal static SourceProvenance? TryBuildManifestProvenance(
@@ -506,7 +527,12 @@ public sealed partial class DotNetPublishPipelineRunner
                 .ToArray(),
             provenances.SelectMany(static provenance => provenance.PublishInputFiles)
                 .Distinct(IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
-                .ToArray());
+                .ToArray(),
+            validateCurrentSourceWithTrackedGeneratedPaths: additionalTrackedGeneratedPaths =>
+            {
+                foreach (SourceProvenance provenance in provenances)
+                    provenance.ValidateCurrentSource(additionalTrackedGeneratedPaths);
+            });
     }
 
 }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.cs
@@ -723,12 +723,27 @@ public sealed partial class DotNetPublishPipelineRunner
             expectedSha256 = sha256;
             if (ActiveToolSnapshotScope.Value)
             {
-                ActiveGitExecutablePath.Value = path;
-                ActiveGitExecutableSha256.Value = sha256;
+                PublishProvenanceLease gitExecutableLease = PublishProvenanceLease.Create(new[] { path });
+                try
+                {
+                    ValidateGitExecutableSnapshot(path, sha256);
+                    ActiveGitExecutablePath.Value = path;
+                    ActiveGitExecutableSha256.Value = sha256;
+                    ActiveGitExecutableLease.Value = gitExecutableLease;
+                }
+                catch
+                {
+                    gitExecutableLease.Dispose();
+                    throw;
+                }
             }
         }
         string resolvedPath = path!;
-        ValidateGitExecutableSnapshot(resolvedPath, expectedSha256);
+        PublishProvenanceLease? lease = ActiveGitExecutableLease.Value;
+        if (ActiveToolSnapshotScope.Value && lease is not null)
+            lease.ValidateUnchanged();
+        else
+            ValidateGitExecutableSnapshot(resolvedPath, expectedSha256);
         return resolvedPath;
     }
 

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SourceDirtyState.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SourceDirtyState.cs
@@ -33,7 +33,6 @@ public sealed partial class DotNetPublishPipelineRunner
         scope.BuildInputs = buildInputs;
         scope.SourceInputs = sourceInputs;
         scope.NoBuildPublishInputs = noBuildPublishInputs;
-
         foreach (string directory in projectDirectories)
             AddProjectDirectoryScopePath(scope, projectRoot, gitRoot, directory);
         foreach (string path in buildInputs)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SourceDirtyState.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SourceDirtyState.cs
@@ -170,6 +170,12 @@ public sealed partial class DotNetPublishPipelineRunner
 
         internal bool IsScoped => DirectoryPaths.Count > 0 || ProjectDirectoryPaths.Count > 0;
 
+        internal bool IsWithinProjectDirectory(string path, StringComparison comparison)
+            => ProjectDirectoryPaths.Any(directory =>
+                directory.Length == 0 ||
+                string.Equals(path, directory, comparison) ||
+                path.StartsWith(directory + "/", comparison));
+
         internal bool Contains(string path, string gitRoot, StringComparison comparison)
         {
             if (FilePaths.Contains(path))

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SourceProvenanceValidation.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SourceProvenanceValidation.cs
@@ -1,0 +1,139 @@
+namespace PowerForge;
+
+public sealed partial class DotNetPublishPipelineRunner
+{
+    private static void ValidateCurrentSourceProvenance(
+        string projectRoot,
+        string gitRoot,
+        string expectedRevision,
+        string verifiedUntrackedOutput,
+        IEnumerable<string> generatedPaths,
+        IEnumerable<string> trackedGeneratedPaths,
+        SourceDirtyScope dirtyScope)
+    {
+        string? initialRevision = ReadGitText(projectRoot, "rev-parse HEAD");
+        string? initialReplacementRefs = ReadGitRawText(
+            gitRoot,
+            "for-each-ref --format=\"%(refname)\" refs/replace");
+        string? initialTrackedStatus = ReadGitRawText(
+            gitRoot,
+            "status --porcelain=v1 -z --untracked-files=no");
+        string? initialUntrackedOutput = ReadGitText(
+            gitRoot,
+            "ls-files --others --exclude-standard -z");
+        string? finalTrackedStatus = ReadGitRawText(
+            gitRoot,
+            "status --porcelain=v1 -z --untracked-files=no");
+        string? finalUntrackedOutput = ReadGitText(
+            gitRoot,
+            "ls-files --others --exclude-standard -z");
+        string? finalReplacementRefs = ReadGitRawText(
+            gitRoot,
+            "for-each-ref --format=\"%(refname)\" refs/replace");
+        string? finalRevision = ReadGitText(projectRoot, "rev-parse HEAD");
+
+        if (string.IsNullOrWhiteSpace(initialRevision) ||
+            string.IsNullOrWhiteSpace(finalRevision) ||
+            !string.Equals(initialRevision, expectedRevision, StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(finalRevision, expectedRevision, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Release source revision changed after publish provenance was confirmed; expected '{expectedRevision}', " +
+                $"received '{finalRevision ?? initialRevision ?? "unknown"}'.");
+        }
+
+        if (initialReplacementRefs is null || finalReplacementRefs is null)
+        {
+            throw new InvalidOperationException(
+                "Release source could not be revalidated because the Git replacement-ref query failed.");
+        }
+        if (!string.IsNullOrWhiteSpace(initialReplacementRefs) ||
+            !string.IsNullOrWhiteSpace(finalReplacementRefs))
+        {
+            throw new InvalidOperationException(
+                "Release source changed after publish provenance was confirmed; Git replacement refs are active.");
+        }
+        if (initialTrackedStatus is null || finalTrackedStatus is null ||
+            initialUntrackedOutput is null || finalUntrackedOutput is null)
+        {
+            throw new InvalidOperationException(
+                "Release source could not be revalidated because a Git status query failed.");
+        }
+        if (!string.Equals(initialTrackedStatus, finalTrackedStatus, StringComparison.Ordinal) ||
+            !string.Equals(initialUntrackedOutput, finalUntrackedOutput, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Release source changed during final publish-provenance validation.");
+        }
+
+        string[]? trackedSourceChanges = FindTrackedSourceChanges(
+            projectRoot,
+            gitRoot,
+            finalTrackedStatus,
+            trackedGeneratedPaths,
+            dirtyScope);
+        string[] untrackedSourceFiles = FindUntrackedSourceFiles(
+            projectRoot,
+            gitRoot,
+            finalUntrackedOutput,
+            generatedPaths,
+            dirtyScope);
+        string[] newUntrackedProjectFiles = FindNewUntrackedProjectFiles(
+            projectRoot,
+            gitRoot,
+            verifiedUntrackedOutput,
+            finalUntrackedOutput,
+            generatedPaths,
+            dirtyScope);
+        if (trackedSourceChanges is null)
+        {
+            throw new InvalidOperationException(
+                "Release source could not be revalidated because tracked Git status could not be parsed.");
+        }
+        if (trackedSourceChanges.Length == 0 &&
+            untrackedSourceFiles.Length == 0 &&
+            newUntrackedProjectFiles.Length == 0)
+            return;
+
+        string details = string.Join(
+            ", ",
+            trackedSourceChanges
+                .Concat(untrackedSourceFiles)
+                .Concat(newUntrackedProjectFiles)
+                .Distinct(IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
+                .Take(10));
+        throw new InvalidOperationException(
+            "Release source changed after publish provenance was confirmed; final manifest generation is blocked." +
+            (details.Length == 0 ? string.Empty : " Paths: " + details));
+    }
+
+    private static string[] FindNewUntrackedProjectFiles(
+        string projectRoot,
+        string gitRoot,
+        string verifiedUntrackedOutput,
+        string currentUntrackedOutput,
+        IEnumerable<string> generatedPaths,
+        SourceDirtyScope dirtyScope)
+    {
+        StringComparer comparer = IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+        StringComparison comparison = IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        var verifiedPaths = new HashSet<string>(
+            verifiedUntrackedOutput.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(static path => path.Replace('\\', '/').TrimStart('/')),
+            comparer);
+        string[] exclusions = BuildGeneratedPathExclusions(projectRoot, gitRoot, generatedPaths);
+        return currentUntrackedOutput
+            .Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(static path => path.Replace('\\', '/').TrimStart('/'))
+            .Where(path => !verifiedPaths.Contains(path))
+            .Where(path => !IsGeneratedPath(path, exclusions, comparison))
+            .Where(path => dirtyScope.IsWithinProjectDirectory(path, comparison))
+            .Distinct(comparer)
+            .OrderBy(path => path, comparer)
+            .ToArray();
+    }
+}

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -301,33 +301,17 @@ public sealed partial class DotNetPublishPipelineRunner
         string reservationOwner,
         NoBuildPublishInputSnapshot? inputSnapshot,
         PublishProvenanceLease? provenanceLease,
-        SourceProvenance? verifiedSourceProvenance)
+        SourceProvenance? verifiedSourceProvenance,
+        IReadOnlyCollection<string> plannedPublishOutputDirectories,
+        out SourceProvenance? finalSourceProvenance)
     {
         var target = plan.Targets.FirstOrDefault(t => string.Equals(t.Name, targetName, StringComparison.OrdinalIgnoreCase))
             ?? throw new InvalidOperationException($"Target not found: {targetName}");
 
-        var cfg = plan.Configuration;
         var tfm = string.IsNullOrWhiteSpace(framework) ? target.Publish.Framework : framework.Trim();
         var style = styleOverride ?? target.Publish.Style;
-        string releaseVersion = ResolvePublishReleaseVersion(plan, target.Name, tfm, rid, style) ?? string.Empty;
-
-        var tokens = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["target"] = target.Name,
-            ["rid"] = rid,
-            ["framework"] = tfm,
-            ["style"] = style.ToString(),
-            ["configuration"] = cfg,
-            ["version"] = releaseVersion
-        };
-
-        var outputDirTemplate = string.IsNullOrWhiteSpace(target.Publish.OutputPath)
-            ? Path.Combine("Artifacts", "DotNetPublish", "{target}", "{rid}", "{framework}", "{style}")
-            : target.Publish.OutputPath!;
-
-        var outputDir = ResolvePath(plan.ProjectRoot, ApplyTemplate(outputDirTemplate, tokens));
-        if (!plan.AllowOutputOutsideProjectRoot)
-            EnsurePathWithinRoot(plan.ProjectRoot, outputDir, $"Target '{target.Name}' output path");
+        var tokens = BuildPublishOutputTokens(plan, target, tfm, rid, style);
+        string outputDir = ResolvePublishOutputDirectory(plan, target, tfm, rid, style);
 
         string[] evidencePaths = Array.Empty<string>();
         SourceProvenance? signingProvenance = null;
@@ -421,6 +405,14 @@ public sealed partial class DotNetPublishPipelineRunner
             signedFilePaths = TrySignOutput(outputDir, target.Publish.Sign);
             if (signedFilePaths.Length > 0)
             {
+                signingProvenance = ReadPortableInventorySourceProvenance(
+                    plan,
+                    outputDir,
+                    plannedPublishOutputDirectories);
+                provenanceLease?.EnsureCovers(PublishProvenanceLease.BuildGuardedPaths(
+                    signingProvenance.PublishInputFiles,
+                    signingProvenance.NoBuildPublishInputs));
+                provenanceLease?.ValidateUnchanged();
                 string executable = ResolvePrimaryExecutable(outputDir, rid, target.ExecutableIdentities)
                     ?? throw new InvalidOperationException(
                         "Signed portable output does not contain a primary executable matching the configured project identity.");
@@ -498,6 +490,7 @@ public sealed partial class DotNetPublishPipelineRunner
         string? primaryExecutable = Directory.Exists(outputDir)
             ? ResolvePrimaryExecutable(outputDir, rid, target.ExecutableIdentities)
             : null;
+        finalSourceProvenance = signingProvenance ?? verifiedSourceProvenance;
         return new DotNetPublishArtefactResult
         {
             Target = target.Name,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -302,7 +302,7 @@ public sealed partial class DotNetPublishPipelineRunner
         NoBuildPublishInputSnapshot? inputSnapshot,
         PublishProvenanceLease? provenanceLease,
         SourceProvenance? verifiedSourceProvenance,
-        IReadOnlyCollection<string> plannedPublishOutputDirectories,
+        IReadOnlyCollection<string> plannedPublishGeneratedPaths,
         out SourceProvenance? finalSourceProvenance)
     {
         var target = plan.Targets.FirstOrDefault(t => string.Equals(t.Name, targetName, StringComparison.OrdinalIgnoreCase))
@@ -408,7 +408,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 signingProvenance = ReadPortableInventorySourceProvenance(
                     plan,
                     outputDir,
-                    plannedPublishOutputDirectories);
+                    plannedPublishGeneratedPaths);
                 provenanceLease?.EnsureCovers(PublishProvenanceLease.BuildGuardedPaths(
                     signingProvenance.PublishInputFiles,
                     signingProvenance.NoBuildPublishInputs));

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -300,7 +300,8 @@ public sealed partial class DotNetPublishPipelineRunner
         DotNetPublishStyle? styleOverride,
         string reservationOwner,
         NoBuildPublishInputSnapshot? inputSnapshot,
-        PublishProvenanceLease? provenanceLease)
+        PublishProvenanceLease? provenanceLease,
+        SourceProvenance? verifiedSourceProvenance)
     {
         var target = plan.Targets.FirstOrDefault(t => string.Equals(t.Name, targetName, StringComparison.OrdinalIgnoreCase))
             ?? throw new InvalidOperationException($"Target not found: {targetName}");
@@ -329,8 +330,12 @@ public sealed partial class DotNetPublishPipelineRunner
             EnsurePathWithinRoot(plan.ProjectRoot, outputDir, $"Target '{target.Name}' output path");
 
         string[] evidencePaths = Array.Empty<string>();
+        SourceProvenance? signingProvenance = null;
         if (target.Publish.Sign?.Enabled == true)
-            _ = ReadPortableInventorySourceProvenance(plan, outputDir);
+        {
+            signingProvenance = verifiedSourceProvenance ??
+                ReadPortableInventorySourceProvenance(plan, outputDir);
+        }
 
         EnsureOutputDirectoryUnlocked(
             plan,
@@ -435,7 +440,10 @@ public sealed partial class DotNetPublishPipelineRunner
                         "when the signed product identity is supplied by imported or generated build properties.");
                 }
                 string portableVersion = FirstText(versionInfo.ProductVersion, versionInfo.FileVersion);
-                SourceProvenance provenance = ReadPortableInventorySourceProvenance(plan, outputDir);
+                provenanceLease?.ValidateUnchanged();
+                SourceProvenance provenance = signingProvenance
+                    ?? throw new InvalidOperationException(
+                        $"Signed publish target '{target.Name}' has no verified source provenance.");
                 (string inventoryPath, string signaturePath) = PowerForgePortablePayloadInventoryCms.ResolveEvidencePaths(
                     outputDir,
                     executable,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.cs
@@ -24,6 +24,7 @@ public sealed partial class DotNetPublishPipelineRunner
     private static readonly AsyncLocal<TrustedNativeAotPathSnapshot?> ActiveNativeAotPathSnapshot = new();
     private static readonly AsyncLocal<string?> ActiveGitExecutablePath = new();
     private static readonly AsyncLocal<string?> ActiveGitExecutableSha256 = new();
+    private static readonly AsyncLocal<PublishProvenanceLease?> ActiveGitExecutableLease = new();
     private static readonly AsyncLocal<bool> ActiveNativeAotPublish = new();
     private static readonly AsyncLocal<bool> ActiveStrictDotNetEnvironment = new();
     private static readonly AsyncLocal<bool> ActiveToolSnapshotScope = new();


### PR DESCRIPTION
## What changed

- reuses confirmed source provenance and one shared immutable lease across publish combinations instead of rebuilding the same proof for every artifact
- rechecks Git state, ignored evaluated signing inputs, and authorized pipeline-generated state at their consuming boundaries
- scopes no-build provenance leases to each matrix build/publish pair so the next combination can rebuild its generated inputs safely
- excludes every planned publish directory, ZIP, and declared hook output from cached source checks while still validating each output before use
- binds the selected Git executable and dotnet SDK/runtime closure, using synchronous file-set and metadata checks between steps plus final SHA-256 verification
- verifies SDK-managed package evidence for each distinct referenced-project graph, including child-only SDK dependencies
- resolves static project references without controlled builds when the selected child framework is reliable, and retains controlled resolution for imported or computed frameworks plus dynamic, target-time, and output-shaping references

## Why

Large multi-project release plans, including EvotecIT/TestimoX, were spending tens of minutes repeating expensive executable trust checks and project/package graph work. The same real TestimoX.Monitoring publish completes in about five minutes while focused provenance boundaries remain fail closed.

## Release order

Merge and publish PSPublishModule/PowerForge first, then update TestimoX to the released three-part package version before producing its private control.evotec.xyz preview.