### PR TITLE
Retry transient GitHub release asset failures

### DIFF
--- a/PowerForge.Tests/GitHubReleasePublisherRetrySafetyTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherRetrySafetyTests.cs
@@ -1,0 +1,198 @@
+using PowerForge;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace PowerForge.Tests;
+
+public sealed class GitHubReleasePublisherRetrySafetyTests
+{
+    [Fact]
+    public async Task PublishRelease_HonorsRetryAfterDuringPostUploadVerification()
+    {
+        using var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(assetPath, "retry-after-verification");
+        var assetName = Path.GetFileName(assetPath);
+        var delays = new List<TimeSpan>();
+
+        async Task<HttpListenerContext> NextRequest()
+            => await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        static async Task Respond(
+            HttpListenerContext context,
+            string json,
+            int statusCode = 200,
+            string? retryAfter = null)
+        {
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            if (!string.IsNullOrWhiteSpace(retryAfter))
+                context.Response.Headers["Retry-After"] = retryAfter;
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var server = Task.Run(async () =>
+        {
+            await Respond(
+                await NextRequest(),
+                $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""",
+                201);
+            await Respond(await NextRequest(), $$"""{"id":99,"name":"{{assetName}}"}""", 201);
+            await Respond(
+                await NextRequest(),
+                "{\"message\":\"rate limited\"}",
+                429,
+                retryAfter: "30");
+
+            var uploadedAsset = $$"""[{"id":99,"name":"{{assetName}}","state":"uploaded"}]""";
+            await Respond(await NextRequest(), uploadedAsset);
+            await Respond(await NextRequest(), uploadedAsset);
+        });
+
+        try
+        {
+            var publisher = new GitHubReleasePublisher(
+                new NullLogger(),
+                (delay, cancellationToken) =>
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    delays.Add(delay);
+                });
+            var result = publisher.PublishRelease(
+                new GitHubReleasePublishRequest
+                {
+                    Owner = "EvotecIT",
+                    Repository = "example",
+                    Token = "token",
+                    ApiBaseUrl = apiBaseUrl,
+                    TagName = "v1.2.3",
+                    AssetFilePaths = [assetPath]
+                });
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.True(result.Succeeded);
+            Assert.Equal(TimeSpan.FromSeconds(30), Assert.Single(delays));
+        }
+        finally
+        {
+            listener.Stop();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
+    public async Task PublishRelease_RefusesReplacementStarterIdChangeAcrossReconciliationRetries()
+    {
+        using var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(assetPath, "starter-id-race");
+        var assetName = Path.GetFileName(assetPath);
+        var requests = new List<string>();
+        var delays = new List<TimeSpan>();
+
+        async Task<HttpListenerContext> NextRequest()
+        {
+            var context = await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            requests.Add($"{context.Request.HttpMethod} {context.Request.Url!.AbsolutePath}");
+            return context;
+        }
+
+        static async Task Respond(
+            HttpListenerContext context,
+            string json,
+            int statusCode = 200,
+            string? retryAfter = null)
+        {
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            if (!string.IsNullOrWhiteSpace(retryAfter))
+                context.Response.Headers["Retry-After"] = retryAfter;
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var server = Task.Run(async () =>
+        {
+            await Respond(
+                await NextRequest(),
+                $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""",
+                201);
+            await Respond(await NextRequest(), "{\"message\":\"Bad Gateway\"}", 502);
+
+            var originalStarter = $$"""[{"id":88,"name":"{{assetName}}","state":"starter"}]""";
+            await Respond(await NextRequest(), originalStarter);
+            await Respond(await NextRequest(), originalStarter);
+            await Respond(
+                await NextRequest(),
+                "{\"message\":\"rate limited\"}",
+                429,
+                retryAfter: "30");
+
+            var replacementStarter = $$"""[{"id":89,"name":"{{assetName}}","state":"starter"}]""";
+            await Respond(await NextRequest(), replacementStarter);
+        });
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new GitHubReleasePublisher(
+                    new NullLogger(),
+                    (delay, cancellationToken) =>
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        delays.Add(delay);
+                    })
+                .PublishRelease(
+                    new GitHubReleasePublishRequest
+                    {
+                        Owner = "EvotecIT",
+                        Repository = "example",
+                        Token = "token",
+                        ApiBaseUrl = apiBaseUrl,
+                        TagName = "v1.2.3",
+                        AssetFilePaths = [assetPath]
+                    }));
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Contains("changed from id 88 to 89", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(TimeSpan.FromSeconds(30), Assert.Single(delays));
+            Assert.Single(requests, request => request == "DELETE /repos/EvotecIT/example/releases/assets/88");
+            Assert.DoesNotContain(requests, request => request.EndsWith("/89", StringComparison.Ordinal));
+        }
+        finally
+        {
+            listener.Stop();
+            File.Delete(assetPath);
+        }
+    }
+
+    private static int GetAvailablePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+}

--- a/PowerForge.Tests/GitHubReleasePublisherRetrySafetyTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherRetrySafetyTests.cs
@@ -90,7 +90,7 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
     }
 
     [Fact]
-    public async Task PublishRelease_RefusesReplacementStarterIdChangeAcrossReconciliationRetries()
+    public async Task PublishRelease_RetriesDirectUploadForbiddenWithRetryAfter()
     {
         using var listener = new HttpListener();
         var port = GetAvailablePort();
@@ -98,7 +98,7 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
         listener.Prefixes.Add(apiBaseUrl);
         listener.Start();
         var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
-        await File.WriteAllTextAsync(assetPath, "starter-id-race");
+        await File.WriteAllTextAsync(assetPath, "direct-forbidden-retry");
         var assetName = Path.GetFileName(assetPath);
         var requests = new List<string>();
         var delays = new List<TimeSpan>();
@@ -133,19 +133,253 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
                 await NextRequest(),
                 $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""",
                 201);
-            await Respond(await NextRequest(), "{\"message\":\"Bad Gateway\"}", 502);
-
-            var originalStarter = $$"""[{"id":88,"name":"{{assetName}}","state":"starter"}]""";
-            await Respond(await NextRequest(), originalStarter);
-            await Respond(await NextRequest(), originalStarter);
             await Respond(
                 await NextRequest(),
                 "{\"message\":\"rate limited\"}",
-                429,
-                retryAfter: "30");
+                403,
+                retryAfter: "120");
+            await Respond(await NextRequest(), "[]");
+            await Respond(await NextRequest(), $$"""{"id":99,"name":"{{assetName}}"}""", 201);
+            var uploadedAsset = $$"""[{"id":99,"name":"{{assetName}}","state":"uploaded"}]""";
+            await Respond(await NextRequest(), uploadedAsset);
+            await Respond(await NextRequest(), uploadedAsset);
+        });
 
-            var replacementStarter = $$"""[{"id":89,"name":"{{assetName}}","state":"starter"}]""";
-            await Respond(await NextRequest(), replacementStarter);
+        try
+        {
+            var result = new GitHubReleasePublisher(
+                    new NullLogger(),
+                    (delay, cancellationToken) =>
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        delays.Add(delay);
+                    })
+                .PublishRelease(
+                    new GitHubReleasePublishRequest
+                    {
+                        Owner = "EvotecIT",
+                        Repository = "example",
+                        Token = "token",
+                        ApiBaseUrl = apiBaseUrl,
+                        TagName = "v1.2.3",
+                        AssetFilePaths = [assetPath]
+                    });
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.True(result.Succeeded);
+            Assert.Equal(TimeSpan.FromMinutes(2), Assert.Single(delays));
+            Assert.Equal(2, requests.Count(request => request == "POST /uploads"));
+        }
+        finally
+        {
+            listener.Stop();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
+    public async Task PublishRelease_RetriesReplacementInventoryAndAmbiguousDelete()
+    {
+        using var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(assetPath, "replacement-retry");
+        var assetName = Path.GetFileName(assetPath);
+        var delays = new List<TimeSpan>();
+
+        async Task<HttpListenerContext> NextRequest()
+            => await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        static async Task Respond(
+            HttpListenerContext context,
+            string json,
+            int statusCode = 200,
+            string? retryAfter = null)
+        {
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            if (!string.IsNullOrWhiteSpace(retryAfter))
+                context.Response.Headers["Retry-After"] = retryAfter;
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var release = $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""";
+        var existingAsset = $$"""[{"id":88,"name":"{{assetName}}","state":"uploaded"}]""";
+        var uploadedAsset = $$"""[{"id":99,"name":"{{assetName}}","state":"uploaded"}]""";
+        var server = Task.Run(async () =>
+        {
+            await Respond(await NextRequest(), release);
+            await Respond(await NextRequest(), "{\"message\":\"rate limited\"}", 403, retryAfter: "120");
+            await Respond(await NextRequest(), existingAsset);
+            await Respond(await NextRequest(), existingAsset);
+            await Respond(await NextRequest(), "{\"message\":\"Service Unavailable\"}", 503, retryAfter: "30");
+            await Respond(await NextRequest(), "[]");
+            await Respond(await NextRequest(), $$"""{"id":99,"name":"{{assetName}}"}""", 201);
+            await Respond(await NextRequest(), uploadedAsset);
+            await Respond(await NextRequest(), uploadedAsset);
+        });
+
+        try
+        {
+            var result = new GitHubReleasePublisher(
+                new NullLogger(),
+                (delay, cancellationToken) =>
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    delays.Add(delay);
+                })
+                .PublishRelease(
+                    new GitHubReleasePublishRequest
+                    {
+                        Owner = "EvotecIT",
+                        Repository = "example",
+                        Token = "token",
+                        ApiBaseUrl = apiBaseUrl,
+                        TagName = "v1.2.3",
+                        ReuseExistingReleaseOnConflict = true,
+                        RequireExpectedExistingRelease = true,
+                        ExpectedExistingReleaseId = 42,
+                        ReplaceExistingAssets = true,
+                        AssetFilePaths = [assetPath]
+                    });
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.True(result.Succeeded);
+            Assert.Equal([TimeSpan.FromMinutes(2), TimeSpan.FromSeconds(30)], delays);
+            Assert.Equal(assetName, Assert.Single(result.ReplacedExistingAssets));
+            Assert.Equal(assetName, Assert.Single(result.UploadedAssets));
+        }
+        finally
+        {
+            listener.Stop();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
+    public async Task PublishRelease_ReusedMixedAssetsRejectEarlierUploadedIdentityReplacement()
+    {
+        using var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var firstAssetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        var skippedAssetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(firstAssetPath, "first");
+        await File.WriteAllTextAsync(skippedAssetPath, "skipped");
+        var firstAssetName = Path.GetFileName(firstAssetPath);
+        var skippedAssetName = Path.GetFileName(skippedAssetPath);
+
+        async Task<HttpListenerContext> NextRequest()
+            => await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        static async Task Respond(HttpListenerContext context, string json, int statusCode = 200)
+        {
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var changedAssets = $$"""[{"id":101,"name":"{{firstAssetName}}","state":"uploaded"},{"id":200,"name":"{{skippedAssetName}}","state":"uploaded"}]""";
+        var server = Task.Run(async () =>
+        {
+            await Respond(
+                await NextRequest(),
+                $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""");
+            await Respond(await NextRequest(), $$"""{"id":100,"name":"{{firstAssetName}}"}""", 201);
+            await Respond(await NextRequest(), $$"""[{"id":100,"name":"{{firstAssetName}}","state":"uploaded"}]""");
+            await Respond(
+                await NextRequest(),
+                "{\"message\":\"Validation Failed\",\"errors\":[{\"resource\":\"ReleaseAsset\",\"code\":\"already_exists\",\"field\":\"name\"}]}",
+                422);
+            await Respond(await NextRequest(), changedAssets);
+            await Respond(await NextRequest(), changedAssets);
+            await Respond(await NextRequest(), changedAssets);
+        });
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new GitHubReleasePublisher(
+                    new NullLogger(),
+                    static (_, cancellationToken) => cancellationToken.ThrowIfCancellationRequested())
+                .PublishRelease(
+                    new GitHubReleasePublishRequest
+                    {
+                        Owner = "EvotecIT",
+                        Repository = "example",
+                        Token = "token",
+                        ApiBaseUrl = apiBaseUrl,
+                        TagName = "v1.2.3",
+                        ReuseExistingReleaseOnConflict = true,
+                        RequireExpectedExistingRelease = true,
+                        ExpectedExistingReleaseId = 42,
+                        AssetFilePaths = [firstAssetPath, skippedAssetPath]
+                    }));
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Contains("changed from id 100 to 101", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            listener.Stop();
+            File.Delete(firstAssetPath);
+            File.Delete(skippedAssetPath);
+        }
+    }
+
+    [Fact]
+    public async Task PublishRelease_DoesNotTreatTransientInventoryAsAmbiguousDelete()
+    {
+        using var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(assetPath, "inventory-before-delete");
+        var assetName = Path.GetFileName(assetPath);
+        var requests = new List<string>();
+        var delays = new List<TimeSpan>();
+
+        async Task<HttpListenerContext> NextRequest()
+            => await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        async Task Respond(HttpListenerContext context, string json, int statusCode = 200, string? retryAfter = null)
+        {
+            requests.Add($"{context.Request.HttpMethod} {context.Request.Url!.AbsolutePath}");
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            if (!string.IsNullOrWhiteSpace(retryAfter))
+                context.Response.Headers["Retry-After"] = retryAfter;
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var existingAsset = $$"""[{"id":88,"name":"{{assetName}}","state":"uploaded"}]""";
+        var server = Task.Run(async () =>
+        {
+            await Respond(
+                await NextRequest(),
+                $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""");
+            await Respond(await NextRequest(), existingAsset);
+            await Respond(await NextRequest(), "{\"message\":\"rate limited\"}", 403, retryAfter: "15");
+            await Respond(await NextRequest(), "[]");
         });
 
         try
@@ -166,14 +400,17 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
                         Token = "token",
                         ApiBaseUrl = apiBaseUrl,
                         TagName = "v1.2.3",
+                        ReuseExistingReleaseOnConflict = true,
+                        RequireExpectedExistingRelease = true,
+                        ExpectedExistingReleaseId = 42,
+                        ReplaceExistingAssets = true,
                         AssetFilePaths = [assetPath]
                     }));
 
             await server.WaitAsync(TimeSpan.FromSeconds(10));
-            Assert.Contains("changed from id 88 to 89", exception.Message, StringComparison.OrdinalIgnoreCase);
-            Assert.Equal(TimeSpan.FromSeconds(30), Assert.Single(delays));
-            Assert.Single(requests, request => request == "DELETE /repos/EvotecIT/example/releases/assets/88");
-            Assert.DoesNotContain(requests, request => request.EndsWith("/89", StringComparison.Ordinal));
+            Assert.Contains("disappeared before deletion", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(TimeSpan.FromSeconds(15), Assert.Single(delays));
+            Assert.DoesNotContain(requests, request => request.StartsWith("DELETE ", StringComparison.Ordinal));
         }
         finally
         {

--- a/PowerForge.Tests/GitHubReleasePublisherRetrySafetyTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherRetrySafetyTests.cs
@@ -51,7 +51,7 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
                 await NextRequest(),
                 "{\"message\":\"rate limited\"}",
                 429,
-                retryAfter: "30");
+                retryAfter: "120");
 
             var uploadedAsset = $$"""[{"id":99,"name":"{{assetName}}","state":"uploaded"}]""";
             await Respond(await NextRequest(), uploadedAsset);
@@ -80,7 +80,7 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
 
             await server.WaitAsync(TimeSpan.FromSeconds(10));
             Assert.True(result.Succeeded);
-            Assert.Equal(TimeSpan.FromSeconds(30), Assert.Single(delays));
+            Assert.Equal(TimeSpan.FromMinutes(2), Assert.Single(delays));
         }
         finally
         {

--- a/PowerForge.Tests/GitHubReleasePublisherRetrySafetyTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherRetrySafetyTests.cs
@@ -190,6 +190,86 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
     }
 
     [Fact]
+    public async Task PublishRelease_DoesNotWaitOrReconcileAfterTerminalRateLimitResponse()
+    {
+        using var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(assetPath, "terminal-rate-limit");
+        var requests = new List<string>();
+        var delays = new List<TimeSpan>();
+
+        async Task<HttpListenerContext> NextRequest()
+        {
+            var context = await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            requests.Add($"{context.Request.HttpMethod} {context.Request.Url!.AbsolutePath}");
+            return context;
+        }
+
+        static async Task Respond(HttpListenerContext context, string json, int statusCode = 200)
+        {
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var server = Task.Run(async () =>
+        {
+            await Respond(
+                await NextRequest(),
+                $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""",
+                201);
+            for (var attempt = 1; attempt < 4; attempt++)
+            {
+                await Respond(await NextRequest(), "{\"message\":\"rate limited\"}", 429);
+                await Respond(await NextRequest(), "[]");
+            }
+            await Respond(await NextRequest(), "{\"message\":\"rate limited\"}", 429);
+        });
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new GitHubReleasePublisher(
+                    new NullLogger(),
+                    (delay, cancellationToken) =>
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        delays.Add(delay);
+                    })
+                .PublishRelease(
+                    new GitHubReleasePublishRequest
+                    {
+                        Owner = "EvotecIT",
+                        Repository = "example",
+                        Token = "token",
+                        ApiBaseUrl = apiBaseUrl,
+                        TagName = "v1.2.3",
+                        AssetFilePaths = [assetPath]
+                    }));
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Contains("429", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(3, delays.Count);
+            Assert.All(delays, delay => Assert.Equal(TimeSpan.FromMinutes(1), delay));
+            Assert.Equal(4, requests.Count(request => request == "POST /uploads"));
+            Assert.Equal(3, requests.Count(request => request == "GET /repos/EvotecIT/example/releases/42/assets"));
+        }
+        finally
+        {
+            listener.Stop();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
     public async Task PublishRelease_RevalidatesProvenanceBeforeRetriedUpload()
     {
         using var listener = new HttpListener();
@@ -601,6 +681,92 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
             Assert.Contains("disappeared before deletion", exception.Message, StringComparison.OrdinalIgnoreCase);
             Assert.Equal(TimeSpan.FromSeconds(15), Assert.Single(delays));
             Assert.DoesNotContain(requests, request => request.StartsWith("DELETE ", StringComparison.Ordinal));
+        }
+        finally
+        {
+            listener.Stop();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
+    public async Task PublishRelease_RetriesStalePostDeleteInventoryWithoutDeletingAgain()
+    {
+        using var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(assetPath, "stale-post-delete-inventory");
+        var assetName = Path.GetFileName(assetPath);
+        var requests = new List<string>();
+        var delays = new List<TimeSpan>();
+
+        async Task<HttpListenerContext> NextRequest()
+        {
+            var context = await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            requests.Add($"{context.Request.HttpMethod} {context.Request.Url!.AbsolutePath}");
+            return context;
+        }
+
+        static async Task Respond(HttpListenerContext context, string json, int statusCode = 200)
+        {
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var release = $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""";
+        var existingAsset = $$"""[{"id":88,"name":"{{assetName}}","state":"uploaded"}]""";
+        var uploadedAsset = $$"""[{"id":99,"name":"{{assetName}}","state":"uploaded"}]""";
+        var server = Task.Run(async () =>
+        {
+            await Respond(await NextRequest(), release);
+            await Respond(await NextRequest(), existingAsset);
+            await Respond(await NextRequest(), existingAsset);
+            await Respond(await NextRequest(), "{}", 204);
+            await Respond(await NextRequest(), existingAsset);
+            await Respond(await NextRequest(), "[]");
+            await Respond(await NextRequest(), $$"""{"id":99,"name":"{{assetName}}"}""", 201);
+            await Respond(await NextRequest(), uploadedAsset);
+            await Respond(await NextRequest(), uploadedAsset);
+        });
+
+        try
+        {
+            var result = new GitHubReleasePublisher(
+                    new NullLogger(),
+                    (delay, cancellationToken) =>
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        delays.Add(delay);
+                    })
+                .PublishRelease(
+                    new GitHubReleasePublishRequest
+                    {
+                        Owner = "EvotecIT",
+                        Repository = "example",
+                        Token = "token",
+                        ApiBaseUrl = apiBaseUrl,
+                        TagName = "v1.2.3",
+                        ReuseExistingReleaseOnConflict = true,
+                        RequireExpectedExistingRelease = true,
+                        ExpectedExistingReleaseId = 42,
+                        ReplaceExistingAssets = true,
+                        AssetFilePaths = [assetPath]
+                    });
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.True(result.Succeeded);
+            Assert.Equal(TimeSpan.FromSeconds(2), Assert.Single(delays));
+            Assert.Single(requests, request => request.StartsWith("DELETE ", StringComparison.Ordinal));
+            Assert.Equal(assetName, Assert.Single(result.ReplacedExistingAssets));
+            Assert.Equal(assetName, Assert.Single(result.UploadedAssets));
         }
         finally
         {

--- a/PowerForge.Tests/GitHubReleasePublisherRetrySafetyTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherRetrySafetyTests.cs
@@ -52,6 +52,10 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
                 "{\"message\":\"rate limited\"}",
                 429,
                 retryAfter: "120");
+            await Respond(
+                await NextRequest(),
+                "{\"message\":\"You have exceeded a secondary rate limit.\"}",
+                403);
 
             var uploadedAsset = $$"""[{"id":99,"name":"{{assetName}}","state":"uploaded"}]""";
             await Respond(await NextRequest(), uploadedAsset);
@@ -80,7 +84,7 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
 
             await server.WaitAsync(TimeSpan.FromSeconds(10));
             Assert.True(result.Succeeded);
-            Assert.Equal(TimeSpan.FromMinutes(2), Assert.Single(delays));
+            Assert.Equal([TimeSpan.FromMinutes(2), TimeSpan.FromMinutes(1)], delays);
         }
         finally
         {
@@ -90,7 +94,7 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
     }
 
     [Fact]
-    public async Task PublishRelease_RetriesDirectUploadForbiddenWithRetryAfter()
+    public async Task PublishRelease_RetriesDirectUploadRateLimitsBeforeReconciliation()
     {
         using var listener = new HttpListener();
         var port = GetAvailablePort();
@@ -140,6 +144,11 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
                 403,
                 retryAfter: "120");
             await Respond(await NextRequest(), "[]");
+            await Respond(
+                await NextRequest(),
+                "{\"message\":\"You have exceeded a secondary rate limit.\"}",
+                403);
+            await Respond(await NextRequest(), "[]");
             await Respond(await NextRequest(), $$"""{"id":99,"name":"{{assetName}}"}""", 201);
             var uploadedAsset = $$"""[{"id":99,"name":"{{assetName}}","state":"uploaded"}]""";
             await Respond(await NextRequest(), uploadedAsset);
@@ -169,9 +178,9 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
 
             await server.WaitAsync(TimeSpan.FromSeconds(10));
             Assert.True(result.Succeeded);
-            Assert.Equal(TimeSpan.FromMinutes(2), Assert.Single(delays));
-            Assert.Equal(2, Assert.Single(requestCountsAtDelay));
-            Assert.Equal(2, requests.Count(request => request == "POST /uploads"));
+            Assert.Equal([TimeSpan.FromMinutes(2), TimeSpan.FromMinutes(1)], delays);
+            Assert.Equal([2, 4], requestCountsAtDelay);
+            Assert.Equal(3, requests.Count(request => request == "POST /uploads"));
         }
         finally
         {

--- a/PowerForge.Tests/GitHubReleasePublisherRetrySafetyTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherRetrySafetyTests.cs
@@ -102,6 +102,7 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
         var assetName = Path.GetFileName(assetPath);
         var requests = new List<string>();
         var delays = new List<TimeSpan>();
+        var requestCountsAtDelay = new List<int>();
 
         async Task<HttpListenerContext> NextRequest()
         {
@@ -153,6 +154,7 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
                     {
                         cancellationToken.ThrowIfCancellationRequested();
                         delays.Add(delay);
+                        requestCountsAtDelay.Add(requests.Count);
                     })
                 .PublishRelease(
                     new GitHubReleasePublishRequest
@@ -168,6 +170,7 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
             await server.WaitAsync(TimeSpan.FromSeconds(10));
             Assert.True(result.Succeeded);
             Assert.Equal(TimeSpan.FromMinutes(2), Assert.Single(delays));
+            Assert.Equal(2, Assert.Single(requestCountsAtDelay));
             Assert.Equal(2, requests.Count(request => request == "POST /uploads"));
         }
         finally

--- a/PowerForge.Tests/GitHubReleasePublisherRetrySafetyTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherRetrySafetyTests.cs
@@ -181,6 +181,92 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
     }
 
     [Fact]
+    public async Task PublishRelease_RevalidatesProvenanceBeforeRetriedUpload()
+    {
+        using var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(assetPath, "provenance-upload-retry");
+        const string marker = "<!-- trusted-release -->";
+        var requests = new List<string>();
+        var delays = new List<TimeSpan>();
+
+        async Task<HttpListenerContext> NextRequest()
+        {
+            var context = await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            requests.Add($"{context.Request.HttpMethod} {context.Request.Url!.AbsolutePath}");
+            return context;
+        }
+
+        static async Task Respond(
+            HttpListenerContext context,
+            string json,
+            int statusCode = 200,
+            string? retryAfter = null)
+        {
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            if (!string.IsNullOrWhiteSpace(retryAfter))
+                context.Response.Headers["Retry-After"] = retryAfter;
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var stableRelease = $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}","body":"{{marker}}"}""";
+        var changedRelease = $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}","body":"foreign"}""";
+        var server = Task.Run(async () =>
+        {
+            await Respond(await NextRequest(), stableRelease);
+            await Respond(await NextRequest(), stableRelease);
+            await Respond(await NextRequest(), "{\"message\":\"Service Unavailable\"}", 503, retryAfter: "30");
+            await Respond(await NextRequest(), "[]");
+            await Respond(await NextRequest(), changedRelease);
+        });
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new GitHubReleasePublisher(
+                    new NullLogger(),
+                    (delay, cancellationToken) =>
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        delays.Add(delay);
+                    })
+                .PublishRelease(
+                    new GitHubReleasePublishRequest
+                    {
+                        Owner = "EvotecIT",
+                        Repository = "example",
+                        Token = "token",
+                        ApiBaseUrl = apiBaseUrl,
+                        TagName = "v1.2.3",
+                        ReuseExistingReleaseOnConflict = true,
+                        RequireExpectedExistingRelease = true,
+                        ExpectedExistingReleaseId = 42,
+                        ExpectedReleaseBodyMarker = marker,
+                        AssetFilePaths = [assetPath]
+                    }));
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Contains("no longer contains", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(TimeSpan.FromSeconds(30), Assert.Single(delays));
+            Assert.Single(requests, request => request == "POST /uploads");
+        }
+        finally
+        {
+            listener.Stop();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
     public async Task PublishRelease_RetriesReplacementInventoryAndAmbiguousDelete()
     {
         using var listener = new HttpListener();
@@ -258,6 +344,98 @@ public sealed class GitHubReleasePublisherRetrySafetyTests
             Assert.Equal([TimeSpan.FromMinutes(2), TimeSpan.FromSeconds(30)], delays);
             Assert.Equal(assetName, Assert.Single(result.ReplacedExistingAssets));
             Assert.Equal(assetName, Assert.Single(result.UploadedAssets));
+        }
+        finally
+        {
+            listener.Stop();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
+    public async Task PublishRelease_RevalidatesProvenanceBeforeRetriedDelete()
+    {
+        using var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(assetPath, "provenance-delete-retry");
+        var assetName = Path.GetFileName(assetPath);
+        const string marker = "<!-- trusted-release -->";
+        var requests = new List<string>();
+        var delays = new List<TimeSpan>();
+
+        async Task<HttpListenerContext> NextRequest()
+        {
+            var context = await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            requests.Add($"{context.Request.HttpMethod} {context.Request.Url!.AbsolutePath}");
+            return context;
+        }
+
+        static async Task Respond(
+            HttpListenerContext context,
+            string json,
+            int statusCode = 200,
+            string? retryAfter = null)
+        {
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            if (!string.IsNullOrWhiteSpace(retryAfter))
+                context.Response.Headers["Retry-After"] = retryAfter;
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var stableRelease = $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}","body":"{{marker}}"}""";
+        var changedRelease = $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}","body":"foreign"}""";
+        var existingAsset = $$"""[{"id":88,"name":"{{assetName}}","state":"uploaded"}]""";
+        var server = Task.Run(async () =>
+        {
+            await Respond(await NextRequest(), stableRelease);
+            await Respond(await NextRequest(), existingAsset);
+            await Respond(await NextRequest(), stableRelease);
+            await Respond(await NextRequest(), existingAsset);
+            await Respond(await NextRequest(), stableRelease);
+            await Respond(await NextRequest(), "{\"message\":\"Service Unavailable\"}", 503, retryAfter: "30");
+            await Respond(await NextRequest(), existingAsset);
+            await Respond(await NextRequest(), changedRelease);
+        });
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new GitHubReleasePublisher(
+                    new NullLogger(),
+                    (delay, cancellationToken) =>
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        delays.Add(delay);
+                    })
+                .PublishRelease(
+                    new GitHubReleasePublishRequest
+                    {
+                        Owner = "EvotecIT",
+                        Repository = "example",
+                        Token = "token",
+                        ApiBaseUrl = apiBaseUrl,
+                        TagName = "v1.2.3",
+                        ReuseExistingReleaseOnConflict = true,
+                        RequireExpectedExistingRelease = true,
+                        ExpectedExistingReleaseId = 42,
+                        ExpectedReleaseBodyMarker = marker,
+                        ReplaceExistingAssets = true,
+                        AssetFilePaths = [assetPath]
+                    }));
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Contains("no longer contains", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(TimeSpan.FromSeconds(30), Assert.Single(delays));
+            Assert.Single(requests, request => request.StartsWith("DELETE ", StringComparison.Ordinal));
         }
         finally
         {

--- a/PowerForge.Tests/GitHubReleasePublisherRetryTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherRetryTests.cs
@@ -19,6 +19,26 @@ public sealed class GitHubReleasePublisherRetryTests
     }
 
     [Fact]
+    public void UploadRetryClassification_UsesPrimaryRateLimitResetForForbiddenResponses()
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.Forbidden);
+        var reset = DateTimeOffset.UtcNow.AddMinutes(2).ToUnixTimeSeconds();
+        response.Headers.TryAddWithoutValidation("X-RateLimit-Remaining", "0");
+        response.Headers.TryAddWithoutValidation(
+            "X-RateLimit-Reset",
+            reset.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        Assert.True(GitHubReleasePublisher.IsTransientAssetUploadResponse(response));
+        var delay = GitHubReleasePublisher.GetAssetRetryAfterDelay(response);
+        Assert.NotNull(delay);
+        Assert.InRange(delay.Value.TotalSeconds, 115, 121);
+
+        response.Headers.Remove("X-RateLimit-Remaining");
+        response.Headers.TryAddWithoutValidation("X-RateLimit-Remaining", "1");
+        Assert.False(GitHubReleasePublisher.IsTransientAssetUploadResponse(response));
+    }
+
+    [Fact]
     public async Task PublishRelease_RetriesTransientAssetFailureWithFreshContent()
     {
         var listener = new HttpListener();

--- a/PowerForge.Tests/GitHubReleasePublisherRetryTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherRetryTests.cs
@@ -39,6 +39,25 @@ public sealed class GitHubReleasePublisherRetryTests
     }
 
     [Fact]
+    public void UploadRetryClassification_UsesSecondaryRateLimitFallbackWithoutRetryHeaders()
+    {
+        const string secondaryRateLimit = "{\"message\":\"You have exceeded a secondary rate limit.\"}";
+        using var forbidden = new HttpResponseMessage(HttpStatusCode.Forbidden);
+        forbidden.Headers.TryAddWithoutValidation("X-RateLimit-Remaining", "100");
+
+        Assert.True(GitHubReleasePublisher.IsTransientAssetUploadResponse(forbidden, secondaryRateLimit));
+        Assert.Equal(
+            TimeSpan.FromMinutes(1),
+            GitHubReleasePublisher.GetAssetRetryAfterDelay(forbidden, secondaryRateLimit));
+        Assert.False(GitHubReleasePublisher.IsTransientAssetUploadResponse(
+            forbidden,
+            "{\"message\":\"Resource not accessible by integration\"}"));
+
+        using var tooManyRequests = new HttpResponseMessage((HttpStatusCode)429);
+        Assert.Equal(TimeSpan.FromMinutes(1), GitHubReleasePublisher.GetAssetRetryAfterDelay(tooManyRequests));
+    }
+
+    [Fact]
     public async Task PublishRelease_RetriesTransientAssetFailureWithFreshContent()
     {
         var listener = new HttpListener();

--- a/PowerForge.Tests/GitHubReleasePublisherRetryTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherRetryTests.cs
@@ -68,7 +68,7 @@ public sealed class GitHubReleasePublisherRetryTests
 
         try
         {
-            var result = new GitHubReleasePublisher(new NullLogger()).PublishRelease(
+            var result = CreatePublisher().PublishRelease(
                 new GitHubReleasePublishRequest
                 {
                     Owner = "EvotecIT",
@@ -149,7 +149,7 @@ public sealed class GitHubReleasePublisherRetryTests
 
         try
         {
-            var result = new GitHubReleasePublisher(new NullLogger()).PublishRelease(
+            var result = CreatePublisher().PublishRelease(
                 new GitHubReleasePublishRequest
                 {
                     Owner = "EvotecIT",
@@ -172,6 +172,255 @@ public sealed class GitHubReleasePublisherRetryTests
                     "GET /repos/EvotecIT/example/releases/42/assets",
                     "DELETE /repos/EvotecIT/example/releases/assets/88",
                     "POST /uploads",
+                    "GET /repos/EvotecIT/example/releases/42/assets",
+                    "GET /repos/EvotecIT/example/releases/42/assets"
+                ],
+                requests);
+        }
+        finally
+        {
+            listener.Stop();
+            listener.Close();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
+    public async Task PublishRelease_RetriesTransientFailureDuringStarterReconciliation()
+    {
+        var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(assetPath, "reconciliation-retry");
+        var assetName = Path.GetFileName(assetPath);
+        var requests = new List<string>();
+
+        async Task<HttpListenerContext> NextRequest()
+        {
+            var context = await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            requests.Add($"{context.Request.HttpMethod} {context.Request.Url!.AbsolutePath}");
+            return context;
+        }
+
+        static async Task Respond(HttpListenerContext context, string json, int statusCode = 200)
+        {
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var server = Task.Run(async () =>
+        {
+            await Respond(
+                await NextRequest(),
+                $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""",
+                201);
+            await Respond(await NextRequest(), "{\"message\":\"Bad Gateway\"}", 502);
+
+            var starterAsset = $$"""[{"id":88,"name":"{{assetName}}","state":"starter"}]""";
+            await Respond(await NextRequest(), starterAsset);
+            await Respond(await NextRequest(), "{\"message\":\"Service Unavailable\"}", 503);
+            await Respond(await NextRequest(), starterAsset);
+            await Respond(await NextRequest(), starterAsset);
+            await Respond(await NextRequest(), string.Empty, 204);
+
+            await Respond(await NextRequest(), $$"""{"id":99,"name":"{{assetName}}"}""", 201);
+            var uploadedAsset = $$"""[{"id":99,"name":"{{assetName}}","state":"uploaded"}]""";
+            await Respond(await NextRequest(), uploadedAsset);
+            await Respond(await NextRequest(), uploadedAsset);
+        });
+
+        try
+        {
+            var result = CreatePublisher().PublishRelease(
+                new GitHubReleasePublishRequest
+                {
+                    Owner = "EvotecIT",
+                    Repository = "example",
+                    Token = "token",
+                    ApiBaseUrl = apiBaseUrl,
+                    TagName = "v1.2.3",
+                    AssetFilePaths = [assetPath]
+                });
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.True(result.Succeeded);
+            Assert.Equal(assetName, Assert.Single(result.UploadedAssets));
+            Assert.Equal(
+                [
+                    "POST /repos/EvotecIT/example/releases",
+                    "POST /uploads",
+                    "GET /repos/EvotecIT/example/releases/42/assets",
+                    "GET /repos/EvotecIT/example/releases/42/assets",
+                    "GET /repos/EvotecIT/example/releases/42/assets",
+                    "GET /repos/EvotecIT/example/releases/42/assets",
+                    "DELETE /repos/EvotecIT/example/releases/assets/88",
+                    "POST /uploads",
+                    "GET /repos/EvotecIT/example/releases/42/assets",
+                    "GET /repos/EvotecIT/example/releases/42/assets"
+                ],
+                requests);
+        }
+        finally
+        {
+            listener.Stop();
+            listener.Close();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
+    public async Task PublishRelease_ExhaustedReconciliationPreservesTerminalCause()
+    {
+        var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(assetPath, "terminal-reconciliation");
+        var assetName = Path.GetFileName(assetPath);
+        var requests = new List<string>();
+
+        async Task<HttpListenerContext> NextRequest()
+        {
+            var context = await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            requests.Add($"{context.Request.HttpMethod} {context.Request.Url!.AbsolutePath}");
+            return context;
+        }
+
+        static async Task Respond(HttpListenerContext context, string json, int statusCode = 200)
+        {
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var server = Task.Run(async () =>
+        {
+            await Respond(
+                await NextRequest(),
+                $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""",
+                201);
+            await Respond(await NextRequest(), "{\"message\":\"Bad Gateway\"}", 502);
+            for (var attempt = 0; attempt < 3; attempt++)
+                await Respond(await NextRequest(), "{\"message\":\"Service Unavailable\"}", 503);
+        });
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                CreatePublisher().PublishRelease(
+                    new GitHubReleasePublishRequest
+                    {
+                        Owner = "EvotecIT",
+                        Repository = "example",
+                        Token = "token",
+                        ApiBaseUrl = apiBaseUrl,
+                        TagName = "v1.2.3",
+                        AssetFilePaths = [assetPath]
+                    }));
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Contains(assetName, exception.Message, StringComparison.Ordinal);
+            Assert.Contains("reconciliation", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("3 attempts", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("503 Service Unavailable", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.NotNull(exception.InnerException);
+            Assert.Equal(
+                [
+                    "POST /repos/EvotecIT/example/releases",
+                    "POST /uploads",
+                    "GET /repos/EvotecIT/example/releases/42/assets",
+                    "GET /repos/EvotecIT/example/releases/42/assets",
+                    "GET /repos/EvotecIT/example/releases/42/assets"
+                ],
+                requests);
+        }
+        finally
+        {
+            listener.Stop();
+            listener.Close();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
+    public async Task PublishRelease_RetriesTransientPostUploadVerificationFailure()
+    {
+        var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllTextAsync(assetPath, "verification-retry");
+        var assetName = Path.GetFileName(assetPath);
+        var requests = new List<string>();
+
+        async Task<HttpListenerContext> NextRequest()
+        {
+            var context = await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            requests.Add($"{context.Request.HttpMethod} {context.Request.Url!.AbsolutePath}");
+            return context;
+        }
+
+        static async Task Respond(HttpListenerContext context, string json, int statusCode = 200)
+        {
+            await context.Request.InputStream.CopyToAsync(Stream.Null);
+            var responseBytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            context.Response.ContentLength64 = responseBytes.Length;
+            await context.Response.OutputStream.WriteAsync(responseBytes);
+            context.Response.Close();
+        }
+
+        var server = Task.Run(async () =>
+        {
+            await Respond(
+                await NextRequest(),
+                $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}"}""",
+                201);
+            await Respond(await NextRequest(), $$"""{"id":99,"name":"{{assetName}}"}""", 201);
+            await Respond(await NextRequest(), "{\"message\":\"Service Unavailable\"}", 503);
+            var uploadedAsset = $$"""[{"id":99,"name":"{{assetName}}","state":"uploaded"}]""";
+            await Respond(await NextRequest(), uploadedAsset);
+            await Respond(await NextRequest(), uploadedAsset);
+        });
+
+        try
+        {
+            var result = CreatePublisher().PublishRelease(
+                new GitHubReleasePublishRequest
+                {
+                    Owner = "EvotecIT",
+                    Repository = "example",
+                    Token = "token",
+                    ApiBaseUrl = apiBaseUrl,
+                    TagName = "v1.2.3",
+                    AssetFilePaths = [assetPath]
+                });
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.True(result.Succeeded);
+            Assert.Equal(assetName, Assert.Single(result.UploadedAssets));
+            Assert.Equal(
+                [
+                    "POST /repos/EvotecIT/example/releases",
+                    "POST /uploads",
+                    "GET /repos/EvotecIT/example/releases/42/assets",
                     "GET /repos/EvotecIT/example/releases/42/assets",
                     "GET /repos/EvotecIT/example/releases/42/assets"
                 ],
@@ -233,7 +482,7 @@ public sealed class GitHubReleasePublisherRetryTests
         try
         {
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                new GitHubReleasePublisher(new NullLogger()).PublishRelease(
+                CreatePublisher().PublishRelease(
                     new GitHubReleasePublishRequest
                     {
                         Owner = "EvotecIT",
@@ -309,7 +558,7 @@ public sealed class GitHubReleasePublisherRetryTests
 
         try
         {
-            var result = new GitHubReleasePublisher(new NullLogger()).PublishRelease(
+            var result = CreatePublisher().PublishRelease(
                 new GitHubReleasePublishRequest
                 {
                     Owner = "EvotecIT",
@@ -383,7 +632,7 @@ public sealed class GitHubReleasePublisherRetryTests
         try
         {
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                new GitHubReleasePublisher(new NullLogger()).PublishRelease(
+                CreatePublisher().PublishRelease(
                     new GitHubReleasePublishRequest
                     {
                         Owner = "EvotecIT",
@@ -451,7 +700,7 @@ public sealed class GitHubReleasePublisherRetryTests
         try
         {
             Assert.ThrowsAny<OperationCanceledException>(() =>
-                new GitHubReleasePublisher(new NullLogger()).PublishRelease(
+                CreatePublisher().PublishRelease(
                     new GitHubReleasePublishRequest
                     {
                         Owner = "EvotecIT",
@@ -498,15 +747,33 @@ public sealed class GitHubReleasePublisherRetryTests
     [InlineData(HttpStatusCode.RequestTimeout, true)]
     [InlineData((HttpStatusCode)429, true)]
     [InlineData(HttpStatusCode.InternalServerError, true)]
+    [InlineData(HttpStatusCode.NotImplemented, true)]
     [InlineData(HttpStatusCode.BadGateway, true)]
     [InlineData(HttpStatusCode.ServiceUnavailable, true)]
     [InlineData(HttpStatusCode.GatewayTimeout, true)]
+    [InlineData(HttpStatusCode.HttpVersionNotSupported, true)]
+    [InlineData((HttpStatusCode)599, true)]
     [InlineData(HttpStatusCode.UnprocessableEntity, false)]
     [InlineData(HttpStatusCode.BadRequest, false)]
     public void UploadRetryClassification_RetriesOnlyTransientHttpStatuses(
         HttpStatusCode statusCode,
         bool expected)
         => Assert.Equal(expected, GitHubReleasePublisher.IsTransientAssetUploadStatus(statusCode));
+
+    [Fact]
+    public void DescribeException_IncludesDistinctInnerCause()
+    {
+        var exception = new HttpRequestException(
+            "An error occurred while sending the request.",
+            new IOException("The response ended prematurely."));
+
+        Assert.Equal(
+            "An error occurred while sending the request. -> The response ended prematurely.",
+            GitHubReleasePublisher.DescribeException(exception));
+    }
+
+    private static GitHubReleasePublisher CreatePublisher()
+        => new(new NullLogger(), static (_, cancellationToken) => cancellationToken.ThrowIfCancellationRequested());
 
     private static int GetAvailablePort()
     {

--- a/PowerForge.Tests/GitHubReleasePublisherRetryTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherRetryTests.cs
@@ -1,5 +1,6 @@
 using PowerForge;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Sockets;
 using System.Text;
 
@@ -7,6 +8,16 @@ namespace PowerForge.Tests;
 
 public sealed class GitHubReleasePublisherRetryTests
 {
+    [Fact]
+    public void UploadRetryClassification_RequiresRetryAfterForForbiddenResponses()
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.Forbidden);
+        Assert.False(GitHubReleasePublisher.IsTransientAssetUploadResponse(response));
+
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(45));
+        Assert.True(GitHubReleasePublisher.IsTransientAssetUploadResponse(response));
+    }
+
     [Fact]
     public async Task PublishRelease_RetriesTransientAssetFailureWithFreshContent()
     {
@@ -94,7 +105,7 @@ public sealed class GitHubReleasePublisherRetryTests
     }
 
     [Fact]
-    public async Task PublishRelease_RemovesExistingStarterAssetBeforeRetry()
+    public async Task PublishRelease_RefusesAmbiguousStarterAfterNameCollision()
     {
         var listener = new HttpListener();
         var port = GetAvailablePort();
@@ -138,39 +149,28 @@ public sealed class GitHubReleasePublisherRetryTests
             var starterAsset = $$"""[{"id":88,"name":"{{assetName}}","state":"starter"}]""";
             await Respond(await NextRequest(), "{\"message\":\"Service Unavailable\"}", 503);
             await Respond(await NextRequest(), starterAsset);
-            await Respond(await NextRequest(), starterAsset);
-            await Respond(await NextRequest(), string.Empty, 204);
-
-            await Respond(await NextRequest(), $$"""{"id":99,"name":"{{assetName}}"}""", 201);
-            var uploadedAsset = $$"""[{"id":99,"name":"{{assetName}}","state":"uploaded"}]""";
-            await Respond(await NextRequest(), uploadedAsset);
-            await Respond(await NextRequest(), uploadedAsset);
         });
 
         try
         {
-            var result = CreatePublisher().PublishRelease(
-                new GitHubReleasePublishRequest
-                {
-                    Owner = "EvotecIT",
-                    Repository = "example",
-                    Token = "token",
-                    ApiBaseUrl = apiBaseUrl,
-                    TagName = "v1.2.3",
-                    AssetFilePaths = [assetPath]
-                });
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                CreatePublisher().PublishRelease(
+                    new GitHubReleasePublishRequest
+                    {
+                        Owner = "EvotecIT",
+                        Repository = "example",
+                        Token = "token",
+                        ApiBaseUrl = apiBaseUrl,
+                        TagName = "v1.2.3",
+                        AssetFilePaths = [assetPath]
+                    }));
 
             await server.WaitAsync(TimeSpan.FromSeconds(10));
-            Assert.True(result.Succeeded);
-            Assert.Equal(assetName, Assert.Single(result.UploadedAssets));
+            Assert.Contains("publisher cannot be proven", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(requests, request => request.StartsWith("DELETE ", StringComparison.Ordinal));
             Assert.Equal(
                 [
                     "POST /repos/EvotecIT/example/releases",
-                    "POST /uploads",
-                    "GET /repos/EvotecIT/example/releases/42/assets",
-                    "GET /repos/EvotecIT/example/releases/42/assets",
-                    "GET /repos/EvotecIT/example/releases/42/assets",
-                    "DELETE /repos/EvotecIT/example/releases/assets/88",
                     "POST /uploads",
                     "GET /repos/EvotecIT/example/releases/42/assets",
                     "GET /repos/EvotecIT/example/releases/42/assets"
@@ -186,7 +186,7 @@ public sealed class GitHubReleasePublisherRetryTests
     }
 
     [Fact]
-    public async Task PublishRelease_RetriesTransientFailureDuringStarterReconciliation()
+    public async Task PublishRelease_RefusesAmbiguousStarterAfterInterruptedUpload()
     {
         var listener = new HttpListener();
         var port = GetAvailablePort();
@@ -226,44 +226,29 @@ public sealed class GitHubReleasePublisherRetryTests
 
             var starterAsset = $$"""[{"id":88,"name":"{{assetName}}","state":"starter"}]""";
             await Respond(await NextRequest(), starterAsset);
-            await Respond(await NextRequest(), "{\"message\":\"Service Unavailable\"}", 503);
-            await Respond(await NextRequest(), starterAsset);
-            await Respond(await NextRequest(), starterAsset);
-            await Respond(await NextRequest(), string.Empty, 204);
-
-            await Respond(await NextRequest(), $$"""{"id":99,"name":"{{assetName}}"}""", 201);
-            var uploadedAsset = $$"""[{"id":99,"name":"{{assetName}}","state":"uploaded"}]""";
-            await Respond(await NextRequest(), uploadedAsset);
-            await Respond(await NextRequest(), uploadedAsset);
         });
 
         try
         {
-            var result = CreatePublisher().PublishRelease(
-                new GitHubReleasePublishRequest
-                {
-                    Owner = "EvotecIT",
-                    Repository = "example",
-                    Token = "token",
-                    ApiBaseUrl = apiBaseUrl,
-                    TagName = "v1.2.3",
-                    AssetFilePaths = [assetPath]
-                });
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                CreatePublisher().PublishRelease(
+                    new GitHubReleasePublishRequest
+                    {
+                        Owner = "EvotecIT",
+                        Repository = "example",
+                        Token = "token",
+                        ApiBaseUrl = apiBaseUrl,
+                        TagName = "v1.2.3",
+                        AssetFilePaths = [assetPath]
+                    }));
 
             await server.WaitAsync(TimeSpan.FromSeconds(10));
-            Assert.True(result.Succeeded);
-            Assert.Equal(assetName, Assert.Single(result.UploadedAssets));
+            Assert.Contains("publisher cannot be proven", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(requests, request => request.StartsWith("DELETE ", StringComparison.Ordinal));
             Assert.Equal(
                 [
                     "POST /repos/EvotecIT/example/releases",
                     "POST /uploads",
-                    "GET /repos/EvotecIT/example/releases/42/assets",
-                    "GET /repos/EvotecIT/example/releases/42/assets",
-                    "GET /repos/EvotecIT/example/releases/42/assets",
-                    "GET /repos/EvotecIT/example/releases/42/assets",
-                    "DELETE /repos/EvotecIT/example/releases/assets/88",
-                    "POST /uploads",
-                    "GET /repos/EvotecIT/example/releases/42/assets",
                     "GET /repos/EvotecIT/example/releases/42/assets"
                 ],
                 requests);
@@ -435,7 +420,7 @@ public sealed class GitHubReleasePublisherRetryTests
     }
 
     [Fact]
-    public async Task PublishRelease_RefusesToDeleteStarterThatBecameUploaded()
+    public async Task PublishRelease_RefusesToDeleteUnownedStarterBeforeStateRace()
     {
         var listener = new HttpListener();
         var port = GetAvailablePort();
@@ -476,7 +461,6 @@ public sealed class GitHubReleasePublisherRetryTests
                 "{\"message\":\"Validation Failed\",\"errors\":[{\"resource\":\"ReleaseAsset\",\"code\":\"already_exists\",\"field\":\"name\"}]}",
                 422);
             await Respond(await NextRequest(), $$"""[{"id":88,"name":"{{assetName}}","state":"starter"}]""");
-            await Respond(await NextRequest(), $$"""[{"id":88,"name":"{{assetName}}","state":"uploaded"}]""");
         });
 
         try
@@ -494,7 +478,7 @@ public sealed class GitHubReleasePublisherRetryTests
                     }));
 
             await server.WaitAsync(TimeSpan.FromSeconds(10));
-            Assert.Contains("changed from state 'starter' to 'uploaded'", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("publisher cannot be proven", exception.Message, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain(requests, request => request.StartsWith("DELETE ", StringComparison.Ordinal));
         }
         finally
@@ -506,7 +490,7 @@ public sealed class GitHubReleasePublisherRetryTests
     }
 
     [Fact]
-    public async Task PublishRelease_ReconcilesLateStarterAfterInterruptedUpload()
+    public async Task PublishRelease_RefusesLateStarterAfterInterruptedUpload()
     {
         var listener = new HttpListener();
         var port = GetAvailablePort();
@@ -547,31 +531,24 @@ public sealed class GitHubReleasePublisherRetryTests
             var starterAsset = $$"""[{"id":88,"name":"{{assetName}}","state":"starter"}]""";
             await Respond(await NextRequest(), "{\"message\":\"Service Unavailable\"}", 503);
             await Respond(await NextRequest(), starterAsset);
-            await Respond(await NextRequest(), starterAsset);
-            await Respond(await NextRequest(), string.Empty, 204);
-
-            await Respond(await NextRequest(), $$"""{"id":99,"name":"{{assetName}}"}""", 201);
-            var uploadedAsset = $$"""[{"id":99,"name":"{{assetName}}","state":"uploaded"}]""";
-            await Respond(await NextRequest(), uploadedAsset);
-            await Respond(await NextRequest(), uploadedAsset);
         });
 
         try
         {
-            var result = CreatePublisher().PublishRelease(
-                new GitHubReleasePublishRequest
-                {
-                    Owner = "EvotecIT",
-                    Repository = "example",
-                    Token = "token",
-                    ApiBaseUrl = apiBaseUrl,
-                    TagName = "v1.2.3",
-                    AssetFilePaths = [assetPath]
-                });
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                CreatePublisher().PublishRelease(
+                    new GitHubReleasePublishRequest
+                    {
+                        Owner = "EvotecIT",
+                        Repository = "example",
+                        Token = "token",
+                        ApiBaseUrl = apiBaseUrl,
+                        TagName = "v1.2.3",
+                        AssetFilePaths = [assetPath]
+                    }));
 
             await server.WaitAsync(TimeSpan.FromSeconds(10));
-            Assert.True(result.Succeeded);
-            Assert.Equal(assetName, Assert.Single(result.UploadedAssets));
+            Assert.Contains("publisher cannot be proven", exception.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {
@@ -582,7 +559,7 @@ public sealed class GitHubReleasePublisherRetryTests
     }
 
     [Fact]
-    public async Task PublishRelease_TerminalTransientFailureRemovesStarterBeforeFailing()
+    public async Task PublishRelease_TerminalTransientFailureRefusesStarterDeletion()
     {
         var listener = new HttpListener();
         var port = GetAvailablePort();
@@ -592,7 +569,6 @@ public sealed class GitHubReleasePublisherRetryTests
         var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
         await File.WriteAllTextAsync(assetPath, "terminal-starter-cleanup");
         var assetName = Path.GetFileName(assetPath);
-        var deleteObserved = false;
 
         async Task<HttpListenerContext> NextRequest()
             => await listener.GetContextAsync().WaitAsync(TimeSpan.FromSeconds(10));
@@ -623,10 +599,6 @@ public sealed class GitHubReleasePublisherRetryTests
             await Respond(await NextRequest(), "{\"message\":\"Bad Gateway\"}", 502);
             var starterAsset = $$"""[{"id":88,"name":"{{assetName}}","state":"starter"}]""";
             await Respond(await NextRequest(), starterAsset);
-            await Respond(await NextRequest(), starterAsset);
-            var delete = await NextRequest();
-            deleteObserved = delete.Request.HttpMethod == "DELETE";
-            await Respond(delete, string.Empty, 204);
         });
 
         try
@@ -644,8 +616,7 @@ public sealed class GitHubReleasePublisherRetryTests
                     }));
 
             await server.WaitAsync(TimeSpan.FromSeconds(10));
-            Assert.Contains("502", exception.Message, StringComparison.OrdinalIgnoreCase);
-            Assert.True(deleteObserved);
+            Assert.Contains("publisher cannot be proven", exception.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/PowerForge.Tests/GitHubReleasePublisherTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherTests.cs
@@ -309,7 +309,7 @@ public sealed class GitHubReleasePublisherTests
     }
 
     [Fact]
-    public async Task PublishRelease_ReusedReleaseRetainsOrdinarySameNameSkipCompatibility()
+    public async Task PublishRelease_ReusedReleaseAllowsUnrelatedAssetsDuringSameNameSkip()
     {
         var listener = new HttpListener();
         var port = GetAvailablePort();
@@ -337,10 +337,10 @@ public sealed class GitHubReleasePublisherTests
             await Respond(
                 """{"message":"Validation Failed","errors":[{"resource":"ReleaseAsset","code":"already_exists","field":"name"}]}""",
                 422);
-            var existingAsset = $$"""[{"id":99,"name":"{{Path.GetFileName(assetPath)}}","state":"uploaded"}]""";
-            await Respond(existingAsset, 200);
-            await Respond(existingAsset, 200);
-            await Respond(existingAsset, 200);
+            var existingAssets = $$"""[{"id":99,"name":"{{Path.GetFileName(assetPath)}}","state":"uploaded"},{"id":100,"name":"unrelated.zip","state":"uploaded"}]""";
+            await Respond(existingAssets, 200);
+            await Respond(existingAssets, 200);
+            await Respond(existingAssets, 200);
         });
 
         try

--- a/PowerForge.Tests/GitHubReleasePublisherTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherTests.cs
@@ -439,6 +439,8 @@ public sealed class GitHubReleasePublisherTests
             await Respond(await listener.GetContextAsync(), releaseJson);
             await Respond(await listener.GetContextAsync(), $"{{\"object\":{{\"sha\":\"{commit}\",\"type\":\"commit\"}}}}");
             await Respond(await listener.GetContextAsync(), $"[{{\"id\":99,\"name\":\"{Path.GetFileName(assetPath)}\"}}]");
+            await Respond(await listener.GetContextAsync(), releaseJson);
+            await Respond(await listener.GetContextAsync(), $"{{\"object\":{{\"sha\":\"{commit}\",\"type\":\"commit\"}}}}");
             await Respond(await listener.GetContextAsync(), string.Empty, 204);
             await Respond(await listener.GetContextAsync(), "[]");
             await Respond(await listener.GetContextAsync(), releaseJson);
@@ -484,6 +486,8 @@ public sealed class GitHubReleasePublisherTests
                     "GET /repos/EvotecIT/example/releases/tags/v1.2.3",
                     "GET /repos/EvotecIT/example/git/ref/tags/v1.2.3",
                     "GET /repos/EvotecIT/example/releases/42/assets",
+                    "GET /repos/EvotecIT/example/releases/tags/v1.2.3",
+                    "GET /repos/EvotecIT/example/git/ref/tags/v1.2.3",
                     "DELETE /repos/EvotecIT/example/releases/assets/99",
                     "GET /repos/EvotecIT/example/releases/42/assets",
                     "GET /repos/EvotecIT/example/releases/tags/v1.2.3",

--- a/PowerForge.Tests/GitHubReleasePublisherTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherTests.cs
@@ -279,7 +279,8 @@ public sealed class GitHubReleasePublisherTests
             await Respond(
                 """{"message":"Validation Failed","errors":[{"resource":"ReleaseAsset","code":"already_exists","field":"name"}]}""",
                 422);
-            await Respond($$"""[{"id":99,"name":"{{Path.GetFileName(assetPath)}}","state":"uploaded"}]""", 200);
+            var existingAsset = $$"""[{"id":99,"name":"{{Path.GetFileName(assetPath)}}","state":"uploaded"}]""";
+            await Respond(existingAsset, 200);
         });
 
         try
@@ -336,7 +337,10 @@ public sealed class GitHubReleasePublisherTests
             await Respond(
                 """{"message":"Validation Failed","errors":[{"resource":"ReleaseAsset","code":"already_exists","field":"name"}]}""",
                 422);
-            await Respond($$"""[{"id":99,"name":"{{Path.GetFileName(assetPath)}}","state":"uploaded"}]""", 200);
+            var existingAsset = $$"""[{"id":99,"name":"{{Path.GetFileName(assetPath)}}","state":"uploaded"}]""";
+            await Respond(existingAsset, 200);
+            await Respond(existingAsset, 200);
+            await Respond(existingAsset, 200);
         });
 
         try
@@ -436,6 +440,7 @@ public sealed class GitHubReleasePublisherTests
             await Respond(await listener.GetContextAsync(), $"{{\"object\":{{\"sha\":\"{commit}\",\"type\":\"commit\"}}}}");
             await Respond(await listener.GetContextAsync(), $"[{{\"id\":99,\"name\":\"{Path.GetFileName(assetPath)}\"}}]");
             await Respond(await listener.GetContextAsync(), string.Empty, 204);
+            await Respond(await listener.GetContextAsync(), "[]");
             await Respond(await listener.GetContextAsync(), releaseJson);
             await Respond(await listener.GetContextAsync(), $"{{\"object\":{{\"sha\":\"{commit}\",\"type\":\"commit\"}}}}");
             await Respond(await listener.GetContextAsync(), $"{{\"id\":100,\"name\":\"{Path.GetFileName(assetPath)}\"}}", 201);
@@ -480,6 +485,7 @@ public sealed class GitHubReleasePublisherTests
                     "GET /repos/EvotecIT/example/git/ref/tags/v1.2.3",
                     "GET /repos/EvotecIT/example/releases/42/assets",
                     "DELETE /repos/EvotecIT/example/releases/assets/99",
+                    "GET /repos/EvotecIT/example/releases/42/assets",
                     "GET /repos/EvotecIT/example/releases/tags/v1.2.3",
                     "GET /repos/EvotecIT/example/git/ref/tags/v1.2.3",
                     "POST /uploads",

--- a/PowerForge/Services/GitHubReleasePublisher.AssetRecovery.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.AssetRecovery.cs
@@ -86,7 +86,10 @@ public sealed partial class GitHubReleasePublisher {
         string fileName,
         long expectedAssetId,
         string? requiredState,
+        Action validateReleaseBeforeDelete,
         CancellationToken cancellationToken) {
+        if (validateReleaseBeforeDelete is null)
+            throw new ArgumentNullException(nameof(validateReleaseBeforeDelete));
         var deleteMayHaveSucceeded = false;
         for (var attempt = 1; attempt <= MaximumAssetUploadAttempts; attempt++) {
             cancellationToken.ThrowIfCancellationRequested();
@@ -120,6 +123,7 @@ public sealed partial class GitHubReleasePublisher {
             }
 
             try {
+                validateReleaseBeforeDelete();
                 var uri = BuildApiUri(apiBaseUrl, $"/repos/{owner}/{repo}/releases/assets/{expectedAssetId}");
                 using var request = new HttpRequestMessage(HttpMethod.Delete, uri);
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);

--- a/PowerForge/Services/GitHubReleasePublisher.AssetRecovery.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.AssetRecovery.cs
@@ -141,7 +141,7 @@ public sealed partial class GitHubReleasePublisher {
                     throw new GitHubApiRequestException(
                         $"GitHub asset delete failed for '{fileName}' ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}",
                         response.StatusCode,
-                        GetAssetRetryAfterDelay(response));
+                        GetAssetRetryAfterDelay(response, responseText));
                 }
 
                 var remainingAsset = FindUniqueReleaseAsset(

--- a/PowerForge/Services/GitHubReleasePublisher.AssetRecovery.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.AssetRecovery.cs
@@ -144,21 +144,16 @@ public sealed partial class GitHubReleasePublisher {
                         GetAssetRetryAfterDelay(response, responseText));
                 }
 
-                var remainingAsset = FindUniqueReleaseAsset(
-                    ListReleaseAssetsWithRetry(
-                        $"{operation} post-delete verification",
-                        owner,
-                        repo,
-                        token,
-                        apiBaseUrl,
-                        releaseId,
-                        cancellationToken),
-                    fileName);
-                if (remainingAsset is not null) {
-                    ValidateExpectedAssetId(fileName, expectedAssetId, remainingAsset.Id);
-                    throw new InvalidOperationException(
-                        $"GitHub release asset '{fileName}' remained present after deletion of id {expectedAssetId}.");
-                }
+                VerifyExpectedAssetDeletedWithRetry(
+                    operation,
+                    owner,
+                    repo,
+                    token,
+                    apiBaseUrl,
+                    releaseId,
+                    fileName,
+                    expectedAssetId,
+                    cancellationToken);
 
                 _logger.Info($"Deleted existing GitHub release asset before replacement: {fileName}");
                 return true;
@@ -180,5 +175,44 @@ public sealed partial class GitHubReleasePublisher {
         }
 
         throw new InvalidOperationException($"{operation} did not complete.");
+    }
+
+    private void VerifyExpectedAssetDeletedWithRetry(
+        string operation,
+        string owner,
+        string repo,
+        string token,
+        string apiBaseUrl,
+        long releaseId,
+        string fileName,
+        long expectedAssetId,
+        CancellationToken cancellationToken) {
+        for (var attempt = 1; attempt <= MaximumAssetUploadAttempts; attempt++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            var remainingAsset = FindUniqueReleaseAsset(
+                ListReleaseAssetsWithRetry(
+                    $"{operation} post-delete verification",
+                    owner,
+                    repo,
+                    token,
+                    apiBaseUrl,
+                    releaseId,
+                    cancellationToken),
+                fileName);
+            if (remainingAsset is null)
+                return;
+
+            ValidateExpectedAssetId(fileName, expectedAssetId, remainingAsset.Id);
+            if (attempt >= MaximumAssetUploadAttempts) {
+                throw new InvalidOperationException(
+                    $"GitHub release asset '{fileName}' remained present after deletion of id {expectedAssetId}.");
+            }
+
+            var delay = GetAssetUploadExponentialDelay(attempt);
+            _logger.Warn(
+                $"GitHub release asset '{fileName}' remained visible after deletion of id {expectedAssetId}; " +
+                $"retrying verification {attempt + 1}/{MaximumAssetUploadAttempts} in {FormatRetryDelay(delay)}.");
+            WaitBeforeAssetUploadRetry(delay, cancellationToken);
+        }
     }
 }

--- a/PowerForge/Services/GitHubReleasePublisher.AssetRecovery.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.AssetRecovery.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+
+namespace PowerForge;
+
+public sealed partial class GitHubReleasePublisher {
+    private IReadOnlyList<GitHubReleaseAssetResponse> ListReleaseAssetsWithRetry(
+        string operation,
+        string owner,
+        string repo,
+        string token,
+        string apiBaseUrl,
+        long releaseId,
+        CancellationToken cancellationToken) {
+        IReadOnlyList<GitHubReleaseAssetResponse>? assets = null;
+        ExecuteAssetVerificationWithRetry(
+            operation,
+            () => assets = ListReleaseAssets(owner, repo, token, apiBaseUrl, releaseId, cancellationToken),
+            cancellationToken);
+        return assets ?? throw new InvalidOperationException($"{operation} returned no asset inventory.");
+    }
+
+    private long ReadCurrentAssetIdWithRetry(
+        string operation,
+        string owner,
+        string repo,
+        string token,
+        string apiBaseUrl,
+        long releaseId,
+        string fileName,
+        CancellationToken cancellationToken) {
+        long assetId = 0;
+        ExecuteAssetVerificationWithRetry(
+            operation,
+            () => assetId = ReadCurrentAssetId(
+                owner,
+                repo,
+                token,
+                apiBaseUrl,
+                releaseId,
+                fileName,
+                cancellationToken),
+            cancellationToken);
+        return assetId;
+    }
+
+    private static long ReadCurrentAssetId(
+        string owner,
+        string repo,
+        string token,
+        string apiBaseUrl,
+        long releaseId,
+        string fileName,
+        CancellationToken cancellationToken) {
+        var asset = FindUniqueReleaseAsset(
+            ListReleaseAssets(owner, repo, token, apiBaseUrl, releaseId, cancellationToken),
+            fileName);
+        return asset?.Id ?? throw new InvalidOperationException(
+            $"GitHub release asset '{fileName}' was not present when its identity was verified.");
+    }
+
+    private static GitHubReleaseAssetResponse? FindUniqueReleaseAsset(
+        IEnumerable<GitHubReleaseAssetResponse> assets,
+        string fileName) {
+        var matches = assets
+            .Where(asset => string.Equals(asset.Name, fileName, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (matches.Length > 1)
+            throw new InvalidOperationException(
+                $"GitHub release contains duplicate asset name '{fileName}'; identity is ambiguous.");
+        return matches.Length == 0 ? null : matches[0];
+    }
+
+    private bool DeleteExpectedExistingAssetWithRetry(
+        string operation,
+        string owner,
+        string repo,
+        string token,
+        string apiBaseUrl,
+        long releaseId,
+        string fileName,
+        long expectedAssetId,
+        string? requiredState,
+        CancellationToken cancellationToken) {
+        var deleteMayHaveSucceeded = false;
+        for (var attempt = 1; attempt <= MaximumAssetUploadAttempts; attempt++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            var asset = FindUniqueReleaseAsset(
+                ListReleaseAssetsWithRetry(
+                    $"{operation} identity verification",
+                    owner,
+                    repo,
+                    token,
+                    apiBaseUrl,
+                    releaseId,
+                    cancellationToken),
+                fileName);
+            if (asset is null) {
+                if (deleteMayHaveSucceeded) {
+                    _logger.Info(
+                        $"Confirmed GitHub release asset '{fileName}' is absent after an interrupted deletion.");
+                    return true;
+                }
+
+                throw new InvalidOperationException(
+                    $"GitHub release asset '{fileName}' disappeared before deletion of expected id {expectedAssetId}.");
+            }
+
+            ValidateExpectedAssetId(fileName, expectedAssetId, asset.Id);
+            if (!string.IsNullOrWhiteSpace(requiredState) &&
+                !string.Equals(asset.State, requiredState, StringComparison.OrdinalIgnoreCase)) {
+                throw new InvalidOperationException(
+                    $"GitHub release asset '{fileName}' changed from state '{requiredState}' to " +
+                    $"'{asset.State ?? "<missing>"}' before deletion.");
+            }
+
+            try {
+                var uri = BuildApiUri(apiBaseUrl, $"/repos/{owner}/{repo}/releases/assets/{expectedAssetId}");
+                using var request = new HttpRequestMessage(HttpMethod.Delete, uri);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                deleteMayHaveSucceeded = true;
+
+                using var response = SharedClient.SendAsync(request, cancellationToken)
+                    .ConfigureAwait(false)
+                    .GetAwaiter()
+                    .GetResult();
+                var responseText = response.Content.ReadAsStringAsync()
+                    .ConfigureAwait(false)
+                    .GetAwaiter()
+                    .GetResult();
+                if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound) {
+                    throw new GitHubApiRequestException(
+                        $"GitHub asset delete failed for '{fileName}' ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}",
+                        response.StatusCode,
+                        GetAssetRetryAfterDelay(response));
+                }
+
+                var remainingAsset = FindUniqueReleaseAsset(
+                    ListReleaseAssetsWithRetry(
+                        $"{operation} post-delete verification",
+                        owner,
+                        repo,
+                        token,
+                        apiBaseUrl,
+                        releaseId,
+                        cancellationToken),
+                    fileName);
+                if (remainingAsset is not null) {
+                    ValidateExpectedAssetId(fileName, expectedAssetId, remainingAsset.Id);
+                    throw new InvalidOperationException(
+                        $"GitHub release asset '{fileName}' remained present after deletion of id {expectedAssetId}.");
+                }
+
+                _logger.Info($"Deleted existing GitHub release asset before replacement: {fileName}");
+                return true;
+            }
+            catch (Exception exception) when (IsTransientAssetUploadException(exception, cancellationToken)) {
+                if (attempt >= MaximumAssetUploadAttempts) {
+                    throw new InvalidOperationException(
+                        $"{operation} failed after {MaximumAssetUploadAttempts} attempts. " +
+                        DescribeException(exception),
+                        exception);
+                }
+
+                var delay = GetAssetUploadRetryDelay(exception, attempt);
+                _logger.Warn(
+                    $"{operation} was interrupted ({DescribeException(exception)}); retrying attempt " +
+                    $"{attempt + 1}/{MaximumAssetUploadAttempts} in {FormatRetryDelay(delay)}.");
+                WaitBeforeAssetUploadRetry(delay, cancellationToken);
+            }
+        }
+
+        throw new InvalidOperationException($"{operation} did not complete.");
+    }
+}

--- a/PowerForge/Services/GitHubReleasePublisher.Assets.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.Assets.cs
@@ -222,12 +222,14 @@ public sealed partial class GitHubReleasePublisher {
                 var statusCode = response.StatusCode;
                 var reasonPhrase = response.ReasonPhrase;
                 var terminalAttempt = attempt >= MaximumAssetUploadAttempts;
-                if (!terminalAttempt)
-                    response.Dispose();
-
                 var waitBeforeReconciliation = serverDelay.HasValue ||
                                                (int)statusCode == 429 ||
                                                statusCode == HttpStatusCode.Forbidden;
+                if (terminalAttempt && waitBeforeReconciliation)
+                    return response;
+
+                if (!terminalAttempt)
+                    response.Dispose();
                 if (waitBeforeReconciliation) {
                     _logger.Warn(
                         $"GitHub release asset upload for '{fileName}' returned " +

--- a/PowerForge/Services/GitHubReleasePublisher.Assets.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.Assets.cs
@@ -349,11 +349,11 @@ public sealed partial class GitHubReleasePublisher {
     private static TimeSpan? GetAssetRetryAfterDelay(HttpResponseMessage? response) {
         var retryAfter = response?.Headers.RetryAfter;
         if (retryAfter?.Delta is TimeSpan delta && delta > TimeSpan.Zero)
-            return delta > TimeSpan.FromSeconds(30) ? TimeSpan.FromSeconds(30) : delta;
+            return delta;
         if (retryAfter?.Date is DateTimeOffset date) {
             var until = date - DateTimeOffset.UtcNow;
             if (until > TimeSpan.Zero)
-                return until > TimeSpan.FromSeconds(30) ? TimeSpan.FromSeconds(30) : until;
+                return until;
         }
 
         return null;

--- a/PowerForge/Services/GitHubReleasePublisher.Assets.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.Assets.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -145,21 +146,25 @@ public sealed partial class GitHubReleasePublisher {
         string apiBaseUrl,
         long releaseId,
         IReadOnlyDictionary<string, long> expectedAssets,
+        bool requireExactAssetSet,
         CancellationToken cancellationToken) {
-        var current = CreateReplaceableAssetMap(
-            ListReleaseAssets(owner, repo, token, apiBaseUrl, releaseId, cancellationToken));
-        ValidateExistingAssetNamesAuthorized(current.Keys, new HashSet<string>(
-            expectedAssets.Keys,
-            StringComparer.OrdinalIgnoreCase));
-        if (current.Count != expectedAssets.Count)
-            throw new InvalidOperationException(
-                $"GitHub release asset reconciliation returned {current.Count} asset(s), expected {expectedAssets.Count}.");
+        var currentAssets = ListReleaseAssets(owner, repo, token, apiBaseUrl, releaseId, cancellationToken);
+        if (requireExactAssetSet) {
+            var current = CreateReplaceableAssetMap(currentAssets);
+            ValidateExistingAssetNamesAuthorized(current.Keys, new HashSet<string>(
+                expectedAssets.Keys,
+                StringComparer.OrdinalIgnoreCase));
+            if (current.Count != expectedAssets.Count)
+                throw new InvalidOperationException(
+                    $"GitHub release asset reconciliation returned {current.Count} asset(s), expected {expectedAssets.Count}.");
+        }
 
         foreach (var expected in expectedAssets) {
-            if (!current.TryGetValue(expected.Key, out var actualId))
+            var current = FindUniqueReleaseAsset(currentAssets, expected.Key);
+            if (current is null)
                 throw new InvalidOperationException(
                     $"GitHub release asset '{expected.Key}' disappeared before recovery completed.");
-            ValidateExpectedAssetId(expected.Key, expected.Value, actualId);
+            ValidateExpectedAssetId(expected.Key, expected.Value, current.Id);
         }
     }
 
@@ -344,7 +349,7 @@ public sealed partial class GitHubReleasePublisher {
         return GetAssetUploadExponentialDelay(failedAttempt);
     }
 
-    private static TimeSpan? GetAssetRetryAfterDelay(HttpResponseMessage? response) {
+    internal static TimeSpan? GetAssetRetryAfterDelay(HttpResponseMessage? response) {
         var retryAfter = response?.Headers.RetryAfter;
         if (retryAfter?.Delta is TimeSpan delta && delta > TimeSpan.Zero)
             return delta;
@@ -354,7 +359,33 @@ public sealed partial class GitHubReleasePublisher {
                 return until;
         }
 
+        if (response?.StatusCode == HttpStatusCode.Forbidden &&
+            TryGetSingleInt64Header(response, "X-RateLimit-Remaining", out var remaining) &&
+            remaining == 0 &&
+            TryGetSingleInt64Header(response, "X-RateLimit-Reset", out var resetUnixSeconds)) {
+            try {
+                var untilReset = DateTimeOffset.FromUnixTimeSeconds(resetUnixSeconds) - DateTimeOffset.UtcNow;
+                if (untilReset > TimeSpan.Zero)
+                    return untilReset + TimeSpan.FromSeconds(1);
+            }
+            catch (ArgumentOutOfRangeException) {
+                return null;
+            }
+        }
+
         return null;
+    }
+
+    private static bool TryGetSingleInt64Header(
+        HttpResponseMessage response,
+        string headerName,
+        out long value) {
+        value = 0;
+        if (!response.Headers.TryGetValues(headerName, out var values))
+            return false;
+        var text = values.FirstOrDefault();
+        return text is not null &&
+               long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
     }
 
     private static TimeSpan GetAssetUploadExponentialDelay(int failedAttempt)
@@ -518,6 +549,7 @@ public sealed partial class GitHubReleasePublisher {
         string? expectedTagCommitSha,
         bool requirePublishedStableRelease,
         IReadOnlyDictionary<string, long> verifiedAssetIds,
+        bool requireExactAssetSet,
         CancellationToken cancellationToken)
         => ExecuteAssetVerificationWithRetry(
             operation,
@@ -540,6 +572,7 @@ public sealed partial class GitHubReleasePublisher {
                     apiBaseUrl,
                     releaseId,
                     verifiedAssetIds,
+                    requireExactAssetSet,
                     cancellationToken);
                 ValidateReleaseBeforeAssetMutation(
                     owner,

--- a/PowerForge/Services/GitHubReleasePublisher.Assets.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.Assets.cs
@@ -174,12 +174,16 @@ public sealed partial class GitHubReleasePublisher {
         string fileName,
         string token,
         Action<long, long>? reportProgress,
+        Action validateReleaseBeforeRetry,
         Func<AssetUploadReconciliationState> reconcileUpload,
         CancellationToken cancellationToken) {
+        if (validateReleaseBeforeRetry is null) throw new ArgumentNullException(nameof(validateReleaseBeforeRetry));
         if (reconcileUpload is null) throw new ArgumentNullException(nameof(reconcileUpload));
         var sawTransientFailure = false;
         for (var attempt = 1; ; attempt++) {
             cancellationToken.ThrowIfCancellationRequested();
+            if (attempt > 1)
+                validateReleaseBeforeRetry();
             HttpResponseMessage response;
             try {
                 response = UploadAssetOnce(

--- a/PowerForge/Services/GitHubReleasePublisher.Assets.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.Assets.cs
@@ -195,13 +195,13 @@ public sealed partial class GitHubReleasePublisher {
                 if (attempt >= MaximumAssetUploadAttempts) {
                     throw new InvalidOperationException(
                         $"GitHub asset upload failed for '{fileName}' after {MaximumAssetUploadAttempts} attempts. " +
-                        exception.Message,
+                        DescribeException(exception),
                         exception);
                 }
 
                 var delay = GetAssetUploadRetryDelay(response: null, attempt);
                 _logger.Warn(
-                    $"GitHub release asset upload for '{fileName}' was interrupted ({exception.Message}); " +
+                    $"GitHub release asset upload for '{fileName}' was interrupted ({DescribeException(exception)}); " +
                     $"retrying attempt {attempt + 1}/{MaximumAssetUploadAttempts} in {FormatRetryDelay(delay)}.");
                 WaitBeforeAssetUploadRetry(delay, cancellationToken);
                 continue;
@@ -329,10 +329,7 @@ public sealed partial class GitHubReleasePublisher {
     internal static bool IsTransientAssetUploadStatus(HttpStatusCode statusCode)
         => statusCode == HttpStatusCode.RequestTimeout ||
            (int)statusCode == 429 ||
-           statusCode == HttpStatusCode.InternalServerError ||
-           statusCode == HttpStatusCode.BadGateway ||
-           statusCode == HttpStatusCode.ServiceUnavailable ||
-           statusCode == HttpStatusCode.GatewayTimeout;
+           (int)statusCode is >= 500 and <= 599;
 
     private static TimeSpan GetAssetUploadRetryDelay(HttpResponseMessage? response, int failedAttempt) {
         var retryAfter = response?.Headers.RetryAfter;
@@ -344,11 +341,11 @@ public sealed partial class GitHubReleasePublisher {
                 return until > TimeSpan.FromSeconds(30) ? TimeSpan.FromSeconds(30) : until;
         }
 
-        return TimeSpan.FromMilliseconds(250 * (1 << Math.Min(failedAttempt - 1, 3)));
+        return TimeSpan.FromSeconds(1 << Math.Min(failedAttempt, 4));
     }
 
-    private static void WaitBeforeAssetUploadRetry(TimeSpan delay, CancellationToken cancellationToken)
-        => Task.Delay(delay, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+    private void WaitBeforeAssetUploadRetry(TimeSpan delay, CancellationToken cancellationToken)
+        => _assetRetryDelay(delay, cancellationToken);
 
     private static string FormatRetryDelay(TimeSpan delay)
         => delay.TotalSeconds >= 1
@@ -361,7 +358,24 @@ public sealed partial class GitHubReleasePublisher {
         CancellationToken cancellationToken) {
         for (var attempt = 1; attempt <= MaximumAssetReconciliationAttempts; attempt++) {
             cancellationToken.ThrowIfCancellationRequested();
-            var reconciliation = reconcileUpload();
+            AssetUploadReconciliationState reconciliation;
+            try {
+                reconciliation = reconcileUpload();
+            }
+            catch (Exception exception) when (IsTransientAssetUploadException(exception, cancellationToken)) {
+                if (attempt >= MaximumAssetReconciliationAttempts) {
+                    throw new InvalidOperationException(
+                        $"GitHub release asset reconciliation for '{fileName}' failed after " +
+                        $"{MaximumAssetReconciliationAttempts} attempts. {DescribeException(exception)}",
+                        exception);
+                }
+
+                reconciliation = AssetUploadReconciliationState.TemporarilyUnavailable;
+                _logger.Warn(
+                    $"Could not reconcile interrupted GitHub release asset '{fileName}' " +
+                    $"({DescribeException(exception)}).");
+            }
+
             if (reconciliation != AssetUploadReconciliationState.TemporarilyUnavailable ||
                 attempt >= MaximumAssetReconciliationAttempts)
                 return reconciliation;
@@ -376,6 +390,166 @@ public sealed partial class GitHubReleasePublisher {
         return AssetUploadReconciliationState.TemporarilyUnavailable;
     }
 
+    private void ExecuteAssetVerificationWithRetry(
+        string operation,
+        Action verify,
+        CancellationToken cancellationToken) {
+        if (verify is null) throw new ArgumentNullException(nameof(verify));
+
+        for (var attempt = 1; attempt <= MaximumAssetUploadAttempts; attempt++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            try {
+                verify();
+                return;
+            }
+            catch (Exception exception) when (IsTransientAssetUploadException(exception, cancellationToken)) {
+                if (attempt >= MaximumAssetUploadAttempts) {
+                    throw new InvalidOperationException(
+                        $"{operation} failed after {MaximumAssetUploadAttempts} attempts. " +
+                        DescribeException(exception),
+                        exception);
+                }
+
+                var delay = GetAssetUploadRetryDelay(response: null, attempt);
+                _logger.Warn(
+                    $"{operation} was interrupted ({DescribeException(exception)}); retrying attempt " +
+                    $"{attempt + 1}/{MaximumAssetUploadAttempts} in {FormatRetryDelay(delay)}.");
+                WaitBeforeAssetUploadRetry(delay, cancellationToken);
+            }
+        }
+    }
+
+    private void ValidateReleaseBeforeAssetMutationWithRetry(
+        string operation,
+        string owner,
+        string repo,
+        string token,
+        string apiBaseUrl,
+        long releaseId,
+        string tagName,
+        string? expectedReleaseBodyMarker,
+        string? expectedTagCommitSha,
+        bool requirePublishedStableRelease,
+        CancellationToken cancellationToken)
+        => ExecuteAssetVerificationWithRetry(
+            operation,
+            () => ValidateReleaseBeforeAssetMutation(
+                owner,
+                repo,
+                token,
+                apiBaseUrl,
+                releaseId,
+                tagName,
+                expectedReleaseBodyMarker,
+                expectedTagCommitSha,
+                requirePublishedStableRelease,
+                cancellationToken),
+            cancellationToken);
+
+    private void ValidateUploadedAssetWithRetry(
+        string operation,
+        string owner,
+        string repo,
+        string token,
+        string apiBaseUrl,
+        long releaseId,
+        string tagName,
+        string? expectedReleaseBodyMarker,
+        string? expectedTagCommitSha,
+        bool requirePublishedStableRelease,
+        string fileName,
+        long uploadedAssetId,
+        CancellationToken cancellationToken)
+        => ExecuteAssetVerificationWithRetry(
+            operation,
+            () => {
+                ValidateReleaseBeforeAssetMutation(
+                    owner,
+                    repo,
+                    token,
+                    apiBaseUrl,
+                    releaseId,
+                    tagName,
+                    expectedReleaseBodyMarker,
+                    expectedTagCommitSha,
+                    requirePublishedStableRelease,
+                    cancellationToken);
+                ValidateCurrentAssetIdentity(
+                    owner,
+                    repo,
+                    token,
+                    apiBaseUrl,
+                    releaseId,
+                    fileName,
+                    uploadedAssetId,
+                    cancellationToken);
+            },
+            cancellationToken);
+
+    private void ValidateFinalAssetSetWithRetry(
+        string operation,
+        string owner,
+        string repo,
+        string token,
+        string apiBaseUrl,
+        long releaseId,
+        string tagName,
+        string? expectedReleaseBodyMarker,
+        string? expectedTagCommitSha,
+        bool requirePublishedStableRelease,
+        IReadOnlyDictionary<string, long> uploadedAssetIds,
+        CancellationToken cancellationToken)
+        => ExecuteAssetVerificationWithRetry(
+            operation,
+            () => {
+                ValidateReleaseBeforeAssetMutation(
+                    owner,
+                    repo,
+                    token,
+                    apiBaseUrl,
+                    releaseId,
+                    tagName,
+                    expectedReleaseBodyMarker,
+                    expectedTagCommitSha,
+                    requirePublishedStableRelease,
+                    cancellationToken);
+                ValidateFinalAssetSet(
+                    owner,
+                    repo,
+                    token,
+                    apiBaseUrl,
+                    releaseId,
+                    uploadedAssetIds,
+                    cancellationToken);
+                ValidateReleaseBeforeAssetMutation(
+                    owner,
+                    repo,
+                    token,
+                    apiBaseUrl,
+                    releaseId,
+                    tagName,
+                    expectedReleaseBodyMarker,
+                    expectedTagCommitSha,
+                    requirePublishedStableRelease,
+                    cancellationToken);
+            },
+            cancellationToken);
+
+    internal static string DescribeException(Exception exception) {
+        if (exception is null) throw new ArgumentNullException(nameof(exception));
+        var messages = new List<string>();
+        for (var current = exception; current is not null; current = current.InnerException) {
+            if (string.IsNullOrWhiteSpace(current.Message)) continue;
+            if (messages.Count == 0 ||
+                !string.Equals(messages[^1], current.Message, StringComparison.Ordinal))
+                messages.Add(current.Message);
+        }
+
+        return messages.Count > 0
+            ? string.Join(" -> ", messages)
+            : exception.GetType().Name;
+    }
+
     private AssetUploadReconciliationState ReconcileReleaseAssetAfterUploadFailure(
         string owner,
         string repo,
@@ -388,16 +562,7 @@ public sealed partial class GitHubReleasePublisher {
         bool requirePublishedStableRelease,
         string fileName,
         CancellationToken cancellationToken) {
-        IReadOnlyList<GitHubReleaseAssetResponse> currentAssets;
-        try {
-            currentAssets = ListReleaseAssets(owner, repo, token, apiBaseUrl, releaseId, cancellationToken);
-        }
-        catch (Exception exception) when (IsTransientAssetUploadException(exception, cancellationToken)) {
-            _logger.Warn(
-                $"Could not reconcile interrupted GitHub release asset '{fileName}' before retry. " +
-                exception.Message);
-            return AssetUploadReconciliationState.TemporarilyUnavailable;
-        }
+        var currentAssets = ListReleaseAssets(owner, repo, token, apiBaseUrl, releaseId, cancellationToken);
 
         var sameNameAssets = currentAssets
             .Where(asset => string.Equals(asset.Name, fileName, StringComparison.Ordinal))
@@ -485,7 +650,9 @@ public sealed partial class GitHubReleasePublisher {
         var responseText = response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
         using (response) {
             if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
-                throw new InvalidOperationException($"GitHub asset delete failed for '{fileName}' ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}");
+                throw new GitHubApiRequestException(
+                    $"GitHub asset delete failed for '{fileName}' ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}",
+                    response.StatusCode);
         }
 
         _logger.Info($"Deleted existing GitHub release asset before replacement: {fileName}");

--- a/PowerForge/Services/GitHubReleasePublisher.Assets.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.Assets.cs
@@ -14,14 +14,9 @@ public sealed partial class GitHubReleasePublisher {
 
     private enum AssetUploadReconciliationState {
         Absent,
-        StarterRemoved,
         Uploaded,
         LegacyStateUnavailable,
         TemporarilyUnavailable
-    }
-
-    private sealed class AssetUploadReconciliationContext {
-        internal long? StarterAssetId { get; set; }
     }
 
     private static void ReportAssetProgress(
@@ -137,13 +132,10 @@ public sealed partial class GitHubReleasePublisher {
         string fileName,
         long expectedAssetId,
         CancellationToken cancellationToken) {
-        var current = ListReleaseAssets(owner, repo, token, apiBaseUrl, releaseId, cancellationToken)
-            .Where(asset => string.Equals(asset.Name, fileName, StringComparison.Ordinal))
-            .ToArray();
-        if (current.Length != 1)
-            throw new InvalidOperationException(
-                $"GitHub release asset '{fileName}' was not uniquely present after upload.");
-        ValidateExpectedAssetId(fileName, expectedAssetId, current[0].Id);
+        ValidateExpectedAssetId(
+            fileName,
+            expectedAssetId,
+            ReadCurrentAssetId(owner, repo, token, apiBaseUrl, releaseId, fileName, cancellationToken));
     }
 
     private static void ValidateFinalAssetSet(
@@ -177,7 +169,7 @@ public sealed partial class GitHubReleasePublisher {
         string fileName,
         string token,
         Action<long, long>? reportProgress,
-        Func<AssetUploadReconciliationContext, AssetUploadReconciliationState> reconcileUpload,
+        Func<AssetUploadReconciliationState> reconcileUpload,
         CancellationToken cancellationToken) {
         if (reconcileUpload is null) throw new ArgumentNullException(nameof(reconcileUpload));
         var sawTransientFailure = false;
@@ -211,7 +203,7 @@ public sealed partial class GitHubReleasePublisher {
                 continue;
             }
 
-            if (IsTransientAssetUploadStatus(response.StatusCode)) {
+            if (IsTransientAssetUploadResponse(response)) {
                 sawTransientFailure = true;
                 var delay = GetAssetUploadRetryDelay(response, attempt);
                 var statusCode = response.StatusCode;
@@ -254,8 +246,7 @@ public sealed partial class GitHubReleasePublisher {
                         throw;
                     }
 
-                    if (reconciliation == AssetUploadReconciliationState.Absent ||
-                        reconciliation == AssetUploadReconciliationState.StarterRemoved) {
+                    if (reconciliation == AssetUploadReconciliationState.Absent) {
                         response.Dispose();
                         if (attempt >= MaximumAssetUploadAttempts) {
                             throw new InvalidOperationException(
@@ -324,7 +315,8 @@ public sealed partial class GitHubReleasePublisher {
         if (exception is null) throw new ArgumentNullException(nameof(exception));
         if (cancellationToken.IsCancellationRequested) return false;
         if (exception is GitHubApiRequestException apiException)
-            return IsTransientAssetUploadStatus(apiException.StatusCode);
+            return IsTransientAssetUploadStatus(apiException.StatusCode) ||
+                   (apiException.StatusCode == HttpStatusCode.Forbidden && apiException.RetryAfter.HasValue);
         return exception is HttpRequestException ||
                exception is IOException ||
                exception is TaskCanceledException;
@@ -334,6 +326,12 @@ public sealed partial class GitHubReleasePublisher {
         => statusCode == HttpStatusCode.RequestTimeout ||
            (int)statusCode == 429 ||
            (int)statusCode is >= 500 and <= 599;
+
+    internal static bool IsTransientAssetUploadResponse(HttpResponseMessage response) {
+        if (response is null) throw new ArgumentNullException(nameof(response));
+        return IsTransientAssetUploadStatus(response.StatusCode) ||
+               (response.StatusCode == HttpStatusCode.Forbidden && GetAssetRetryAfterDelay(response).HasValue);
+    }
 
     private static TimeSpan GetAssetUploadRetryDelay(HttpResponseMessage? response, int failedAttempt)
         => GetAssetRetryAfterDelay(response) ?? GetAssetUploadExponentialDelay(failedAttempt);
@@ -371,16 +369,15 @@ public sealed partial class GitHubReleasePublisher {
             : $"{delay.TotalMilliseconds:0}ms";
 
     private AssetUploadReconciliationState ReconcileUploadWithRetry(
-        Func<AssetUploadReconciliationContext, AssetUploadReconciliationState> reconcileUpload,
+        Func<AssetUploadReconciliationState> reconcileUpload,
         string fileName,
         CancellationToken cancellationToken) {
-        var reconciliationContext = new AssetUploadReconciliationContext();
         for (var attempt = 1; attempt <= MaximumAssetReconciliationAttempts; attempt++) {
             cancellationToken.ThrowIfCancellationRequested();
             AssetUploadReconciliationState reconciliation;
             Exception? transientException = null;
             try {
-                reconciliation = reconcileUpload(reconciliationContext);
+                reconciliation = reconcileUpload();
             }
             catch (Exception exception) when (IsTransientAssetUploadException(exception, cancellationToken)) {
                 if (attempt >= MaximumAssetReconciliationAttempts) {
@@ -520,7 +517,7 @@ public sealed partial class GitHubReleasePublisher {
         string? expectedReleaseBodyMarker,
         string? expectedTagCommitSha,
         bool requirePublishedStableRelease,
-        IReadOnlyDictionary<string, long> uploadedAssetIds,
+        IReadOnlyDictionary<string, long> verifiedAssetIds,
         CancellationToken cancellationToken)
         => ExecuteAssetVerificationWithRetry(
             operation,
@@ -542,7 +539,7 @@ public sealed partial class GitHubReleasePublisher {
                     token,
                     apiBaseUrl,
                     releaseId,
-                    uploadedAssetIds,
+                    verifiedAssetIds,
                     cancellationToken);
                 ValidateReleaseBeforeAssetMutation(
                     owner,
@@ -579,17 +576,12 @@ public sealed partial class GitHubReleasePublisher {
         string token,
         string apiBaseUrl,
         long releaseId,
-        string tagName,
-        string? expectedReleaseBodyMarker,
-        string? expectedTagCommitSha,
-        bool requirePublishedStableRelease,
         string fileName,
-        AssetUploadReconciliationContext reconciliationContext,
         CancellationToken cancellationToken) {
         var currentAssets = ListReleaseAssets(owner, repo, token, apiBaseUrl, releaseId, cancellationToken);
 
         var sameNameAssets = currentAssets
-            .Where(asset => string.Equals(asset.Name, fileName, StringComparison.Ordinal))
+            .Where(asset => string.Equals(asset.Name, fileName, StringComparison.OrdinalIgnoreCase))
             .ToArray();
         if (sameNameAssets.Length == 0)
             return AssetUploadReconciliationState.Absent;
@@ -606,37 +598,9 @@ public sealed partial class GitHubReleasePublisher {
             throw new InvalidOperationException(
                 $"GitHub release asset '{fileName}' has unexpected state '{incompleteAsset.State}'.");
 
-        if (reconciliationContext.StarterAssetId is long expectedStarterAssetId)
-            ValidateExpectedAssetId(fileName, expectedStarterAssetId, incompleteAsset.Id);
-        else
-            reconciliationContext.StarterAssetId = incompleteAsset.Id;
-
-        ValidateReleaseBeforeAssetMutation(
-            owner,
-            repo,
-            token,
-            apiBaseUrl,
-            releaseId,
-            tagName,
-            expectedReleaseBodyMarker,
-            expectedTagCommitSha,
-            requirePublishedStableRelease,
-            cancellationToken);
-        if (DeleteExpectedExistingAsset(
-            owner,
-            repo,
-            token,
-            apiBaseUrl,
-            releaseId,
-            fileName,
-            reconciliationContext.StarterAssetId!.Value,
-            requiredState: "starter",
-            cancellationToken)) {
-            _logger.Warn($"Removed incomplete GitHub release asset '{fileName}' before retrying its upload.");
-            return AssetUploadReconciliationState.StarterRemoved;
-        }
-
-        return AssetUploadReconciliationState.Absent;
+        throw new InvalidOperationException(
+            $"GitHub release asset '{fileName}' is in state 'starter' after an interrupted upload. " +
+            "Its publisher cannot be proven, so recovery refuses to delete it.");
     }
 
     private sealed class GitHubApiRequestException : InvalidOperationException {
@@ -651,49 +615,6 @@ public sealed partial class GitHubReleasePublisher {
 
         internal HttpStatusCode StatusCode { get; }
         internal TimeSpan? RetryAfter { get; }
-    }
-
-    private bool DeleteExpectedExistingAsset(
-        string owner,
-        string repo,
-        string token,
-        string apiBaseUrl,
-        long releaseId,
-        string fileName,
-        long expectedAssetId,
-        string? requiredState,
-        CancellationToken cancellationToken) {
-        if (releaseId <= 0)
-            throw new InvalidOperationException("GitHub release asset replacement requires the release id returned by GitHub.");
-
-        var asset = ListReleaseAssets(owner, repo, token, apiBaseUrl, releaseId, cancellationToken)
-            .FirstOrDefault(existing => string.Equals(existing.Name, fileName, StringComparison.OrdinalIgnoreCase));
-        if (asset is null)
-            return false;
-        ValidateExpectedAssetId(fileName, expectedAssetId, asset.Id);
-        if (!string.IsNullOrWhiteSpace(requiredState) &&
-            !string.Equals(asset.State, requiredState, StringComparison.OrdinalIgnoreCase)) {
-            throw new InvalidOperationException(
-                $"GitHub release asset '{fileName}' changed from state '{requiredState}' to " +
-                $"'{asset.State ?? "<missing>"}' before deletion.");
-        }
-
-        var uri = BuildApiUri(apiBaseUrl, $"/repos/{owner}/{repo}/releases/assets/{expectedAssetId}");
-        using var request = new HttpRequestMessage(HttpMethod.Delete, uri);
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-        var response = SharedClient.SendAsync(request, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
-        var responseText = response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-        using (response) {
-            if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
-                throw new GitHubApiRequestException(
-                    $"GitHub asset delete failed for '{fileName}' ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}",
-                    response.StatusCode,
-                    GetAssetRetryAfterDelay(response));
-        }
-
-        _logger.Info($"Deleted existing GitHub release asset before replacement: {fileName}");
-        return true;
     }
 
     private static IReadOnlyList<GitHubReleaseAssetResponse> ListReleaseAssets(

--- a/PowerForge/Services/GitHubReleasePublisher.Assets.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.Assets.cs
@@ -20,6 +20,10 @@ public sealed partial class GitHubReleasePublisher {
         TemporarilyUnavailable
     }
 
+    private sealed class AssetUploadReconciliationContext {
+        internal long? StarterAssetId { get; set; }
+    }
+
     private static void ReportAssetProgress(
         IGitHubReleaseProgressReporter? progress,
         string assetPath,
@@ -173,7 +177,7 @@ public sealed partial class GitHubReleasePublisher {
         string fileName,
         string token,
         Action<long, long>? reportProgress,
-        Func<AssetUploadReconciliationState> reconcileUpload,
+        Func<AssetUploadReconciliationContext, AssetUploadReconciliationState> reconcileUpload,
         CancellationToken cancellationToken) {
         if (reconcileUpload is null) throw new ArgumentNullException(nameof(reconcileUpload));
         var sawTransientFailure = false;
@@ -331,7 +335,18 @@ public sealed partial class GitHubReleasePublisher {
            (int)statusCode == 429 ||
            (int)statusCode is >= 500 and <= 599;
 
-    private static TimeSpan GetAssetUploadRetryDelay(HttpResponseMessage? response, int failedAttempt) {
+    private static TimeSpan GetAssetUploadRetryDelay(HttpResponseMessage? response, int failedAttempt)
+        => GetAssetRetryAfterDelay(response) ?? GetAssetUploadExponentialDelay(failedAttempt);
+
+    private static TimeSpan GetAssetUploadRetryDelay(Exception exception, int failedAttempt) {
+        if (exception is GitHubApiRequestException apiException &&
+            apiException.RetryAfter is TimeSpan retryAfter)
+            return retryAfter;
+
+        return GetAssetUploadExponentialDelay(failedAttempt);
+    }
+
+    private static TimeSpan? GetAssetRetryAfterDelay(HttpResponseMessage? response) {
         var retryAfter = response?.Headers.RetryAfter;
         if (retryAfter?.Delta is TimeSpan delta && delta > TimeSpan.Zero)
             return delta > TimeSpan.FromSeconds(30) ? TimeSpan.FromSeconds(30) : delta;
@@ -341,8 +356,11 @@ public sealed partial class GitHubReleasePublisher {
                 return until > TimeSpan.FromSeconds(30) ? TimeSpan.FromSeconds(30) : until;
         }
 
-        return TimeSpan.FromSeconds(1 << Math.Min(failedAttempt, 4));
+        return null;
     }
+
+    private static TimeSpan GetAssetUploadExponentialDelay(int failedAttempt)
+        => TimeSpan.FromSeconds(1 << Math.Min(failedAttempt, 4));
 
     private void WaitBeforeAssetUploadRetry(TimeSpan delay, CancellationToken cancellationToken)
         => _assetRetryDelay(delay, cancellationToken);
@@ -353,14 +371,16 @@ public sealed partial class GitHubReleasePublisher {
             : $"{delay.TotalMilliseconds:0}ms";
 
     private AssetUploadReconciliationState ReconcileUploadWithRetry(
-        Func<AssetUploadReconciliationState> reconcileUpload,
+        Func<AssetUploadReconciliationContext, AssetUploadReconciliationState> reconcileUpload,
         string fileName,
         CancellationToken cancellationToken) {
+        var reconciliationContext = new AssetUploadReconciliationContext();
         for (var attempt = 1; attempt <= MaximumAssetReconciliationAttempts; attempt++) {
             cancellationToken.ThrowIfCancellationRequested();
             AssetUploadReconciliationState reconciliation;
+            Exception? transientException = null;
             try {
-                reconciliation = reconcileUpload();
+                reconciliation = reconcileUpload(reconciliationContext);
             }
             catch (Exception exception) when (IsTransientAssetUploadException(exception, cancellationToken)) {
                 if (attempt >= MaximumAssetReconciliationAttempts) {
@@ -370,6 +390,7 @@ public sealed partial class GitHubReleasePublisher {
                         exception);
                 }
 
+                transientException = exception;
                 reconciliation = AssetUploadReconciliationState.TemporarilyUnavailable;
                 _logger.Warn(
                     $"Could not reconcile interrupted GitHub release asset '{fileName}' " +
@@ -380,7 +401,9 @@ public sealed partial class GitHubReleasePublisher {
                 attempt >= MaximumAssetReconciliationAttempts)
                 return reconciliation;
 
-            var delay = GetAssetUploadRetryDelay(response: null, attempt);
+            var delay = transientException is null
+                ? GetAssetUploadRetryDelay(response: null, attempt)
+                : GetAssetUploadRetryDelay(transientException, attempt);
             _logger.Warn(
                 $"GitHub release asset reconciliation for '{fileName}' is temporarily unavailable; " +
                 $"retrying check {attempt + 1}/{MaximumAssetReconciliationAttempts} in {FormatRetryDelay(delay)}.");
@@ -410,7 +433,7 @@ public sealed partial class GitHubReleasePublisher {
                         exception);
                 }
 
-                var delay = GetAssetUploadRetryDelay(response: null, attempt);
+                var delay = GetAssetUploadRetryDelay(exception, attempt);
                 _logger.Warn(
                     $"{operation} was interrupted ({DescribeException(exception)}); retrying attempt " +
                     $"{attempt + 1}/{MaximumAssetUploadAttempts} in {FormatRetryDelay(delay)}.");
@@ -541,7 +564,7 @@ public sealed partial class GitHubReleasePublisher {
         for (var current = exception; current is not null; current = current.InnerException) {
             if (string.IsNullOrWhiteSpace(current.Message)) continue;
             if (messages.Count == 0 ||
-                !string.Equals(messages[^1], current.Message, StringComparison.Ordinal))
+                !string.Equals(messages[messages.Count - 1], current.Message, StringComparison.Ordinal))
                 messages.Add(current.Message);
         }
 
@@ -561,6 +584,7 @@ public sealed partial class GitHubReleasePublisher {
         string? expectedTagCommitSha,
         bool requirePublishedStableRelease,
         string fileName,
+        AssetUploadReconciliationContext reconciliationContext,
         CancellationToken cancellationToken) {
         var currentAssets = ListReleaseAssets(owner, repo, token, apiBaseUrl, releaseId, cancellationToken);
 
@@ -582,6 +606,11 @@ public sealed partial class GitHubReleasePublisher {
             throw new InvalidOperationException(
                 $"GitHub release asset '{fileName}' has unexpected state '{incompleteAsset.State}'.");
 
+        if (reconciliationContext.StarterAssetId is long expectedStarterAssetId)
+            ValidateExpectedAssetId(fileName, expectedStarterAssetId, incompleteAsset.Id);
+        else
+            reconciliationContext.StarterAssetId = incompleteAsset.Id;
+
         ValidateReleaseBeforeAssetMutation(
             owner,
             repo,
@@ -600,7 +629,7 @@ public sealed partial class GitHubReleasePublisher {
             apiBaseUrl,
             releaseId,
             fileName,
-            incompleteAsset.Id,
+            reconciliationContext.StarterAssetId!.Value,
             requiredState: "starter",
             cancellationToken)) {
             _logger.Warn($"Removed incomplete GitHub release asset '{fileName}' before retrying its upload.");
@@ -611,10 +640,17 @@ public sealed partial class GitHubReleasePublisher {
     }
 
     private sealed class GitHubApiRequestException : InvalidOperationException {
-        internal GitHubApiRequestException(string message, HttpStatusCode statusCode)
-            : base(message) => StatusCode = statusCode;
+        internal GitHubApiRequestException(
+            string message,
+            HttpStatusCode statusCode,
+            TimeSpan? retryAfter = null)
+            : base(message) {
+            StatusCode = statusCode;
+            RetryAfter = retryAfter is TimeSpan delay && delay > TimeSpan.Zero ? delay : null;
+        }
 
         internal HttpStatusCode StatusCode { get; }
+        internal TimeSpan? RetryAfter { get; }
     }
 
     private bool DeleteExpectedExistingAsset(
@@ -652,7 +688,8 @@ public sealed partial class GitHubReleasePublisher {
             if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
                 throw new GitHubApiRequestException(
                     $"GitHub asset delete failed for '{fileName}' ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}",
-                    response.StatusCode);
+                    response.StatusCode,
+                    GetAssetRetryAfterDelay(response));
         }
 
         _logger.Info($"Deleted existing GitHub release asset before replacement: {fileName}");
@@ -679,7 +716,8 @@ public sealed partial class GitHubReleasePublisher {
                 if (!response.IsSuccessStatusCode)
                     throw new GitHubApiRequestException(
                         $"GitHub list-release-assets failed for release '{releaseId}' ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}",
-                        response.StatusCode);
+                        response.StatusCode,
+                        GetAssetRetryAfterDelay(response));
             }
 
             var pageAssets = Deserialize<GitHubReleaseAssetResponse[]>(responseText) ?? Array.Empty<GitHubReleaseAssetResponse>();

--- a/PowerForge/Services/GitHubReleasePublisher.Assets.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.Assets.cs
@@ -212,9 +212,12 @@ public sealed partial class GitHubReleasePublisher {
                 continue;
             }
 
-            if (IsTransientAssetUploadResponse(response)) {
+            var forbiddenResponseText = response.StatusCode == HttpStatusCode.Forbidden
+                ? response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult()
+                : null;
+            if (IsTransientAssetUploadResponse(response, forbiddenResponseText)) {
                 sawTransientFailure = true;
-                var serverDelay = GetAssetRetryAfterDelay(response);
+                var serverDelay = GetAssetRetryAfterDelay(response, forbiddenResponseText);
                 var delay = serverDelay ?? GetAssetUploadExponentialDelay(attempt);
                 var statusCode = response.StatusCode;
                 var reasonPhrase = response.ReasonPhrase;
@@ -351,10 +354,13 @@ public sealed partial class GitHubReleasePublisher {
            (int)statusCode == 429 ||
            (int)statusCode is >= 500 and <= 599;
 
-    internal static bool IsTransientAssetUploadResponse(HttpResponseMessage response) {
+    internal static bool IsTransientAssetUploadResponse(
+        HttpResponseMessage response,
+        string? responseText = null) {
         if (response is null) throw new ArgumentNullException(nameof(response));
         return IsTransientAssetUploadStatus(response.StatusCode) ||
-               (response.StatusCode == HttpStatusCode.Forbidden && GetAssetRetryAfterDelay(response).HasValue);
+               (response.StatusCode == HttpStatusCode.Forbidden &&
+                GetAssetRetryAfterDelay(response, responseText).HasValue);
     }
 
     private static TimeSpan GetAssetUploadRetryDelay(HttpResponseMessage? response, int failedAttempt)
@@ -368,7 +374,9 @@ public sealed partial class GitHubReleasePublisher {
         return GetAssetUploadExponentialDelay(failedAttempt);
     }
 
-    internal static TimeSpan? GetAssetRetryAfterDelay(HttpResponseMessage? response) {
+    internal static TimeSpan? GetAssetRetryAfterDelay(
+        HttpResponseMessage? response,
+        string? responseText = null) {
         var retryAfter = response?.Headers.RetryAfter;
         if (retryAfter?.Delta is TimeSpan delta && delta > TimeSpan.Zero)
             return delta;
@@ -392,8 +400,16 @@ public sealed partial class GitHubReleasePublisher {
             }
         }
 
+        if ((int?)response?.StatusCode == 429 ||
+            (response?.StatusCode == HttpStatusCode.Forbidden &&
+             IsSecondaryRateLimitResponse(responseText)))
+            return TimeSpan.FromMinutes(1);
+
         return null;
     }
+
+    private static bool IsSecondaryRateLimitResponse(string? responseText)
+        => (responseText?.IndexOf("secondary rate limit", StringComparison.OrdinalIgnoreCase) ?? -1) >= 0;
 
     private static bool TryGetSingleInt64Header(
         HttpResponseMessage response,
@@ -690,7 +706,7 @@ public sealed partial class GitHubReleasePublisher {
                     throw new GitHubApiRequestException(
                         $"GitHub list-release-assets failed for release '{releaseId}' ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}",
                         response.StatusCode,
-                        GetAssetRetryAfterDelay(response));
+                        GetAssetRetryAfterDelay(response, responseText));
             }
 
             var pageAssets = Deserialize<GitHubReleaseAssetResponse[]>(responseText) ?? Array.Empty<GitHubReleaseAssetResponse>();

--- a/PowerForge/Services/GitHubReleasePublisher.Assets.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.Assets.cs
@@ -210,13 +210,26 @@ public sealed partial class GitHubReleasePublisher {
 
             if (IsTransientAssetUploadResponse(response)) {
                 sawTransientFailure = true;
-                var delay = GetAssetUploadRetryDelay(response, attempt);
+                var serverDelay = GetAssetRetryAfterDelay(response);
+                var delay = serverDelay ?? GetAssetUploadExponentialDelay(attempt);
                 var statusCode = response.StatusCode;
                 var reasonPhrase = response.ReasonPhrase;
                 var terminalAttempt = attempt >= MaximumAssetUploadAttempts;
                 if (!terminalAttempt)
                     response.Dispose();
+
+                var waitBeforeReconciliation = serverDelay.HasValue ||
+                                               (int)statusCode == 429 ||
+                                               statusCode == HttpStatusCode.Forbidden;
+                if (waitBeforeReconciliation) {
+                    _logger.Warn(
+                        $"GitHub release asset upload for '{fileName}' returned " +
+                        $"{(int)statusCode} {reasonPhrase}; waiting {FormatRetryDelay(delay)} before reconciliation.");
+                }
+
                 try {
+                    if (waitBeforeReconciliation)
+                        WaitBeforeAssetUploadRetry(delay, cancellationToken);
                     ReconcileUploadWithRetry(reconcileUpload, fileName, cancellationToken);
                 }
                 catch {
@@ -228,11 +241,13 @@ public sealed partial class GitHubReleasePublisher {
                 if (terminalAttempt)
                     return response;
 
-                _logger.Warn(
-                    $"GitHub release asset upload for '{fileName}' returned " +
-                    $"{(int)statusCode} {reasonPhrase}; retrying attempt " +
-                    $"{attempt + 1}/{MaximumAssetUploadAttempts} in {FormatRetryDelay(delay)}.");
-                WaitBeforeAssetUploadRetry(delay, cancellationToken);
+                if (!waitBeforeReconciliation) {
+                    _logger.Warn(
+                        $"GitHub release asset upload for '{fileName}' returned " +
+                        $"{(int)statusCode} {reasonPhrase}; retrying attempt " +
+                        $"{attempt + 1}/{MaximumAssetUploadAttempts} in {FormatRetryDelay(delay)}.");
+                    WaitBeforeAssetUploadRetry(delay, cancellationToken);
+                }
                 continue;
             }
 

--- a/PowerForge/Services/GitHubReleasePublisher.Provenance.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.Provenance.cs
@@ -126,7 +126,7 @@ public sealed partial class GitHubReleasePublisher {
                 throw new GitHubApiRequestException(
                     $"GitHub tag provenance check failed ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}",
                     response.StatusCode,
-                    GetAssetRetryAfterDelay(response));
+                    GetAssetRetryAfterDelay(response, responseText));
         }
 
         var parsed = Deserialize<GitHubGitObjectEnvelope>(responseText);

--- a/PowerForge/Services/GitHubReleasePublisher.Provenance.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.Provenance.cs
@@ -123,7 +123,9 @@ public sealed partial class GitHubReleasePublisher {
         var responseText = response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
         using (response) {
             if (!response.IsSuccessStatusCode)
-                throw new InvalidOperationException($"GitHub tag provenance check failed ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}");
+                throw new GitHubApiRequestException(
+                    $"GitHub tag provenance check failed ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}",
+                    response.StatusCode);
         }
 
         var parsed = Deserialize<GitHubGitObjectEnvelope>(responseText);

--- a/PowerForge/Services/GitHubReleasePublisher.Provenance.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.Provenance.cs
@@ -125,7 +125,8 @@ public sealed partial class GitHubReleasePublisher {
             if (!response.IsSuccessStatusCode)
                 throw new GitHubApiRequestException(
                     $"GitHub tag provenance check failed ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}",
-                    response.StatusCode);
+                    response.StatusCode,
+                    GetAssetRetryAfterDelay(response));
         }
 
         var parsed = Deserialize<GitHubGitObjectEnvelope>(responseText);

--- a/PowerForge/Services/GitHubReleasePublisher.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.cs
@@ -318,7 +318,7 @@ public sealed partial class GitHubReleasePublisher
             throw new GitHubApiRequestException(
                 $"GitHub get-release-by-tag failed for '{tagName}' ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}",
                 response.StatusCode,
-                GetAssetRetryAfterDelay(response));
+                GetAssetRetryAfterDelay(response, responseText));
 
         var parsed = Deserialize<CreateReleaseResponse>(responseText);
         var html = parsed.HtmlUrl ?? string.Empty;

--- a/PowerForge/Services/GitHubReleasePublisher.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.cs
@@ -358,9 +358,16 @@ public sealed partial class GitHubReleasePublisher
     {
         var skippedAssets = new List<string>();
         var authorizedAssetNames = CreateAuthorizedAssetNameSet(assets);
-        var uploadedAssetIds = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+        var verifiedAssetIds = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
         var replaceableAssets = replaceExistingAssets
-            ? CreateReplaceableAssetMap(ListReleaseAssets(owner, repo, token, apiBaseUrl, releaseId, cancellationToken))
+            ? CreateReplaceableAssetMap(ListReleaseAssetsWithRetry(
+                "GitHub replacement asset inventory",
+                owner,
+                repo,
+                token,
+                apiBaseUrl,
+                releaseId,
+                cancellationToken))
             : new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
         if (replaceExistingAssets)
             ValidateExistingAssetNamesAuthorized(replaceableAssets.Keys, authorizedAssetNames);
@@ -396,7 +403,8 @@ public sealed partial class GitHubReleasePublisher
                     assets.Length,
                     GitHubReleaseAssetProgressState.Replacing,
                     totalBytes: assetSize);
-                if (DeleteExpectedExistingAsset(
+                if (DeleteExpectedExistingAssetWithRetry(
+                    $"GitHub replacement deletion for '{fileName}'",
                     owner,
                     repo,
                     token,
@@ -451,18 +459,13 @@ public sealed partial class GitHubReleasePublisher
                     GitHubReleaseAssetProgressState.Uploading,
                     transferred,
                     total),
-                reconciliationContext => ReconcileReleaseAssetAfterUploadFailure(
+                () => ReconcileReleaseAssetAfterUploadFailure(
                     owner,
                     repo,
                     token,
                     apiBaseUrl,
                     releaseId,
-                    tagName,
-                    expectedReleaseBodyMarker,
-                    expectedTagCommitSha,
-                    requirePublishedStableRelease,
                     fileName,
-                    reconciliationContext,
                     cancellationToken),
                 cancellationToken);
             var respText = resp.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
@@ -490,6 +493,16 @@ public sealed partial class GitHubReleasePublisher
                                 $"GitHub release asset '{fileName}' appeared during first publication; refusing to accept unverified bytes.");
                         }
 
+                        var skippedAssetId = ReadCurrentAssetIdWithRetry(
+                            $"GitHub skipped asset identity verification for '{fileName}'",
+                            owner,
+                            repo,
+                            token,
+                            apiBaseUrl,
+                            releaseId,
+                            fileName,
+                            cancellationToken);
+                        verifiedAssetIds.Add(fileName, skippedAssetId);
                         assetWatch.Stop();
                         _logger.Info($"GitHub release asset '{fileName}' already exists; skipping upload after {DotNetRepositoryReleaseService.FormatDuration(assetWatch.Elapsed)}.");
                         skippedAssets.Add(fileName);
@@ -547,7 +560,7 @@ public sealed partial class GitHubReleasePublisher
                 fileName,
                 uploadedAssetId,
                 cancellationToken);
-            uploadedAssetIds.Add(fileName, uploadedAssetId);
+            verifiedAssetIds.Add(fileName, uploadedAssetId);
 
             assetWatch.Stop();
             uploadedAssets.Add(fileName);
@@ -562,8 +575,7 @@ public sealed partial class GitHubReleasePublisher
             _logger.Success($"Uploaded GitHub release asset: {fileName} in {DotNetRepositoryReleaseService.FormatDuration(assetWatch.Elapsed)} ({DotNetRepositoryReleaseService.FormatBytes(assetSize)}).");
         }
 
-        if (replaceExistingAssets || uploadedAssetIds.Count == assets.Length)
-        {
+        if (verifiedAssetIds.Count > 0) {
             ValidateFinalAssetSetWithRetry(
                 "GitHub final release asset verification",
                 owner,
@@ -575,7 +587,7 @@ public sealed partial class GitHubReleasePublisher
                 expectedReleaseBodyMarker,
                 expectedTagCommitSha,
                 requirePublishedStableRelease,
-                uploadedAssetIds,
+                verifiedAssetIds,
                 cancellationToken);
         }
 

--- a/PowerForge/Services/GitHubReleasePublisher.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.cs
@@ -588,6 +588,7 @@ public sealed partial class GitHubReleasePublisher
                 expectedTagCommitSha,
                 requirePublishedStableRelease,
                 verifiedAssetIds,
+                requireExactAssetSet: replaceExistingAssets || !reusedExistingRelease,
                 cancellationToken);
         }
 

--- a/PowerForge/Services/GitHubReleasePublisher.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.cs
@@ -413,7 +413,18 @@ public sealed partial class GitHubReleasePublisher
                     fileName,
                     expectedAssetId,
                     requiredState: null,
-                    cancellationToken))
+                    validateReleaseBeforeDelete: () => ValidateReleaseBeforeAssetMutation(
+                        owner,
+                        repo,
+                        token,
+                        apiBaseUrl,
+                        releaseId,
+                        tagName,
+                        expectedReleaseBodyMarker,
+                        expectedTagCommitSha,
+                        requirePublishedStableRelease,
+                        cancellationToken),
+                    cancellationToken: cancellationToken))
                 {
                     replacedExistingAssets.Add(fileName);
                     deletedExistingAsset = true;
@@ -459,6 +470,18 @@ public sealed partial class GitHubReleasePublisher
                     GitHubReleaseAssetProgressState.Uploading,
                     transferred,
                     total),
+                () => ValidateReleaseBeforeAssetMutationWithRetry(
+                    $"GitHub pre-retry verification for '{fileName}'",
+                    owner,
+                    repo,
+                    token,
+                    apiBaseUrl,
+                    releaseId,
+                    tagName,
+                    expectedReleaseBodyMarker,
+                    expectedTagCommitSha,
+                    requirePublishedStableRelease,
+                    cancellationToken),
                 () => ReconcileReleaseAssetAfterUploadFailure(
                     owner,
                     repo,

--- a/PowerForge/Services/GitHubReleasePublisher.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.cs
@@ -19,12 +19,25 @@ namespace PowerForge;
 public sealed partial class GitHubReleasePublisher
 {
     private readonly ILogger _logger;
+    private readonly Action<TimeSpan, CancellationToken> _assetRetryDelay;
     private static readonly HttpClient SharedClient = CreateSharedClient();
 
     /// <summary>
     /// Creates a new publisher using the provided logger.
     /// </summary>
-    public GitHubReleasePublisher(ILogger logger) => _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    public GitHubReleasePublisher(ILogger logger)
+        : this(logger, assetRetryDelay: null)
+    {
+    }
+
+    internal GitHubReleasePublisher(
+        ILogger logger,
+        Action<TimeSpan, CancellationToken>? assetRetryDelay)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _assetRetryDelay = assetRetryDelay ?? ((delay, cancellationToken) =>
+            Task.Delay(delay, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult());
+    }
 
     /// <summary>
     /// Creates a GitHub release and uploads assets.
@@ -302,7 +315,9 @@ public sealed partial class GitHubReleasePublisher
         var response = SharedClient.SendAsync(request, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
         var responseText = response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
         if (!response.IsSuccessStatusCode)
-            throw new InvalidOperationException($"GitHub get-release-by-tag failed for '{tagName}' ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}");
+            throw new GitHubApiRequestException(
+                $"GitHub get-release-by-tag failed for '{tagName}' ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}",
+                response.StatusCode);
 
         var parsed = Deserialize<CreateReleaseResponse>(responseText);
         var html = parsed.HtmlUrl ?? string.Empty;
@@ -356,7 +371,8 @@ public sealed partial class GitHubReleasePublisher
             var fileName = Path.GetFileName(assetPath) ?? assetPath;
             var assetSize = new FileInfo(assetPath).Length;
 
-            ValidateReleaseBeforeAssetMutation(
+            ValidateReleaseBeforeAssetMutationWithRetry(
+                $"GitHub pre-upload verification for '{fileName}'",
                 owner,
                 repo,
                 token,
@@ -397,7 +413,8 @@ public sealed partial class GitHubReleasePublisher
 
             if (deletedExistingAsset)
             {
-                ValidateReleaseBeforeAssetMutation(
+                ValidateReleaseBeforeAssetMutationWithRetry(
+                    $"GitHub post-replacement verification for '{fileName}'",
                     owner,
                     repo,
                     token,
@@ -514,7 +531,8 @@ public sealed partial class GitHubReleasePublisher
             }
 
             var uploadedAssetId = ReadUploadedAssetId(fileName, respText);
-            ValidateReleaseBeforeAssetMutation(
+            ValidateUploadedAssetWithRetry(
+                $"GitHub post-upload verification for '{fileName}'",
                 owner,
                 repo,
                 token,
@@ -524,13 +542,6 @@ public sealed partial class GitHubReleasePublisher
                 expectedReleaseBodyMarker,
                 expectedTagCommitSha,
                 requirePublishedStableRelease,
-                cancellationToken);
-            ValidateCurrentAssetIdentity(
-                owner,
-                repo,
-                token,
-                apiBaseUrl,
-                releaseId,
                 fileName,
                 uploadedAssetId,
                 cancellationToken);
@@ -551,7 +562,8 @@ public sealed partial class GitHubReleasePublisher
 
         if (replaceExistingAssets || uploadedAssetIds.Count == assets.Length)
         {
-            ValidateReleaseBeforeAssetMutation(
+            ValidateFinalAssetSetWithRetry(
+                "GitHub final release asset verification",
                 owner,
                 repo,
                 token,
@@ -561,25 +573,7 @@ public sealed partial class GitHubReleasePublisher
                 expectedReleaseBodyMarker,
                 expectedTagCommitSha,
                 requirePublishedStableRelease,
-                cancellationToken);
-            ValidateFinalAssetSet(
-                owner,
-                repo,
-                token,
-                apiBaseUrl,
-                releaseId,
                 uploadedAssetIds,
-                cancellationToken);
-            ValidateReleaseBeforeAssetMutation(
-                owner,
-                repo,
-                token,
-                apiBaseUrl,
-                releaseId,
-                tagName,
-                expectedReleaseBodyMarker,
-                expectedTagCommitSha,
-                requirePublishedStableRelease,
                 cancellationToken);
         }
 

--- a/PowerForge/Services/GitHubReleasePublisher.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.cs
@@ -317,7 +317,8 @@ public sealed partial class GitHubReleasePublisher
         if (!response.IsSuccessStatusCode)
             throw new GitHubApiRequestException(
                 $"GitHub get-release-by-tag failed for '{tagName}' ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}",
-                response.StatusCode);
+                response.StatusCode,
+                GetAssetRetryAfterDelay(response));
 
         var parsed = Deserialize<CreateReleaseResponse>(responseText);
         var html = parsed.HtmlUrl ?? string.Empty;
@@ -450,7 +451,7 @@ public sealed partial class GitHubReleasePublisher
                     GitHubReleaseAssetProgressState.Uploading,
                     transferred,
                     total),
-                () => ReconcileReleaseAssetAfterUploadFailure(
+                reconciliationContext => ReconcileReleaseAssetAfterUploadFailure(
                     owner,
                     repo,
                     token,
@@ -461,6 +462,7 @@ public sealed partial class GitHubReleasePublisher
                     expectedTagCommitSha,
                     requirePublishedStableRelease,
                     fileName,
+                    reconciliationContext,
                     cancellationToken),
                 cancellationToken);
             var respText = resp.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();


### PR DESCRIPTION
## Summary

- retry transient GitHub release asset uploads, inventories, deletions, reconciliation, and verification
- use bounded exponential backoff for transport errors, HTTP 408/5xx responses, and explicit GitHub rate-limit handling
- honor the full `Retry-After` interval, primary quota reset headers, or a one-minute fallback for headerless HTTP 429 and secondary-rate-limit HTTP 403 responses before reconciliation traffic
- stop immediately on a terminal rate-limit response instead of waiting or reconciling when no retry remains
- revalidate release and tag provenance immediately before every retried upload or deletion mutation
- retry stale post-delete inventory without repeating the accepted deletion, while rejecting changed asset identities
- verify uploaded and safely skipped asset identities while preserving partial idempotent reuse of releases with unrelated assets

## Why

A temporary GitHub transport or rate-limit failure could escape during asset reconciliation or post-upload verification even though the upload request itself had retry handling. That could stop a unified release after only part of its asset set had been published. Ordinary replacement inventory and deletion calls also lacked the same resilience.

Recovery now keeps every mutation fail-closed. An interrupted delete is accepted only after absence is verified, changed asset IDs are rejected, and an incomplete `starter` asset is never deleted when its publisher cannot be proven. A successful delete also tolerates briefly stale inventory without issuing the mutation again.

## Validation

- PowerForge, PowerForge.PowerShell, and PSPublishModule build successfully for .NET Framework 4.7.2
- the restored core product graph builds in Release with zero warnings or errors
- 55 release-publisher, asset-workflow, and retry-safety tests pass
- independent release-safety audit completed and its findings were addressed

No public API changes are introduced.
