### PR TITLE
Fix release provenance and multi-artifact staging

### DIFF
--- a/Docs/PSPublishModule.UnifiedModuleProjectRelease.md
+++ b/Docs/PSPublishModule.UnifiedModuleProjectRelease.md
@@ -411,6 +411,43 @@ The same model supports:
 - generated `Build/release.json` for CI if the repo wants checked-in JSON
 - pure `Build-Module.ps1` for repos that prefer PowerShell DSL only
 
+## Validate The Complete Staged Release
+
+Use the top-level `Validation.AfterStaging` action when a repository needs to prove that its module, NuGet packages,
+CLI archives, manifest, and checksums work together before any registry or GitHub publication. This action belongs in
+`powerforge.release.json`, not in a module `BeforePublish` hook, because only the release engine sees the complete asset
+set.
+
+```json
+{
+  "Outputs": {
+    "Staging": {
+      "RootPath": "../Artefacts/UploadReady/Release"
+    }
+  },
+  "Validation": {
+    "AfterStaging": [
+      {
+        "Name": "Validate release artifacts",
+        "FilePath": "Test-ReleaseReady.ps1",
+        "WorkingDirectory": "..",
+        "TimeoutSeconds": 1800
+      }
+    ]
+  }
+}
+```
+
+PowerForge passes a JSON context file through `POWERFORGE_CONTEXT`. The context includes the resolved version,
+module staging path, release manifest and checksums paths, staging root, and the final staged asset paths. Convenience
+environment variables expose the same primary values, including `POWERFORGE_RELEASE_VERSION`,
+`POWERFORGE_RELEASE_MANIFEST`, and `POWERFORGE_MODULE_STAGING_PATH`.
+
+The action runs in both Build and Publish modes. Build mode creates and validates the release without publishing it.
+Publish mode continues only after every enabled action succeeds, and publishes the exact validated package and module
+checkpoints without rebuilding them. A missing script, invalid timeout, non-zero exit code, cancellation, or timeout
+fails the release before NuGet, PowerShell Gallery, or GitHub is changed.
+
 ## Naming
 
 Use "release" only for the coordinated top-level artifact set, usually the thing that gets a GitHub tag,
@@ -497,11 +534,11 @@ The release runtime executes these phases:
 3. Plan packages and module before doing any destructive or publishing work.
 4. If the module needs packages from this same release, build packages to a local staging feed first.
 5. Build the module against either project references or the staged local package feed.
-6. Validate module import and package outputs.
-7. Publish NuGet packages.
-8. Publish the module to PSGallery or configured private gallery.
-9. Stage all release assets into one upload-ready folder.
-10. Write `release-manifest.json` and `SHA256SUMS.txt`.
+6. Stage all module, package, tool, installer, and other selected assets into one upload-ready folder.
+7. Write `release-manifest.json` and `SHA256SUMS.txt` for that staged set.
+8. Run every enabled `Validation.AfterStaging` action against the complete staged release.
+9. Publish the validated NuGet package files.
+10. Publish the checkpointed module to PSGallery or the configured private gallery without rebuilding it.
 11. Publish one GitHub release from the staged asset list, with visible per-asset byte progress and an explicit created-versus-recovery result.
 
 This keeps publication fail-fast while avoiding a half-published release where NuGet is updated before the

--- a/Module/Docs/Readme.md
+++ b/Module/Docs/Readme.md
@@ -2,7 +2,7 @@
 Module Name: PSPublishModule
 Module Guid: eb76426a-1992-40a5-82cd-6480f883ef4d
 Download Help Link: https://github.com/EvotecIT/PSPublishModule
-Help Version: 3.0.131
+Help Version: 3.0.132
 Locale: en-US
 ---
 # PSPublishModule Module

--- a/Module/PSPublishModule.psd1
+++ b/Module/PSPublishModule.psd1
@@ -9,7 +9,7 @@
     DotNetFrameworkVersion = '4.5.2'
     FunctionsToExport      = @()
     GUID                   = 'eb76426a-1992-40a5-82cd-6480f883ef4d'
-    ModuleVersion          = '3.0.131'
+    ModuleVersion          = '3.0.132'
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{

--- a/PSPublishModule/packages.lock.json
+++ b/PSPublishModule/packages.lock.json
@@ -319,7 +319,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.5.ReferenceAssemblies": "[1.1.0, )",
-          "PowerForge": "[3.0.128, )",
+          "PowerForge": "[3.0.131, )",
           "System.Security.Cryptography.Xml": "[10.0.11, )",
           "System.Text.Json": "[10.0.11, )"
         }
@@ -1128,7 +1128,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.6.5, )",
-          "PowerForge": "[3.0.128, )",
+          "PowerForge": "[3.0.131, )",
           "System.Security.Cryptography.Xml": "[10.0.11, )"
         }
       }
@@ -1896,7 +1896,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.4.18, )",
-          "PowerForge": "[3.0.128, )",
+          "PowerForge": "[3.0.131, )",
           "System.Security.Cryptography.Xml": "[10.0.11, )"
         }
       }

--- a/PowerForge.Cli/packages.lock.json
+++ b/PowerForge.Cli/packages.lock.json
@@ -756,7 +756,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.6.5, )",
-          "PowerForge": "[3.0.128, )",
+          "PowerForge": "[3.0.131, )",
           "System.Security.Cryptography.Xml": "[10.0.11, )"
         }
       }
@@ -1476,7 +1476,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.4.18, )",
-          "PowerForge": "[3.0.128, )",
+          "PowerForge": "[3.0.131, )",
           "System.Security.Cryptography.Xml": "[10.0.11, )"
         }
       }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -524,63 +524,11 @@ public sealed partial class ModulePipelineRunner
         NuGetPackagePublishResult publish,
         bool publishSymbolsSeparately = false,
         bool skipDuplicate = true)
-    {
-        var publishedPrimaryPackages = new HashSet<string>(publish.PublishedItems, StringComparer.OrdinalIgnoreCase);
-        var skippedPrimaryPackages = new HashSet<string>(publish.SkippedDuplicateItems, StringComparer.OrdinalIgnoreCase);
-        var failedPrimaryPackages = new HashSet<string>(publish.FailedItems, StringComparer.OrdinalIgnoreCase);
-        var publishedArtifacts = new HashSet<string>(release.PublishedPackages, StringComparer.OrdinalIgnoreCase);
-        var skippedArtifacts = new HashSet<string>(release.SkippedDuplicatePackages, StringComparer.OrdinalIgnoreCase);
-        var failedArtifacts = new HashSet<string>(release.FailedPackages, StringComparer.OrdinalIgnoreCase);
-        var attemptedPackages = publish.PackagePushResults.Keys
-            .Concat(publish.PublishedItems)
-            .Concat(publish.FailedItems)
-            .Distinct(StringComparer.OrdinalIgnoreCase);
-        foreach (var package in attemptedPackages)
-        {
-            var project = release.Projects.FirstOrDefault(candidate =>
-                candidate.Packages.Contains(package, StringComparer.OrdinalIgnoreCase) ||
-                candidate.SymbolPackages.Contains(package, StringComparer.OrdinalIgnoreCase));
-            var artifacts = DotNetRepositoryReleaseService.GetPublishedArtifacts(
-                project,
-                package,
-                includeCompanionSymbols: !publishSymbolsSeparately);
-            if (!publish.PackagePushResults.TryGetValue(package, out var pushResult))
-            {
-                pushResult = new DotNetRepositoryReleaseService.PackagePushResult
-                {
-                    Outcome = failedPrimaryPackages.Contains(package)
-                        ? DotNetRepositoryReleaseService.PackagePushOutcome.Failed
-                        : skippedPrimaryPackages.Contains(package)
-                            ? DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate
-                            : publishedPrimaryPackages.Contains(package)
-                                ? DotNetRepositoryReleaseService.PackagePushOutcome.Published
-                                : DotNetRepositoryReleaseService.PackagePushOutcome.Failed
-                };
-            }
-
-            var outcomes = DotNetRepositoryReleaseService.ClassifyPublishedArtifacts(
-                artifacts,
-                pushResult,
-                skipDuplicate);
-            foreach (var artifact in artifacts)
-            {
-                if (outcomes[artifact] == DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate)
-                {
-                    if (skippedArtifacts.Add(artifact))
-                        release.SkippedDuplicatePackages.Add(artifact);
-                }
-                else if (outcomes[artifact] == DotNetRepositoryReleaseService.PackagePushOutcome.Published)
-                {
-                    if (publishedArtifacts.Add(artifact))
-                        release.PublishedPackages.Add(artifact);
-                }
-                else if (failedArtifacts.Add(artifact))
-                {
-                    release.FailedPackages.Add(artifact);
-                }
-            }
-        }
-    }
+        => DotNetRepositoryReleaseService.ApplyPublishedNuGetArtifactOutcomes(
+            release,
+            publish,
+            publishSymbolsSeparately,
+            skipDuplicate);
 
     private void PublishExistingGitHubRelease(
         ProjectBuildHostExecutionResult existing,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Phases.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Phases.cs
@@ -751,10 +751,18 @@ public sealed partial class ModulePipelineRunner
         ExecutePackageBuildsAfterModule(plan, session, state);
         ValidateRequestedReleaseVersion(plan, state);
 
-        ExecuteActions(ModulePipelineActionStage.BeforePublish, plan, session, state);
-        ValidateFinalizedPackedArtefactIntegrity(state);
-        ExecutePublishOperations(plan, session, buildResult, state);
-        ExecuteActions(ModulePipelineActionStage.AfterPublish, plan, session, state);
+        var publishingEnabled = plan.GateMode is null or ConfigurationGateMode.Publish;
+        if (publishingEnabled)
+        {
+            ExecuteActions(ModulePipelineActionStage.BeforePublish, plan, session, state);
+            ValidateFinalizedPackedArtefactIntegrity(state);
+            ExecutePublishOperations(plan, session, buildResult, state);
+            ExecuteActions(ModulePipelineActionStage.AfterPublish, plan, session, state);
+        }
+        else
+        {
+            ExecutePublishOperations(plan, session, buildResult, state);
+        }
 
         state.ReleaseCoordinationResult ??= PrepareUnifiedReleaseAssets(plan, state, publishId: null);
 

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerBundleExecutablePermissionsTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerBundleExecutablePermissionsTests.cs
@@ -1,0 +1,140 @@
+using System.IO.Compression;
+
+namespace PowerForge.Tests;
+
+public sealed class DotNetPublishPipelineRunnerBundleExecutablePermissionsTests
+{
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void BuildBundle_PatchesEveryUnixExecutableAndScopesProvenanceToIncludedTargets()
+    {
+        string root = CreateTempRoot();
+        try
+        {
+            string appOutput = Directory.CreateDirectory(Path.Combine(root, "publish", "app")).FullName;
+            string helperOutput = Directory.CreateDirectory(Path.Combine(root, "publish", "helper")).FullName;
+            string appExecutable = Path.Combine(appOutput, "app");
+            string helperExecutable = Path.Combine(helperOutput, "helper");
+            File.WriteAllText(appExecutable, "app");
+            File.WriteAllText(helperExecutable, "helper");
+            string bundleOutput = Path.Combine(root, "bundle");
+            string bundleZip = Path.Combine(root, "bundle.zip");
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Targets =
+                [
+                    new DotNetPublishTargetPlan
+                    {
+                        Name = "app",
+                        ExecutableIdentities = ["app"],
+                        Publish = new DotNetPublishPublishOptions()
+                    },
+                    new DotNetPublishTargetPlan
+                    {
+                        Name = "helper",
+                        ExecutableIdentities = ["helper"],
+                        Publish = new DotNetPublishPublishOptions()
+                    }
+                ],
+                Bundles =
+                [
+                    new DotNetPublishBundlePlan
+                    {
+                        Id = "portable",
+                        PrepareFromTarget = "app",
+                        PrimarySubdirectory = "app",
+                        Zip = true,
+                        Includes =
+                        [
+                            new DotNetPublishBundleIncludePlan
+                            {
+                                Target = "helper",
+                                Subdirectory = "tools",
+                                Required = true
+                            }
+                        ]
+                    }
+                ]
+            };
+            DotNetPublishArtefactResult[] artefacts =
+            [
+                new()
+                {
+                    Category = DotNetPublishArtefactCategory.Publish,
+                    Target = "app",
+                    Framework = "net10.0",
+                    Runtime = "linux-x64",
+                    Style = DotNetPublishStyle.PortableCompat,
+                    OutputDir = appOutput,
+                    PublishDir = appOutput,
+                    ExePath = appExecutable
+                },
+                new()
+                {
+                    Category = DotNetPublishArtefactCategory.Publish,
+                    Target = "helper",
+                    Framework = "net10.0",
+                    Runtime = "linux-x64",
+                    Style = DotNetPublishStyle.PortableCompat,
+                    OutputDir = helperOutput,
+                    PublishDir = helperOutput,
+                    ExePath = helperExecutable
+                }
+            ];
+            var step = new DotNetPublishStep
+            {
+                Key = "bundle:portable:app:net10.0:linux-x64:PortableCompat",
+                Kind = DotNetPublishStepKind.Bundle,
+                BundleId = "portable",
+                TargetName = "app",
+                Framework = "net10.0",
+                Runtime = "linux-x64",
+                Style = DotNetPublishStyle.PortableCompat,
+                BundleOutputPath = bundleOutput,
+                BundleZipPath = bundleZip
+            };
+
+            DotNetPublishStep[] provenanceSteps = DotNetPublishPipelineRunner.ResolveBundleProvenanceSteps(
+                plan,
+                artefacts,
+                plan.Bundles[0],
+                artefacts[0],
+                "net10.0",
+                "linux-x64",
+                DotNetPublishStyle.PortableCompat);
+            var runner = new DotNetPublishPipelineRunner(new NullLogger());
+            DotNetPublishArtefactResult result = runner.BuildBundle(plan, artefacts, step);
+
+            Assert.Equal(new[] { "app", "helper" }, provenanceSteps.Select(entry => entry.TargetName));
+            Assert.Equal(bundleZip, result.ZipPath);
+            using ZipArchive archive = ZipFile.OpenRead(bundleZip);
+            Assert.Equal(unchecked((int)0x81ED0000u), archive.GetEntry("app/app")!.ExternalAttributes);
+            Assert.Equal(unchecked((int)0x81ED0000u), archive.GetEntry("tools/helper")!.ExternalAttributes);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    private static string CreateTempRoot()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // best effort
+        }
+    }
+}

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -1007,6 +1007,196 @@ public sealed partial class DotNetPublishPipelineRunnerHardeningTests
     }
 
     [Fact]
+    public void BuildRestoreRuntimeIdentifiers_UsesConfiguredMatrixWhenExecutionIsFiltered()
+    {
+        var plan = new DotNetPublishPlan
+        {
+            Targets = new[]
+            {
+                new DotNetPublishTargetPlan
+                {
+                    ProjectPath = "Service.csproj",
+                    Combinations = new[]
+                    {
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net10.0",
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.FrameworkDependent
+                        }
+                    },
+                    RestoreCombinations = new[]
+                    {
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net10.0",
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.FrameworkDependent
+                        },
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net10.0",
+                            Runtime = "linux-x64",
+                            Style = DotNetPublishStyle.FrameworkDependent
+                        }
+                    }
+                }
+            }
+        };
+
+        var runtimes = DotNetPublishPipelineRunner.BuildRestoreRuntimeIdentifiers(
+            plan,
+            "Service.csproj",
+            "win-x64",
+            "net10.0");
+
+        Assert.Equal(new[] { "linux-x64", "win-x64" }, runtimes);
+        Assert.Equal(
+            "/p:RuntimeIdentifiers=\"linux-x64;win-x64\"",
+            DotNetPublishPipelineRunner.BuildRestoreArguments(
+                plan,
+                "Service.csproj",
+                "win-x64",
+                "net10.0")[3]);
+    }
+
+    [Fact]
+    public void RetainConfiguredRestoreCombinations_PreservesOnlySelectedFrameworkAndStyleMatrix()
+    {
+        var selectedPlan = new DotNetPublishPlan
+        {
+            Targets = new[]
+            {
+                new DotNetPublishTargetPlan
+                {
+                    Name = "CLI",
+                    ProjectPath = "Cli.csproj",
+                    Combinations = new[]
+                    {
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net10.0",
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.FrameworkDependent
+                        }
+                    }
+                }
+            }
+        };
+        var configuredPlan = new DotNetPublishPlan
+        {
+            Targets = new[]
+            {
+                new DotNetPublishTargetPlan
+                {
+                    Name = "CLI",
+                    ProjectPath = "Cli.csproj",
+                    Combinations = new[]
+                    {
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net10.0",
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.FrameworkDependent
+                        },
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net10.0",
+                            Runtime = "linux-x64",
+                            Style = DotNetPublishStyle.FrameworkDependent
+                        },
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net10.0",
+                            Runtime = "linux-x64",
+                            Style = DotNetPublishStyle.PortableCompat
+                        },
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net9.0",
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.FrameworkDependent
+                        }
+                    }
+                }
+            }
+        };
+
+        PowerForgeReleaseService.RetainConfiguredRestoreCombinations(selectedPlan, configuredPlan);
+
+        Assert.Collection(
+            selectedPlan.Targets[0].RestoreCombinations,
+            combination =>
+            {
+                Assert.Equal("net10.0", combination.Framework);
+                Assert.Equal("win-x64", combination.Runtime);
+                Assert.Equal(DotNetPublishStyle.FrameworkDependent, combination.Style);
+            },
+            combination =>
+            {
+                Assert.Equal("net10.0", combination.Framework);
+                Assert.Equal("linux-x64", combination.Runtime);
+                Assert.Equal(DotNetPublishStyle.FrameworkDependent, combination.Style);
+            });
+    }
+
+    [Fact]
+    public void RetainConfiguredRestoreCombinations_IncludesSelectedRuntimeOutsideConfiguredMatrix()
+    {
+        var selectedCombination = new DotNetPublishTargetCombination
+        {
+            Framework = "net10.0",
+            Runtime = "osx-x64",
+            Style = DotNetPublishStyle.FrameworkDependent
+        };
+        var selectedPlan = new DotNetPublishPlan
+        {
+            Targets =
+            [
+                new DotNetPublishTargetPlan
+                {
+                    Name = "CLI",
+                    ProjectPath = "Cli.csproj",
+                    Combinations = [selectedCombination]
+                }
+            ]
+        };
+        var configuredPlan = new DotNetPublishPlan
+        {
+            Targets =
+            [
+                new DotNetPublishTargetPlan
+                {
+                    Name = "CLI",
+                    ProjectPath = "Cli.csproj",
+                    Combinations =
+                    [
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net10.0",
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.FrameworkDependent
+                        }
+                    ]
+                }
+            ]
+        };
+
+        PowerForgeReleaseService.RetainConfiguredRestoreCombinations(selectedPlan, configuredPlan);
+
+        Assert.Contains(
+            selectedPlan.Targets[0].RestoreCombinations,
+            combination => ReferenceEquals(combination, selectedCombination));
+        Assert.Equal(
+            new[] { "osx-x64", "win-x64" },
+            DotNetPublishPipelineRunner.BuildRestoreRuntimeIdentifiers(
+                selectedPlan,
+                "Cli.csproj",
+                "osx-x64",
+                "net10.0"));
+    }
+
+    [Fact]
     public void BuildRestoreArguments_DoesNotForceTopLevelFrameworkAcrossProjectReferences()
     {
         var plan = new DotNetPublishPlan

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave81.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave81.cs
@@ -276,7 +276,8 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
             root,
             $"build \"{projectPath}\" -c Release -f net8.0 --no-restore --nologo " +
             $"/p:SourceRevisionId={revision} " +
-            "/p:IncludeSourceRevisionInInformationalVersion=true");
+            "/p:IncludeSourceRevisionInInformationalVersion=true " +
+            "/p:ContinuousIntegrationBuild=true");
         provenAppBytes = File.ReadAllBytes(Path.Combine(root, "bin", "Release", "net8.0", "App.dll"));
         var plan = new DotNetPublishPlan
         {

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave82.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave82.cs
@@ -219,7 +219,8 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
             RunDotNet(
                 root,
                 $"build \"{projectPath}\" -c Release -f net8.0 --no-restore --nologo " +
-                $"/p:SourceRevisionId={revision} /p:IncludeSourceRevisionInInformationalVersion=true");
+                $"/p:SourceRevisionId={revision} /p:IncludeSourceRevisionInInformationalVersion=true " +
+                "/p:ContinuousIntegrationBuild=true");
             var plan = new DotNetPublishPlan
             {
                 ProjectRoot = root,

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave86.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave86.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Security.Cryptography;
+using System.Text.Json;
 using PowerForge;
 using Xunit;
 
@@ -7,6 +8,264 @@ namespace PowerForge.Tests;
 
 public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
 {
+    [Fact]
+    public void PowerForgeRestorePackageHashes_ReadsNormalizedEvidence()
+    {
+        using JsonDocument document = JsonDocument.Parse("""
+            {
+              "powerForgeRestorePackages": {
+                "System.Runtime|4.3.1.0": "trusted-content-hash"
+              }
+            }
+            """);
+
+        Assert.True(DotNetPublishPipelineRunner.TryReadPowerForgeRestorePackageHashes(
+            document.RootElement,
+            out Dictionary<string, string> hashes));
+        Assert.Equal("trusted-content-hash", hashes["System.Runtime|4.3.1"]);
+    }
+
+    [Fact]
+    public void PowerForgeRestorePackageHashes_RejectsConflictingNormalizedEvidence()
+    {
+        using JsonDocument document = JsonDocument.Parse("""
+            {
+              "powerForgeRestorePackages": {
+                "System.Runtime|4.3.1": "first-content-hash",
+                "system.runtime|4.3.1.0": "second-content-hash"
+              }
+            }
+            """);
+
+        Assert.False(DotNetPublishPipelineRunner.TryReadPowerForgeRestorePackageHashes(
+            document.RootElement,
+            out Dictionary<string, string> hashes));
+        Assert.Empty(hashes);
+    }
+
+    [Fact]
+    public void PowerForgeRestorePackageHashes_AllowsMissingEvidenceSection()
+    {
+        using JsonDocument document = JsonDocument.Parse("{\"version\": 1}");
+
+        Assert.True(DotNetPublishPipelineRunner.TryReadPowerForgeRestorePackageHashes(
+            document.RootElement,
+            out Dictionary<string, string> hashes));
+        Assert.Empty(hashes);
+    }
+
+    [Fact]
+    public void PublishProvenanceScope_SelectsOnlyCurrentCombination()
+    {
+        var step = new DotNetPublishStep
+        {
+            TargetName = "App",
+            Framework = "net10.0",
+            Runtime = "linux-arm64",
+            Style = DotNetPublishStyle.PortableCompat
+        };
+        var selected = new DotNetPublishTargetCombination
+        {
+            Framework = "net10.0",
+            Runtime = "linux-arm64",
+            Style = DotNetPublishStyle.PortableCompat
+        };
+        var otherRuntime = new DotNetPublishTargetCombination
+        {
+            Framework = "net10.0",
+            Runtime = "win-x64",
+            Style = DotNetPublishStyle.PortableCompat
+        };
+        var otherStyle = new DotNetPublishTargetCombination
+        {
+            Framework = "net10.0",
+            Runtime = "linux-arm64",
+            Style = DotNetPublishStyle.FrameworkDependent
+        };
+
+        Assert.True(DotNetPublishPipelineRunner.IsPublishProvenanceCombinationInScope(
+            "App",
+            selected,
+            step));
+        Assert.False(DotNetPublishPipelineRunner.IsPublishProvenanceCombinationInScope(
+            "Other",
+            selected,
+            step));
+        Assert.False(DotNetPublishPipelineRunner.IsPublishProvenanceCombinationInScope(
+            "App",
+            otherRuntime,
+            step));
+        Assert.False(DotNetPublishPipelineRunner.IsPublishProvenanceCombinationInScope(
+            "App",
+            otherStyle,
+            step));
+        Assert.True(DotNetPublishPipelineRunner.IsPublishProvenanceCombinationInScope(
+            "App",
+            otherStyle,
+            buildStep: null));
+    }
+
+    [Fact]
+    public void BuildPreBuildArguments_DisablesIncrementalReuse()
+    {
+        var plan = new DotNetPublishPlan
+        {
+            Configuration = "Release",
+            Restore = true
+        };
+        var target = new DotNetPublishTargetPlan
+        {
+            Name = "App",
+            ProjectPath = "App.csproj"
+        };
+
+        List<string> arguments = DotNetPublishPipelineRunner.BuildPreBuildArguments(
+            plan,
+            target,
+            "net10.0",
+            "linux-arm64",
+            DotNetPublishStyle.PortableCompat);
+
+        Assert.Contains("--no-incremental", arguments);
+        Assert.Contains("--no-restore", arguments);
+    }
+
+    [Fact]
+    public void BuildPublishMsBuildProperties_EnableDeterministicSourcePathsForPinnedRevision()
+    {
+        var plan = new DotNetPublishPlan
+        {
+            SourceRevision = "0123456789abcdef0123456789abcdef01234567"
+        };
+        var target = new DotNetPublishTargetPlan
+        {
+            Name = "App"
+        };
+
+        Dictionary<string, string> properties =
+            DotNetPublishPipelineRunner.BuildPublishMsBuildProperties(
+                plan,
+                target,
+                "net10.0",
+                "linux-arm64",
+                DotNetPublishStyle.PortableCompat);
+
+        Assert.Equal("true", properties["ContinuousIntegrationBuild"]);
+        Assert.Equal(plan.SourceRevision, properties["SourceRevisionId"]);
+        Assert.Equal("true", properties["IncludeSourceRevisionInInformationalVersion"]);
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void ReadSourceProvenance_PortableRootDoesNotPublishReferencedLibrary()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string appDirectory = Directory.CreateDirectory(Path.Combine(root, "App")).FullName;
+            string libraryDirectory = Directory.CreateDirectory(Path.Combine(root, "Library")).FullName;
+            string appProject = Path.Combine(appDirectory, "App.csproj");
+            string libraryProject = Path.Combine(libraryDirectory, "Library.csproj");
+            File.WriteAllText(appProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+                  </PropertyGroup>
+                  <ItemGroup><ProjectReference Include="../Library/Library.csproj" /></ItemGroup>
+                </Project>
+                """);
+            File.WriteAllText(libraryProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFrameworks>netstandard2.1;net8.0-windows</TargetFrameworks>
+                  </PropertyGroup>
+                  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+                    <PackageReference Include="System.Diagnostics.EventLog" Version="6.0.0" />
+                  </ItemGroup>
+                </Project>
+                """);
+            File.WriteAllText(
+                Path.Combine(appDirectory, "Program.cs"),
+                "internal static class Program { private static void Main() { _ = Library.Value; } }");
+            File.WriteAllText(
+                Path.Combine(libraryDirectory, "Library.cs"),
+                "public static class Library { public const int Value = 1; }");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
+            RunDotNet(
+                root,
+                $"restore \"{appProject}\" -r win-x64 --use-lock-file --nologo " +
+                "-p:SelfContained=true -p:PublishSingleFile=true " +
+                "-p:IncludeNativeLibrariesForSelfExtract=true " +
+                "-p:PortableTrim=false -p:PortableTrimMode=partial");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source\"");
+            RunDotNet(
+                root,
+                $"build \"{appProject}\" -c Release -f net10.0 -r win-x64 --no-restore --nologo " +
+                "-p:SelfContained=true -p:PublishSingleFile=true " +
+                "-p:IncludeNativeLibrariesForSelfExtract=true " +
+                "-p:PortableTrim=false -p:PortableTrimMode=partial " +
+                "-p:UseSharedCompilation=false -nodeReuse:false");
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Configuration = "Release",
+                NoBuildInPublish = true,
+                NoRestoreInPublish = true,
+                Targets =
+                [
+                    new DotNetPublishTargetPlan
+                    {
+                        Name = "App",
+                        ProjectPath = appProject,
+                        Combinations =
+                        [
+                            new DotNetPublishTargetCombination
+                            {
+                                Framework = "net10.0",
+                                Runtime = "win-x64",
+                                Style = DotNetPublishStyle.PortableCompat
+                            }
+                        ]
+                    }
+                ]
+            };
+
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(root, buildPlan: plan);
+
+            Assert.False(provenance.Dirty, string.Join(Environment.NewLine, provenance.DirtyReasons));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Theory]
+    [InlineData("App.pdb", false, false, false)]
+    [InlineData("App.pdb", true, false, true)]
+    [InlineData("App.xml", false, false, false)]
+    [InlineData("App.xml", false, true, true)]
+    [InlineData("Guide.pdf", false, false, false)]
+    [InlineData("Guide.pdf", false, true, true)]
+    [InlineData("App.dll", false, false, true)]
+    public void IsFinalPublishInputRetained_HonorsFinalLayoutPolicy(
+        string path,
+        bool keepSymbols,
+        bool keepDocs,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            DotNetPublishPipelineRunner.IsFinalPublishInputRetained(path, keepSymbols, keepDocs));
+    }
+
     [Fact]
     public void ControlledBuildEnvironment_DropsPrivateFeedCredential()
     {

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave89.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave89.cs
@@ -8,6 +8,54 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
 {
     [Fact]
     [Trait("Category", "DotNetPublishPrGate")]
+    public void IsFinalPublishInputRetained_KeepsNestedFilesThatCleanupDoesNotRemove()
+    {
+        Assert.False(DotNetPublishPipelineRunner.IsFinalPublishInputRetained(
+            "App.pdb",
+            "App.pdb",
+            keepSymbols: false,
+            keepDocs: false));
+        Assert.True(DotNetPublishPipelineRunner.IsFinalPublishInputRetained(
+            "plugin/App.pdb",
+            "plugin/App.pdb",
+            keepSymbols: false,
+            keepDocs: false));
+        Assert.True(DotNetPublishPipelineRunner.IsFinalPublishInputRetained(
+            "docs/App.xml",
+            "docs\\App.xml",
+            keepSymbols: false,
+            keepDocs: false));
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void ValidatePublishProvenanceEntries_RevalidatesEveryDistinctArtifactScope()
+    {
+        int firstValidations = 0;
+        int secondValidations = 0;
+        var first = new DotNetPublishPipelineRunner.SourceProvenance(
+            "revision",
+            dirty: false,
+            validateCurrentSource: () => firstValidations++);
+        var second = new DotNetPublishPipelineRunner.SourceProvenance(
+            "revision",
+            dirty: false,
+            validateCurrentSource: () => secondValidations++);
+        var provenances = new Dictionary<string, DotNetPublishPipelineRunner.SourceProvenance>
+        {
+            ["first"] = first,
+            ["duplicate"] = first,
+            ["second"] = second
+        };
+
+        DotNetPublishPipelineRunner.ValidatePublishProvenanceEntries(provenances);
+
+        Assert.Equal(1, firstValidations);
+        Assert.Equal(1, secondValidations);
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
     public void ResolvePlannedPublishGeneratedPaths_ExcludesEveryPublishDirectoryAndZipFromCachedSourceChecks()
     {
         string root = Directory.CreateTempSubdirectory().FullName;

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave93.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave93.cs
@@ -1,0 +1,190 @@
+using PowerForge;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
+{
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void ReadSourceProvenance_PortableDiamondBuildsRidAgnosticReferencesInDependencyOrder()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string appDirectory = Directory.CreateDirectory(Path.Combine(root, "App")).FullName;
+            string middleDirectory = Directory.CreateDirectory(Path.Combine(root, "Middle")).FullName;
+            string libraryDirectory = Directory.CreateDirectory(Path.Combine(root, "Library")).FullName;
+            string appProject = Path.Combine(appDirectory, "App.csproj");
+            string middleProject = Path.Combine(middleDirectory, "Middle.csproj");
+            string libraryProject = Path.Combine(libraryDirectory, "Library.csproj");
+            File.WriteAllText(appProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <ProjectReference Include="../Library/Library.csproj" />
+                    <ProjectReference Include="../Middle/Middle.csproj" />
+                  </ItemGroup>
+                </Project>
+                """);
+            File.WriteAllText(middleProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup><TargetFrameworks>netstandard2.1;net8.0-windows</TargetFrameworks></PropertyGroup>
+                  <ItemGroup><ProjectReference Include="../Library/Library.csproj" /></ItemGroup>
+                </Project>
+                """);
+            File.WriteAllText(libraryProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup><TargetFrameworks>netstandard2.1;net8.0-windows</TargetFrameworks></PropertyGroup>
+                </Project>
+                """);
+            File.WriteAllText(
+                Path.Combine(appDirectory, "Program.cs"),
+                "internal static class Program { private static void Main() { _ = Middle.Value + Library.Value; } }");
+            File.WriteAllText(
+                Path.Combine(middleDirectory, "Middle.cs"),
+                "public static class Middle { public static int Value => Library.Value; }");
+            File.WriteAllText(
+                Path.Combine(libraryDirectory, "Library.cs"),
+                "public static class Library { public const int Value = 1; }");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
+            RunDotNet(
+                root,
+                $"restore \"{appProject}\" -r win-x64 --use-lock-file --nologo " +
+                "-p:SelfContained=false");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source and lock\"");
+            RunDotNet(
+                root,
+                $"build \"{appProject}\" -c Release -f net10.0 -r win-x64 --no-restore --nologo");
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Configuration = "Release",
+                NoBuildInPublish = true,
+                NoRestoreInPublish = true,
+                Targets =
+                [
+                    new DotNetPublishTargetPlan
+                    {
+                        Name = "App",
+                        ProjectPath = appProject,
+                        Combinations =
+                        [
+                            new DotNetPublishTargetCombination
+                            {
+                                Framework = "net10.0",
+                                Runtime = "win-x64",
+                                Style = DotNetPublishStyle.FrameworkDependent
+                            }
+                        ]
+                    }
+                ]
+            };
+
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(root, buildPlan: plan);
+
+            Assert.False(provenance.Dirty, string.Join(Environment.NewLine, provenance.DirtyReasons));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void ReadSourceProvenance_ControlledRestoreHonorsConditionalReleaseProperty()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string appDirectory = Directory.CreateDirectory(Path.Combine(root, "App")).FullName;
+            string libraryDirectory = Directory.CreateDirectory(Path.Combine(root, "Library")).FullName;
+            string appProject = Path.Combine(appDirectory, "App.csproj");
+            string libraryProject = Path.Combine(libraryDirectory, "Library.csproj");
+            File.WriteAllText(appProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+                  </PropertyGroup>
+                  <ItemGroup Condition="'$(PowerForgeFlavor)' == 'Release'">
+                    <ProjectReference Include="../Library/Library.csproj" />
+                  </ItemGroup>
+                </Project>
+                """);
+            File.WriteAllText(libraryProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>
+                </Project>
+                """);
+            File.WriteAllText(
+                Path.Combine(appDirectory, "Program.cs"),
+                "internal static class Program { private static void Main() { _ = Library.Value; } }");
+            File.WriteAllText(
+                Path.Combine(libraryDirectory, "Library.cs"),
+                "public static class Library { public const int Value = 1; }");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
+            RunDotNet(
+                root,
+                $"restore \"{appProject}\" -r win-x64 --use-lock-file --nologo " +
+                "-p:SelfContained=false -p:PowerForgeFlavor=Release");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source and lock\"");
+            RunDotNet(
+                root,
+                $"build \"{appProject}\" -c Release -f net10.0 -r win-x64 --no-restore --nologo " +
+                "-p:PowerForgeFlavor=Release");
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Configuration = "Release",
+                NoBuildInPublish = true,
+                NoRestoreInPublish = true,
+                MsBuildProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["PowerForgeFlavor"] = "Release"
+                },
+                Targets =
+                [
+                    new DotNetPublishTargetPlan
+                    {
+                        Name = "App",
+                        ProjectPath = appProject,
+                        Combinations =
+                        [
+                            new DotNetPublishTargetCombination
+                            {
+                                Framework = "net10.0",
+                                Runtime = "win-x64",
+                                Style = DotNetPublishStyle.FrameworkDependent
+                            }
+                        ]
+                    }
+                ]
+            };
+
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(root, buildPlan: plan);
+
+            Assert.False(provenance.Dirty, string.Join(Environment.NewLine, provenance.DirtyReasons));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+}

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave93.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave93.cs
@@ -36,13 +36,13 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
                 """);
             File.WriteAllText(middleProject, """
                 <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup><TargetFrameworks>netstandard2.1;net8.0-windows</TargetFrameworks></PropertyGroup>
+                  <PropertyGroup><TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks></PropertyGroup>
                   <ItemGroup><ProjectReference Include="../Library/Library.csproj" /></ItemGroup>
                 </Project>
                 """);
             File.WriteAllText(libraryProject, """
                 <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup><TargetFrameworks>netstandard2.1;net8.0-windows</TargetFrameworks></PropertyGroup>
+                  <PropertyGroup><TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks></PropertyGroup>
                 </Project>
                 """);
             File.WriteAllText(
@@ -54,6 +54,16 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
             File.WriteAllText(
                 Path.Combine(libraryDirectory, "Library.cs"),
                 "public static class Library { public const int Value = 1; }");
+            File.WriteAllText(
+                Path.Combine(root, "Directory.Build.targets"),
+                """
+                <Project>
+                  <Target Name="RemovePathDependentCompilerPropertyForGraphTest"
+                          BeforeTargets="GenerateMSBuildEditorConfigFileCore">
+                    <ItemGroup><CompilerVisibleProperty Remove="ProjectDir" /></ItemGroup>
+                  </Target>
+                </Project>
+                """);
             File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
             RunDotNet(
                 root,
@@ -61,13 +71,17 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
                 "-p:SelfContained=false");
             RunGit(root, "add .");
             RunGit(root, "commit -m \"approved source and lock\"");
+            string revision = RunGit(root, "rev-parse HEAD").Trim();
             RunDotNet(
                 root,
-                $"build \"{appProject}\" -c Release -f net10.0 -r win-x64 --no-restore --nologo");
+                $"build \"{appProject}\" -c Release -f net10.0 -r win-x64 --no-restore --nologo " +
+                $"/p:SourceRevisionId={revision} /p:IncludeSourceRevisionInInformationalVersion=true " +
+                "/p:ContinuousIntegrationBuild=true");
             var plan = new DotNetPublishPlan
             {
                 ProjectRoot = root,
                 Configuration = "Release",
+                SourceRevision = revision,
                 NoBuildInPublish = true,
                 NoRestoreInPublish = true,
                 Targets =

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -1601,6 +1601,52 @@ public sealed class DotNetRepositoryReleaseServiceTests
         }
     }
 
+    [Fact]
+    public void Execute_WhatIfPlansSignedOutputsWithoutSigningHandlers()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Sample.Package"));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Sample.Package.csproj"), string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFramework>net8.0</TargetFramework>",
+                "    <PackageId>Sample.Package</PackageId>",
+                "    <VersionPrefix>1.2.3</VersionPrefix>",
+                "    <IsPackable>true</IsPackable>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                OutputPath = Path.Combine(root.FullName, "packages"),
+                Pack = true,
+                Publish = false,
+                UpdateVersions = false,
+                WhatIf = true,
+                CertificateThumbprint = "ABC123",
+                SignAssemblies = true,
+                SignPackages = true
+            };
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(spec);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            var project = Assert.Single(result.Projects);
+            Assert.Equal(
+                Path.Combine(root.FullName, "packages", "Sample.Package.1.2.3.nupkg"),
+                Assert.Single(project.Packages));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     [Theory]
     [InlineData(5_400_000, "1h 30.0m")]
     [InlineData(65_000, "1.1m")]

--- a/PowerForge.Tests/ModuleBuildHostServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildHostServiceTests.cs
@@ -526,19 +526,78 @@ public sealed class ModuleBuildHostServiceTests
         });
 
         Assert.NotNull(captured);
-        Assert.Contains(
-            "$buildScriptCommand.Parameters.ContainsKey('NoDotnetBuild')",
-            captured!.CommandText!,
-            StringComparison.Ordinal);
-        Assert.Contains(
-            "$buildScriptCommand.Parameters.ContainsKey('StagingPath')",
-            captured.CommandText!,
-            StringComparison.Ordinal);
+        foreach (var parameterName in new[]
+        {
+            "NoDotnetBuild",
+            "StagingPath",
+            "ReuseStaging",
+            "IncludeProjectPackages",
+            "IncludeModulePublishing",
+            "SkipInstall"
+        })
+        {
+            Assert.Contains($"'{parameterName}'", captured!.CommandText!, StringComparison.Ordinal);
+        }
+        Assert.Contains("$missingCheckpointParameters", captured!.CommandText!, StringComparison.Ordinal);
+        Assert.Contains("Parameters.ContainsKey('RunMode')", captured.CommandText!, StringComparison.Ordinal);
+        Assert.Contains("Parameters.ContainsKey('ConfigurationGateMode')", captured.CommandText!, StringComparison.Ordinal);
         Assert.Contains(
             "Deferred module publication requires the legacy build script",
             captured.CommandText!,
             StringComparison.Ordinal);
         Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task ExecuteBuildAsync_DeferredLegacyPublishRejectsWrapperWithoutGateParameter()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "pf-module-host-checkpoint-gate-" + Guid.NewGuid().ToString("N")));
+        try
+        {
+            var moduleName = "CheckpointHost";
+            var modulePath = Path.Combine(root.FullName, moduleName + ".psd1");
+            var scriptPath = Path.Combine(root.FullName, "Build-Module.ps1");
+            var markerPath = Path.Combine(root.FullName, "invoked.txt");
+            File.WriteAllText(Path.Combine(root.FullName, moduleName + ".psm1"), string.Empty);
+            File.WriteAllText(
+                modulePath,
+                $"@{{ RootModule = '{moduleName}.psm1'; ModuleVersion = '1.0.0' }}");
+            File.WriteAllText(
+                scriptPath,
+                $$"""
+                [CmdletBinding()]
+                param(
+                    [bool] $NoDotnetBuild = $false,
+                    [string] $StagingPath,
+                    [bool] $ReuseStaging = $false,
+                    [bool] $IncludeProjectPackages = $true,
+                    [bool] $IncludeModulePublishing = $true,
+                    [bool] $SkipInstall = $false
+                )
+                [IO.File]::WriteAllText('{{markerPath.Replace("'", "''")}}', 'invoked')
+                """);
+
+            var result = await new ModuleBuildHostService().ExecuteBuildAsync(new ModuleBuildHostBuildRequest
+            {
+                RepositoryRoot = root.FullName,
+                ScriptPath = scriptPath,
+                ModulePath = modulePath,
+                RunMode = ConfigurationGateMode.Build,
+                StagingPath = Path.Combine(root.FullName, "staging"),
+                RequireReusableOutput = true,
+                Timeout = TimeSpan.FromMinutes(1)
+            });
+
+            Assert.False(result.Succeeded);
+            Assert.Contains("RunMode or ConfigurationGateMode", result.StandardError, StringComparison.Ordinal);
+            Assert.False(File.Exists(markerPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
     }
 
     [Fact]

--- a/PowerForge.Tests/ModuleBuildHostServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildHostServiceTests.cs
@@ -281,7 +281,9 @@ public sealed class ModuleBuildHostServiceTests
             ScriptPath = @"C:\repo\Build\Build-Module.ps1",
             ModulePath = @"C:\repo\Module\PSPublishModule.psd1",
             NoDotnetBuild = true,
-            SignModule = true
+            SignModule = true,
+            ReuseStaging = true,
+            SkipInstall = true
         });
 
         Assert.NotNull(captured);
@@ -289,8 +291,37 @@ public sealed class ModuleBuildHostServiceTests
         Assert.Contains("$buildScriptArguments['NoDotnetBuild'] = $true", captured.CommandText!, StringComparison.Ordinal);
         Assert.Contains("$buildScriptCommand.Parameters.ContainsKey('SignModule')", captured.CommandText!, StringComparison.Ordinal);
         Assert.Contains("$buildScriptArguments['SignModule'] = $true", captured.CommandText!, StringComparison.Ordinal);
+        Assert.Contains("$buildScriptCommand.Parameters.ContainsKey('ReuseStaging')", captured.CommandText!, StringComparison.Ordinal);
+        Assert.Contains("$buildScriptArguments['ReuseStaging'] = $true", captured.CommandText!, StringComparison.Ordinal);
+        Assert.Contains("$buildScriptCommand.Parameters.ContainsKey('SkipInstall')", captured.CommandText!, StringComparison.Ordinal);
+        Assert.Contains("$buildScriptArguments['SkipInstall'] = $true", captured.CommandText!, StringComparison.Ordinal);
         Assert.DoesNotContain("$buildScriptArguments += '-SignModule'", captured.CommandText!, StringComparison.Ordinal);
         Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task ExecuteBuildAsync_ForwardsExplicitSignModuleFalseToLegacyScript()
+    {
+        PowerShellRunRequest? captured = null;
+        var service = new ModuleBuildHostService(new StubPowerShellRunner(request =>
+        {
+            captured = request;
+            return new PowerShellRunResult(0, "ok", string.Empty, "pwsh");
+        }));
+
+        var result = await service.ExecuteBuildAsync(new ModuleBuildHostBuildRequest
+        {
+            RepositoryRoot = @"C:\repo",
+            ScriptPath = @"C:\repo\Build\Build-Module.ps1",
+            ModulePath = @"C:\repo\Module\PSPublishModule.psd1",
+            SignModule = false,
+            SignModuleWasSpecified = true
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(captured);
+        Assert.Contains("$buildScriptCommand.Parameters.ContainsKey('SignModule')", captured!.CommandText!, StringComparison.Ordinal);
+        Assert.Contains("$buildScriptArguments['SignModule'] = $false", captured.CommandText!, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/PowerForge.Tests/ModulePackageReleaseCheckpointServiceTests.cs
+++ b/PowerForge.Tests/ModulePackageReleaseCheckpointServiceTests.cs
@@ -79,6 +79,9 @@ public sealed class ModulePackageReleaseCheckpointServiceTests
             var project = Assert.Single(checkpoint.Release.Projects);
 
             Assert.Equal(Path.GetFullPath(projectPath), Path.GetFullPath(project.CsprojPath));
+            Assert.Equal(
+                Path.Combine(moduleRoot, "bin", "Release", "Sample.Library.1.0.0.nupkg"),
+                Assert.Single(project.Packages));
             Assert.True(checkpoint.PublishNuget);
             Assert.False(checkpoint.PublishGitHub);
         }

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseLifecycleTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseLifecycleTests.cs
@@ -8,6 +8,74 @@ namespace PowerForge.Tests;
 public sealed partial class ModulePipelineUnifiedReleaseTests
 {
     [Fact]
+    public void Run_BuildGate_DoesNotRunPublishLifecycleActions()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var stagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "2.0.10");
+            var events = new List<string>();
+            var hosted = new FakeHostedOperations(events)
+            {
+                ModuleAction = (action, context) =>
+                {
+                    events.Add(context.Stage.ToString());
+                    return CreateActionResult(action, context, succeeded: true);
+                }
+            };
+            var runner = CreateRunner(
+                hosted,
+                (_, _, _) => throw new InvalidOperationException("Package builds should not run."));
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "2.0.10",
+                    StagingPath = stagingPath
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationActionSegment
+                    {
+                        Configuration = new ModulePipelineActionConfiguration
+                        {
+                            At = ModulePipelineActionStage.BeforePublish,
+                            InlineScript = "Write-Output ignored"
+                        }
+                    },
+                    new ConfigurationActionSegment
+                    {
+                        Configuration = new ModulePipelineActionConfiguration
+                        {
+                            At = ModulePipelineActionStage.AfterPublish,
+                            InlineScript = "Write-Output ignored"
+                        }
+                    },
+                    new ConfigurationGateSegment
+                    {
+                        Configuration = new GateConfiguration { Mode = ConfigurationGateMode.Build }
+                    }
+                }
+            };
+
+            var result = runner.Run(spec);
+
+            Assert.Empty(events);
+            Assert.Empty(result.ActionResults);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+            try { if (Directory.Exists(stagingPath)) Directory.Delete(stagingPath, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void Run_PreservesDependencyActionOrderingWithoutVersionSynchronization()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseReviewTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseReviewTests.cs
@@ -181,7 +181,7 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
     }
 
     [Fact]
-    public void Run_PreflightsSynchronizedModuleVersionBeforePublishingNuGet()
+    public void Run_RejectsIncompatibleSynchronizedVersionBeforePublishingNuGet()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         var stagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
@@ -288,8 +288,8 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
 
             var exception = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
 
-            Assert.Contains("not greater than repository version", exception.Message, StringComparison.OrdinalIgnoreCase);
-            Assert.Equal(1, dependencyBuildCalls);
+            Assert.Contains("cannot produce a version greater than current version", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(0, dependencyBuildCalls);
             Assert.Equal(0, nugetPublishCalls);
             Assert.Empty(hostedOperations.PublishedModuleVersions);
         }

--- a/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
+++ b/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
@@ -5,6 +5,53 @@ namespace PowerForge.Tests;
 public sealed class NuGetPackagePublishServiceTests
 {
     [Fact]
+    public void ExecutePackages_StopsBeforeNextPackageWhenCancellationIsRequested()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "pf-nuget-publish-cancellation-" + Guid.NewGuid().ToString("N")));
+        try
+        {
+            var packages = new[]
+            {
+                Path.Combine(root.FullName, "Sample.One.1.0.0.nupkg"),
+                Path.Combine(root.FullName, "Sample.Two.1.0.0.nupkg")
+            };
+            foreach (var package in packages)
+            {
+                File.WriteAllText(package, "package");
+            }
+
+            using var cancellation = new CancellationTokenSource();
+            var pushed = new List<string>();
+            var service = new NuGetPackagePublishService(
+                new NullLogger(),
+                request =>
+                {
+                    pushed.Add(request.PackagePath);
+                    cancellation.Cancel();
+                    return new DotNetRepositoryReleaseService.PackagePushResult
+                    {
+                        Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Published
+                    };
+                });
+
+            Assert.Throws<OperationCanceledException>(() => service.ExecutePackages(
+                packages,
+                "key",
+                "https://api.nuget.org/v3/index.json",
+                skipDuplicate: true,
+                cancellationToken: cancellation.Token));
+
+            Assert.Equal(packages[0], Assert.Single(pushed));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void ExecutePackages_ReportsEveryPublishedPackageAsDurableWork()
     {
         var root = Directory.CreateDirectory(Path.Combine(

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePackages.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePackages.cs
@@ -3,6 +3,97 @@ namespace PowerForge.Tests;
 public sealed partial class PowerForgeReleaseServiceTests
 {
     [Fact]
+    public void ModulePackageCheckpoint_UsesValidatedStagedPackageForPublication()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var sourcePath = Path.Combine(root, "artifacts", "Sample.1.2.3.nupkg");
+            var stagedPath = Path.Combine(root, "staged", "nuget", "Sample.1.2.3.nupkg");
+            Directory.CreateDirectory(Path.GetDirectoryName(sourcePath)!);
+            Directory.CreateDirectory(Path.GetDirectoryName(stagedPath)!);
+            File.WriteAllText(sourcePath, "source");
+            File.WriteAllText(stagedPath, "validated staged bytes");
+            var source = new DotNetRepositoryReleaseResult
+            {
+                Success = true,
+                ResolvedVersion = "1.2.3",
+                Projects =
+                [
+                    new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = "Sample",
+                        PackageId = "Sample",
+                        IsPackable = true,
+                        NewVersion = "1.2.3",
+                        Packages = [sourcePath]
+                    }
+                ]
+            };
+            source.ResolvedVersionsByProject["Sample"] = "1.2.3";
+
+            var publication = ModulePackageReleaseCheckpointService.CreatePublicationRelease(
+                source,
+                [
+                    new PowerForgeReleaseAssetEntry
+                    {
+                        Path = sourcePath,
+                        StagedPath = stagedPath,
+                        Category = PowerForgeReleaseAssetCategory.Package,
+                        IsFinalPackageOutput = true
+                    }
+                ],
+                requireStagedAssets: true);
+
+            Assert.Equal(stagedPath, Assert.Single(Assert.Single(publication.Projects).Packages));
+            Assert.Equal("1.2.3", publication.ResolvedVersionsByProject["Sample"]);
+            Assert.Equal("source", File.ReadAllText(sourcePath));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void ModulePackageCheckpoint_RejectsPackageMissingFromValidatedStage()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var sourcePath = Path.Combine(root, "artifacts", "Sample.1.2.3.nupkg");
+            Directory.CreateDirectory(Path.GetDirectoryName(sourcePath)!);
+            File.WriteAllText(sourcePath, "source");
+            var source = new DotNetRepositoryReleaseResult
+            {
+                Success = true,
+                Projects =
+                [
+                    new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = "Sample",
+                        PackageId = "Sample",
+                        IsPackable = true,
+                        Packages = [sourcePath]
+                    }
+                ]
+            };
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                ModulePackageReleaseCheckpointService.CreatePublicationRelease(
+                    source,
+                    Array.Empty<PowerForgeReleaseAssetEntry>(),
+                    requireStagedAssets: true));
+
+            Assert.Contains("validated staged release", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_ModulePlan_InfersModuleNameFromJsonBuildContract()
     {
         var root = CreateSandbox();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePackages.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePackages.cs
@@ -14,6 +14,7 @@ public sealed partial class PowerForgeReleaseServiceTests
             Directory.CreateDirectory(Path.GetDirectoryName(stagedPath)!);
             File.WriteAllText(sourcePath, "source");
             File.WriteAllText(stagedPath, "validated staged bytes");
+            var stagedSha256 = ComputeTestSha256(stagedPath);
             var source = new DotNetRepositoryReleaseResult
             {
                 Success = true,
@@ -40,7 +41,8 @@ public sealed partial class PowerForgeReleaseServiceTests
                         Path = sourcePath,
                         StagedPath = stagedPath,
                         Category = PowerForgeReleaseAssetCategory.Package,
-                        IsFinalPackageOutput = true
+                        IsFinalPackageOutput = true,
+                        StagedSha256 = stagedSha256
                     }
                 ],
                 requireStagedAssets: true);
@@ -48,6 +50,167 @@ public sealed partial class PowerForgeReleaseServiceTests
             Assert.Equal(stagedPath, Assert.Single(Assert.Single(publication.Projects).Packages));
             Assert.Equal("1.2.3", publication.ResolvedVersionsByProject["Sample"]);
             Assert.Equal("source", File.ReadAllText(sourcePath));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void ModulePackageCheckpoint_RejectsStagedPackageChangedAfterValidation()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var sourcePath = Path.Combine(root, "artifacts", "Sample.1.2.3.nupkg");
+            var stagedPath = Path.Combine(root, "staged", "nuget", "Sample.1.2.3.nupkg");
+            Directory.CreateDirectory(Path.GetDirectoryName(sourcePath)!);
+            Directory.CreateDirectory(Path.GetDirectoryName(stagedPath)!);
+            File.WriteAllText(sourcePath, "source");
+            File.WriteAllText(stagedPath, "validated staged bytes");
+            var stagedSha256 = ComputeTestSha256(stagedPath);
+            File.WriteAllText(stagedPath, "changed after validation");
+            var source = new DotNetRepositoryReleaseResult
+            {
+                Success = true,
+                Projects =
+                [
+                    new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = "Sample",
+                        PackageId = "Sample",
+                        IsPackable = true,
+                        Packages = [sourcePath]
+                    }
+                ]
+            };
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                ModulePackageReleaseCheckpointService.CreatePublicationRelease(
+                    source,
+                    [
+                        new PowerForgeReleaseAssetEntry
+                        {
+                            Path = sourcePath,
+                            StagedPath = stagedPath,
+                            Category = PowerForgeReleaseAssetCategory.Package,
+                            IsFinalPackageOutput = true,
+                            StagedSha256 = stagedSha256
+                        }
+                    ],
+                    requireStagedAssets: true));
+
+            Assert.Contains("changed after release staging", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void ModulePackagePublicationSnapshot_UsesPrivateImmutableBytesAndMapsResultsBack()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var stagedPath = Path.Combine(root, "staged", "Sample.1.2.3.nupkg");
+            Directory.CreateDirectory(Path.GetDirectoryName(stagedPath)!);
+            File.WriteAllText(stagedPath, "validated staged bytes");
+            var release = new DotNetRepositoryReleaseResult
+            {
+                Success = true,
+                Projects =
+                [
+                    new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = "Sample",
+                        PackageId = "Sample",
+                        IsPackable = true,
+                        Packages = [stagedPath]
+                    }
+                ]
+            };
+
+            using var snapshot = ModulePackagePublicationSnapshot.Create(release);
+            var snapshotPath = Assert.Single(Assert.Single(snapshot.Release.Projects).Packages);
+
+            Assert.NotEqual(Path.GetFullPath(stagedPath), snapshotPath);
+            Assert.True(File.Exists(snapshotPath));
+            Assert.True(File.GetAttributes(snapshotPath).HasFlag(FileAttributes.ReadOnly));
+            Assert.Equal(stagedPath, Assert.Single(snapshot.ResolveOriginalPaths([snapshotPath])));
+            snapshot.ValidateUnchanged();
+
+            File.SetAttributes(snapshotPath, FileAttributes.Normal);
+            File.WriteAllText(snapshotPath, "tampered publication bytes");
+            var exception = Assert.Throws<InvalidOperationException>(snapshot.ValidateUnchanged);
+            Assert.Contains("publication snapshot changed", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    private static string ComputeTestSha256(string path)
+    {
+        using var stream = File.OpenRead(path);
+        using var sha256 = System.Security.Cryptography.SHA256.Create();
+        return string.Concat(sha256.ComputeHash(stream).Select(static value => value.ToString("x2")));
+    }
+
+    [Fact]
+    public void Execute_ModuleOwnedPackages_CapturesCurrentRunProvenanceWithoutVirusTotal()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var scriptPath = Path.Combine(root, "Build-Module.ps1");
+            var releasePath = Path.Combine(root, "release.json");
+            var packagePath = Path.Combine(root, "Sample.1.2.3.nupkg");
+            File.WriteAllText(scriptPath, "# module build");
+            File.WriteAllText(releasePath, "{}");
+            var moduleCalls = new List<ModuleExecutionSnapshot>();
+            var service = CreateReleaseService(
+                root,
+                moduleCalls,
+                new PowerForgeToolReleaseResult { Success = true },
+                _ =>
+                {
+                    using var archive = System.IO.Compression.ZipFile.Open(
+                        packagePath,
+                        System.IO.Compression.ZipArchiveMode.Create);
+                    var nuspec = archive.CreateEntry("Sample.nuspec");
+                    using var writer = new StreamWriter(nuspec.Open());
+                    writer.Write("<package><metadata><id>Sample</id><version>1.2.3</version></metadata></package>");
+                });
+            var spec = new PowerForgeReleaseSpec
+            {
+                Module = new PowerForgeModuleReleaseOptions
+                {
+                    RepositoryRoot = root,
+                    ScriptPath = scriptPath,
+                    ModuleVersion = "1.2.3",
+                    IncludesPackages = true,
+                    ArtifactPaths = [packagePath]
+                }
+            };
+
+            var result = service.Execute(
+                spec,
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = releasePath,
+                    ModuleOnly = true,
+                    ModuleRunMode = ConfigurationGateMode.Build
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Contains(packagePath, result.ModuleProducedAssets, StringComparer.OrdinalIgnoreCase);
+            var package = Assert.Single(result.ReleaseAssetEntries);
+            Assert.Equal(PowerForgeReleaseAssetCategory.Package, package.Category);
+            Assert.True(package.IsFinalPackageOutput);
         }
         finally
         {

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ModuleProducedAssets.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ModuleProducedAssets.cs
@@ -29,7 +29,8 @@ public sealed partial class PowerForgeReleaseServiceTests
             PowerForgeReleaseAssetEntry entry = Assert.Single(
                 PowerForgeReleaseService.CreateModuleAssetEntries(
                     packagePath,
-                    new PowerForgeModuleReleasePlanSummary { ModuleVersion = "4.0.0" }));
+                    new PowerForgeModuleReleasePlanSummary { ModuleVersion = "4.0.0" },
+                    new[] { packagePath }));
 
             Assert.Equal(PowerForgeReleaseAssetCategory.Package, entry.Category);
             Assert.Equal("ModuleProjectBuild", entry.Source);
@@ -37,6 +38,34 @@ public sealed partial class PowerForgeReleaseServiceTests
             Assert.Equal("Company.Library", entry.PackageId);
             Assert.Equal("4.0.0", entry.Version);
             Assert.True(entry.IsFinalPackageOutput);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void CreateModuleAssetEntries_ExistingNuGetPackageWithoutCurrentRunProofIsNotFinal()
+    {
+        string root = CreateSandbox();
+        try
+        {
+            string packagePath = Path.Combine(root, "Company.Library.4.0.0.nupkg");
+            using (ZipArchive archive = ZipFile.Open(packagePath, ZipArchiveMode.Create))
+            {
+                ZipArchiveEntry nuspec = archive.CreateEntry("Company.Library.nuspec");
+                using var writer = new StreamWriter(nuspec.Open());
+                writer.Write("<package><metadata><id>Company.Library</id><version>4.0.0</version></metadata></package>");
+            }
+
+            PowerForgeReleaseAssetEntry entry = Assert.Single(
+                PowerForgeReleaseService.CreateModuleAssetEntries(
+                    packagePath,
+                    new PowerForgeModuleReleasePlanSummary { ModuleVersion = "4.0.0" },
+                    producedArtifactPaths: Array.Empty<string>()));
+
+            Assert.False(entry.IsFinalPackageOutput);
         }
         finally
         {

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ModuleProducedAssets.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ModuleProducedAssets.cs
@@ -45,6 +45,38 @@ public sealed partial class PowerForgeReleaseServiceTests
         }
     }
 
+    [Theory]
+    [InlineData("Company.Library.4.0.0.snupkg")]
+    [InlineData("Company.Library.4.0.0.symbols.nupkg")]
+    public void CreateModuleAssetEntries_ClassifiesCurrentRunSymbolPackageAsFinal(string fileName)
+    {
+        string root = CreateSandbox();
+        try
+        {
+            string packagePath = Path.Combine(root, fileName);
+            using (ZipArchive archive = ZipFile.Open(packagePath, ZipArchiveMode.Create))
+            {
+                ZipArchiveEntry nuspec = archive.CreateEntry("Company.Library.nuspec");
+                using var writer = new StreamWriter(nuspec.Open());
+                writer.Write("<package><metadata><id>Company.Library</id><version>4.0.0</version></metadata></package>");
+            }
+
+            PowerForgeReleaseAssetEntry entry = Assert.Single(
+                PowerForgeReleaseService.CreateModuleAssetEntries(
+                    packagePath,
+                    new PowerForgeModuleReleasePlanSummary { ModuleVersion = "4.0.0" },
+                    new[] { packagePath }));
+
+            Assert.Equal(PowerForgeReleaseAssetCategory.Package, entry.Category);
+            Assert.Equal("Company.Library", entry.PackageId);
+            Assert.True(entry.IsFinalPackageOutput);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
     [Fact]
     public void CreateModuleAssetEntries_ExistingNuGetPackageWithoutCurrentRunProofIsNotFinal()
     {

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ModuleProducedAssets.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ModuleProducedAssets.cs
@@ -1,0 +1,68 @@
+using System.IO.Compression;
+
+namespace PowerForge.Tests;
+
+public sealed partial class PowerForgeReleaseServiceTests
+{
+    [Fact]
+    public void CreateModuleAssetEntries_ClassifiesProjectBuildNuGetPackage()
+    {
+        string root = CreateSandbox();
+        try
+        {
+            string packagePath = Path.Combine(root, "Company.Library.4.0.0.nupkg");
+            using (ZipArchive archive = ZipFile.Open(packagePath, ZipArchiveMode.Create))
+            {
+                ZipArchiveEntry nuspec = archive.CreateEntry("Company.Library.nuspec");
+                using var writer = new StreamWriter(nuspec.Open());
+                writer.Write("""
+                    <?xml version="1.0"?>
+                    <package>
+                      <metadata>
+                        <id>Company.Library</id>
+                        <version>4.0.0</version>
+                      </metadata>
+                    </package>
+                    """);
+            }
+
+            PowerForgeReleaseAssetEntry entry = Assert.Single(
+                PowerForgeReleaseService.CreateModuleAssetEntries(
+                    packagePath,
+                    new PowerForgeModuleReleasePlanSummary { ModuleVersion = "4.0.0" }));
+
+            Assert.Equal(PowerForgeReleaseAssetCategory.Package, entry.Category);
+            Assert.Equal("ModuleProjectBuild", entry.Source);
+            Assert.Equal("Company.Library", entry.Target);
+            Assert.Equal("Company.Library", entry.PackageId);
+            Assert.Equal("4.0.0", entry.Version);
+            Assert.True(entry.IsFinalPackageOutput);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void CreateModuleAssetEntries_PreservesModuleArchiveClassification()
+    {
+        string root = CreateSandbox();
+        try
+        {
+            string archivePath = Path.Combine(root, "Company.Tools.4.0.0.zip");
+            File.WriteAllText(archivePath, "module");
+
+            PowerForgeReleaseAssetEntry entry = Assert.Single(
+                PowerForgeReleaseService.CreateModuleAssetEntries(archivePath));
+
+            Assert.Equal(PowerForgeReleaseAssetCategory.Module, entry.Category);
+            Assert.Equal("Module", entry.Source);
+            Assert.Null(entry.PackageId);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+}

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePublicationOrdering.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePublicationOrdering.cs
@@ -476,6 +476,140 @@ public sealed partial class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_ValidatesStagedReleaseBeforeDeferredModulePublication()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var scriptPath = Path.Combine(root, "Build-Module.ps1");
+            var validationPath = Path.Combine(root, "Test-Release.ps1");
+            var releasePath = Path.Combine(root, "release.json");
+            File.WriteAllText(scriptPath, "# module build");
+            File.WriteAllText(validationPath, "# validation");
+            File.WriteAllText(releasePath, "{}");
+            var moduleCalls = new List<ModuleExecutionSnapshot>();
+            var toolCompleted = false;
+            var validationCalls = 0;
+            var service = CreateReleaseService(
+                root,
+                moduleCalls,
+                new PowerForgeToolReleaseResult { Success = true },
+                onToolExecution: () => toolCompleted = true,
+                runReleaseValidation: (_, context, _, _) =>
+                {
+                    validationCalls++;
+                    Assert.True(toolCompleted);
+                    Assert.Single(moduleCalls);
+                    Assert.True(File.Exists(context.ReleaseManifestPath), context.ReleaseManifestPath);
+                    Assert.Equal("1.2.3", context.ResolvedVersion);
+                    return new PowerForgeReleaseValidationResult
+                    {
+                        Name = "release",
+                        Succeeded = true,
+                        ExitCode = 0
+                    };
+                });
+            var spec = CreateReleaseSpec(root, scriptPath);
+            spec.Module!.ModuleVersion = "1.2.3";
+            spec.Outputs.Staging = new PowerForgeReleaseStagingOptions
+            {
+                RootPath = Path.Combine(root, "staged")
+            };
+            spec.Validation = new PowerForgeReleaseValidationOptions
+            {
+                AfterStaging =
+                [
+                    new PowerForgeReleaseValidationAction
+                    {
+                        Name = "release",
+                        FilePath = validationPath
+                    }
+                ]
+            };
+
+            var result = service.Execute(
+                spec,
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = releasePath,
+                    ModuleRunMode = ConfigurationGateMode.Publish,
+                    ModuleVersion = "1.2.3"
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(1, validationCalls);
+            Assert.Equal(2, moduleCalls.Count);
+            Assert.Single(result.ReleaseValidations);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_FailedStagedReleaseValidationBlocksDeferredPublication()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var scriptPath = Path.Combine(root, "Build-Module.ps1");
+            var validationPath = Path.Combine(root, "Test-Release.ps1");
+            var releasePath = Path.Combine(root, "release.json");
+            File.WriteAllText(scriptPath, "# module build");
+            File.WriteAllText(validationPath, "# validation");
+            File.WriteAllText(releasePath, "{}");
+            var moduleCalls = new List<ModuleExecutionSnapshot>();
+            var service = CreateReleaseService(
+                root,
+                moduleCalls,
+                new PowerForgeToolReleaseResult { Success = true },
+                runReleaseValidation: (_, _, _, _) => new PowerForgeReleaseValidationResult
+                {
+                    Name = "release",
+                    Succeeded = false,
+                    ExitCode = 17,
+                    StdErr = "release contract failed"
+                });
+            var spec = CreateReleaseSpec(root, scriptPath);
+            spec.Module!.ModuleVersion = "1.2.3";
+            spec.Outputs.Staging = new PowerForgeReleaseStagingOptions
+            {
+                RootPath = Path.Combine(root, "staged")
+            };
+            spec.Validation = new PowerForgeReleaseValidationOptions
+            {
+                AfterStaging =
+                [
+                    new PowerForgeReleaseValidationAction
+                    {
+                        Name = "release",
+                        FilePath = validationPath
+                    }
+                ]
+            };
+
+            var result = service.Execute(
+                spec,
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = releasePath,
+                    ModuleRunMode = ConfigurationGateMode.Publish,
+                    ModuleVersion = "1.2.3"
+                });
+
+            Assert.False(result.Success);
+            Assert.Contains("release contract failed", result.ErrorMessage, StringComparison.Ordinal);
+            Assert.Single(moduleCalls);
+            Assert.Null(result.ModulePublication);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_does_not_publish_module_after_tool_build_failure()
     {
         var root = CreateSandbox();
@@ -1104,7 +1238,8 @@ public sealed partial class PowerForgeReleaseServiceTests
         Func<string, string, string, IEnumerable<string>, CancellationToken, string[]>? restorePublishedModuleAssets = null,
         Func<VirusTotalMonitorPublishRequest, CancellationToken, VirusTotalMonitorPublishResult>? publishVirusTotalMonitor = null,
         Action? onToolExecution = null,
-        Func<ProjectBuildHostRequest, ProjectBuildConfiguration, string, ProjectBuildHostExecutionResult>? executePackages = null)
+        Func<ProjectBuildHostRequest, ProjectBuildConfiguration, string, ProjectBuildHostExecutionResult>? executePackages = null,
+        Func<PowerForgeReleaseValidationAction, PowerForgeReleaseValidationContext, string, CancellationToken, PowerForgeReleaseValidationResult>? runReleaseValidation = null)
         => new(
             new NullLogger(),
             executePackages: executePackages ?? ((_, _, _) =>
@@ -1134,6 +1269,7 @@ public sealed partial class PowerForgeReleaseServiceTests
             restorePublishedNuGetAssets: restorePublishedNuGetAssets,
             restorePublishedModuleAssets: restorePublishedModuleAssets,
             publishVirusTotalMonitor: publishVirusTotalMonitor,
+            runReleaseValidation: runReleaseValidation,
             executeModuleBuild: (request, cancellationToken) =>
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePublicationOrdering.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePublicationOrdering.cs
@@ -490,6 +490,7 @@ public sealed partial class PowerForgeReleaseServiceTests
             var moduleCalls = new List<ModuleExecutionSnapshot>();
             var toolCompleted = false;
             var validationCalls = 0;
+            var stageRoot = Path.Combine(root, "request-staged");
             var service = CreateReleaseService(
                 root,
                 moduleCalls,
@@ -502,6 +503,7 @@ public sealed partial class PowerForgeReleaseServiceTests
                     Assert.Single(moduleCalls);
                     Assert.True(File.Exists(context.ReleaseManifestPath), context.ReleaseManifestPath);
                     Assert.Equal("1.2.3", context.ResolvedVersion);
+                    Assert.Equal(stageRoot, context.StagingRoot);
                     return new PowerForgeReleaseValidationResult
                     {
                         Name = "release",
@@ -511,10 +513,6 @@ public sealed partial class PowerForgeReleaseServiceTests
                 });
             var spec = CreateReleaseSpec(root, scriptPath);
             spec.Module!.ModuleVersion = "1.2.3";
-            spec.Outputs.Staging = new PowerForgeReleaseStagingOptions
-            {
-                RootPath = Path.Combine(root, "staged")
-            };
             spec.Validation = new PowerForgeReleaseValidationOptions
             {
                 AfterStaging =
@@ -533,13 +531,107 @@ public sealed partial class PowerForgeReleaseServiceTests
                 {
                     ConfigPath = releasePath,
                     ModuleRunMode = ConfigurationGateMode.Publish,
-                    ModuleVersion = "1.2.3"
+                    ModuleVersion = "1.2.3",
+                    StageRoot = stageRoot
                 });
 
             Assert.True(result.Success, result.ErrorMessage);
             Assert.Equal(1, validationCalls);
             Assert.Equal(2, moduleCalls.Count);
             Assert.Single(result.ReleaseValidations);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_ValidatesStagedReleaseBeforePublishingPerToolGitHubRelease()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var releasePath = Path.Combine(root, "release.json");
+            var validationPath = Path.Combine(root, "Test-Release.ps1");
+            var toolZip = Path.Combine(root, "SampleTool-1.2.3.zip");
+            var toolExecutable = Path.Combine(root, "SampleTool.exe");
+            File.WriteAllText(releasePath, "{}");
+            File.WriteAllText(validationPath, "# validation");
+            File.WriteAllText(toolZip, "tool archive");
+            File.WriteAllText(toolExecutable, "tool executable");
+            var validationCompleted = false;
+            var publicationCalls = 0;
+            var service = CreateReleaseService(
+                root,
+                new List<ModuleExecutionSnapshot>(),
+                new PowerForgeToolReleaseResult
+                {
+                    Success = true,
+                    Artefacts =
+                    [
+                        new PowerForgeToolReleaseArtifactResult
+                        {
+                            Target = "SampleTool",
+                            Version = "1.2.3",
+                            ExecutablePath = toolExecutable,
+                            ZipPath = toolZip
+                        }
+                    ]
+                },
+                publishGitHubRelease: _ =>
+                {
+                    Assert.True(validationCompleted);
+                    publicationCalls++;
+                    return new GitHubReleasePublishResult { Succeeded = true };
+                },
+                runReleaseValidation: (_, _, _, _) =>
+                {
+                    Assert.Equal(0, publicationCalls);
+                    validationCompleted = true;
+                    return new PowerForgeReleaseValidationResult
+                    {
+                        Name = "release",
+                        Succeeded = true,
+                        ExitCode = 0
+                    };
+                });
+            var spec = CreateReleaseSpec(root, Path.Combine(root, "unused-Build-Module.ps1"));
+            spec.Module = null;
+            spec.Tools!.GitHub = new PowerForgeToolReleaseGitHubOptions
+            {
+                Publish = true,
+                Owner = "EvotecIT",
+                Repository = "Sample",
+                TokenEnvName = "PATH",
+                TagTemplate = "{Target}-v{Version}",
+                ReleaseNameTemplate = "{Target} {Version}"
+            };
+            spec.Validation = new PowerForgeReleaseValidationOptions
+            {
+                AfterStaging =
+                [
+                    new PowerForgeReleaseValidationAction
+                    {
+                        Name = "release",
+                        FilePath = validationPath
+                    }
+                ]
+            };
+
+            var result = service.Execute(
+                spec,
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = releasePath,
+                    ToolsOnly = true,
+                    StageRoot = Path.Combine(root, "staged")
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.True(validationCompleted);
+            Assert.Equal(1, publicationCalls);
+            Assert.Single(result.ToolGitHubReleases);
         }
         finally
         {

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ModuleRegistryOrdering.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ModuleRegistryOrdering.cs
@@ -1,0 +1,201 @@
+namespace PowerForge.Tests;
+
+public sealed partial class PowerForgeReleaseServiceTests
+{
+    [Fact]
+    public void Execute_PublishesModuleRegistriesBeforePerToolGitHubRelease()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var releasePath = Path.Combine(root, "release.json");
+            var moduleConfigPath = Path.Combine(root, "module.json");
+            var projectConfigPath = Path.Combine(root, "project.build.json");
+            var projectPath = Path.Combine(root, "Sample.Package.csproj");
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(root, "Module")).FullName;
+            var projectBuildRoot = Path.Combine(root, "project-build");
+            var packagePath = Path.Combine(projectBuildRoot, "packages", "Sample.Package.1.2.3.nupkg");
+            var moduleZip = Path.Combine(root, "SampleModule.v1.2.3.zip");
+            var toolZip = Path.Combine(root, "SampleTool-1.2.3.zip");
+            var toolExecutable = Path.Combine(root, "SampleTool.exe");
+            var validationPath = Path.Combine(root, "Test-Release.ps1");
+            var feedPath = Path.Combine(root, "feed");
+            Directory.CreateDirectory(feedPath);
+            File.WriteAllText(releasePath, "{}");
+            File.WriteAllText(validationPath, "# validation");
+            File.WriteAllText(Path.Combine(moduleRoot, "SampleModule.psm1"), string.Empty);
+            File.WriteAllText(
+                Path.Combine(moduleRoot, "SampleModule.psd1"),
+                "@{ RootModule = 'SampleModule.psm1'; ModuleVersion = '1.2.3' }");
+            File.WriteAllText(
+                projectPath,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <Version>1.2.3</Version>
+                    <PackageId>Sample.Package</PackageId>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            File.WriteAllText(
+                projectConfigPath,
+                $$"""
+                {
+                  "RootPath": ".",
+                  "ExpectedVersionMap": { "Sample.Package": "1.2.3" },
+                  "ExpectedVersionMapAsInclude": true,
+                  "ExpectedVersionMapUseWildcards": false,
+                  "StagingPath": "{{projectBuildRoot.Replace("\\", "\\\\")}}",
+                  "UpdateVersions": false,
+                  "Build": false,
+                  "PublishNuget": true,
+                  "PublishSource": "{{feedPath.Replace("\\", "\\\\")}}",
+                  "PublishApiKey": "test-key",
+                  "SkipDuplicate": false
+                }
+                """);
+            File.WriteAllText(
+                moduleConfigPath,
+                """
+                {
+                  "Build": {
+                    "Name": "SampleModule",
+                    "SourcePath": "Module",
+                    "Version": "1.2.3"
+                  },
+                  "Install": { "Enabled": false },
+                  "Segments": [
+                    {
+                      "Type": "ProjectBuild",
+                      "Configuration": {
+                        "Name": "Sample.Package",
+                        "ConfigPath": "project.build.json",
+                        "Enabled": true,
+                        "BuildBeforeModule": true,
+                        "PublishNuget": true
+                      }
+                    }
+                  ]
+                }
+                """);
+            var events = new List<string>();
+            var moduleCalls = new List<ModuleExecutionSnapshot>();
+            var service = CreateReleaseService(
+                root,
+                moduleCalls,
+                new PowerForgeToolReleaseResult
+                {
+                    Success = true,
+                    Artefacts =
+                    [
+                        new PowerForgeToolReleaseArtifactResult
+                        {
+                            Target = "SampleTool",
+                            Version = "1.2.3",
+                            ExecutablePath = toolExecutable,
+                            ZipPath = toolZip
+                        }
+                    ]
+                },
+                onModuleExecution: request =>
+                {
+                    if (request.RunMode == ConfigurationGateMode.Build)
+                    {
+                        events.Add("module-build");
+                        Directory.CreateDirectory(Path.GetDirectoryName(packagePath)!);
+                        using (var archive = System.IO.Compression.ZipFile.Open(
+                                   packagePath,
+                                   System.IO.Compression.ZipArchiveMode.Create))
+                        {
+                            var nuspec = archive.CreateEntry("Sample.Package.nuspec");
+                            using var writer = new StreamWriter(nuspec.Open());
+                            writer.Write("<package><metadata><id>Sample.Package</id><version>1.2.3</version></metadata></package>");
+                        }
+                        File.WriteAllText(moduleZip, "module archive");
+                        File.WriteAllText(toolZip, "tool archive");
+                        File.WriteAllText(toolExecutable, "tool executable");
+                    }
+                    else
+                    {
+                        events.Add("module-publish");
+                    }
+                },
+                publishGitHubRelease: _ =>
+                {
+                    events.Add("tool-github");
+                    Assert.True(Directory.Exists(feedPath));
+                    Assert.Contains(
+                        Directory.EnumerateFiles(feedPath, "*.nupkg", SearchOption.AllDirectories),
+                        path => Path.GetFileName(path).Equals("Sample.Package.1.2.3.nupkg", StringComparison.OrdinalIgnoreCase));
+                    Assert.Equal(ConfigurationGateMode.Publish, moduleCalls[^1].RunMode);
+                    return new GitHubReleasePublishResult { Succeeded = true };
+                },
+                onToolExecution: () => events.Add("tool-build"),
+                runReleaseValidation: (_, _, _, _) =>
+                {
+                    events.Add("validation");
+                    return new PowerForgeReleaseValidationResult
+                    {
+                        Name = "release",
+                        Succeeded = true,
+                        ExitCode = 0
+                    };
+                });
+            var spec = CreateReleaseSpec(root, Path.Combine(root, "unused-Build-Module.ps1"));
+            spec.Module = new PowerForgeModuleReleaseOptions
+            {
+                RepositoryRoot = root,
+                ConfigPath = moduleConfigPath,
+                ModulePath = typeof(PowerForgeReleaseService).Assembly.Location,
+                ModuleName = "SampleModule",
+                ModuleVersion = "1.2.3",
+                IncludesPackages = true,
+                ArtifactPaths = [moduleZip, packagePath]
+            };
+            spec.Tools!.GitHub = new PowerForgeToolReleaseGitHubOptions
+            {
+                Publish = true,
+                Owner = "EvotecIT",
+                Repository = "Sample",
+                TokenEnvName = "PATH",
+                TagTemplate = "{Target}-v{Version}",
+                ReleaseNameTemplate = "{Target} {Version}"
+            };
+            spec.Validation = new PowerForgeReleaseValidationOptions
+            {
+                AfterStaging =
+                [
+                    new PowerForgeReleaseValidationAction
+                    {
+                        Name = "release",
+                        FilePath = validationPath
+                    }
+                ]
+            };
+
+            var result = service.Execute(
+                spec,
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = releasePath,
+                    ModuleRunMode = ConfigurationGateMode.Publish,
+                    PublishNuget = true,
+                    StageRoot = Path.Combine(root, "staged")
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(
+                new[] { "module-build", "tool-build", "validation", "module-publish", "tool-github" },
+                events);
+            Assert.Single(result.ModulePackagePublications);
+            Assert.NotNull(result.ModulePublication);
+            Assert.Single(result.ToolGitHubReleases);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+}

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.StagingCollisions.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.StagingCollisions.cs
@@ -1,0 +1,187 @@
+using System.Text;
+
+namespace PowerForge.Tests;
+
+public sealed partial class PowerForgeReleaseServiceTests
+{
+    [Fact]
+    public void ValidateReleaseOutputDestinations_RejectsGeneratedChecksumOverStagedMetadata()
+    {
+        string root = CreateSandbox();
+        try
+        {
+            string source = Path.Combine(root, "dotnet", "SHA256SUMS.txt");
+            string destination = Path.Combine(root, "release", "SHA256SUMS.txt");
+            Directory.CreateDirectory(Path.GetDirectoryName(source)!);
+            File.WriteAllText(source, "dotnet-checksums", new UTF8Encoding(false));
+            var entry = new PowerForgeReleaseAssetEntry
+            {
+                Path = source,
+                StagedPath = destination,
+                Category = PowerForgeReleaseAssetCategory.Metadata,
+                Source = "DotNetPublish"
+            };
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                PowerForgeReleaseService.ValidateReleaseOutputDestinations(
+                    [entry],
+                    manifestPath: Path.Combine(root, "release", "release-manifest.json"),
+                    checksumsPath: destination));
+
+            Assert.Contains("collides with staged asset", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(source, exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_StageRoot_RejectsDistinctAssetsWithSameDestinationBeforeCopying()
+    {
+        string root = CreateSandbox();
+        string firstDirectory = Directory.CreateDirectory(Path.Combine(root, "first")).FullName;
+        string secondDirectory = Directory.CreateDirectory(Path.Combine(root, "second")).FullName;
+        string firstPackage = Path.Combine(firstDirectory, "Sample.1.0.0.nupkg");
+        string secondPackage = Path.Combine(secondDirectory, "Sample.1.0.0.nupkg");
+        File.WriteAllText(firstPackage, "first", new UTF8Encoding(false));
+        File.WriteAllText(secondPackage, "second", new UTF8Encoding(false));
+
+        try
+        {
+            PowerForgeReleaseService service = CreatePackageReleaseService(firstPackage, secondPackage);
+            string stageRoot = Path.Combine(root, "release");
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Packages = new ProjectBuildConfiguration
+                    {
+                        RootPath = ".",
+                        Configuration = "Release"
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "release.json"),
+                    StageRoot = stageRoot
+                }));
+
+            Assert.Contains("staging destination collision", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(firstPackage, exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(secondPackage, exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.False(File.Exists(Path.Combine(stageRoot, "nuget", "Sample.1.0.0.nupkg")));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_StageRoot_RejectsGeneratedOutputOverOriginalAssetBeforeCopying()
+    {
+        string root = CreateSandbox();
+        string package = Path.Combine(root, "Sample.1.0.0.nupkg");
+        File.WriteAllText(package, "original-package", new UTF8Encoding(false));
+        try
+        {
+            string stageRoot = Path.Combine(root, "release");
+            PowerForgeReleaseService service = CreatePackageReleaseService(package);
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => service.Execute(
+                CreatePackageReleaseSpec(),
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "release.json"),
+                    StageRoot = stageRoot,
+                    ChecksumsPath = package
+                }));
+
+            Assert.Contains("collides with staged asset", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("original-package", File.ReadAllText(package));
+            Assert.False(File.Exists(Path.Combine(stageRoot, "nuget", Path.GetFileName(package))));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_StageRoot_RejectsAssetOverGeneratedOutputBeforeCopying()
+    {
+        string root = CreateSandbox();
+        string package = Path.Combine(root, "source", "Sample.1.0.0.nupkg");
+        Directory.CreateDirectory(Path.GetDirectoryName(package)!);
+        File.WriteAllText(package, "original-package", new UTF8Encoding(false));
+        try
+        {
+            string stageRoot = Path.Combine(root, "release");
+            string checksumsPath = Path.Combine(stageRoot, "nuget", Path.GetFileName(package));
+            Directory.CreateDirectory(Path.GetDirectoryName(checksumsPath)!);
+            File.WriteAllText(checksumsPath, "existing-checksums", new UTF8Encoding(false));
+            PowerForgeReleaseService service = CreatePackageReleaseService(package);
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => service.Execute(
+                CreatePackageReleaseSpec(),
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "release.json"),
+                    StageRoot = stageRoot,
+                    ChecksumsPath = checksumsPath
+                }));
+
+            Assert.Contains("collides with staged asset", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("existing-checksums", File.ReadAllText(checksumsPath));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    private static PowerForgeReleaseSpec CreatePackageReleaseSpec()
+        => new()
+        {
+            Packages = new ProjectBuildConfiguration
+            {
+                RootPath = ".",
+                Configuration = "Release"
+            }
+        };
+
+    private static PowerForgeReleaseService CreatePackageReleaseService(params string[] packagePaths)
+        => new(
+            new NullLogger(),
+            executePackages: (_, _, _) =>
+            {
+                var release = new DotNetRepositoryReleaseResult();
+                var project = new DotNetRepositoryProjectResult
+                {
+                    ProjectName = "Sample",
+                    PackageId = "Sample",
+                    IsPackable = true,
+                    NewVersion = "1.0.0"
+                };
+                foreach (string packagePath in packagePaths)
+                {
+                    project.Packages.Add(packagePath);
+                }
+                release.Projects.Add(project);
+                return new ProjectBuildHostExecutionResult
+                {
+                    Success = true,
+                    ConfigPath = "release.json",
+                    Result = new ProjectBuildResult
+                    {
+                        Success = true,
+                        Release = release
+                    }
+                };
+            },
+            planTools: (_, _, _) => throw new InvalidOperationException("Tools should not run."),
+            runTools: _ => throw new InvalidOperationException("Tools should not run."),
+            publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."));
+}

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ToolArchives.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ToolArchives.cs
@@ -5,6 +5,75 @@ namespace PowerForge.Tests;
 public sealed partial class PowerForgeReleaseServiceTests
 {
     [Fact]
+    public void DotNetPublishArchive_UnixPrimaryExecutablePreservesLaunchPermissions()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var outputRoot = Path.Combine(root, "output");
+            Directory.CreateDirectory(outputRoot);
+
+            var executablePath = Path.Combine(outputRoot, "evx");
+            File.WriteAllText(executablePath, "main");
+
+            var archivePath = Path.Combine(root, "EventViewerX.Cli-linux-x64.zip");
+            ZipFile.CreateFromDirectory(outputRoot, archivePath);
+            RewriteCentralDirectoryAsDos(archivePath);
+
+            DotNetPublishPipelineRunner.ApplyArchiveExecutablePermissions(
+                outputRoot,
+                "linux-x64",
+                archivePath,
+                ["evx"]);
+
+            using var archive = ZipFile.OpenRead(archivePath);
+            Assert.Equal(unchecked((int)0x81ED0000u), archive.GetEntry("evx")!.ExternalAttributes);
+            Assert.All(ReadCentralDirectoryCreatorSystems(archivePath), creatorSystem => Assert.Equal((byte)3, creatorSystem));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void DotNetPublishArchive_WindowsRuntimeLeavesArchiveMetadataUnchanged()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var outputRoot = Path.Combine(root, "output");
+            Directory.CreateDirectory(outputRoot);
+
+            var executablePath = Path.Combine(outputRoot, "EventViewerX.Cli.exe");
+            File.WriteAllText(executablePath, "main");
+
+            var archivePath = Path.Combine(root, "EventViewerX.Cli-win-x64.zip");
+            ZipFile.CreateFromDirectory(outputRoot, archivePath);
+            RewriteCentralDirectoryAsDos(archivePath);
+
+            int expectedAttributes;
+            using (var before = ZipFile.OpenRead(archivePath))
+            {
+                expectedAttributes = before.GetEntry("EventViewerX.Cli.exe")!.ExternalAttributes;
+            }
+
+            DotNetPublishPipelineRunner.ApplyArchiveExecutablePermissions(
+                outputRoot,
+                "win-x64",
+                archivePath,
+                ["EventViewerX.Cli"]);
+
+            using var after = ZipFile.OpenRead(archivePath);
+            Assert.Equal(expectedAttributes, after.GetEntry("EventViewerX.Cli.exe")!.ExternalAttributes);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void ToolArchive_UnixExecutablesPreserveLaunchPermissions()
     {
         var root = CreateSandbox();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ToolArchives.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ToolArchives.cs
@@ -74,6 +74,20 @@ public sealed partial class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void DotNetPublishArchive_RenamedExecutableIdentityIsRetained()
+    {
+        var target = new DotNetPublishTargetPlan
+        {
+            ExecutableIdentities = new[] { "OriginalName" },
+            Publish = new DotNetPublishPublishOptions { RenameTo = "renamed-tool" }
+        };
+
+        Assert.Equal(
+            new[] { "OriginalName", "renamed-tool" },
+            DotNetPublishPipelineRunner.EnumerateEffectiveExecutableIdentities(target));
+    }
+
+    [Fact]
     public void ToolArchive_UnixExecutablesPreserveLaunchPermissions()
     {
         var root = CreateSandbox();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -5548,6 +5548,7 @@ public sealed partial class PowerForgeReleaseServiceTests
         var msi = Path.Combine(root, "IntelligenceX.Chat.Installer.msi");
         var storeUpload = Path.Combine(root, "IntelligenceX.Chat.Store.msixupload");
         var dotNetManifest = Path.Combine(root, "dotnet-manifest.json");
+        var dotNetChecksums = Path.Combine(root, "SHA256SUMS.txt");
         var authorizedConfig = Path.Combine(
             root,
             ".release.authorized.1.2.3.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json");
@@ -5557,6 +5558,7 @@ public sealed partial class PowerForgeReleaseServiceTests
         File.WriteAllText(msi, "msi", new UTF8Encoding(false));
         File.WriteAllText(storeUpload, "upload", new UTF8Encoding(false));
         File.WriteAllText(dotNetManifest, "{}", new UTF8Encoding(false));
+        File.WriteAllText(dotNetChecksums, "dotnet checksums", new UTF8Encoding(false));
         File.WriteAllText(authorizedConfig, "{ \"effective\": true }", new UTF8Encoding(false));
 
         try
@@ -5629,6 +5631,7 @@ public sealed partial class PowerForgeReleaseServiceTests
                 {
                     Succeeded = true,
                     ManifestJsonPath = dotNetManifest,
+                    ChecksumsPath = dotNetChecksums,
                     Artefacts = new[]
                     {
                         new DotNetPublishArtefactResult
@@ -5701,6 +5704,7 @@ public sealed partial class PowerForgeReleaseServiceTests
             Assert.True(File.Exists(Path.Combine(stageRoot, "installer", Path.GetFileName(msi))));
             Assert.True(File.Exists(Path.Combine(stageRoot, "store", Path.GetFileName(storeUpload))));
             Assert.True(File.Exists(Path.Combine(stageRoot, "metadata", Path.GetFileName(dotNetManifest))));
+            Assert.True(File.Exists(Path.Combine(stageRoot, "metadata", "DotNetPublish.SHA256SUMS.txt")));
             Assert.True(File.Exists(Path.Combine(stageRoot, "metadata", Path.GetFileName(authorizedConfig))));
             Assert.Contains(Path.Combine(stageRoot, "nuget", Path.GetFileName(package)), result.ReleaseAssets, StringComparer.OrdinalIgnoreCase);
             Assert.Contains(Path.Combine(stageRoot, "nuget", Path.GetFileName(symbolPackage)), result.ReleaseAssets, StringComparer.OrdinalIgnoreCase);
@@ -5715,6 +5719,7 @@ public sealed partial class PowerForgeReleaseServiceTests
             Assert.Contains("*" + Path.GetFileName(package), checksumText, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("*" + Path.GetFileName(symbolPackage), checksumText, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("*" + Path.GetFileName(bundleZip), checksumText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("*DotNetPublish.SHA256SUMS.txt", checksumText, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("*" + Path.GetFileName(authorizedConfig), checksumText, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("nuget/", checksumText.Replace('\\', '/'), StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain(package.Replace('\\', '/'), checksumText, StringComparison.OrdinalIgnoreCase);

--- a/PowerForge.Tests/PowerForgeReleaseValidationServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseValidationServiceTests.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed class PowerForgeReleaseValidationServiceTests
+{
+    [Fact]
+    public void Run_ProvidesStableReleaseContextAndEnvironment()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            "release-validation-" + Guid.NewGuid().ToString("N")));
+        try
+        {
+            var scriptPath = Path.Combine(root.FullName, "Validate.ps1");
+            File.WriteAllText(
+                scriptPath,
+                """
+                $context = Get-Content -LiteralPath $env:POWERFORGE_CONTEXT -Raw | ConvertFrom-Json
+                if ($context.ResolvedVersion -ne '4.0.0') { throw 'version' }
+                if ($context.ActionName -ne 'Release contract') { throw 'name' }
+                if ($context.StagedAssets.Count -ne 2) { throw 'assets' }
+                if ($env:POWERFORGE_RELEASE_STAGE -ne 'AfterStaging') { throw 'stage' }
+                if ($env:POWERFORGE_RELEASE_VERSION -ne '4.0.0') { throw 'environment version' }
+                Write-Output ($context | ConvertTo-Json -Compress)
+                """);
+            var context = new PowerForgeReleaseValidationContext
+            {
+                ResolvedVersion = "4.0.0",
+                ConfigPath = Path.Combine(root.FullName, "release.json"),
+                ProjectRoot = root.FullName,
+                StagedAssets = ["module.zip", "cli.zip"]
+            };
+
+            var result = new PowerForgeReleaseValidationService(new NullLogger()).Run(
+                new PowerForgeReleaseValidationAction
+                {
+                    Name = "Release contract",
+                    FilePath = scriptPath,
+                    WorkingDirectory = root.FullName,
+                    TimeoutSeconds = 30
+                },
+                context,
+                root.FullName,
+                CancellationToken.None);
+
+            Assert.True(result.Succeeded, result.StdErr);
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal("Release contract", result.Name);
+            using var output = JsonDocument.Parse(result.StdOut.Trim());
+            Assert.Equal("4.0.0", output.RootElement.GetProperty("ResolvedVersion").GetString());
+            Assert.False(File.Exists(context.ContextPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Run_CapturesValidationFailureWithoutThrowing()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            "release-validation-" + Guid.NewGuid().ToString("N")));
+        try
+        {
+            var scriptPath = Path.Combine(root.FullName, "Reject.ps1");
+            File.WriteAllText(scriptPath, "[Console]::Error.WriteLine('invalid staged release'); exit 17");
+
+            var result = new PowerForgeReleaseValidationService(new NullLogger()).Run(
+                new PowerForgeReleaseValidationAction
+                {
+                    FilePath = scriptPath,
+                    TimeoutSeconds = 30
+                },
+                new PowerForgeReleaseValidationContext(),
+                root.FullName,
+                CancellationToken.None);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal(17, result.ExitCode);
+            Assert.Contains("invalid staged release", result.StdErr, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+}

--- a/PowerForge.Tests/PowerForgeReleaseValidationServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseValidationServiceTests.cs
@@ -90,4 +90,46 @@ public sealed class PowerForgeReleaseValidationServiceTests
             try { root.Delete(recursive: true); } catch { }
         }
     }
+
+    [Fact]
+    public void Run_TimeoutTerminatesValidationProcessTree()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            "release-validation-tree-" + Guid.NewGuid().ToString("N")));
+        try
+        {
+            var markerPath = Path.Combine(root.FullName, "child-survived.txt");
+            var childScriptPath = Path.Combine(root.FullName, "Child.ps1");
+            var parentScriptPath = Path.Combine(root.FullName, "Parent.ps1");
+            File.WriteAllText(
+                childScriptPath,
+                $"Start-Sleep -Seconds 3{Environment.NewLine}[IO.File]::WriteAllText('{markerPath.Replace("'", "''")}', 'alive')");
+            File.WriteAllText(
+                parentScriptPath,
+                $"Start-Process -FilePath (Get-Process -Id $PID).Path -ArgumentList @('-NoProfile', '-File', '{childScriptPath.Replace("'", "''")}') | Out-Null{Environment.NewLine}Start-Sleep -Seconds 30");
+
+            var result = new PowerForgeReleaseValidationService(new NullLogger()).Run(
+                new PowerForgeReleaseValidationAction
+                {
+                    Name = "process tree timeout",
+                    FilePath = parentScriptPath,
+                    WorkingDirectory = root.FullName,
+                    TimeoutSeconds = 1
+                },
+                new PowerForgeReleaseValidationContext(),
+                root.FullName,
+                CancellationToken.None);
+
+            Assert.False(result.Succeeded);
+            Assert.True(result.TimedOut);
+            Thread.Sleep(TimeSpan.FromSeconds(4));
+            Assert.False(File.Exists(markerPath), "The validation child process survived the timeout boundary.");
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
 }

--- a/PowerForge.Tests/packages.lock.json
+++ b/PowerForge.Tests/packages.lock.json
@@ -1127,7 +1127,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.6.5, )",
-          "PowerForge": "[3.0.128, )",
+          "PowerForge": "[3.0.131, )",
           "System.Security.Cryptography.Xml": "[10.0.11, )"
         }
       },
@@ -1138,7 +1138,7 @@
           "HtmlTinkerX": "[3.0.1, )",
           "Magick.NET-Q8-AnyCPU": "[14.16.0, )",
           "OfficeIMO.Markdown": "[3.2.6, )",
-          "PowerForge": "[3.0.128, )",
+          "PowerForge": "[3.0.131, )",
           "Scriban": "[7.2.6, )",
           "YamlDotNet": "[18.1.0, )"
         }
@@ -1148,7 +1148,7 @@
         "dependencies": {
           "DBAClientX.SQLite": "[1.0.8, )",
           "NuGet.Versioning": "[7.9.0, )",
-          "PowerForge.Web": "[3.0.128, )"
+          "PowerForge.Web": "[3.0.131, )"
         }
       },
       "powerforgestudio.domain": {
@@ -1160,8 +1160,8 @@
           "HtmlForgeX": "[0.56.0, )",
           "HtmlForgeX.Markdown": "[0.56.0, )",
           "OfficeIMO.Markdown": "[3.2.6, )",
-          "PowerForge": "[3.0.128, )",
-          "PowerForge.PowerShell": "[3.0.128, )",
+          "PowerForge": "[3.0.131, )",
+          "PowerForge.PowerShell": "[3.0.131, )",
           "Spectre.Console": "[0.57.2, )",
           "Spectre.Console.Json": "[0.57.2, )",
           "System.IO.Packaging": "[10.0.11, )",

--- a/PowerForge.Web.Cli/packages.lock.json
+++ b/PowerForge.Web.Cli/packages.lock.json
@@ -368,7 +368,7 @@
           "HtmlTinkerX": "[3.0.1, )",
           "Magick.NET-Q8-AnyCPU": "[14.16.0, )",
           "OfficeIMO.Markdown": "[3.2.6, )",
-          "PowerForge": "[3.0.128, )",
+          "PowerForge": "[3.0.131, )",
           "Scriban": "[7.2.6, )",
           "YamlDotNet": "[18.1.0, )"
         }

--- a/PowerForge/Models/DotNetPublish/DotNetPublishPlan.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishPlan.cs
@@ -124,6 +124,13 @@ public sealed class DotNetPublishTargetPlan
 
     /// <summary>Resolved framework/runtime/style publish combinations for this target.</summary>
     public DotNetPublishTargetCombination[] Combinations { get; set; } = Array.Empty<DotNetPublishTargetCombination>();
+
+    /// <summary>
+    /// Restore combinations retained from configuration when execution-time filters select
+    /// only part of a runtime matrix. This keeps comprehensive NuGet lock files valid while
+    /// limiting build and publish steps to the requested combinations.
+    /// </summary>
+    public DotNetPublishTargetCombination[] RestoreCombinations { get; set; } = Array.Empty<DotNetPublishTargetCombination>();
 }
 
 /// <summary>

--- a/PowerForge/Models/PowerForgeModulePackageReleaseCheckpoint.cs
+++ b/PowerForge/Models/PowerForgeModulePackageReleaseCheckpoint.cs
@@ -35,3 +35,21 @@ internal sealed class PowerForgeModulePackageReleaseCheckpoint
     /// </summary>
     public DotNetRepositoryReleaseResult Release { get; set; } = new();
 }
+
+/// <summary>Publication outcome for one module-owned NuGet package lane.</summary>
+internal sealed class PowerForgeModulePackagePublicationResult
+{
+    public string Name { get; set; } = string.Empty;
+
+    public bool Success { get; set; }
+
+    public string? ErrorMessage { get; set; }
+
+    public string? PublishSource { get; set; }
+
+    public string[] PublishedPackages { get; set; } = Array.Empty<string>();
+
+    public string[] SkippedDuplicatePackages { get; set; } = Array.Empty<string>();
+
+    public string[] FailedPackages { get; set; } = Array.Empty<string>();
+}

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -1164,6 +1164,8 @@ internal sealed class PowerForgeReleaseAssetEntry
 
     public string? StagedPath { get; set; }
 
+    internal string? StagedSha256 { get; set; }
+
     public bool IsFinalPackageOutput { get; set; }
 }
 

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -28,6 +28,8 @@ internal sealed class PowerForgeReleaseSpec
 
     public PowerForgeWorkspaceValidationOptions? WorkspaceValidation { get; set; }
 
+    public PowerForgeReleaseValidationOptions? Validation { get; set; }
+
     public PowerForgeReleaseOutputsOptions Outputs { get; set; } = new();
 
     public PowerForgeReleaseGitHubOptions? GitHub { get; set; }
@@ -318,6 +320,9 @@ internal sealed class PowerForgeReleaseResult
     public PowerForgeModulePackageReleaseCheckpoint[] ModulePackagePlans { get; set; } =
         Array.Empty<PowerForgeModulePackageReleaseCheckpoint>();
 
+    public PowerForgeModulePackagePublicationResult[] ModulePackagePublications { get; set; } =
+        Array.Empty<PowerForgeModulePackagePublicationResult>();
+
     public ProjectBuildHostExecutionResult? Packages { get; set; }
 
     public PowerForgeToolReleasePlan? ToolPlan { get; set; }
@@ -337,6 +342,9 @@ internal sealed class PowerForgeReleaseResult
     public WorkspaceValidationPlan? WorkspaceValidationPlan { get; set; }
 
     public WorkspaceValidationResult? WorkspaceValidation { get; set; }
+
+    public PowerForgeReleaseValidationResult[] ReleaseValidations { get; set; } =
+        Array.Empty<PowerForgeReleaseValidationResult>();
 
     public PowerForgeToolGitHubReleaseResult[] ToolGitHubReleases { get; set; } = Array.Empty<PowerForgeToolGitHubReleaseResult>();
 
@@ -1168,6 +1176,93 @@ internal sealed class PowerForgeWorkspaceValidationOptions
     public string[] EnableFeatures { get; set; } = Array.Empty<string>();
 
     public string[] DisableFeatures { get; set; } = Array.Empty<string>();
+}
+
+/// <summary>
+/// Validation actions that inspect the complete staged release before publication continues.
+/// </summary>
+internal sealed class PowerForgeReleaseValidationOptions
+{
+    /// <summary>PowerShell scripts executed after release assets and manifests are staged.</summary>
+    public PowerForgeReleaseValidationAction[] AfterStaging { get; set; } =
+        Array.Empty<PowerForgeReleaseValidationAction>();
+}
+
+/// <summary>One staged-release validation action.</summary>
+internal sealed class PowerForgeReleaseValidationAction
+{
+    /// <summary>Enables or disables the action.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Friendly name used in progress and result output.</summary>
+    public string? Name { get; set; }
+
+    /// <summary>PowerShell script path. Relative paths resolve from the release configuration directory.</summary>
+    public string FilePath { get; set; } = string.Empty;
+
+    /// <summary>Optional working directory. Relative paths resolve from the release configuration directory.</summary>
+    public string? WorkingDirectory { get; set; }
+
+    /// <summary>Environment variable overrides passed to the validation process.</summary>
+    public Dictionary<string, string?> Environment { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Timeout in seconds. Defaults to thirty minutes.</summary>
+    public int TimeoutSeconds { get; set; } = 1800;
+
+    /// <summary>Prefer Windows PowerShell over PowerShell 7 on Windows.</summary>
+    public bool PreferWindowsPowerShell { get; set; }
+}
+
+/// <summary>Stable JSON context supplied to staged-release validation scripts.</summary>
+internal sealed class PowerForgeReleaseValidationContext
+{
+    public int SchemaVersion { get; set; } = 1;
+
+    public string Stage { get; set; } = "AfterStaging";
+
+    public string ActionName { get; set; } = string.Empty;
+
+    public string ConfigPath { get; set; } = string.Empty;
+
+    public string ProjectRoot { get; set; } = string.Empty;
+
+    public string ResolvedVersion { get; set; } = string.Empty;
+
+    public string? ReleaseManifestPath { get; set; }
+
+    public string? ReleaseChecksumsPath { get; set; }
+
+    public string? StagingRoot { get; set; }
+
+    public string? ModuleStagingPath { get; set; }
+
+    public string[] ReleaseAssets { get; set; } = Array.Empty<string>();
+
+    public string[] StagedAssets { get; set; } = Array.Empty<string>();
+
+    public string ContextPath { get; set; } = string.Empty;
+}
+
+/// <summary>Result of one staged-release validation action.</summary>
+internal sealed class PowerForgeReleaseValidationResult
+{
+    public string Name { get; set; } = string.Empty;
+
+    public bool Succeeded { get; set; }
+
+    public int ExitCode { get; set; }
+
+    public string Executable { get; set; } = string.Empty;
+
+    public string FilePath { get; set; } = string.Empty;
+
+    public string WorkingDirectory { get; set; } = string.Empty;
+
+    public string StdOut { get; set; } = string.Empty;
+
+    public string StdErr { get; set; } = string.Empty;
+
+    public bool TimedOut { get; set; }
 }
 
 /// <summary>

--- a/PowerForge/Models/PowerForgeReleaseProgress.cs
+++ b/PowerForge/Models/PowerForgeReleaseProgress.cs
@@ -16,7 +16,9 @@ public enum PowerForgeReleaseProgressPhase
     /// <summary>Opt-in VirusTotal Monitor publisher registration lane.</summary>
     VirusTotal = 5,
     /// <summary>Apple exact-source validation, archive, export, and release automation lane.</summary>
-    AppleApps = 6
+    AppleApps = 6,
+    /// <summary>Consumer-owned checks against the complete staged release.</summary>
+    Validation = 7
 }
 
 /// <summary>Receives structured high-level progress for a unified release.</summary>

--- a/PowerForge/Models/ProjectBuildPublishHostConfiguration.cs
+++ b/PowerForge/Models/ProjectBuildPublishHostConfiguration.cs
@@ -61,4 +61,7 @@ public sealed class ProjectBuildPublishHostConfiguration
 
     /// <summary>Whether an already-published NuGet package should be treated as a successful skip.</summary>
     public bool SkipDuplicate { get; set; } = true;
+
+    /// <summary>Whether symbol packages are published as separate artifacts for local feeds.</summary>
+    public bool IncludeSymbols { get; set; }
 }

--- a/PowerForge/Services/AppleArchiveUploadSnapshot.cs
+++ b/PowerForge/Services/AppleArchiveUploadSnapshot.cs
@@ -4,6 +4,7 @@ namespace PowerForge;
 internal sealed class AppleArchiveUploadSnapshot : IDisposable
 {
     private readonly SnapshotIdentity _identity;
+    private long _expectedScratchActivityUntilUtcTicks;
     private bool _disposed;
 
     private AppleArchiveUploadSnapshot(
@@ -67,7 +68,9 @@ internal sealed class AppleArchiveUploadSnapshot : IDisposable
             "Discard the upload/export result and inspect remote state before retrying.",
             ignoredMutation: IsExpectedXcodeExportMutation);
 
-    internal void ValidateUnchanged(string expectedSha256)
+    internal void ValidateUnchanged(
+        string expectedSha256,
+        bool allowExpectedScratchDirectoryMutation = false)
     {
         var current = CaptureCompleteIdentity(ArchivePath);
         if (!current.Sha256.Equals(expectedSha256, StringComparison.OrdinalIgnoreCase))
@@ -76,7 +79,13 @@ internal sealed class AppleArchiveUploadSnapshot : IDisposable
                 $"The private Apple upload snapshot changed while xcodebuild was reading it. Expected '{expectedSha256}', received '{current.Sha256}'. Discard the upload/export result and inspect remote state before retrying.");
         }
 
-        if (!_identity.MutationDigest.Equals(current.MutationDigest, StringComparison.Ordinal))
+        var expectedMutationDigest = allowExpectedScratchDirectoryMutation
+            ? _identity.ApprovedFileMutationDigest
+            : _identity.MutationDigest;
+        var currentMutationDigest = allowExpectedScratchDirectoryMutation
+            ? current.ApprovedFileMutationDigest
+            : current.MutationDigest;
+        if (!expectedMutationDigest.Equals(currentMutationDigest, StringComparison.Ordinal))
         {
             throw new InvalidOperationException(
                 "The private Apple upload archive snapshot file identity changed while xcodebuild was reading it. " +
@@ -128,11 +137,27 @@ internal sealed class AppleArchiveUploadSnapshot : IDisposable
             return new SnapshotIdentity(
                 sha256,
                 ExistingFilePathIdentityResolver.CapturePrivateFileMutationIdentity(archivePath, description),
+                ExistingFilePathIdentityResolver.CapturePrivateFileMutationIdentity(archivePath, description),
                 new HashSet<string>(GetPathComparer(archivePath)));
         }
         var identities = CaptureFileMutationIdentities(archivePath, description);
+        var digest = ComputeMutationDigest(identities, includeRoot: true);
+        var approvedFileMutationDigest = ComputeMutationDigest(identities, includeRoot: false);
+        return new SnapshotIdentity(
+            sha256,
+            digest,
+            approvedFileMutationDigest,
+            new HashSet<string>(identities.Keys, GetPathComparer(archivePath)));
+    }
+
+    private static string ComputeMutationDigest(
+        IReadOnlyDictionary<string, string> identities,
+        bool includeRoot)
+    {
         var canonical = new System.Text.StringBuilder();
-        foreach (var pair in identities.OrderBy(static pair => pair.Key, StringComparer.Ordinal))
+        foreach (var pair in identities
+                     .Where(pair => includeRoot || !string.Equals(pair.Key, ".", StringComparison.Ordinal))
+                     .OrderBy(static pair => pair.Key, StringComparer.Ordinal))
         {
             canonical.Append(pair.Key.Length).Append(':').Append(pair.Key);
             canonical.Append(pair.Value.Length).Append(':').Append(pair.Value);
@@ -141,10 +166,7 @@ internal sealed class AppleArchiveUploadSnapshot : IDisposable
         var digest = BitConverter.ToString(hash.ComputeHash(System.Text.Encoding.UTF8.GetBytes(canonical.ToString())))
             .Replace("-", string.Empty)
             .ToLowerInvariant();
-        return new SnapshotIdentity(
-            sha256,
-            digest,
-            new HashSet<string>(identities.Keys, GetPathComparer(archivePath)));
+        return digest;
     }
 
     internal bool IsExpectedXcodeExportMutation(FileSystemEventArgs args)
@@ -172,8 +194,41 @@ internal sealed class AppleArchiveUploadSnapshot : IDisposable
             return true;
         }
 
-        return IsExpectedXcodeExportScratchPath(path);
+        if (IsExpectedXcodeExportScratchPath(path))
+        {
+            MarkExpectedScratchActivity();
+            return true;
+        }
+
+        if ((args.ChangeType == WatcherChangeTypes.Changed ||
+             args.ChangeType == WatcherChangeTypes.Created ||
+             args.ChangeType == WatcherChangeTypes.Deleted) &&
+            path.Equals(
+                Path.GetFullPath(ArchivePath),
+                Path.DirectorySeparatorChar == '\\'
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal) &&
+            (HasExpectedXcodeExportScratchPath() ||
+             DateTime.UtcNow.Ticks <= Interlocked.Read(ref _expectedScratchActivityUntilUtcTicks)))
+        {
+            // Creating and deleting the approved sandbox scratch file also changes the archive
+            // directory metadata. Accept that companion signal only while recognized scratch
+            // activity is present or has just been observed; unrelated directory changes remain fatal.
+            return true;
+        }
+
+        return false;
     }
+
+    private bool HasExpectedXcodeExportScratchPath()
+        => Directory.Exists(ArchivePath) &&
+           Directory.EnumerateFiles(ArchivePath, "*", SearchOption.TopDirectoryOnly)
+               .Any(IsExpectedXcodeExportScratchPath);
+
+    private void MarkExpectedScratchActivity()
+        => Interlocked.Exchange(
+            ref _expectedScratchActivityUntilUtcTicks,
+            DateTime.UtcNow.AddSeconds(2).Ticks);
 
     private bool IsExpectedXcodeExportScratchPath(string path)
     {
@@ -297,16 +352,20 @@ internal sealed class AppleArchiveUploadSnapshot : IDisposable
         internal SnapshotIdentity(
             string sha256,
             string mutationDigest,
+            string approvedFileMutationDigest,
             HashSet<string> approvedFiles)
         {
             Sha256 = sha256;
             MutationDigest = mutationDigest;
+            ApprovedFileMutationDigest = approvedFileMutationDigest;
             ApprovedFiles = approvedFiles;
         }
 
         internal string Sha256 { get; }
 
         internal string MutationDigest { get; }
+
+        internal string ApprovedFileMutationDigest { get; }
 
         internal HashSet<string> ApprovedFiles { get; }
 

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
@@ -305,7 +305,9 @@ public sealed partial class DotNetPublishPipelineRunner
                 controlledEnvironment,
                 TimeSpan.FromMinutes(5));
             if (process.ExitCode != 0 || process.TimedOut)
+            {
                 return CacheAll(false);
+            }
 
             int jsonStart = process.StdOut.IndexOf('{');
             int jsonEnd = process.StdOut.LastIndexOf('}');

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ControlledPublishItems.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ControlledPublishItems.cs
@@ -16,9 +16,11 @@ public sealed partial class DotNetPublishPipelineRunner
         bool proveControlledGeneratedInputs,
         IReadOnlyCollection<ControlledPublishGraphNode> graphBuildNodes,
         IReadOnlyDictionary<string, string> evaluatedProperties,
-        out EvaluatedPublishInput[] publishInputs)
+        out EvaluatedPublishInput[] publishInputs,
+        out string? failureReason)
     {
         publishInputs = Array.Empty<EvaluatedPublishInput>();
+        failureReason = null;
         string controlledOutputRoot = Path.Combine(
             Path.GetTempPath(),
             "pfpi-" + Guid.NewGuid().ToString("N"));
@@ -40,6 +42,7 @@ public sealed partial class DotNetPublishPipelineRunner
                     out controlledGitRoot,
                     out string? controlledProjectPath))
             {
+                failureReason = "the controlled source checkout could not be created.";
                 return false;
             }
             if (!TryCreateControlledBuildEnvironment(
@@ -50,6 +53,7 @@ public sealed partial class DotNetPublishPipelineRunner
                     Path.GetDirectoryName(request.ProjectPath)!,
                     out IReadOnlyDictionary<string, string?> controlledEnvironment))
             {
+                failureReason = "the controlled build environment could not be created.";
                 return false;
             }
             if (!TryCreateControlledPublishInputPlaceholders(
@@ -59,6 +63,7 @@ public sealed partial class DotNetPublishPipelineRunner
                     executableMsBuildInputs,
                     request.GlobalProperties))
             {
+                failureReason = "controlled publish-input placeholders could not be created.";
                 return false;
             }
 
@@ -78,6 +83,7 @@ public sealed partial class DotNetPublishPipelineRunner
                         out string[] catalogSources,
                         allowSdkManagedToolchainPackages: true))
                 {
+                    failureReason = "the verified offline package source could not be seeded.";
                     return false;
                 }
                 offlinePackageSources.AddRange(catalogSources);
@@ -107,8 +113,26 @@ public sealed partial class DotNetPublishPipelineRunner
                     controlledEnvironment,
                     controlledNuGetConfig,
                     offlinePackageSourceList,
+                    controlledOutputRoot,
+                    out string? controlledGraphFailureReason))
+            {
+                failureReason = "the controlled project-reference graph could not be built" +
+                    (string.IsNullOrWhiteSpace(controlledGraphFailureReason)
+                        ? "."
+                        : $": {controlledGraphFailureReason}");
+                return false;
+            }
+            if (!TryRestoreControlledPublishRoot(
+                    request,
+                    controlledGitRoot!,
+                    controlledSourceRoot,
+                    controlledProjectPath!,
+                    controlledEnvironment,
+                    controlledNuGetConfig,
+                    offlinePackageSourceList,
                     controlledOutputRoot))
             {
+                failureReason = "the controlled root project could not be restored.";
                 return false;
             }
 
@@ -118,8 +142,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 controlledProjectPath!,
                 "-nologo",
                 "-verbosity:quiet",
-                "-restore",
-                "-target:Build;ComputeFilesToPublish",
+                "-target:Rebuild;ComputeFilesToPublish",
                 "-getItem:ResolvedFileToPublish"
             };
             if (!TryAppendControlledProjectEvaluationProperties(
@@ -128,15 +151,21 @@ public sealed partial class DotNetPublishPipelineRunner
                     controlledGitRoot!,
                     controlledSourceRoot))
             {
+                failureReason = "controlled project evaluation properties could not be remapped.";
                 return false;
             }
-            arguments.Add("-p:BuildProjectReferences=false");
+            // The graph nodes are restored and validated independently above. Rebuild the
+            // final root graph without recursive restore so referenced assembly identities
+            // match the real root prebuild as well as its portable PDB metadata.
+            arguments.Add("-p:BuildProjectReferences=true");
+            arguments.Add("-p:RestoreRecursive=false");
             if (!TryBuildControlledPathMap(
                     controlledSourceRoot,
                     controlledGitRoot!,
                     evaluatedPathMap,
                     out string controlledPathMap))
             {
+                failureReason = "the controlled PathMap could not be constructed.";
                 return false;
             }
             arguments.Add("-p:PathMap=" + EscapeMsBuildPropertyValue(controlledPathMap));
@@ -154,6 +183,9 @@ public sealed partial class DotNetPublishPipelineRunner
                 TimeSpan.FromMinutes(5));
             if (process.ExitCode != 0 || process.TimedOut)
             {
+                failureReason = process.TimedOut
+                    ? "the controlled root publish-input evaluation timed out."
+                    : $"the controlled root publish-input evaluation exited with code {process.ExitCode}.";
                 return false;
             }
 
@@ -163,7 +195,10 @@ public sealed partial class DotNetPublishPipelineRunner
                 : process.StdOut.LastIndexOf('{', itemsMarker);
             int jsonEnd = process.StdOut.LastIndexOf('}');
             if (jsonStart < 0 || jsonEnd < jsonStart)
+            {
+                failureReason = "the controlled root publish-input evaluation returned no readable item JSON.";
                 return false;
+            }
             using JsonDocument document = JsonDocument.Parse(
                 process.StdOut.Substring(jsonStart, jsonEnd - jsonStart + 1));
             if (!document.RootElement.TryGetProperty("Items", out JsonElement items) ||
@@ -195,11 +230,15 @@ public sealed partial class DotNetPublishPipelineRunner
                     !item.Metadata.TryGetValue("RelativePath", out string? relativePath) ||
                     !IsControlledPublishRelativePath(relativePath))
                 {
+                    failureReason = "a controlled publish item has no safe RelativePath.";
                     return false;
                 }
 
                 if (IsSameOrBelowBuildInputPath(item.FullPath, offlinePackageSource))
+                {
+                    failureReason = "a controlled publish item resolved inside the temporary offline package source.";
                     return false;
+                }
                 if (IsTrustedExternalBuildInfrastructurePath(
                         item.FullPath,
                         trustedBuildInfrastructureRoots))
@@ -215,6 +254,7 @@ public sealed partial class DotNetPublishPipelineRunner
                         out string originalInputPath,
                         out bool isPackageBacked))
                 {
+                    failureReason = $"controlled publish item '{item.FullPath}' could not be mapped to its original input.";
                     return false;
                 }
                 if (!TryMapControlledPublishMetadata(
@@ -226,6 +266,7 @@ public sealed partial class DotNetPublishPipelineRunner
                         packageCatalogs,
                         out IReadOnlyDictionary<string, string> mappedMetadata))
                 {
+                    failureReason = $"metadata for controlled publish item '{item.FullPath}' could not be mapped safely.";
                     return false;
                 }
 
@@ -275,9 +316,10 @@ public sealed partial class DotNetPublishPipelineRunner
             publishInputs = results.ToArray();
             return true;
         }
-        catch
+        catch (Exception ex)
         {
             publishInputs = Array.Empty<EvaluatedPublishInput>();
+            failureReason = "controlled publish-input evaluation threw " + ex.GetType().Name + ".";
             return false;
         }
         finally
@@ -292,6 +334,54 @@ public sealed partial class DotNetPublishPipelineRunner
             {
                 // Temporary controlled-build cleanup is best effort.
             }
+        }
+    }
+
+    private static bool TryRestoreControlledPublishRoot(
+        ProjectEvaluationRequest request,
+        string originalGitRoot,
+        string controlledSourceRoot,
+        string controlledProjectPath,
+        IReadOnlyDictionary<string, string?> controlledEnvironment,
+        string controlledNuGetConfig,
+        string offlinePackageSourceList,
+        string controlledOutputRoot)
+    {
+        try
+        {
+            var arguments = new List<string>
+            {
+                "restore",
+                controlledProjectPath,
+                "-nologo",
+                "-verbosity:quiet",
+                "-p:RestoreRecursive=false"
+            };
+            if (!TryAppendControlledProjectEvaluationProperties(
+                    arguments,
+                    request,
+                    originalGitRoot,
+                    controlledSourceRoot))
+            {
+                return false;
+            }
+            AppendControlledProofSafeguards(
+                arguments,
+                controlledNuGetConfig,
+                offlinePackageSourceList,
+                Path.Combine(controlledOutputRoot, "root-packages.lock.json"));
+
+            var process = RunBuildInputEvaluationProcess(
+                "dotnet",
+                Path.GetDirectoryName(controlledProjectPath)!,
+                arguments,
+                controlledEnvironment,
+                TimeSpan.FromMinutes(5));
+            return process.ExitCode == 0 && !process.TimedOut;
+        }
+        catch
+        {
+            return false;
         }
     }
 
@@ -336,19 +426,25 @@ public sealed partial class DotNetPublishPipelineRunner
         IReadOnlyDictionary<string, string?> controlledEnvironment,
         string controlledNuGetConfig,
         string offlinePackageSourceList,
-        string controlledOutputRoot)
+        string controlledOutputRoot,
+        out string? failureReason)
     {
+        failureReason = null;
         foreach (ControlledPublishGraphNode node in graphBuildNodes)
         {
             string originalProjectPath = Path.GetFullPath(node.Request.ProjectPath);
             if (!IsSameOrBelowBuildInputPath(originalProjectPath, originalGitRoot))
+            {
+                failureReason = $"project '{originalProjectPath}' is outside the controlled Git root.";
                 return false;
+            }
             string controlledProjectPath = Path.GetFullPath(Path.Combine(
                 controlledSourceRoot,
                 FrameworkCompatibility.GetRelativePath(originalGitRoot, originalProjectPath)));
             if (!IsSameOrBelowBuildInputPath(controlledProjectPath, controlledSourceRoot) ||
                 !File.Exists(controlledProjectPath))
             {
+                failureReason = $"controlled project '{originalProjectPath}' is missing or outside the controlled checkout.";
                 return false;
             }
 
@@ -369,15 +465,18 @@ public sealed partial class DotNetPublishPipelineRunner
                     originalGitRoot,
                     controlledSourceRoot))
             {
+                failureReason = $"properties for controlled project '{originalProjectPath}' could not be remapped.";
                 return false;
             }
             arguments.Add("-p:BuildProjectReferences=false");
+            arguments.Add("-p:RestoreRecursive=false");
             if (!TryBuildControlledPathMap(
                     controlledSourceRoot,
                     originalGitRoot,
                     node.PathMap,
                     out string controlledPathMap))
             {
+                failureReason = $"PathMap for controlled project '{originalProjectPath}' could not be constructed.";
                 return false;
             }
             arguments.Add("-p:PathMap=" + EscapeMsBuildPropertyValue(controlledPathMap));
@@ -394,7 +493,20 @@ public sealed partial class DotNetPublishPipelineRunner
                 controlledEnvironment,
                 TimeSpan.FromMinutes(5));
             if (process.ExitCode != 0 || process.TimedOut)
+            {
+                string? detail = TailLines(
+                    string.IsNullOrWhiteSpace(process.StdErr) ? process.StdOut : process.StdErr,
+                    maxLines: 8,
+                    maxChars: 2000);
+                failureReason = process.TimedOut
+                    ? $"project '{originalProjectPath}' timed out."
+                    : $"project '{originalProjectPath}' exited with code {process.ExitCode}.";
+                if (!string.IsNullOrWhiteSpace(detail))
+                {
+                    failureReason += " " + detail!.Trim();
+                }
                 return false;
+            }
         }
         return true;
     }
@@ -444,6 +556,7 @@ public sealed partial class DotNetPublishPipelineRunner
             if (property.Key.Equals("Configuration", StringComparison.OrdinalIgnoreCase) ||
                 property.Key.Equals("TargetFramework", StringComparison.OrdinalIgnoreCase) ||
                 property.Key.Equals("BuildProjectReferences", StringComparison.OrdinalIgnoreCase) ||
+                property.Key.Equals("RestoreRecursive", StringComparison.OrdinalIgnoreCase) ||
                 property.Key.Equals("PathMap", StringComparison.OrdinalIgnoreCase))
             {
                 continue;

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ProjectItemLists.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.ProjectItemLists.cs
@@ -273,9 +273,11 @@ public sealed partial class DotNetPublishPipelineRunner
         bool proveControlledGeneratedInputs,
         IReadOnlyCollection<ControlledPublishGraphNode> graphBuildNodes,
         IReadOnlyDictionary<string, string> evaluatedProperties,
-        out EvaluatedPublishInput[] publishInputs)
+        out EvaluatedPublishInput[] publishInputs,
+        out string? failureReason)
     {
         publishInputs = Array.Empty<EvaluatedPublishInput>();
+        failureReason = null;
         if (!proveControlledGeneratedInputs &&
             !ContainsPotentialPublishItemMutation(
                 request.ProjectPath,
@@ -297,7 +299,8 @@ public sealed partial class DotNetPublishPipelineRunner
             proveControlledGeneratedInputs,
             graphBuildNodes,
             evaluatedProperties,
-            out publishInputs);
+            out publishInputs,
+            out failureReason);
     }
 
     private static bool TryReadFrozenProjectReferenceGraph(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
@@ -508,6 +508,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 publishInputs
                     .Where(input => IsFinalPublishInputRetained(
                         input.FullPath,
+                        input.RelativePath,
                         request,
                         buildPlan,
                         buildStep))
@@ -698,6 +699,7 @@ public sealed partial class DotNetPublishPipelineRunner
 
     private static bool IsFinalPublishInputRetained(
         string path,
+        string? relativePath,
         ProjectEvaluationRequest request,
         DotNetPublishPlan? buildPlan,
         DotNetPublishStep? buildStep)
@@ -721,14 +723,27 @@ public sealed partial class DotNetPublishPipelineRunner
 
         bool keepSymbols = targets.Any(target => target.Publish?.KeepSymbols == true);
         bool keepDocs = targets.Any(target => target.Publish?.KeepDocs == true);
-        return IsFinalPublishInputRetained(path, keepSymbols, keepDocs);
+        return IsFinalPublishInputRetained(path, relativePath, keepSymbols, keepDocs);
     }
 
     internal static bool IsFinalPublishInputRetained(
         string path,
         bool keepSymbols,
         bool keepDocs)
+        => IsFinalPublishInputRetained(path, Path.GetFileName(path), keepSymbols, keepDocs);
+
+    internal static bool IsFinalPublishInputRetained(
+        string path,
+        string? relativePath,
+        bool keepSymbols,
+        bool keepDocs)
     {
+        if (!string.IsNullOrWhiteSpace(relativePath) &&
+            relativePath!.IndexOfAny(new[] { '/', '\\' }) >= 0)
+        {
+            return true;
+        }
+
         string extension = Path.GetExtension(path);
         if (!keepSymbols && extension.Equals(".pdb", StringComparison.OrdinalIgnoreCase))
             return false;

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
@@ -304,17 +304,23 @@ public sealed partial class DotNetPublishPipelineRunner
         IEnumerable<string>? projectPaths,
         string? configuration,
         DotNetPublishPlan? buildPlan,
+        DotNetPublishStep? buildStep,
         out string[] projectDirectories,
         out HashSet<string> buildInputs,
         out HashSet<string> sourceInputs,
-        out NoBuildPublishInput[] noBuildPublishInputs)
+        out NoBuildPublishInput[] noBuildPublishInputs,
+        out string? failureReason)
     {
         var comparison = IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
         ProjectEvaluationRequest[] roots = BuildProjectEvaluationRequests(
                 projectPaths,
                 configuration,
-                buildPlan)
+                buildPlan,
+                buildStep)
             .ToArray();
+        HashSet<string> rootProjectPaths = roots
+            .Select(request => Path.GetFullPath(request.ProjectPath))
+            .ToHashSet(comparison);
         var visited = new HashSet<string>(StringComparer.Ordinal);
         var directories = new HashSet<string>(comparison);
         var outputRootsByEvaluation = new Dictionary<string, string[]>(StringComparer.Ordinal);
@@ -337,6 +343,13 @@ public sealed partial class DotNetPublishPipelineRunner
         buildInputs = new HashSet<string>(comparison);
         sourceInputs = new HashSet<string>(comparison);
         noBuildPublishInputs = Array.Empty<NoBuildPublishInput>();
+        failureReason = null;
+        if (!string.IsNullOrWhiteSpace(buildStep?.TargetName) && roots.Length == 0)
+        {
+            projectDirectories = Array.Empty<string>();
+            failureReason = $"MSBuild input evaluation failed: publish target '{buildStep!.TargetName}' has no matching project combination.";
+            return false;
+        }
 
         foreach (ProjectEvaluationRequest root in roots)
         {
@@ -347,6 +360,7 @@ public sealed partial class DotNetPublishPipelineRunner
                     .Select(request => Path.GetDirectoryName(request.ProjectPath)!)
                     .Distinct(comparison)
                     .ToArray();
+                failureReason = $"MSBuild input evaluation failed: locked restore refresh failed for '{root.ProjectPath}'.";
                 return false;
             }
 
@@ -369,6 +383,10 @@ public sealed partial class DotNetPublishPipelineRunner
                         out EvaluatedProjectInputs? evaluation) || evaluation is null)
                 {
                     projectDirectories = directories.ToArray();
+                    failureReason = $"MSBuild input evaluation failed: evaluated project inputs could not be read for '{request.ProjectPath}'" +
+                        (string.IsNullOrWhiteSpace(request.TargetFramework)
+                            ? "."
+                            : $" ({request.TargetFramework}).");
                     return false;
                 }
                 foreach (string input in evaluation.BuildInputs)
@@ -426,6 +444,10 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             string evaluationKey = entry.Key;
             ProjectEvaluationRequest request = entry.Value;
+            // Only release roots are publish surfaces. Referenced projects are rebuilt and
+            // attested through the frozen graph using their own project-reference context.
+            if (!rootProjectPaths.Contains(Path.GetFullPath(request.ProjectPath)))
+                continue;
             if (string.IsNullOrWhiteSpace(request.TargetFramework) ||
                 !TryReadFrozenProjectReferenceGraph(
                     request,
@@ -438,6 +460,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 if (!string.IsNullOrWhiteSpace(request.TargetFramework))
                 {
                     projectDirectories = directories.ToArray();
+                    failureReason = $"MSBuild input evaluation failed: the frozen project-reference graph could not be resolved for '{request.ProjectPath}' ({request.TargetFramework}).";
                     return false;
                 }
                 continue;
@@ -471,13 +494,24 @@ public sealed partial class DotNetPublishPipelineRunner
                     buildPlan?.NoBuildInPublish == true,
                     graphNodes,
                     evaluationsByEvaluation[evaluationKey].EvaluatedProperties,
-                    out EvaluatedPublishInput[] publishInputs))
+                    out EvaluatedPublishInput[] publishInputs,
+                    out string? publishInputFailureReason))
             {
                 projectDirectories = directories.ToArray();
+                failureReason = $"MSBuild input evaluation failed: publish inputs could not be evaluated for '{request.ProjectPath}' ({request.TargetFramework})" +
+                    (string.IsNullOrWhiteSpace(publishInputFailureReason)
+                        ? "."
+                        : $": {publishInputFailureReason}");
                 return false;
             }
             evaluatedPublishInputs.AddRange(
-                publishInputs.Select(input => (evaluationKey, input)));
+                publishInputs
+                    .Where(input => IsFinalPublishInputRetained(
+                        input.FullPath,
+                        request,
+                        buildPlan,
+                        buildStep))
+                    .Select(input => (evaluationKey, input)));
         }
 
         var provenNoBuildPublishInputsByEvaluation =
@@ -522,6 +556,21 @@ public sealed partial class DotNetPublishPipelineRunner
                     entry.Input.IsPackageBacked)));
         }
 
+        HashSet<string> fullyProvenGeneratedPublishInputPaths = evaluatedPublishInputs
+            .Where(entry => !entry.Input.IsPackageBacked)
+            .GroupBy(entry => entry.Input.FullPath, comparison)
+            .Where(group => group.All(entry =>
+                provenNoBuildPublishInputsByEvaluation.TryGetValue(
+                    entry.EvaluationKey,
+                    out HashSet<string>? provenInputs) &&
+                provenInputs.Contains(entry.Input.FullPath)))
+            .Select(group => group.Key)
+            .ToHashSet(comparison);
+        HashSet<string> evaluatedPublishInputPaths = evaluatedPublishInputs
+            .Where(entry => !entry.Input.IsPackageBacked)
+            .Select(entry => Path.GetFullPath(entry.Input.FullPath))
+            .ToHashSet(comparison);
+
         foreach ((string evaluationKey, EvaluatedPublishInput publishInput) in evaluatedPublishInputs)
         {
             if (publishInput.IsPackageBacked)
@@ -548,6 +597,15 @@ public sealed partial class DotNetPublishPipelineRunner
 
         foreach ((ProjectEvaluationRequest request, GeneratedProjectReferenceOutput output) in generatedProjectReferenceOutputs)
         {
+            string fullOutputPath = Path.GetFullPath(output.OutputPath);
+            if (buildPlan?.NoBuildInPublish == true &&
+                !evaluatedPublishInputPaths.Contains(fullOutputPath))
+            {
+                continue;
+            }
+            if (fullyProvenGeneratedPublishInputPaths.Contains(fullOutputPath))
+                continue;
+
             ProjectEvaluationRequest referencedProject = request.ForProject(output.ProjectReference);
             if (!TryResolveProjectEvaluationKey(
                     referencedProject,
@@ -638,15 +696,68 @@ public sealed partial class DotNetPublishPipelineRunner
         return true;
     }
 
+    private static bool IsFinalPublishInputRetained(
+        string path,
+        ProjectEvaluationRequest request,
+        DotNetPublishPlan? buildPlan,
+        DotNetPublishStep? buildStep)
+    {
+        if (buildPlan?.Targets is not { Length: > 0 })
+            return true;
+
+        StringComparison comparison = IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        string projectPath = Path.GetFullPath(request.ProjectPath);
+        DotNetPublishTargetPlan[] targets = buildPlan.Targets
+            .Where(target =>
+                target is not null &&
+                !string.IsNullOrWhiteSpace(target.ProjectPath) &&
+                string.Equals(Path.GetFullPath(target.ProjectPath), projectPath, comparison) &&
+                IsPublishProvenanceCombinationInScope(target.Name, combination: null, buildStep))
+            .ToArray();
+        if (targets.Length == 0)
+            return true;
+
+        bool keepSymbols = targets.Any(target => target.Publish?.KeepSymbols == true);
+        bool keepDocs = targets.Any(target => target.Publish?.KeepDocs == true);
+        return IsFinalPublishInputRetained(path, keepSymbols, keepDocs);
+    }
+
+    internal static bool IsFinalPublishInputRetained(
+        string path,
+        bool keepSymbols,
+        bool keepDocs)
+    {
+        string extension = Path.GetExtension(path);
+        if (!keepSymbols && extension.Equals(".pdb", StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (!keepDocs &&
+            (extension.Equals(".xml", StringComparison.OrdinalIgnoreCase) ||
+             extension.Equals(".pdf", StringComparison.OrdinalIgnoreCase)))
+            return false;
+        return true;
+    }
+
     private static IEnumerable<ProjectEvaluationRequest> BuildProjectEvaluationRequests(
         IEnumerable<string>? projectPaths,
         string? configuration,
-        DotNetPublishPlan? buildPlan)
+        DotNetPublishPlan? buildPlan,
+        DotNetPublishStep? buildStep)
     {
         string effectiveConfiguration = string.IsNullOrWhiteSpace(buildPlan?.Configuration)
             ? string.IsNullOrWhiteSpace(configuration) ? "Release" : configuration!.Trim()
             : buildPlan!.Configuration.Trim();
         DotNetPublishTargetPlan[] targets = buildPlan?.Targets ?? Array.Empty<DotNetPublishTargetPlan>();
+        if (!string.IsNullOrWhiteSpace(buildStep?.TargetName))
+        {
+            targets = targets
+                .Where(target => IsPublishProvenanceCombinationInScope(
+                    target.Name,
+                    combination: null,
+                    buildStep))
+                .ToArray();
+        }
         if (targets.Length > 0)
         {
             foreach (DotNetPublishTargetPlan target in targets)
@@ -654,6 +765,17 @@ public sealed partial class DotNetPublishPipelineRunner
                 if (target is null || string.IsNullOrWhiteSpace(target.ProjectPath))
                     continue;
                 DotNetPublishTargetCombination[] combinations = target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>();
+                if (!string.IsNullOrWhiteSpace(buildStep?.TargetName))
+                {
+                    combinations = combinations
+                        .Where(combination => IsPublishProvenanceCombinationInScope(
+                            target.Name,
+                            combination,
+                            buildStep))
+                        .ToArray();
+                    if (combinations.Length == 0)
+                        continue;
+                }
                 if (combinations.Length == 0)
                 {
                     yield return new ProjectEvaluationRequest(
@@ -742,6 +864,30 @@ public sealed partial class DotNetPublishPipelineRunner
         DotNetPublishTargetCombination combination)
         => PublishConsumesPrebuiltProjectReferenceOutputs(plan, target, combination) ||
            target.Publish?.Sign?.Enabled != true;
+
+    internal static bool IsPublishProvenanceCombinationInScope(
+        string targetName,
+        DotNetPublishTargetCombination? combination,
+        DotNetPublishStep? buildStep)
+    {
+        if (string.IsNullOrWhiteSpace(buildStep?.TargetName))
+            return true;
+        if (!string.Equals(targetName, buildStep!.TargetName, StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (combination is null)
+            return true;
+        return (string.IsNullOrWhiteSpace(buildStep.Framework) ||
+                string.Equals(
+                    combination.Framework,
+                    buildStep.Framework,
+                    StringComparison.OrdinalIgnoreCase)) &&
+               (string.IsNullOrWhiteSpace(buildStep.Runtime) ||
+                string.Equals(
+                    combination.Runtime,
+                    buildStep.Runtime,
+                    StringComparison.OrdinalIgnoreCase)) &&
+               (!buildStep.Style.HasValue || combination.Style == buildStep.Style.Value);
+    }
 
     private static Dictionary<string, string> BuildPublishEvaluationProperties(
         DotNetPublishPlan plan,
@@ -1318,7 +1464,21 @@ public sealed partial class DotNetPublishPipelineRunner
         if (string.IsNullOrWhiteSpace(request.TargetFramework))
             return false;
 
-        return references.Any(reference =>
+        EvaluatedProjectReference[] candidates = references.ToArray();
+        if (candidates.Length == 0)
+            return false;
+
+        // The SDK decides per referenced target whether RuntimeIdentifier and
+        // SelfContained flow into that project. Raw ProjectReference items do not
+        // contain those computed UndefineProperties, so a RID-scoped release must
+        // resolve the SDK-authored context before reconstructing the build graph.
+        if (request.GlobalProperties.ContainsKey("RuntimeIdentifier") ||
+            request.GlobalProperties.ContainsKey("SelfContained"))
+        {
+            return true;
+        }
+
+        return candidates.Any(reference =>
             !reference.UndefineProperties.Contains(
                 "TargetFramework",
                 StringComparer.OrdinalIgnoreCase) &&

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Bundle.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Bundle.cs
@@ -53,17 +53,30 @@ public sealed partial class DotNetPublishPipelineRunner
         var sourceTargetPlan = (plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
             .FirstOrDefault(entry => string.Equals(entry.Name, sourceArtefact.Target, StringComparison.OrdinalIgnoreCase));
         DotNetPublishSignOptions? sign = sourceTargetPlan?.Publish?.Sign;
+        DotNetPublishStep[] bundleProvenanceSteps = ResolveBundleProvenanceSteps(
+            plan,
+            artefacts,
+            bundle,
+            sourceArtefact,
+            framework,
+            runtime,
+            style.Value);
 
         var outputDir = Path.GetFullPath(step.BundleOutputPath!);
         if (!plan.AllowOutputOutsideProjectRoot)
             EnsurePathWithinRoot(plan.ProjectRoot, outputDir, $"Bundle '{bundleId}' output path");
 
         if (sign?.Enabled == true)
-            _ = ReadPortableInventorySourceProvenance(
-                plan,
-                outputDir,
-                EnumerateBundleGeneratedArtefactPaths(artefacts),
-                step);
+        {
+            foreach (DotNetPublishStep provenanceStep in bundleProvenanceSteps)
+            {
+                _ = ReadPortableInventorySourceProvenance(
+                    plan,
+                    outputDir,
+                    EnumerateBundleGeneratedArtefactPaths(artefacts),
+                    provenanceStep);
+            }
+        }
 
         string outputBoundary = plan.AllowOutputOutsideProjectRoot
             ? outputDir
@@ -88,6 +101,8 @@ public sealed partial class DotNetPublishPipelineRunner
         Directory.CreateDirectory(primaryDestination);
         DirectoryCopy(sourceArtefact.OutputDir, primaryDestination, outputDir);
         RemoveCopiedPortableEvidence(plan, sourceArtefact, primaryDestination);
+        var bundleExecutables = new List<(string Runtime, string Path)>();
+        AddCopiedBundleExecutable(plan, sourceArtefact, primaryDestination, bundleExecutables);
 
         foreach (var include in bundle.Includes ?? Array.Empty<DotNetPublishBundleIncludePlan>())
         {
@@ -126,6 +141,7 @@ public sealed partial class DotNetPublishPipelineRunner
             Directory.CreateDirectory(includeDestination);
             DirectoryCopy(includeArtefact.OutputDir, includeDestination, outputDir);
             RemoveCopiedPortableEvidence(plan, includeArtefact, includeDestination);
+            AddCopiedBundleExecutable(plan, includeArtefact, includeDestination, bundleExecutables);
         }
 
         var tokens = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -195,11 +211,14 @@ public sealed partial class DotNetPublishPipelineRunner
             }
 
             string portableVersion = FirstText(versionInfo.ProductVersion, versionInfo.FileVersion);
-            SourceProvenance provenance = ReadPortableInventorySourceProvenance(
-                plan,
-                outputDir,
-                EnumerateBundleGeneratedArtefactPaths(artefacts),
-                step);
+            SourceProvenance provenance = CombineSourceProvenances(
+                bundleProvenanceSteps
+                    .Select(provenanceStep => ReadPortableInventorySourceProvenance(
+                        plan,
+                        outputDir,
+                        EnumerateBundleGeneratedArtefactPaths(artefacts),
+                        provenanceStep))
+                    .ToArray());
             (string inventoryPath, string signaturePath) = PowerForgePortablePayloadInventoryCms.ResolveEvidencePaths(
                 outputDir,
                 primaryExecutable,
@@ -240,7 +259,21 @@ public sealed partial class DotNetPublishPipelineRunner
 
         string? zipPath = null;
         if (bundle.Zip)
+        {
             zipPath = CreateBundleZip(plan, bundle, outputDir, step.BundleZipPath);
+            if (!string.IsNullOrWhiteSpace(zipPath))
+            {
+                foreach (IGrouping<string, (string Runtime, string Path)> runtimeGroup in
+                         bundleExecutables.GroupBy(entry => entry.Runtime, StringComparer.OrdinalIgnoreCase))
+                {
+                    PowerForgeToolReleaseService.ApplyArchiveExecutablePermissions(
+                        runtimeGroup.Key,
+                        outputDir,
+                        zipPath!,
+                        runtimeGroup.Select(entry => entry.Path).ToArray());
+                }
+            }
+        }
 
         var summary = SummarizeDirectory(outputDir, runtime);
         primaryExecutable ??= ResolvePrimaryExecutable(
@@ -331,6 +364,87 @@ public sealed partial class DotNetPublishPipelineRunner
             })
             .Where(static path => !string.IsNullOrWhiteSpace(path))
             .Select(static path => path!);
+
+    internal static DotNetPublishStep[] ResolveBundleProvenanceSteps(
+        DotNetPublishPlan plan,
+        IReadOnlyList<DotNetPublishArtefactResult> artefacts,
+        DotNetPublishBundlePlan bundle,
+        DotNetPublishArtefactResult sourceArtefact,
+        string framework,
+        string runtime,
+        DotNetPublishStyle style)
+    {
+        var steps = new List<DotNetPublishStep>
+        {
+            CreateBundleProvenanceStep(sourceArtefact)
+        };
+        foreach (DotNetPublishBundleIncludePlan include in bundle.Includes ?? Array.Empty<DotNetPublishBundleIncludePlan>())
+        {
+            string includeFramework = string.IsNullOrWhiteSpace(include.Framework) ? framework : include.Framework!.Trim();
+            string includeRuntime = string.IsNullOrWhiteSpace(include.Runtime) ? runtime : include.Runtime!.Trim();
+            DotNetPublishStyle includeStyle = include.Style ?? style;
+            DotNetPublishArtefactResult? includeArtefact = ResolveBundleSourceArtefact(
+                artefacts,
+                include.Target,
+                includeFramework,
+                includeRuntime,
+                includeStyle,
+                bundleId: null);
+            if (includeArtefact is null)
+            {
+                if (include.Required)
+                {
+                    throw new InvalidOperationException(
+                        $"Bundle '{bundle.Id}' include '{include.Target}' has no matching publish artefact for " +
+                        $"framework='{includeFramework}', runtime='{includeRuntime}', style='{includeStyle}'.");
+                }
+                continue;
+            }
+            steps.Add(CreateBundleProvenanceStep(includeArtefact));
+        }
+
+        return steps
+            .GroupBy(BuildPublishProvenanceScopeKey, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .ToArray();
+    }
+
+    private static DotNetPublishStep CreateBundleProvenanceStep(DotNetPublishArtefactResult artefact)
+        => new()
+        {
+            TargetName = artefact.Target,
+            Framework = artefact.Framework,
+            Runtime = artefact.Runtime,
+            Style = artefact.Style
+        };
+
+    private static void AddCopiedBundleExecutable(
+        DotNetPublishPlan plan,
+        DotNetPublishArtefactResult artefact,
+        string destinationRoot,
+        ICollection<(string Runtime, string Path)> executablePaths)
+    {
+        DotNetPublishTargetPlan? target = (plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
+            .FirstOrDefault(entry => string.Equals(entry.Name, artefact.Target, StringComparison.OrdinalIgnoreCase));
+        if (target is null)
+            return;
+
+        string? sourceExecutable = !string.IsNullOrWhiteSpace(artefact.ExePath) && File.Exists(artefact.ExePath)
+            ? Path.GetFullPath(artefact.ExePath)
+            : ResolvePrimaryExecutable(
+                artefact.OutputDir,
+                artefact.Runtime,
+                EnumerateEffectiveExecutableIdentities(target));
+        if (string.IsNullOrWhiteSpace(sourceExecutable))
+            return;
+
+        string relativePath = FrameworkCompatibility.GetRelativePath(
+            Path.GetFullPath(artefact.OutputDir),
+            sourceExecutable!);
+        string destinationPath = Path.GetFullPath(Path.Combine(destinationRoot, relativePath));
+        if (File.Exists(destinationPath))
+            executablePaths.Add((artefact.Runtime, destinationPath));
+    }
 
     private static DotNetPublishArtefactResult? ResolveBundleSourceArtefact(
         IReadOnlyList<DotNetPublishArtefactResult> artefacts,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Bundle.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Bundle.cs
@@ -62,7 +62,8 @@ public sealed partial class DotNetPublishPipelineRunner
             _ = ReadPortableInventorySourceProvenance(
                 plan,
                 outputDir,
-                EnumerateBundleGeneratedArtefactPaths(artefacts));
+                EnumerateBundleGeneratedArtefactPaths(artefacts),
+                step);
 
         string outputBoundary = plan.AllowOutputOutsideProjectRoot
             ? outputDir
@@ -197,7 +198,8 @@ public sealed partial class DotNetPublishPipelineRunner
             SourceProvenance provenance = ReadPortableInventorySourceProvenance(
                 plan,
                 outputDir,
-                EnumerateBundleGeneratedArtefactPaths(artefacts));
+                EnumerateBundleGeneratedArtefactPaths(artefacts),
+                step);
             (string inventoryPath, string signaturePath) = PowerForgePortablePayloadInventoryCms.ResolveEvidencePaths(
                 outputDir,
                 primaryExecutable,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.HookOutputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.HookOutputProvenance.cs
@@ -5,7 +5,8 @@ public sealed partial class DotNetPublishPipelineRunner
     internal static SourceProvenance ReadPortableInventorySourceProvenance(
         DotNetPublishPlan plan,
         string? outputDirectory = null,
-        IEnumerable<string>? additionalGeneratedPaths = null)
+        IEnumerable<string>? additionalGeneratedPaths = null,
+        DotNetPublishStep? publishStep = null)
     {
         string[] projectPaths = (plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
             .Select(target => target.ProjectPath)
@@ -36,7 +37,8 @@ public sealed partial class DotNetPublishPipelineRunner
             trustedExternalInputPaths: plan.GeneratedConfigurationInputPaths,
             buildProjectPaths: projectPaths,
             buildConfiguration: plan.Configuration,
-            buildPlan: plan);
+            buildPlan: plan,
+            buildStep: publishStep);
         if (string.IsNullOrWhiteSpace(provenance.Revision) ||
             !string.Equals(provenance.Revision, plan.SourceRevision, StringComparison.OrdinalIgnoreCase))
         {

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
@@ -118,7 +118,8 @@ public sealed partial class DotNetPublishPipelineRunner
         IEnumerable<string>? buildProjectPaths = null,
         string? buildConfiguration = null,
         DotNetPublishPlan? buildPlan = null,
-        IEnumerable<string>? sourceRootPaths = null)
+        IEnumerable<string>? sourceRootPaths = null,
+        DotNetPublishStep? buildStep = null)
     {
         var gitRevision = ReadGitText(projectRoot, "rev-parse HEAD");
         var environmentRevision = Environment.GetEnvironmentVariable("GITHUB_SHA")?.Trim();
@@ -180,7 +181,8 @@ public sealed partial class DotNetPublishPipelineRunner
             sourceRootPaths,
             buildProjectPaths,
             buildConfiguration,
-            buildPlan);
+            buildPlan,
+            buildStep);
         var postEvaluationTrackedStatus = ReadGitRawText(
             gitRoot!,
             "status --porcelain=v1 -z --untracked-files=no");
@@ -374,7 +376,12 @@ public sealed partial class DotNetPublishPipelineRunner
         SourceDirtyScope dirtyScope)
     {
         if (!dirtyScope.BuildInputsResolved)
-            return new[] { "MSBuild input evaluation failed" };
+            return new[]
+            {
+                string.IsNullOrWhiteSpace(dirtyScope.BuildInputFailureReason)
+                    ? "MSBuild input evaluation failed"
+                    : dirtyScope.BuildInputFailureReason!
+            };
         string[] projectDirectories = dirtyScope.ProjectDirectories;
         HashSet<string> buildInputs = dirtyScope.BuildInputs;
         HashSet<string> sourceInputs = dirtyScope.SourceInputs;

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.ControlledBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.ControlledBuild.cs
@@ -1,6 +1,4 @@
 using System.IO.Compression;
-using System.Security.Cryptography;
-using System.Text;
 using System.Xml.Linq;
 
 namespace PowerForge;
@@ -179,7 +177,6 @@ public sealed partial class DotNetPublishPipelineRunner
             try
             {
                 Directory.CreateDirectory(destination);
-                var sources = new List<string>();
                 foreach (KeyValuePair<string, string> package in archivePathsByPackageKey.OrderBy(
                              entry => entry.Key,
                              StringComparer.OrdinalIgnoreCase))
@@ -204,21 +201,14 @@ public sealed partial class DotNetPublishPipelineRunner
                     {
                         return false;
                     }
-                    string packageSource = Path.Combine(
-                        destination,
-                        CreateControlledPackageSourceDirectoryName(package.Key));
-                    Directory.CreateDirectory(packageSource);
-                    string destinationPath = Path.Combine(packageSource, Path.GetFileName(cached.SourcePath));
+                    string destinationPath = Path.Combine(destination, Path.GetFileName(cached.SourcePath));
                     if (File.Exists(destinationPath))
                     {
                         return false;
                     }
                     cached.Archive.CopyTo(destinationPath);
-                    sources.Add(packageSource);
                 }
-                packageSources = sources.Count == 0
-                    ? new[] { destination }
-                    : sources.ToArray();
+                packageSources = new[] { destination };
                 return true;
             }
             catch
@@ -228,13 +218,6 @@ public sealed partial class DotNetPublishPipelineRunner
             }
         }
 
-        private static string CreateControlledPackageSourceDirectoryName(string packageKey)
-        {
-            using SHA256 sha256 = SHA256.Create();
-            return BitConverter.ToString(sha256.ComputeHash(Encoding.UTF8.GetBytes(packageKey)))
-                .Replace("-", string.Empty)
-                .ToLowerInvariant();
-        }
     }
 
     private sealed partial class VerifiedPackageArchive

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
@@ -11,6 +11,43 @@ namespace PowerForge;
 
 public sealed partial class DotNetPublishPipelineRunner
 {
+    internal static bool TryReadPowerForgeRestorePackageHashes(
+        JsonElement root,
+        out Dictionary<string, string> hashes)
+    {
+        hashes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (!root.TryGetProperty("powerForgeRestorePackages", out JsonElement packages))
+            return true;
+        if (packages.ValueKind != JsonValueKind.Object)
+            return false;
+
+        foreach (JsonProperty package in packages.EnumerateObject())
+        {
+            int separator = package.Name.IndexOf('|');
+            if (separator <= 0 ||
+                separator != package.Name.LastIndexOf('|') ||
+                separator == package.Name.Length - 1 ||
+                package.Value.ValueKind != JsonValueKind.String ||
+                string.IsNullOrWhiteSpace(package.Value.GetString()) ||
+                !NuGetVersion.TryParse(package.Name.Substring(separator + 1), out NuGetVersion? version))
+            {
+                hashes.Clear();
+                return false;
+            }
+
+            string key = package.Name.Substring(0, separator) + "|" + version!.ToNormalizedString();
+            string contentHash = package.Value.GetString()!;
+            if (hashes.TryGetValue(key, out string? existing) &&
+                !string.Equals(existing, contentHash, StringComparison.Ordinal))
+            {
+                hashes.Clear();
+                return false;
+            }
+            hashes[key] = contentHash;
+        }
+        return true;
+    }
+
     internal static bool ShouldRefreshLockedRestoreOutputs(DotNetPublishPlan? plan)
         => plan?.NoRestoreInPublish != true;
 
@@ -745,6 +782,24 @@ public sealed partial class DotNetPublishPipelineRunner
                             hashes[key] = value;
                         }
                     }
+                }
+
+                if (!TryReadPowerForgeRestorePackageHashes(
+                        document.RootElement,
+                        out Dictionary<string, string> restorePackageHashes))
+                {
+                    hashes.Clear();
+                    return false;
+                }
+                foreach (KeyValuePair<string, string> package in restorePackageHashes)
+                {
+                    if (hashes.TryGetValue(package.Key, out string? existing) &&
+                        !string.Equals(existing, package.Value, StringComparison.Ordinal))
+                    {
+                        hashes.Clear();
+                        return false;
+                    }
+                    hashes[package.Key] = package.Value;
                 }
 
                 return hashes.Count > 0;

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PortableEvidenceFinalization.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PortableEvidenceFinalization.cs
@@ -75,6 +75,13 @@ public sealed partial class DotNetPublishPipelineRunner
                 artefact.BundleId,
                 archivePayload,
                 sign);
+            var publishStep = new DotNetPublishStep
+            {
+                TargetName = artefact.Target,
+                Framework = artefact.Framework,
+                Runtime = artefact.Runtime,
+                Style = artefact.Style
+            };
             SourceProvenance provenance = verifiedProvenanceByArtifact is not null &&
                                           verifiedProvenanceByArtifact.TryGetValue(
                                               BuildArtifactProvenanceKey(artefact),
@@ -83,7 +90,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 : ReadPortableInventorySourceProvenance(
                     plan,
                     outputDirectory,
-                    EnumerateBundleGeneratedArtefactPaths(artefacts));
+                    EnumerateBundleGeneratedArtefactPaths(artefacts),
+                    publishStep);
             string portableVersion = FirstText(versionInfo.ProductVersion, versionInfo.FileVersion);
             PowerForgePortablePayloadInventory inventory = archivePayload
                 ? PowerForgePortablePayloadInventoryCms.CreateFromArchive(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PublishLayout.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PublishLayout.cs
@@ -241,6 +241,11 @@ public sealed partial class DotNetPublishPipelineRunner
             if (File.Exists(zipPath)) File.Delete(zipPath);
 
             ZipFile.CreateFromDirectory(outputDir, zipPath);
+            ApplyArchiveExecutablePermissions(
+                outputDir,
+                rid,
+                zipPath,
+                target.ExecutableIdentities);
             return zipPath;
         }
         catch (Exception ex)
@@ -248,6 +253,33 @@ public sealed partial class DotNetPublishPipelineRunner
             _logger.Warn($"Failed to create zip for '{target.Name}' ({rid}). Error: {ex.Message}");
             return null;
         }
+    }
+
+    internal static void ApplyArchiveExecutablePermissions(
+        string outputRoot,
+        string runtime,
+        string archivePath,
+        IEnumerable<string> expectedIdentities)
+    {
+        if (runtime.StartsWith("win-", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        string? executablePath = ResolvePrimaryExecutable(
+            outputRoot,
+            runtime,
+            expectedIdentities);
+        if (string.IsNullOrWhiteSpace(executablePath))
+        {
+            return;
+        }
+
+        PowerForgeToolReleaseService.ApplyArchiveExecutablePermissions(
+            runtime,
+            outputRoot,
+            archivePath,
+            executablePath);
     }
 
     internal static string? ResolvePrimaryExecutable(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PublishLayout.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PublishLayout.cs
@@ -245,7 +245,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 outputDir,
                 rid,
                 zipPath,
-                target.ExecutableIdentities);
+                EnumerateEffectiveExecutableIdentities(target));
             return zipPath;
         }
         catch (Exception ex)
@@ -281,6 +281,15 @@ public sealed partial class DotNetPublishPipelineRunner
             archivePath,
             executablePath);
     }
+
+    internal static IEnumerable<string> EnumerateEffectiveExecutableIdentities(
+        DotNetPublishTargetPlan target)
+        => (target.ExecutableIdentities ?? Array.Empty<string>())
+            .Concat(string.IsNullOrWhiteSpace(target.Publish?.RenameTo)
+                ? Array.Empty<string>()
+                : new[] { target.Publish!.RenameTo! })
+            .Where(static identity => !string.IsNullOrWhiteSpace(identity))
+            .Distinct(StringComparer.OrdinalIgnoreCase);
 
     internal static string? ResolvePrimaryExecutable(
         string root,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
@@ -65,6 +65,7 @@ public sealed partial class DotNetPublishPipelineRunner
         var stepReports = new List<DotNetPublishRunReportStep>();
         PublishProvenanceLease? manifestProvenanceLease = null;
         SourceProvenance? sharedPublishProvenance = null;
+        string? sharedPublishProvenanceScopeKey = null;
         var publishProvenanceByArtifact = new Dictionary<string, SourceProvenance>(StringComparer.OrdinalIgnoreCase);
         string[] plannedPublishGeneratedPaths = Array.Empty<string>();
         IReadOnlyDictionary<string, string> cleanTrackedGeneratedProvenanceState =
@@ -127,12 +128,15 @@ public sealed partial class DotNetPublishPipelineRunner
                                 manifestProvenanceLease.Dispose();
                                 manifestProvenanceLease = null;
                                 sharedPublishProvenance = null;
+                                sharedPublishProvenanceScopeKey = null;
                             }
 
                             if ((plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
                                 .Any(static target => target?.Publish?.Sign?.Enabled == true))
                             {
-                                _ = ReadPortableInventorySourceProvenance(plan);
+                                _ = ReadPortableInventorySourceProvenance(
+                                    plan,
+                                    publishStep: string.IsNullOrWhiteSpace(step.TargetName) ? null : step);
                             }
                             Build(plan, step);
                             break;
@@ -150,12 +154,28 @@ public sealed partial class DotNetPublishPipelineRunner
                             PublishProvenanceLease? provenanceLease = null;
                             if (requiresPublishProvenance)
                             {
-                                if (sharedPublishProvenance is null)
+                                string provenanceScopeKey = BuildPublishProvenanceScopeKey(step);
+                                if (sharedPublishProvenance is null ||
+                                    !string.Equals(
+                                        sharedPublishProvenanceScopeKey,
+                                        provenanceScopeKey,
+                                        StringComparison.OrdinalIgnoreCase))
                                 {
+                                    if (manifestProvenanceLease is not null)
+                                    {
+                                        manifestProvenanceLease.ValidateUnchanged();
+                                        sharedPublishProvenance?.ValidateCurrentSource();
+                                        manifestProvenanceLease.Dispose();
+                                        manifestProvenanceLease = null;
+                                        sharedPublishProvenance = null;
+                                        sharedPublishProvenanceScopeKey = null;
+                                    }
+
                                     SourceProvenance initialProvenance =
                                         ReadPortableInventorySourceProvenance(
                                             plan,
-                                            additionalGeneratedPaths: plannedPublishGeneratedPaths);
+                                            additionalGeneratedPaths: plannedPublishGeneratedPaths,
+                                            publishStep: step);
                                     PublishProvenanceLease candidateLease = PublishProvenanceLease.Create(
                                         PublishProvenanceLease.BuildGuardedPaths(
                                             initialProvenance.PublishInputFiles,
@@ -165,7 +185,8 @@ public sealed partial class DotNetPublishPipelineRunner
                                         SourceProvenance confirmedProvenance =
                                             ReadPortableInventorySourceProvenance(
                                                 plan,
-                                                additionalGeneratedPaths: plannedPublishGeneratedPaths);
+                                                additionalGeneratedPaths: plannedPublishGeneratedPaths,
+                                                publishStep: step);
                                         candidateLease.EnsureCovers(PublishProvenanceLease.BuildGuardedPaths(
                                             confirmedProvenance.PublishInputFiles,
                                             confirmedProvenance.NoBuildPublishInputs));
@@ -173,6 +194,7 @@ public sealed partial class DotNetPublishPipelineRunner
                                         confirmedProvenance.ValidateCurrentSource();
                                         manifestProvenanceLease = candidateLease;
                                         sharedPublishProvenance = confirmedProvenance;
+                                        sharedPublishProvenanceScopeKey = provenanceScopeKey;
                                     }
                                     catch
                                     {
@@ -489,6 +511,14 @@ public sealed partial class DotNetPublishPipelineRunner
             artefact.Framework,
             artefact.Runtime,
             artefact.Style.ToString());
+
+    private static string BuildPublishProvenanceScopeKey(DotNetPublishStep step)
+        => string.Join(
+            "|",
+            step.TargetName,
+            step.Framework,
+            step.Runtime,
+            step.Style.ToString());
 
     private static void ValidateManifestProvenance(
         PublishProvenanceLease? provenanceLease,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
@@ -275,6 +275,7 @@ public sealed partial class DotNetPublishPipelineRunner
                                     plan.ProjectRoot,
                                     cleanTrackedGeneratedProvenanceState,
                                     msiReservationOwner));
+                            ValidatePublishProvenanceEntries(publishProvenanceByArtifact);
                             FinalizePortableEvidence(plan, artefacts, publishProvenanceByArtifact);
                             ValidateManifestProvenance(
                                 manifestProvenanceLease,
@@ -591,6 +592,19 @@ public sealed partial class DotNetPublishPipelineRunner
         if (provenances.All(provenance => ReferenceEquals(provenance, sharedProvenance)))
             return sharedProvenance;
 
+        return CombineSourceProvenances(provenances);
+    }
+
+    internal static SourceProvenance CombineSourceProvenances(
+        IReadOnlyCollection<SourceProvenance> provenances)
+    {
+        if (provenances.Count == 0)
+            throw new ArgumentException("At least one source provenance is required.", nameof(provenances));
+
+        SourceProvenance sharedProvenance = provenances.First();
+        if (provenances.All(provenance => ReferenceEquals(provenance, sharedProvenance)))
+            return sharedProvenance;
+
         string?[] revisions = provenances
             .Select(static provenance => provenance.Revision)
             .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -626,6 +640,13 @@ public sealed partial class DotNetPublishPipelineRunner
                 foreach (SourceProvenance provenance in provenances)
                     provenance.ValidateCurrentSource(additionalTrackedGeneratedPaths);
             });
+    }
+
+    internal static void ValidatePublishProvenanceEntries(
+        IReadOnlyDictionary<string, SourceProvenance> publishProvenanceByArtifact)
+    {
+        foreach (SourceProvenance provenance in publishProvenanceByArtifact.Values.Distinct())
+            provenance.ValidateCurrentSource();
     }
 
 }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SourceDirtyState.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SourceDirtyState.cs
@@ -13,7 +13,8 @@ public sealed partial class DotNetPublishPipelineRunner
         IEnumerable<string>? sourceRootPaths,
         IEnumerable<string>? buildProjectPaths,
         string? buildConfiguration,
-        DotNetPublishPlan? buildPlan)
+        DotNetPublishPlan? buildPlan,
+        DotNetPublishStep? buildStep)
     {
         var scope = new SourceDirtyScope();
         foreach (string path in explicitInputPaths ?? Array.Empty<string>())
@@ -25,10 +26,13 @@ public sealed partial class DotNetPublishPipelineRunner
             buildProjectPaths,
             buildConfiguration,
             buildPlan,
+            buildStep,
             out string[] projectDirectories,
             out HashSet<string> buildInputs,
             out HashSet<string> sourceInputs,
-            out NoBuildPublishInput[] noBuildPublishInputs);
+            out NoBuildPublishInput[] noBuildPublishInputs,
+            out string? buildInputFailureReason);
+        scope.BuildInputFailureReason = buildInputFailureReason;
         scope.ProjectDirectories = projectDirectories;
         scope.BuildInputs = buildInputs;
         scope.SourceInputs = sourceInputs;
@@ -156,6 +160,8 @@ public sealed partial class DotNetPublishPipelineRunner
             IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
 
         internal bool BuildInputsResolved { get; set; }
+
+        internal string? BuildInputFailureReason { get; set; }
 
         internal string[] ProjectDirectories { get; set; } = Array.Empty<string>();
 

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -434,7 +434,10 @@ public sealed partial class DotNetPublishPipelineRunner
                     signingProvenance.PublishInputFiles,
                     signingProvenance.NoBuildPublishInputs));
                 provenanceLease?.ValidateUnchanged();
-                string executable = ResolvePrimaryExecutable(outputDir, rid, target.ExecutableIdentities)
+                string executable = ResolvePrimaryExecutable(
+                    outputDir,
+                    rid,
+                    EnumerateEffectiveExecutableIdentities(target))
                     ?? throw new InvalidOperationException(
                         "Signed portable output does not contain a primary executable matching the configured project identity.");
                 FileVersionInfo versionInfo = FileVersionInfo.GetVersionInfo(executable);

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -71,7 +71,10 @@ public sealed partial class DotNetPublishPipelineRunner
             if (!string.Equals(target.ProjectPath, projectPath, StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            var styles = (target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>())
+            var restoreCombinations = target.RestoreCombinations is { Length: > 0 }
+                ? target.RestoreCombinations
+                : target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>();
+            var styles = restoreCombinations
                 .Where(combination => string.Equals(combination.Runtime, runtime, StringComparison.OrdinalIgnoreCase))
                 .Where(combination => string.IsNullOrWhiteSpace(framework)
                     || string.Equals(combination.Framework, framework, StringComparison.OrdinalIgnoreCase))
@@ -142,7 +145,9 @@ public sealed partial class DotNetPublishPipelineRunner
         var baselineProperties = BuildRestoreMsBuildProperties(plan, projectPath, runtime, framework);
         var runtimes = (plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
             .Where(target => string.Equals(target.ProjectPath, projectPath, StringComparison.OrdinalIgnoreCase))
-            .SelectMany(target => target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>())
+            .SelectMany(target => target.RestoreCombinations is { Length: > 0 }
+                ? target.RestoreCombinations
+                : target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>())
             .Where(combination => string.IsNullOrWhiteSpace(framework)
                 || string.Equals(combination.Framework, framework, StringComparison.OrdinalIgnoreCase))
             .Select(combination => combination.Runtime)
@@ -283,7 +288,15 @@ public sealed partial class DotNetPublishPipelineRunner
         if (plan is null) throw new ArgumentNullException(nameof(plan));
         if (target is null) throw new ArgumentNullException(nameof(target));
 
-        var args = new List<string> { "build", target.ProjectPath, "-c", plan.Configuration, "--nologo" };
+        var args = new List<string>
+        {
+            "build",
+            target.ProjectPath,
+            "-c",
+            plan.Configuration,
+            "--nologo",
+            "--no-incremental"
+        };
         if (!string.IsNullOrWhiteSpace(framework)) args.AddRange(new[] { "-f", framework });
         if (!string.IsNullOrWhiteSpace(runtime)) args.AddRange(new[] { "-r", runtime });
         if (plan.Restore) args.Add("--no-restore");
@@ -310,6 +323,13 @@ public sealed partial class DotNetPublishPipelineRunner
 
         var tfm = string.IsNullOrWhiteSpace(framework) ? target.Publish.Framework : framework.Trim();
         var style = styleOverride ?? target.Publish.Style;
+        var publishStep = new DotNetPublishStep
+        {
+            TargetName = target.Name,
+            Framework = tfm,
+            Runtime = rid,
+            Style = style
+        };
         var tokens = BuildPublishOutputTokens(plan, target, tfm, rid, style);
         string outputDir = ResolvePublishOutputDirectory(plan, target, tfm, rid, style);
 
@@ -318,7 +338,7 @@ public sealed partial class DotNetPublishPipelineRunner
         if (target.Publish.Sign?.Enabled == true)
         {
             signingProvenance = verifiedSourceProvenance ??
-                ReadPortableInventorySourceProvenance(plan, outputDir);
+                ReadPortableInventorySourceProvenance(plan, outputDir, publishStep: publishStep);
         }
 
         EnsureOutputDirectoryUnlocked(
@@ -408,7 +428,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 signingProvenance = ReadPortableInventorySourceProvenance(
                     plan,
                     outputDir,
-                    plannedPublishGeneratedPaths);
+                    plannedPublishGeneratedPaths,
+                    publishStep);
                 provenanceLease?.EnsureCovers(PublishProvenanceLease.BuildGuardedPaths(
                     signingProvenance.PublishInputFiles,
                     signingProvenance.NoBuildPublishInputs));
@@ -646,6 +667,9 @@ public sealed partial class DotNetPublishPipelineRunner
             // Command-line global properties ensure the publisher-signed ProductVersion carries the exact source object ID.
             merged["SourceRevisionId"] = plan.SourceRevision;
             merged["IncludeSourceRevisionInInformationalVersion"] = "true";
+            // Keep Source Link, PDB IDs, and PE MVIDs stable between the real release
+            // build and detached provenance rebuilds rooted at different paths.
+            merged["ContinuousIntegrationBuild"] = "true";
         }
 
         ApplyPublishMsiVersionProperties(merged, plan, target.Name, framework, runtime, style);

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -138,21 +138,21 @@ public sealed partial class DotNetRepositoryReleaseService
                 spec.TimeStampServer = stamp;
             }
 
-            if (signAssemblyOutputs && signAssemblies is null)
+            if (!spec.WhatIf && signAssemblyOutputs && signAssemblies is null)
             {
                 result.Success = false;
                 result.ErrorMessage = "Assembly signing was requested, but no assembly signing handler was provided.";
                 return result;
             }
 
-            if (signAssemblyOutputs && validateAssemblySigning is null)
+            if (!spec.WhatIf && signAssemblyOutputs && validateAssemblySigning is null)
             {
                 result.Success = false;
                 result.ErrorMessage = "Assembly signing was requested, but no assembly signing preflight handler was provided.";
                 return result;
             }
 
-            if (signAssemblyOutputs)
+            if (!spec.WhatIf && signAssemblyOutputs)
             {
                 try
                 {
@@ -171,7 +171,7 @@ public sealed partial class DotNetRepositoryReleaseService
                 }
             }
 
-            if (signNuGetPackages)
+            if (!spec.WhatIf && signNuGetPackages)
             {
                 signingSha256 = _getCertificateSha256(spec.CertificateThumbprint!.Trim(), spec.CertificateStore);
                 if (signingSha256 is null)

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PackagePublication.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PackagePublication.cs
@@ -4,6 +4,66 @@ namespace PowerForge;
 
 public sealed partial class DotNetRepositoryReleaseService
 {
+    internal static void ApplyPublishedNuGetArtifactOutcomes(
+        DotNetRepositoryReleaseResult release,
+        NuGetPackagePublishResult publish,
+        bool publishSymbolsSeparately = false,
+        bool skipDuplicate = true)
+    {
+        var publishedPrimaryPackages = new HashSet<string>(publish.PublishedItems, StringComparer.OrdinalIgnoreCase);
+        var skippedPrimaryPackages = new HashSet<string>(publish.SkippedDuplicateItems, StringComparer.OrdinalIgnoreCase);
+        var failedPrimaryPackages = new HashSet<string>(publish.FailedItems, StringComparer.OrdinalIgnoreCase);
+        var publishedArtifacts = new HashSet<string>(release.PublishedPackages, StringComparer.OrdinalIgnoreCase);
+        var skippedArtifacts = new HashSet<string>(release.SkippedDuplicatePackages, StringComparer.OrdinalIgnoreCase);
+        var failedArtifacts = new HashSet<string>(release.FailedPackages, StringComparer.OrdinalIgnoreCase);
+        var attemptedPackages = publish.PackagePushResults.Keys
+            .Concat(publish.PublishedItems)
+            .Concat(publish.FailedItems)
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+        foreach (var package in attemptedPackages)
+        {
+            var project = release.Projects.FirstOrDefault(candidate =>
+                candidate.Packages.Contains(package, StringComparer.OrdinalIgnoreCase) ||
+                candidate.SymbolPackages.Contains(package, StringComparer.OrdinalIgnoreCase));
+            var artifacts = GetPublishedArtifacts(
+                project,
+                package,
+                includeCompanionSymbols: !publishSymbolsSeparately);
+            if (!publish.PackagePushResults.TryGetValue(package, out var pushResult))
+            {
+                pushResult = new PackagePushResult
+                {
+                    Outcome = failedPrimaryPackages.Contains(package)
+                        ? PackagePushOutcome.Failed
+                        : skippedPrimaryPackages.Contains(package)
+                            ? PackagePushOutcome.SkippedDuplicate
+                            : publishedPrimaryPackages.Contains(package)
+                                ? PackagePushOutcome.Published
+                                : PackagePushOutcome.Failed
+                };
+            }
+
+            var outcomes = ClassifyPublishedArtifacts(artifacts, pushResult, skipDuplicate);
+            foreach (var artifact in artifacts)
+            {
+                if (outcomes[artifact] == PackagePushOutcome.SkippedDuplicate)
+                {
+                    if (skippedArtifacts.Add(artifact))
+                        release.SkippedDuplicatePackages.Add(artifact);
+                }
+                else if (outcomes[artifact] == PackagePushOutcome.Published)
+                {
+                    if (publishedArtifacts.Add(artifact))
+                        release.PublishedPackages.Add(artifact);
+                }
+                else if (failedArtifacts.Add(artifact))
+                {
+                    release.FailedPackages.Add(artifact);
+                }
+            }
+        }
+    }
+
     private bool ExecutePackageSigning(
         DotNetRepositoryReleaseSpec spec,
         DotNetRepositoryReleaseResult result,

--- a/PowerForge/Services/DotNetRepositoryReleaseService.ProcessAndPublishing.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.ProcessAndPublishing.cs
@@ -316,9 +316,16 @@ public sealed partial class DotNetRepositoryReleaseService
             suppressCompanionSymbols));
 
     internal static PackagePushResult PushPackage(DotNetNuGetPushRequest request)
+        => PushPackage(request, CancellationToken.None);
+
+    internal static PackagePushResult PushPackage(
+        DotNetNuGetPushRequest request,
+        CancellationToken cancellationToken)
     {
         if (request is null)
             throw new ArgumentNullException(nameof(request));
+
+        cancellationToken.ThrowIfCancellationRequested();
 
         if (IsLocalPublishSource(request.Source) &&
             request.PackagePath.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase))
@@ -328,11 +335,12 @@ public sealed partial class DotNetRepositoryReleaseService
                 request.Source,
                 request.SkipDuplicate,
                 out var localResult);
+            cancellationToken.ThrowIfCancellationRequested();
             return localResult;
         }
 
         var push = new DotNetNuGetClient()
-            .PushPackageAsync(request)
+            .PushPackageAsync(request, cancellationToken)
             .GetAwaiter()
             .GetResult();
         return ClassifyNuGetPushOutcome(push.ExitCode, request.SkipDuplicate, push.StdErr, push.StdOut);

--- a/PowerForge/Services/ModuleBuildHostService.cs
+++ b/PowerForge/Services/ModuleBuildHostService.cs
@@ -418,7 +418,10 @@ public sealed class ModuleBuildHostService
 
         if (request.RequireReusableOutput)
         {
-            arguments.Add("if (-not $buildScriptCommand.Parameters.ContainsKey('NoDotnetBuild') -or -not $buildScriptCommand.Parameters.ContainsKey('StagingPath')) { throw 'Deferred module publication requires the legacy build script to expose NoDotnetBuild and StagingPath parameters.' }");
+            arguments.Add("$requiredCheckpointParameters = @('NoDotnetBuild', 'StagingPath', 'ReuseStaging', 'IncludeProjectPackages', 'IncludeModulePublishing', 'SkipInstall')");
+            arguments.Add("$missingCheckpointParameters = @($requiredCheckpointParameters | Where-Object { -not $buildScriptCommand.Parameters.ContainsKey($_) })");
+            arguments.Add("if ($missingCheckpointParameters.Count -ne 0) { throw \"Deferred module publication requires the legacy build script to expose checkpoint parameters: $($missingCheckpointParameters -join ', ').\" }");
+            arguments.Add("if (-not $buildScriptCommand.Parameters.ContainsKey('RunMode') -and -not $buildScriptCommand.Parameters.ContainsKey('ConfigurationGateMode')) { throw 'Deferred module publication requires the legacy build script to expose RunMode or ConfigurationGateMode.' }");
         }
 
         if (!string.IsNullOrWhiteSpace(request.Configuration))

--- a/PowerForge/Services/ModuleBuildHostService.cs
+++ b/PowerForge/Services/ModuleBuildHostService.cs
@@ -470,13 +470,17 @@ public sealed class ModuleBuildHostService
         if (request.NoSign)
             arguments.Add("$buildScriptArguments['NoSign'] = $true");
 
-        if (request.SignModule)
+        if (request.SignModule || request.SignModuleWasSpecified)
         {
-            arguments.Add("if ($buildScriptCommand.Parameters.ContainsKey('SignModule')) { $buildScriptArguments['SignModule'] = $true }");
+            arguments.Add($"if ($buildScriptCommand.Parameters.ContainsKey('SignModule')) {{ $buildScriptArguments['SignModule'] = ${request.SignModule.ToString().ToLowerInvariant()} }}");
         }
 
         arguments.Add($"if ($buildScriptCommand.Parameters.ContainsKey('IncludeProjectPackages')) {{ $buildScriptArguments['IncludeProjectPackages'] = ${request.IncludeProjectPackages.ToString().ToLowerInvariant()} }}");
         arguments.Add($"if ($buildScriptCommand.Parameters.ContainsKey('IncludeModulePublishing')) {{ $buildScriptArguments['IncludeModulePublishing'] = ${request.IncludeModulePublishing.ToString().ToLowerInvariant()} }}");
+        if (request.ReuseStaging)
+            arguments.Add("if ($buildScriptCommand.Parameters.ContainsKey('ReuseStaging')) { $buildScriptArguments['ReuseStaging'] = $true }");
+        if (request.SkipInstall)
+            arguments.Add("if ($buildScriptCommand.Parameters.ContainsKey('SkipInstall')) { $buildScriptArguments['SkipInstall'] = $true }");
 
         AddOptionalStringArgument(arguments, "CertificateThumbprint", request.CertificateThumbprint);
         AddOptionalSwitchArgument(arguments, "SignIncludeBinaries", request.SignIncludeBinaries);

--- a/PowerForge/Services/ModulePackageReleaseCheckpointService.cs
+++ b/PowerForge/Services/ModulePackageReleaseCheckpointService.cs
@@ -38,7 +38,7 @@ internal sealed class ModulePackageReleaseCheckpointService
                 ExecuteBuild = false,
                 PlanOnly = true,
                 UpdateVersions = false,
-                Build = false,
+                Build = true,
                 PublishNuget = false,
                 PublishGitHub = false
             };
@@ -87,25 +87,33 @@ internal sealed class ModulePackageReleaseCheckpointService
             var configuration = lane.Reference is not null
                 ? publisher.LoadConfiguration(lane.Reference, lane.ConfigPath)
                 : publisher.LoadConfiguration(lane.Inline!, lane.ConfigPath);
-            var release = CreatePublicationRelease(
+            var stagedRelease = CreatePublicationRelease(
                 checkpoint.Release,
                 releaseAssets,
                 requireStagedAssets);
+            using var publicationSnapshot = ModulePackagePublicationSnapshot.Create(stagedRelease);
+            var release = publicationSnapshot.Release;
             var publish = publisher.PublishNuGet(
                 configuration,
                 release,
                 repositoryRoot: ResolveRepositoryRoot(releaseConfigPath, spec),
-                remotePublishAttempted: remotePublishAttempted,
-                progress: progress);
+                remotePublishAttempted: () =>
+                {
+                    publicationSnapshot.ValidateUnchanged();
+                    remotePublishAttempted?.Invoke();
+                },
+                progress: progress,
+                cancellationToken: cancellationToken);
+            publicationSnapshot.ValidateUnchanged();
             var result = new PowerForgeModulePackagePublicationResult
             {
                 Name = checkpoint.Name,
                 Success = publish.Success,
                 ErrorMessage = publish.ErrorMessage,
                 PublishSource = release.PublishSource,
-                PublishedPackages = release.PublishedPackages.ToArray(),
-                SkippedDuplicatePackages = release.SkippedDuplicatePackages.ToArray(),
-                FailedPackages = release.FailedPackages.ToArray()
+                PublishedPackages = publicationSnapshot.ResolveOriginalPaths(release.PublishedPackages),
+                SkippedDuplicatePackages = publicationSnapshot.ResolveOriginalPaths(release.SkippedDuplicatePackages),
+                FailedPackages = publicationSnapshot.ResolveOriginalPaths(release.FailedPackages)
             };
             publications.Add(result);
             if (!result.Success)
@@ -134,7 +142,7 @@ internal sealed class ModulePackageReleaseCheckpointService
             .GroupBy(asset => Path.GetFullPath(asset.Path), PathComparer)
             .ToDictionary(
                 static group => group.Key,
-                static group => Path.GetFullPath(group.Single().StagedPath!),
+                static group => group.Single(),
                 PathComparer);
         var clone = new DotNetRepositoryReleaseResult
         {
@@ -167,14 +175,29 @@ internal sealed class ModulePackageReleaseCheckpointService
 
     private static string ResolvePublicationPackagePath(
         string path,
-        IReadOnlyDictionary<string, string> stagedBySource,
+        IReadOnlyDictionary<string, PowerForgeReleaseAssetEntry> stagedBySource,
         bool requireStagedAssets)
     {
         var fullPath = Path.GetFullPath(path);
-        if (stagedBySource.TryGetValue(fullPath, out var stagedPath))
+        if (stagedBySource.TryGetValue(fullPath, out var stagedAsset))
         {
+            var stagedPath = Path.GetFullPath(stagedAsset.StagedPath!);
             if (!File.Exists(stagedPath))
                 throw new FileNotFoundException($"The staged package artifact was not found: {stagedPath}", stagedPath);
+            if (requireStagedAssets && string.IsNullOrWhiteSpace(stagedAsset.StagedSha256))
+            {
+                throw new InvalidOperationException(
+                    $"The validated staged package artifact has no captured SHA-256 digest: '{stagedPath}'.");
+            }
+            if (!string.IsNullOrWhiteSpace(stagedAsset.StagedSha256))
+            {
+                var actualSha256 = ComputeSha256(stagedPath);
+                if (!string.Equals(actualSha256, stagedAsset.StagedSha256, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(
+                        $"The staged package artifact changed after release staging: '{stagedPath}'.");
+                }
+            }
             return stagedPath;
         }
 
@@ -186,6 +209,13 @@ internal sealed class ModulePackageReleaseCheckpointService
         if (!File.Exists(fullPath))
             throw new FileNotFoundException($"The package artifact was not found: {fullPath}", fullPath);
         return fullPath;
+    }
+
+    private static string ComputeSha256(string path)
+    {
+        using var stream = File.OpenRead(path);
+        using var sha256 = System.Security.Cryptography.SHA256.Create();
+        return string.Concat(sha256.ComputeHash(stream).Select(static value => value.ToString("x2")));
     }
 
     private static string ResolveRepositoryRoot(string releaseConfigPath, PowerForgeReleaseSpec spec)
@@ -289,6 +319,153 @@ internal sealed class ModulePackageReleaseCheckpointService
 
         return lanes;
     }
+}
+
+internal sealed class ModulePackagePublicationSnapshot : IDisposable
+{
+    private readonly string _rootPath;
+    private readonly Dictionary<string, string> _originalBySnapshot;
+    private readonly Dictionary<string, string> _sha256BySnapshot;
+    private bool _disposed;
+
+    private ModulePackagePublicationSnapshot(
+        string rootPath,
+        DotNetRepositoryReleaseResult release,
+        Dictionary<string, string> originalBySnapshot,
+        Dictionary<string, string> sha256BySnapshot)
+    {
+        _rootPath = rootPath;
+        Release = release;
+        _originalBySnapshot = originalBySnapshot;
+        _sha256BySnapshot = sha256BySnapshot;
+    }
+
+    internal DotNetRepositoryReleaseResult Release { get; }
+
+    internal static ModulePackagePublicationSnapshot Create(DotNetRepositoryReleaseResult release)
+    {
+        if (release is null)
+            throw new ArgumentNullException(nameof(release));
+
+        var rootPath = Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge",
+            "module-package-publication",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(rootPath);
+        var snapshotByOriginal = new Dictionary<string, string>(PathComparer);
+        var originalBySnapshot = new Dictionary<string, string>(PathComparer);
+        var sha256BySnapshot = new Dictionary<string, string>(PathComparer);
+        try
+        {
+            string Snapshot(string path)
+            {
+                var originalPath = Path.GetFullPath(path);
+                if (snapshotByOriginal.TryGetValue(originalPath, out var existing))
+                    return existing;
+                if (!File.Exists(originalPath))
+                    throw new FileNotFoundException($"The package publication input was not found: {originalPath}", originalPath);
+
+                var expectedSha256 = ComputeSha256(originalPath);
+                var snapshotPath = Path.Combine(
+                    rootPath,
+                    snapshotByOriginal.Count.ToString("D4"),
+                    Path.GetFileName(originalPath));
+                Directory.CreateDirectory(Path.GetDirectoryName(snapshotPath)!);
+                File.Copy(originalPath, snapshotPath, overwrite: false);
+                var sourceSha256AfterCopy = ComputeSha256(originalPath);
+                var snapshotSha256 = ComputeSha256(snapshotPath);
+                if (!string.Equals(expectedSha256, sourceSha256AfterCopy, StringComparison.OrdinalIgnoreCase) ||
+                    !string.Equals(expectedSha256, snapshotSha256, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(
+                        $"The staged package changed while its private publication snapshot was created: '{originalPath}'.");
+                }
+
+                File.SetAttributes(snapshotPath, File.GetAttributes(snapshotPath) | FileAttributes.ReadOnly);
+                snapshotByOriginal[originalPath] = snapshotPath;
+                originalBySnapshot[snapshotPath] = originalPath;
+                sha256BySnapshot[snapshotPath] = snapshotSha256;
+                return snapshotPath;
+            }
+
+            foreach (var project in release.Projects)
+            {
+                project.Packages = project.Packages.Select(Snapshot).ToList();
+                project.SymbolPackages = project.SymbolPackages.Select(Snapshot).ToList();
+            }
+
+            return new ModulePackagePublicationSnapshot(
+                rootPath,
+                release,
+                originalBySnapshot,
+                sha256BySnapshot);
+        }
+        catch
+        {
+            DeleteSnapshot(rootPath);
+            throw;
+        }
+    }
+
+    internal void ValidateUnchanged()
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(ModulePackagePublicationSnapshot));
+
+        foreach (var entry in _sha256BySnapshot)
+        {
+            if (!File.Exists(entry.Key) ||
+                !string.Equals(ComputeSha256(entry.Key), entry.Value, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"The private package publication snapshot changed before publication completed: '{entry.Key}'.");
+            }
+        }
+    }
+
+    internal string[] ResolveOriginalPaths(IEnumerable<string> paths)
+        => paths.Select(path =>
+        {
+            var fullPath = Path.GetFullPath(path);
+            return _originalBySnapshot.TryGetValue(fullPath, out var originalPath)
+                ? originalPath
+                : fullPath;
+        }).ToArray();
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        DeleteSnapshot(_rootPath);
+    }
+
+    private static void DeleteSnapshot(string rootPath)
+    {
+        if (!Directory.Exists(rootPath))
+            return;
+
+        foreach (var path in Directory.EnumerateFiles(rootPath, "*", SearchOption.AllDirectories))
+        {
+            try { File.SetAttributes(path, FileAttributes.Normal); }
+            catch { }
+        }
+        try { Directory.Delete(rootPath, recursive: true); }
+        catch { }
+    }
+
+    private static string ComputeSha256(string path)
+    {
+        using var stream = File.OpenRead(path);
+        using var sha256 = System.Security.Cryptography.SHA256.Create();
+        return string.Concat(sha256.ComputeHash(stream).Select(static value => value.ToString("x2")));
+    }
+
+    private static StringComparer PathComparer => Path.DirectorySeparatorChar == '\\'
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
 }
 
 /// <summary>

--- a/PowerForge/Services/ModulePackageReleaseCheckpointService.cs
+++ b/PowerForge/Services/ModulePackageReleaseCheckpointService.cs
@@ -6,10 +6,14 @@ namespace PowerForge;
 internal sealed class ModulePackageReleaseCheckpointService
 {
     private readonly ProjectBuildHostService _projectBuildHostService;
+    private readonly ILogger _logger;
 
-    internal ModulePackageReleaseCheckpointService(ProjectBuildHostService? projectBuildHostService = null)
+    internal ModulePackageReleaseCheckpointService(
+        ProjectBuildHostService? projectBuildHostService = null,
+        ILogger? logger = null)
     {
         _projectBuildHostService = projectBuildHostService ?? new ProjectBuildHostService();
+        _logger = logger ?? new NullLogger();
     }
 
     internal PowerForgeModulePackageReleaseCheckpoint[] Capture(
@@ -60,6 +64,141 @@ internal sealed class ModulePackageReleaseCheckpointService
 
         return checkpoints.ToArray();
     }
+
+    internal PowerForgeModulePackagePublicationResult[] PublishNuGet(
+        string releaseConfigPath,
+        PowerForgeReleaseSpec spec,
+        IEnumerable<PowerForgeModulePackageReleaseCheckpoint>? checkpoints,
+        IEnumerable<PowerForgeReleaseAssetEntry>? releaseAssets,
+        bool requireStagedAssets,
+        Action? remotePublishAttempted,
+        IProjectBuildProgressReporter? progress,
+        CancellationToken cancellationToken)
+    {
+        var lanes = ResolveLanes(releaseConfigPath, spec)
+            .Where(static lane => lane.PublishNuget)
+            .ToArray();
+        var publisher = new ProjectBuildPublishHostService(_logger);
+        var publications = new List<PowerForgeModulePackagePublicationResult>(lanes.Length);
+        foreach (var lane in lanes)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var checkpoint = Restore(lane, checkpoints);
+            var configuration = lane.Reference is not null
+                ? publisher.LoadConfiguration(lane.Reference, lane.ConfigPath)
+                : publisher.LoadConfiguration(lane.Inline!, lane.ConfigPath);
+            var release = CreatePublicationRelease(
+                checkpoint.Release,
+                releaseAssets,
+                requireStagedAssets);
+            var publish = publisher.PublishNuGet(
+                configuration,
+                release,
+                repositoryRoot: ResolveRepositoryRoot(releaseConfigPath, spec),
+                remotePublishAttempted: remotePublishAttempted,
+                progress: progress);
+            var result = new PowerForgeModulePackagePublicationResult
+            {
+                Name = checkpoint.Name,
+                Success = publish.Success,
+                ErrorMessage = publish.ErrorMessage,
+                PublishSource = release.PublishSource,
+                PublishedPackages = release.PublishedPackages.ToArray(),
+                SkippedDuplicatePackages = release.SkippedDuplicatePackages.ToArray(),
+                FailedPackages = release.FailedPackages.ToArray()
+            };
+            publications.Add(result);
+            if (!result.Success)
+                throw new InvalidOperationException(result.ErrorMessage ?? $"NuGet publication failed for module package lane '{checkpoint.Name}'.");
+        }
+
+        return publications.ToArray();
+    }
+
+    internal static DotNetRepositoryReleaseResult CreatePublicationRelease(
+        DotNetRepositoryReleaseResult source,
+        IEnumerable<PowerForgeReleaseAssetEntry>? releaseAssets,
+        bool requireStagedAssets)
+    {
+        if (source is null)
+            throw new ArgumentNullException(nameof(source));
+        if (!source.Success)
+            throw new InvalidOperationException(source.ErrorMessage ?? "The module package release checkpoint was not successful.");
+
+        var stagedBySource = (releaseAssets ?? Array.Empty<PowerForgeReleaseAssetEntry>())
+            .Where(static asset =>
+                asset.Category == PowerForgeReleaseAssetCategory.Package &&
+                asset.IsFinalPackageOutput &&
+                !string.IsNullOrWhiteSpace(asset.Path) &&
+                !string.IsNullOrWhiteSpace(asset.StagedPath))
+            .GroupBy(asset => Path.GetFullPath(asset.Path), PathComparer)
+            .ToDictionary(
+                static group => group.Key,
+                static group => Path.GetFullPath(group.Single().StagedPath!),
+                PathComparer);
+        var clone = new DotNetRepositoryReleaseResult
+        {
+            Success = source.Success,
+            ErrorMessage = source.ErrorMessage,
+            ResolvedVersion = source.ResolvedVersion,
+            Projects = source.Projects.Select(project => new DotNetRepositoryProjectResult
+            {
+                ProjectName = project.ProjectName,
+                CsprojPath = project.CsprojPath,
+                PackageId = project.PackageId,
+                IsPackable = project.IsPackable,
+                OldVersion = project.OldVersion,
+                NewVersion = project.NewVersion,
+                Packages = project.Packages
+                    .Select(path => ResolvePublicationPackagePath(path, stagedBySource, requireStagedAssets))
+                    .ToList(),
+                SymbolPackages = project.SymbolPackages
+                    .Select(path => ResolvePublicationPackagePath(path, stagedBySource, requireStagedAssets))
+                    .ToList(),
+                ReleaseZipPath = project.ReleaseZipPath,
+                PackageBuildDuration = project.PackageBuildDuration,
+                ErrorMessage = project.ErrorMessage
+            }).ToList()
+        };
+        foreach (var version in source.ResolvedVersionsByProject)
+            clone.ResolvedVersionsByProject[version.Key] = version.Value;
+        return clone;
+    }
+
+    private static string ResolvePublicationPackagePath(
+        string path,
+        IReadOnlyDictionary<string, string> stagedBySource,
+        bool requireStagedAssets)
+    {
+        var fullPath = Path.GetFullPath(path);
+        if (stagedBySource.TryGetValue(fullPath, out var stagedPath))
+        {
+            if (!File.Exists(stagedPath))
+                throw new FileNotFoundException($"The staged package artifact was not found: {stagedPath}", stagedPath);
+            return stagedPath;
+        }
+
+        if (requireStagedAssets)
+        {
+            throw new InvalidOperationException(
+                $"The validated staged release does not contain package artifact '{fullPath}'.");
+        }
+        if (!File.Exists(fullPath))
+            throw new FileNotFoundException($"The package artifact was not found: {fullPath}", fullPath);
+        return fullPath;
+    }
+
+    private static string ResolveRepositoryRoot(string releaseConfigPath, PowerForgeReleaseSpec spec)
+    {
+        var releaseDirectory = Path.GetDirectoryName(releaseConfigPath) ?? Directory.GetCurrentDirectory();
+        return string.IsNullOrWhiteSpace(spec.Module?.RepositoryRoot)
+            ? releaseDirectory
+            : PathTokenProtection.GetFullPath(releaseDirectory, spec.Module!.RepositoryRoot!);
+    }
+
+    private static StringComparer PathComparer => Path.DirectorySeparatorChar == '\\'
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
 
     internal static PowerForgeModulePackageReleaseCheckpoint Restore(
         ModulePackageReleaseLane lane,

--- a/PowerForge/Services/NuGetPackagePublishService.cs
+++ b/PowerForge/Services/NuGetPackagePublishService.cs
@@ -7,7 +7,7 @@ namespace PowerForge;
 internal sealed class NuGetPackagePublishService
 {
     private readonly ILogger _logger;
-    private readonly Func<DotNetNuGetPushRequest, DotNetRepositoryReleaseService.PackagePushResult> _pushPackage;
+    private readonly Func<DotNetNuGetPushRequest, CancellationToken, DotNetRepositoryReleaseService.PackagePushResult> _pushPackage;
     private readonly string? _workingDirectory;
 
     public NuGetPackagePublishService(
@@ -16,7 +16,9 @@ internal sealed class NuGetPackagePublishService
         string? workingDirectory = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _pushPackage = pushPackage ?? PushPackage;
+        _pushPackage = pushPackage is null
+            ? PushPackage
+            : (request, _) => pushPackage(request);
         _workingDirectory = workingDirectory;
     }
 
@@ -81,7 +83,8 @@ internal sealed class NuGetPackagePublishService
                     request.SkipDuplicate,
                     request.WorkingDirectory ?? _workingDirectory,
                     timeout: null,
-                    suppressCompanionSymbols: true))
+                    suppressCompanionSymbols: true),
+                CancellationToken.None)
                 ?? new DotNetRepositoryReleaseService.PackagePushResult
                 {
                     Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
@@ -119,7 +122,8 @@ internal sealed class NuGetPackagePublishService
         bool publishFailFast = true,
         bool suppressCompanionSymbols = false,
         Action? remotePublishAttempted = null,
-        IProjectBuildProgressReporter? progress = null)
+        IProjectBuildProgressReporter? progress = null,
+        CancellationToken cancellationToken = default)
     {
         if (packages is null)
             throw new ArgumentNullException(nameof(packages));
@@ -165,6 +169,7 @@ internal sealed class NuGetPackagePublishService
 
         foreach (var package in packagePaths)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var item = progressItems[package];
             var watch = Stopwatch.StartNew();
             detailedProgress?.ItemUpdated(item, ProjectBuildProgressItemState.Started, "publishing");
@@ -227,6 +232,7 @@ internal sealed class NuGetPackagePublishService
             }
 
             remotePublishAttempted?.Invoke();
+            cancellationToken.ThrowIfCancellationRequested();
             var pushResult = _pushPackage(new DotNetNuGetPushRequest(
                     package,
                     apiKey,
@@ -234,7 +240,8 @@ internal sealed class NuGetPackagePublishService
                     skipDuplicate,
                     _workingDirectory,
                     timeout: null,
-                    suppressCompanionSymbols))
+                    suppressCompanionSymbols),
+                cancellationToken)
                 ?? new DotNetRepositoryReleaseService.PackagePushResult
                 {
                     Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
@@ -297,6 +304,8 @@ internal sealed class NuGetPackagePublishService
         return result;
     }
 
-    private static DotNetRepositoryReleaseService.PackagePushResult PushPackage(DotNetNuGetPushRequest request)
-        => DotNetRepositoryReleaseService.PushPackage(request);
+    private static DotNetRepositoryReleaseService.PackagePushResult PushPackage(
+        DotNetNuGetPushRequest request,
+        CancellationToken cancellationToken)
+        => DotNetRepositoryReleaseService.PushPackage(request, cancellationToken);
 }

--- a/PowerForge/Services/PowerForgeReleaseService.ModuleProducedAssets.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.ModuleProducedAssets.cs
@@ -1,0 +1,90 @@
+using System.IO.Compression;
+using System.Xml.Linq;
+
+namespace PowerForge;
+
+internal sealed partial class PowerForgeReleaseService
+{
+    private static PowerForgeReleaseAssetEntry CreateModuleProducedAssetEntry(
+        string fullPath,
+        PowerForgeModuleReleasePlanSummary? plan,
+        HashSet<string>? producedArtifactPaths)
+    {
+        if (IsNuGetPackagePath(fullPath))
+        {
+            bool hasIdentity = TryReadNuGetPackageIdentity(
+                fullPath,
+                out string? packageId,
+                out string? packageVersion);
+            string? releaseVersion = ResolveModuleReleaseVersion(plan);
+            bool versionMatches = string.IsNullOrWhiteSpace(releaseVersion) ||
+                                  string.Equals(packageVersion, releaseVersion, StringComparison.OrdinalIgnoreCase);
+            bool isSymbolsPackage = fullPath.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase) ||
+                                    fullPath.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase);
+            return new PowerForgeReleaseAssetEntry
+            {
+                Path = fullPath,
+                Category = PowerForgeReleaseAssetCategory.Package,
+                Source = "ModuleProjectBuild",
+                Target = packageId,
+                PackageId = packageId,
+                Version = packageVersion ?? releaseVersion,
+                IsFinalPackageOutput = hasIdentity && versionMatches && !isSymbolsPackage
+            };
+        }
+
+        return new PowerForgeReleaseAssetEntry
+        {
+            Path = fullPath,
+            Category = PowerForgeReleaseAssetCategory.Module,
+            Source = "Module",
+            Version = ResolveModuleReleaseVersion(plan),
+            IsFinalPackageOutput = producedArtifactPaths?.Contains(fullPath) == true &&
+                                   IsFinalPowerShellModulePackage(fullPath, plan)
+        };
+    }
+
+    private static bool IsNuGetPackagePath(string path)
+        => path.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase) ||
+           path.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase);
+
+    private static bool TryReadNuGetPackageIdentity(
+        string path,
+        out string? packageId,
+        out string? packageVersion)
+    {
+        packageId = null;
+        packageVersion = null;
+        try
+        {
+            using ZipArchive archive = ZipFile.OpenRead(path);
+            ZipArchiveEntry? nuspec = archive.Entries.FirstOrDefault(entry =>
+                entry.FullName.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase));
+            if (nuspec is null)
+                return false;
+
+            using Stream stream = nuspec.Open();
+            XDocument document = XDocument.Load(stream);
+            XElement? metadata = document
+                .Descendants()
+                .FirstOrDefault(element => element.Name.LocalName.Equals("metadata", StringComparison.OrdinalIgnoreCase));
+            packageId = metadata?
+                .Elements()
+                .FirstOrDefault(element => element.Name.LocalName.Equals("id", StringComparison.OrdinalIgnoreCase))?
+                .Value
+                .Trim();
+            packageVersion = metadata?
+                .Elements()
+                .FirstOrDefault(element => element.Name.LocalName.Equals("version", StringComparison.OrdinalIgnoreCase))?
+                .Value
+                .Trim();
+            return !string.IsNullOrWhiteSpace(packageId) && !string.IsNullOrWhiteSpace(packageVersion);
+        }
+        catch
+        {
+            packageId = null;
+            packageVersion = null;
+            return false;
+        }
+    }
+}

--- a/PowerForge/Services/PowerForgeReleaseService.ModuleProducedAssets.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.ModuleProducedAssets.cs
@@ -29,7 +29,10 @@ internal sealed partial class PowerForgeReleaseService
                 Target = packageId,
                 PackageId = packageId,
                 Version = packageVersion ?? releaseVersion,
-                IsFinalPackageOutput = hasIdentity && versionMatches && !isSymbolsPackage
+                IsFinalPackageOutput = producedArtifactPaths?.Contains(fullPath) == true &&
+                                       hasIdentity &&
+                                       versionMatches &&
+                                       !isSymbolsPackage
             };
         }
 

--- a/PowerForge/Services/PowerForgeReleaseService.ModuleProducedAssets.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.ModuleProducedAssets.cs
@@ -19,8 +19,6 @@ internal sealed partial class PowerForgeReleaseService
             string? releaseVersion = ResolveModuleReleaseVersion(plan);
             bool versionMatches = string.IsNullOrWhiteSpace(releaseVersion) ||
                                   string.Equals(packageVersion, releaseVersion, StringComparison.OrdinalIgnoreCase);
-            bool isSymbolsPackage = fullPath.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase) ||
-                                    fullPath.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase);
             return new PowerForgeReleaseAssetEntry
             {
                 Path = fullPath,
@@ -31,8 +29,7 @@ internal sealed partial class PowerForgeReleaseService
                 Version = packageVersion ?? releaseVersion,
                 IsFinalPackageOutput = producedArtifactPaths?.Contains(fullPath) == true &&
                                        hasIdentity &&
-                                       versionMatches &&
-                                       !isSymbolsPackage
+                                       versionMatches
             };
         }
 

--- a/PowerForge/Services/PowerForgeReleaseService.ModulePublication.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.ModulePublication.cs
@@ -12,11 +12,13 @@ internal sealed partial class PowerForgeReleaseService
         PowerForgeReleaseRequest releaseRequest,
         bool runPackages,
         bool willRunTools,
-        bool willRunAppleApps)
+        bool willRunAppleApps,
+        bool hasAfterStagingValidation)
         => moduleRequest.RunMode == ConfigurationGateMode.Publish &&
            moduleRequest.IncludeModulePublishing &&
-           (!releaseRequest.ModuleOnly || HasPostBuildSourceStateGuard(releaseRequest)) &&
-           (runPackages || willRunTools || willRunAppleApps || HasPostBuildSourceStateGuard(releaseRequest));
+           (hasAfterStagingValidation ||
+            ((!releaseRequest.ModuleOnly || HasPostBuildSourceStateGuard(releaseRequest)) &&
+             (runPackages || willRunTools || willRunAppleApps || HasPostBuildSourceStateGuard(releaseRequest))));
 
     private ModuleBuildHostExecutionResult ExecuteModuleRequest(
         ModuleBuildHostBuildRequest request,

--- a/PowerForge/Services/PowerForgeReleaseService.Validation.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.Validation.cs
@@ -5,12 +5,14 @@ internal sealed partial class PowerForgeReleaseService
     private static void ValidateReleaseValidationConfiguration(
         PowerForgeReleaseValidationOptions? validation,
         PowerForgeReleaseOutputsOptions outputs,
+        PowerForgeReleaseRequest request,
         string configurationDirectory)
     {
         var actions = GetAfterStagingValidationActions(validation);
         if (actions.Length == 0)
             return;
-        if (outputs?.Staging is null || string.IsNullOrWhiteSpace(outputs.Staging.RootPath))
+        if (string.IsNullOrWhiteSpace(request.StageRoot) &&
+            (outputs?.Staging is null || string.IsNullOrWhiteSpace(outputs.Staging.RootPath)))
         {
             throw new InvalidOperationException(
                 "Validation.AfterStaging requires Outputs.Staging.RootPath so the complete release can be inspected before publication.");
@@ -63,7 +65,7 @@ internal sealed partial class PowerForgeReleaseService
                 ResolvedVersion = resolvedVersion ?? result.ModulePlan?.ModuleVersion ?? string.Empty,
                 ReleaseManifestPath = result.ReleaseManifestPath,
                 ReleaseChecksumsPath = result.ReleaseChecksumsPath,
-                StagingRoot = ResolveValidationStagingRoot(spec, configurationDirectory),
+                StagingRoot = ResolveConfiguredStageRoot(spec, request, configurationDirectory),
                 ModuleStagingPath = result.ModulePlan?.StagingPath,
                 ReleaseAssets = result.ReleaseAssets.ToArray(),
                 StagedAssets = result.ReleaseAssetEntries
@@ -110,6 +112,47 @@ internal sealed partial class PowerForgeReleaseService
             : summary + Environment.NewLine + detail;
     }
 
+    private bool PublishToolGitHubAfterStaging(
+        PowerForgeReleaseSpec spec,
+        PowerForgeReleaseRequest request,
+        string configurationDirectory,
+        PowerForgeReleaseResult result,
+        string? resolvedVersion)
+    {
+        if (spec.Tools is null || !(request.PublishToolGitHub ?? spec.Tools.GitHub.Publish))
+            return true;
+
+        ValidatePostBuildSourceState(request);
+        request.CancellationToken.ThrowIfCancellationRequested();
+        if (result.DotNetToolPlan is not null && result.DotNetTools is not null)
+        {
+            result.ToolGitHubReleases = PublishDotNetToolGitHubReleases(
+                spec,
+                configurationDirectory,
+                result.DotNetToolPlan,
+                result.DotNetTools,
+                resolvedVersion,
+                request.CancellationToken);
+        }
+        else if (result.Tools is not null)
+        {
+            result.ToolGitHubReleases = PublishLegacyToolGitHubReleases(
+                spec,
+                configurationDirectory,
+                result.Tools,
+                request.CancellationToken);
+        }
+
+        var failure = result.ToolGitHubReleases.FirstOrDefault(static release => !release.Success);
+        if (failure is null)
+            return true;
+
+        request.Progress?.PhaseFailed(PowerForgeReleaseProgressPhase.Tools, failure.ErrorMessage);
+        result.Success = false;
+        result.ErrorMessage = failure.ErrorMessage ?? "Tool GitHub release publishing failed.";
+        return false;
+    }
+
     private static PowerForgeReleaseValidationAction[] GetAfterStagingValidationActions(
         PowerForgeReleaseValidationOptions? validation)
         => (validation?.AfterStaging ?? Array.Empty<PowerForgeReleaseValidationAction>())
@@ -125,11 +168,6 @@ internal sealed partial class PowerForgeReleaseService
         => string.IsNullOrWhiteSpace(spec.Module?.RepositoryRoot)
             ? configurationDirectory
             : ResolveValidationPath(configurationDirectory, spec.Module!.RepositoryRoot!);
-
-    private static string ResolveValidationStagingRoot(
-        PowerForgeReleaseSpec spec,
-        string configurationDirectory)
-        => ResolveValidationPath(configurationDirectory, spec.Outputs.Staging!.RootPath!);
 
     private static string ResolveValidationPath(string baseDirectory, string path)
         => Path.GetFullPath(Path.IsPathRooted(path)

--- a/PowerForge/Services/PowerForgeReleaseService.Validation.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.Validation.cs
@@ -1,0 +1,142 @@
+namespace PowerForge;
+
+internal sealed partial class PowerForgeReleaseService
+{
+    private static void ValidateReleaseValidationConfiguration(
+        PowerForgeReleaseValidationOptions? validation,
+        PowerForgeReleaseOutputsOptions outputs,
+        string configurationDirectory)
+    {
+        var actions = GetAfterStagingValidationActions(validation);
+        if (actions.Length == 0)
+            return;
+        if (outputs?.Staging is null || string.IsNullOrWhiteSpace(outputs.Staging.RootPath))
+        {
+            throw new InvalidOperationException(
+                "Validation.AfterStaging requires Outputs.Staging.RootPath so the complete release can be inspected before publication.");
+        }
+
+        foreach (var action in actions)
+        {
+            if (string.IsNullOrWhiteSpace(action.FilePath))
+                throw new InvalidOperationException("Validation.AfterStaging actions require FilePath.");
+            if (action.TimeoutSeconds <= 0)
+                throw new InvalidOperationException("Validation.AfterStaging action TimeoutSeconds must be greater than zero.");
+            var scriptPath = ResolveValidationPath(configurationDirectory, action.FilePath);
+            if (!File.Exists(scriptPath))
+                throw new FileNotFoundException($"Staged-release validation script was not found: {scriptPath}", scriptPath);
+            if (!string.IsNullOrWhiteSpace(action.WorkingDirectory))
+            {
+                var workingDirectory = ResolveValidationPath(configurationDirectory, action.WorkingDirectory!);
+                if (!Directory.Exists(workingDirectory))
+                {
+                    throw new DirectoryNotFoundException(
+                        $"Staged-release validation working directory was not found: {workingDirectory}");
+                }
+            }
+        }
+    }
+
+    private bool ExecuteAfterStagingValidations(
+        PowerForgeReleaseSpec spec,
+        PowerForgeReleaseRequest request,
+        string configurationDirectory,
+        PowerForgeReleaseResult result,
+        string? resolvedVersion)
+    {
+        var actions = GetAfterStagingValidationActions(spec.Validation);
+        if (actions.Length == 0)
+            return true;
+
+        request.Progress?.PhaseStarted(
+            PowerForgeReleaseProgressPhase.Validation,
+            actions.Length,
+            "Validating the complete staged release");
+        var validationResults = new List<PowerForgeReleaseValidationResult>(actions.Length);
+        foreach (var action in actions)
+        {
+            request.CancellationToken.ThrowIfCancellationRequested();
+            var context = new PowerForgeReleaseValidationContext
+            {
+                ConfigPath = result.ConfigPath,
+                ProjectRoot = ResolveValidationProjectRoot(spec, configurationDirectory),
+                ResolvedVersion = resolvedVersion ?? result.ModulePlan?.ModuleVersion ?? string.Empty,
+                ReleaseManifestPath = result.ReleaseManifestPath,
+                ReleaseChecksumsPath = result.ReleaseChecksumsPath,
+                StagingRoot = ResolveValidationStagingRoot(spec, configurationDirectory),
+                ModuleStagingPath = result.ModulePlan?.StagingPath,
+                ReleaseAssets = result.ReleaseAssets.ToArray(),
+                StagedAssets = result.ReleaseAssetEntries
+                    .Where(static asset => !string.IsNullOrWhiteSpace(asset.StagedPath))
+                    .Select(static asset => asset.StagedPath!)
+                    .Distinct(PathComparer)
+                    .ToArray()
+            };
+            var validation = _runReleaseValidation(
+                action,
+                context,
+                configurationDirectory,
+                request.CancellationToken);
+            validationResults.Add(validation);
+            result.ReleaseValidations = validationResults.ToArray();
+            if (validation.Succeeded)
+                continue;
+
+            var detail = BuildReleaseValidationFailure(validation);
+            request.Progress?.PhaseFailed(PowerForgeReleaseProgressPhase.Validation, detail);
+            result.Success = false;
+            result.ErrorMessage = detail;
+            return false;
+        }
+
+        request.Progress?.PhaseCompleted(
+            PowerForgeReleaseProgressPhase.Validation,
+            $"{validationResults.Count} staged-release validation action(s) passed");
+        return true;
+    }
+
+    private static string BuildReleaseValidationFailure(PowerForgeReleaseValidationResult result)
+    {
+        var detail = string.Join(
+            Environment.NewLine,
+            new[] { result.StdErr, result.StdOut }
+                .Where(static value => !string.IsNullOrWhiteSpace(value))
+                .Select(static value => value.Trim()));
+        var summary = result.TimedOut
+            ? $"Staged-release validation '{result.Name}' timed out."
+            : $"Staged-release validation '{result.Name}' failed with exit code {result.ExitCode}.";
+        return string.IsNullOrWhiteSpace(detail)
+            ? summary
+            : summary + Environment.NewLine + detail;
+    }
+
+    private static PowerForgeReleaseValidationAction[] GetAfterStagingValidationActions(
+        PowerForgeReleaseValidationOptions? validation)
+        => (validation?.AfterStaging ?? Array.Empty<PowerForgeReleaseValidationAction>())
+            .Where(static action => action is not null && action.Enabled)
+            .ToArray();
+
+    private static bool HasAfterStagingValidation(PowerForgeReleaseSpec spec)
+        => GetAfterStagingValidationActions(spec.Validation).Length > 0;
+
+    private static string ResolveValidationProjectRoot(
+        PowerForgeReleaseSpec spec,
+        string configurationDirectory)
+        => string.IsNullOrWhiteSpace(spec.Module?.RepositoryRoot)
+            ? configurationDirectory
+            : ResolveValidationPath(configurationDirectory, spec.Module!.RepositoryRoot!);
+
+    private static string ResolveValidationStagingRoot(
+        PowerForgeReleaseSpec spec,
+        string configurationDirectory)
+        => ResolveValidationPath(configurationDirectory, spec.Outputs.Staging!.RootPath!);
+
+    private static string ResolveValidationPath(string baseDirectory, string path)
+        => Path.GetFullPath(Path.IsPathRooted(path)
+            ? path
+            : Path.Combine(baseDirectory, path));
+
+    private static StringComparer PathComparer => Path.DirectorySeparatorChar == '\\'
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
+}

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -3550,17 +3550,6 @@ internal sealed partial class PowerForgeReleaseService
             return;
         }
 
-        if (!string.IsNullOrWhiteSpace(stageRootTemplate))
-        {
-            var stageRoot = ResolveOutputPath(configDirectory, stageRootTemplate!);
-            assetEntries = StageReleaseAssets(assetEntries, stageRoot, outputs.Staging).ToArray();
-        }
-
-        result.ReleaseAssetEntries = assetEntries;
-        result.ReleaseAssets = assetEntries
-            .Select(entry => entry.StagedPath ?? entry.Path)
-            .ToArray();
-
         var manifestPathTemplate = outputs.ManifestJsonPath;
         var checksumsPathTemplate = outputs.ChecksumsPath;
         if (!string.IsNullOrWhiteSpace(request.OutputRoot))
@@ -3577,6 +3566,26 @@ internal sealed partial class PowerForgeReleaseService
         var checksumsPath = string.IsNullOrWhiteSpace(checksumsPathTemplate)
             ? null
             : ResolveOutputPath(configDirectory, checksumsPathTemplate!);
+
+        if (!string.IsNullOrWhiteSpace(stageRootTemplate))
+        {
+            var stageRoot = ResolveOutputPath(configDirectory, stageRootTemplate!);
+            assetEntries = StageReleaseAssets(
+                assetEntries,
+                stageRoot,
+                outputs.Staging,
+                manifestPath,
+                checksumsPath).ToArray();
+        }
+        else
+        {
+            ValidateReleaseOutputDestinations(assetEntries, manifestPath, checksumsPath);
+        }
+
+        result.ReleaseAssetEntries = assetEntries;
+        result.ReleaseAssets = assetEntries
+            .Select(entry => entry.StagedPath ?? entry.Path)
+            .ToArray();
 
         if (!string.IsNullOrWhiteSpace(manifestPath))
         {
@@ -4401,9 +4410,14 @@ internal sealed partial class PowerForgeReleaseService
                 "Use DotNet publish Styles in config when Tools uses DotNetPublish.");
         }
 
+        DotNetPublishPipelineRunner runner = new(logger);
+        DotNetPublishPlan? configuredRuntimePlan = request.Runtimes is { Length: > 0 }
+            ? runner.Plan(spec, configPath)
+            : null;
         ApplyDotNetRequestOverrides(spec, request);
         ApplyDotNetToolOutputSelection(spec, selectedOutputs);
-        DotNetPublishPlan plan = new DotNetPublishPipelineRunner(logger).Plan(spec, configPath);
+        DotNetPublishPlan plan = runner.Plan(spec, configPath);
+        RetainConfiguredRestoreCombinations(plan, configuredRuntimePlan);
         string releaseConfigPath = Path.GetFullPath(request.ConfigPath.Trim().Trim('"'));
         plan.ConfigurationInputPaths = plan.ConfigurationInputPaths
             .Concat(new[] { releaseConfigPath })
@@ -4414,6 +4428,46 @@ internal sealed partial class PowerForgeReleaseService
         BindGeneratedConfigurationInput(plan, request);
         request.DotNetPublishPlan = plan;
         return plan;
+    }
+
+    internal static void RetainConfiguredRestoreCombinations(
+        DotNetPublishPlan plan,
+        DotNetPublishPlan? configuredPlan)
+    {
+        if (configuredPlan is null)
+            return;
+
+        foreach (DotNetPublishTargetPlan target in plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
+        {
+            DotNetPublishTargetPlan? configuredTarget = (configuredPlan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
+                .FirstOrDefault(candidate =>
+                    string.Equals(candidate.Name, target.Name, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(candidate.ProjectPath, target.ProjectPath, StringComparison.OrdinalIgnoreCase));
+            if (configuredTarget is null)
+                continue;
+
+            DotNetPublishTargetCombination[] selected = target.Combinations
+                ?? Array.Empty<DotNetPublishTargetCombination>();
+            var restoreCombinations = (configuredTarget.Combinations
+                    ?? Array.Empty<DotNetPublishTargetCombination>())
+                .Where(configured => selected.Any(executed =>
+                    string.Equals(executed.Framework, configured.Framework, StringComparison.OrdinalIgnoreCase)
+                    && executed.Style == configured.Style))
+                .ToList();
+            foreach (DotNetPublishTargetCombination executed in selected)
+            {
+                if (restoreCombinations.Any(configured =>
+                        string.Equals(executed.Framework, configured.Framework, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(executed.Runtime, configured.Runtime, StringComparison.OrdinalIgnoreCase)
+                        && executed.Style == configured.Style))
+                {
+                    continue;
+                }
+
+                restoreCombinations.Add(executed);
+            }
+            target.RestoreCombinations = restoreCombinations.ToArray();
+        }
     }
 
     private static void ApplyDotNetRequestOverrides(DotNetPublishSpec spec, PowerForgeReleaseRequest request)
@@ -5119,15 +5173,7 @@ internal sealed partial class PowerForgeReleaseService
         if (File.Exists(path))
         {
             var fullPath = Path.GetFullPath(path);
-            yield return new PowerForgeReleaseAssetEntry
-            {
-                Path = fullPath,
-                Category = PowerForgeReleaseAssetCategory.Module,
-                Source = "Module",
-                Version = ResolveModuleReleaseVersion(plan),
-                IsFinalPackageOutput = produced?.Contains(fullPath) == true &&
-                                       IsFinalPowerShellModulePackage(fullPath, plan)
-            };
+            yield return CreateModuleProducedAssetEntry(fullPath, plan, produced);
             yield break;
         }
 
@@ -5140,63 +5186,155 @@ internal sealed partial class PowerForgeReleaseService
             .OrderBy(static file => file, StringComparer.OrdinalIgnoreCase))
         {
             var fullPath = Path.GetFullPath(file);
-            yield return new PowerForgeReleaseAssetEntry
-            {
-                Path = fullPath,
-                Category = PowerForgeReleaseAssetCategory.Module,
-                Source = "Module",
-                Version = ResolveModuleReleaseVersion(plan),
-                IsFinalPackageOutput = produced?.Contains(fullPath) == true &&
-                                       IsFinalPowerShellModulePackage(fullPath, plan)
-            };
+            yield return CreateModuleProducedAssetEntry(fullPath, plan, produced);
         }
     }
 
     private static IEnumerable<PowerForgeReleaseAssetEntry> StageReleaseAssets(
         IEnumerable<PowerForgeReleaseAssetEntry> assetEntries,
         string stageRoot,
-        PowerForgeReleaseStagingOptions? stagingOptions)
+        PowerForgeReleaseStagingOptions? stagingOptions,
+        string? manifestPath,
+        string? checksumsPath)
     {
         var options = stagingOptions ?? new PowerForgeReleaseStagingOptions();
-        Directory.CreateDirectory(stageRoot);
-
-        foreach (var entry in assetEntries)
-        {
-            var sourcePath = entry.Path;
-            if (string.IsNullOrWhiteSpace(sourcePath))
-                continue;
-
-            var sourceIsFile = File.Exists(sourcePath);
-            var sourceIsDirectory = !sourceIsFile && Directory.Exists(sourcePath);
-            if (!sourceIsFile && !sourceIsDirectory)
-                continue;
-
-            var categoryDirectory = ResolveStageDirectory(options, entry.Category);
-            var relativeStagePath = Path.Combine(categoryDirectory, GetStageEntryName(entry, sourceIsDirectory, options));
-            var destinationPath = Path.Combine(stageRoot, relativeStagePath);
-            var sourceFullPath = Path.GetFullPath(sourcePath);
-            var destinationFullPath = Path.GetFullPath(destinationPath);
-
-            entry.RelativeStagePath = relativeStagePath.Replace('\\', '/');
-            entry.StagedPath = destinationFullPath;
-
-            if (string.Equals(sourceFullPath, destinationFullPath, StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            Directory.CreateDirectory(Path.GetDirectoryName(destinationFullPath)!);
-            if (sourceIsFile)
+        PowerForgeReleaseAssetEntry[] entries = assetEntries.ToArray();
+        var plannedEntries = entries
+            .Where(entry => !string.IsNullOrWhiteSpace(entry.Path))
+            .Select(entry =>
             {
-                File.Copy(sourceFullPath, destinationFullPath, overwrite: true);
+                string sourcePath = entry.Path;
+                bool sourceIsFile = File.Exists(sourcePath);
+                bool sourceIsDirectory = !sourceIsFile && Directory.Exists(sourcePath);
+                if (!sourceIsFile && !sourceIsDirectory)
+                    return null;
+
+                string categoryDirectory = ResolveStageDirectory(options, entry.Category);
+                string relativeStagePath = Path.Combine(
+                    categoryDirectory,
+                    GetStageEntryName(entry, sourceIsDirectory, options));
+                string sourceFullPath = Path.GetFullPath(sourcePath);
+                string destinationFullPath = Path.GetFullPath(Path.Combine(stageRoot, relativeStagePath));
+                entry.RelativeStagePath = relativeStagePath.Replace('\\', '/');
+                entry.StagedPath = destinationFullPath;
+                return new
+                {
+                    SourceFullPath = sourceFullPath,
+                    DestinationFullPath = destinationFullPath,
+                    SourceIsFile = sourceIsFile
+                };
+            })
+            .Where(entry => entry is not null)
+            .ToArray();
+
+        StringComparison sourcePathComparison = Path.DirectorySeparatorChar == '\\'
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        for (int firstIndex = 0; firstIndex < plannedEntries.Length; firstIndex++)
+        {
+            var first = plannedEntries[firstIndex]!;
+            for (int secondIndex = firstIndex + 1; secondIndex < plannedEntries.Length; secondIndex++)
+            {
+                var second = plannedEntries[secondIndex]!;
+                if (string.Equals(first.SourceFullPath, second.SourceFullPath, sourcePathComparison) &&
+                    string.Equals(
+                        first.DestinationFullPath,
+                        second.DestinationFullPath,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+                if (!ReleasePathsOverlap(first.DestinationFullPath, second.DestinationFullPath))
+                {
+                    continue;
+                }
+
+                throw new InvalidOperationException(
+                    $"Release staging destination collision between '{first.DestinationFullPath}' and " +
+                    $"'{second.DestinationFullPath}'. Distinct sources: '{first.SourceFullPath}', " +
+                    $"'{second.SourceFullPath}'.");
+            }
+        }
+        ValidateReleaseOutputDestinations(entries, manifestPath, checksumsPath);
+
+        Directory.CreateDirectory(stageRoot);
+        foreach (var plannedEntry in plannedEntries)
+        {
+            if (plannedEntry is null || string.Equals(
+                    plannedEntry.SourceFullPath,
+                    plannedEntry.DestinationFullPath,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(plannedEntry.DestinationFullPath)!);
+            if (plannedEntry.SourceIsFile)
+            {
+                File.Copy(plannedEntry.SourceFullPath, plannedEntry.DestinationFullPath, overwrite: true);
             }
             else
             {
-                if (Directory.Exists(destinationFullPath))
-                    Directory.Delete(destinationFullPath, recursive: true);
-                CopyDirectory(sourceFullPath, destinationFullPath);
+                if (Directory.Exists(plannedEntry.DestinationFullPath))
+                    Directory.Delete(plannedEntry.DestinationFullPath, recursive: true);
+                CopyDirectory(plannedEntry.SourceFullPath, plannedEntry.DestinationFullPath);
             }
         }
 
-        return assetEntries;
+        return entries;
+    }
+
+    internal static void ValidateReleaseOutputDestinations(
+        IReadOnlyCollection<PowerForgeReleaseAssetEntry> assetEntries,
+        string? manifestPath,
+        string? checksumsPath)
+    {
+        string[] generatedOutputPaths = new[] { manifestPath, checksumsPath }
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => Path.GetFullPath(path!))
+            .ToArray();
+        if (generatedOutputPaths.Length > 1 && string.Equals(
+                generatedOutputPaths[0],
+                generatedOutputPaths[1],
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Release manifest and checksum outputs resolve to the same destination '{generatedOutputPaths[0]}'.");
+        }
+
+        foreach (string generatedOutputPath in generatedOutputPaths)
+        {
+            PowerForgeReleaseAssetEntry? collision = assetEntries.FirstOrDefault(entry =>
+                (!string.IsNullOrWhiteSpace(entry.Path) &&
+                 ReleasePathsOverlap(Path.GetFullPath(entry.Path), generatedOutputPath)) ||
+                (!string.IsNullOrWhiteSpace(entry.StagedPath) &&
+                 ReleasePathsOverlap(Path.GetFullPath(entry.StagedPath!), generatedOutputPath)));
+            if (collision is null)
+            {
+                continue;
+            }
+
+            throw new InvalidOperationException(
+                $"Generated release output destination '{generatedOutputPath}' collides with staged asset " +
+                $"source '{Path.GetFullPath(collision.Path)}'.");
+        }
+    }
+
+    private static bool ReleasePathsOverlap(string firstPath, string secondPath)
+    {
+        string first = Path.GetFullPath(firstPath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        string second = Path.GetFullPath(secondPath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (string.Equals(first, second, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        string firstPrefix = first + Path.DirectorySeparatorChar;
+        string secondPrefix = second + Path.DirectorySeparatorChar;
+        return first.StartsWith(secondPrefix, StringComparison.OrdinalIgnoreCase) ||
+               second.StartsWith(firstPrefix, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string ResolveStageDirectory(PowerForgeReleaseStagingOptions options, PowerForgeReleaseAssetCategory category)
@@ -5709,7 +5847,15 @@ internal sealed partial class PowerForgeReleaseService
             : Path.GetFileName(sourcePath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
         var template = ResolveStageNameTemplate(options, entry.Category);
         if (string.IsNullOrWhiteSpace(template))
+        {
+            if (entry.Category == PowerForgeReleaseAssetCategory.Metadata &&
+                string.Equals(entry.Source, "DotNetPublish", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(defaultName, "SHA256SUMS.txt", StringComparison.OrdinalIgnoreCase))
+            {
+                return "DotNetPublish." + defaultName;
+            }
             return defaultName;
+        }
 
         var extension = isDirectory ? string.Empty : Path.GetExtension(sourcePath);
         var fileNameWithoutExtension = isDirectory

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -312,7 +312,7 @@ internal sealed partial class PowerForgeReleaseService
         ApplyAppleAction(spec.AppleApps, request);
         var explicitAppleAction = request.AppleAction != PowerForgeAppleReleaseAction.Configured;
         var configDirectory = Path.GetDirectoryName(configPath) ?? Directory.GetCurrentDirectory();
-        ValidateReleaseValidationConfiguration(spec.Validation, spec.Outputs, configDirectory);
+        ValidateReleaseValidationConfiguration(spec.Validation, spec.Outputs, request, configDirectory);
         ValidateVirusTotalConfiguration(spec.VirusTotal);
         var selectedToolOutputs = ResolveSelectedToolOutputs(request);
         var selectedTargets = NormalizeStrings(request.Targets);
@@ -441,10 +441,9 @@ internal sealed partial class PowerForgeReleaseService
             using (AcquireVirusTotalReceiptLock(spec.VirusTotal!, configDirectory))
                 EnsureVirusTotalReceiptWritable(spec.VirusTotal!, configDirectory, virusTotalProject);
         }
-        var captureModuleArtifactProvenance = ShouldCaptureVirusTotalModuleArtifactProvenance(
-            spec,
-            request,
-            runModule);
+        var captureModuleArtifactProvenance =
+            ShouldCaptureVirusTotalModuleArtifactProvenance(spec, request, runModule) ||
+            runModule && spec.Module?.IncludesPackages == true;
 
         if (!runModule && !runPackages && !runTools && !runAppleApps && !runWorkspaceValidation)
         {
@@ -718,27 +717,6 @@ internal sealed partial class PowerForgeReleaseService
                             return result;
                         }
 
-                        var publishToolGitHub = request.PublishToolGitHub ?? spec.Tools!.GitHub.Publish;
-                        if (publishToolGitHub)
-                        {
-                            ValidatePostBuildSourceState(request);
-                            var releases = PublishDotNetToolGitHubReleases(
-                                spec,
-                                configDirectory,
-                                dotNetPlan,
-                                dotNetTools,
-                                sharedReleaseVersion,
-                                request.CancellationToken);
-                            result.ToolGitHubReleases = releases;
-                            var failures = releases.Where(entry => !entry.Success).ToArray();
-                            if (failures.Length > 0)
-                            {
-                                request.Progress?.PhaseFailed(PowerForgeReleaseProgressPhase.Tools, failures[0].ErrorMessage);
-                                result.Success = false;
-                                result.ErrorMessage = failures[0].ErrorMessage ?? "Tool GitHub release publishing failed.";
-                                return result;
-                            }
-                        }
                     }
                 }
             }
@@ -776,25 +754,6 @@ internal sealed partial class PowerForgeReleaseService
                             return result;
                         }
 
-                        var publishToolGitHub = request.PublishToolGitHub ?? spec.Tools!.GitHub.Publish;
-                        if (publishToolGitHub)
-                        {
-                            ValidatePostBuildSourceState(request);
-                            var releases = PublishLegacyToolGitHubReleases(
-                                spec,
-                                configDirectory,
-                                tools,
-                                request.CancellationToken);
-                            result.ToolGitHubReleases = releases;
-                            var failures = releases.Where(entry => !entry.Success).ToArray();
-                            if (failures.Length > 0)
-                            {
-                                request.Progress?.PhaseFailed(PowerForgeReleaseProgressPhase.Tools, failures[0].ErrorMessage);
-                                result.Success = false;
-                                result.ErrorMessage = failures[0].ErrorMessage ?? "Tool GitHub release publishing failed.";
-                                return result;
-                            }
-                        }
                     }
                 }
             }
@@ -1066,6 +1025,19 @@ internal sealed partial class PowerForgeReleaseService
             request.Progress?.PhaseCompleted(
                 PowerForgeReleaseProgressPhase.Module,
                 "Module publication complete");
+        }
+
+        if (!request.PlanOnly &&
+            !request.ValidateOnly &&
+            !explicitAppleAction &&
+            !PublishToolGitHubAfterStaging(
+                spec,
+                request,
+                configDirectory,
+                result,
+                sharedReleaseVersion))
+        {
+            return result;
         }
 
         if (!request.PlanOnly && !request.ValidateOnly && !explicitAppleAction)
@@ -5348,6 +5320,12 @@ internal sealed partial class PowerForgeReleaseService
                     Directory.Delete(plannedEntry.DestinationFullPath, recursive: true);
                 CopyDirectory(plannedEntry.SourceFullPath, plannedEntry.DestinationFullPath);
             }
+        }
+
+        foreach (var entry in entries)
+        {
+            if (!string.IsNullOrWhiteSpace(entry.StagedPath) && File.Exists(entry.StagedPath))
+                entry.StagedSha256 = ComputeSha256(entry.StagedPath!);
         }
 
         return entries;

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -57,6 +57,7 @@ internal sealed partial class PowerForgeReleaseService
     private readonly Func<PowerForgeToolReleaseSpec, string, (DotNetPublishSpec Spec, string SourceConfigPath)> _loadDotNetToolsSpec;
     private readonly Func<DotNetPublishSpec, string, PowerForgeReleaseRequest, ISet<PowerForgeReleaseToolOutputKind>, DotNetPublishPlan> _planDotNetTools;
     private readonly Func<DotNetPublishPlan, IDotNetPublishProgressReporter?, CancellationToken, DotNetPublishResult> _runDotNetTools;
+    private readonly Func<PowerForgeReleaseValidationAction, PowerForgeReleaseValidationContext, string, CancellationToken, PowerForgeReleaseValidationResult> _runReleaseValidation;
     private readonly Func<GitHubReleasePublishRequest, CancellationToken, GitHubReleasePublishResult> _publishGitHubRelease;
     private readonly Func<string, string, IEnumerable<string>, CancellationToken, string[]>? _restorePublishedNuGetAssets;
     private readonly Func<string, string, string, IEnumerable<string>, CancellationToken, string[]>? _restorePublishedModuleAssets;
@@ -186,7 +187,8 @@ internal sealed partial class PowerForgeReleaseService
         Func<AppStoreConnectApiCredential, AppStoreConnectReleaseReadinessRequest, AppStoreConnectReleaseReadinessResult>? checkAppleReleaseReadiness = null,
         Func<string, string, IEnumerable<string>, CancellationToken, string[]>? restorePublishedNuGetAssets = null,
         Func<string, string, string, IEnumerable<string>, CancellationToken, string[]>? restorePublishedModuleAssets = null,
-        Func<VirusTotalMonitorPublishRequest, CancellationToken, VirusTotalMonitorPublishResult>? publishVirusTotalMonitor = null)
+        Func<VirusTotalMonitorPublishRequest, CancellationToken, VirusTotalMonitorPublishResult>? publishVirusTotalMonitor = null,
+        Func<PowerForgeReleaseValidationAction, PowerForgeReleaseValidationContext, string, CancellationToken, PowerForgeReleaseValidationResult>? runReleaseValidation = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _executePackages = executePackages ?? throw new ArgumentNullException(nameof(executePackages));
@@ -244,6 +246,13 @@ internal sealed partial class PowerForgeReleaseService
                 .PublishAsync(publishRequest, cancellationToken)
                 .GetAwaiter()
                 .GetResult());
+        _runReleaseValidation = runReleaseValidation
+            ?? ((action, context, configurationDirectory, cancellationToken) =>
+                new PowerForgeReleaseValidationService(_logger).Run(
+                    action,
+                    context,
+                    configurationDirectory,
+                    cancellationToken));
     }
 
     /// <summary>
@@ -303,6 +312,7 @@ internal sealed partial class PowerForgeReleaseService
         ApplyAppleAction(spec.AppleApps, request);
         var explicitAppleAction = request.AppleAction != PowerForgeAppleReleaseAction.Configured;
         var configDirectory = Path.GetDirectoryName(configPath) ?? Directory.GetCurrentDirectory();
+        ValidateReleaseValidationConfiguration(spec.Validation, spec.Outputs, configDirectory);
         ValidateVirusTotalConfiguration(spec.VirusTotal);
         var selectedToolOutputs = ResolveSelectedToolOutputs(request);
         var selectedTargets = NormalizeStrings(request.Targets);
@@ -532,7 +542,8 @@ internal sealed partial class PowerForgeReleaseService
                 request,
                 runPackages,
                 willRunTools,
-                willRunAppleApps);
+                willRunAppleApps,
+                HasAfterStagingValidation(spec));
             if (deferModulePublishing)
             {
                 if (!request.PlanOnly &&
@@ -949,6 +960,68 @@ internal sealed partial class PowerForgeReleaseService
             }
         }
 
+        if (!request.PlanOnly && !request.ValidateOnly && !explicitAppleAction)
+        {
+            ValidatePostBuildSourceState(request);
+            PopulateReleaseOutputs(spec, request, configDirectory, result, sharedReleaseVersion);
+            result.ToolGitHubReleasePlans = BuildToolGitHubReleasePlans(spec, result);
+            GenerateWingetOutputs(spec, request, configDirectory, result);
+            IncludeWingetOutputsInReleaseAssets(result);
+            RewriteReleaseSummaryFiles(result);
+            if (!ExecuteAfterStagingValidations(
+                    spec,
+                    request,
+                    configDirectory,
+                    result,
+                    sharedReleaseVersion))
+            {
+                return result;
+            }
+        }
+
+        if (deferredModulePublishRequest is not null &&
+            request.PublishNuget != false &&
+            result.ModulePlan?.IncludesProjectPackages == true &&
+            !request.PlanOnly &&
+            !request.ValidateOnly)
+        {
+            if (result.ModulePackagePlans.Length == 0)
+            {
+                result.Success = false;
+                result.ErrorMessage =
+                    "Deferred publication of module-owned NuGet packages requires Module.ConfigPath so PowerForge can publish the exact validated package checkpoint without rebuilding it.";
+                return result;
+            }
+
+            request.Progress?.PhaseStarted(
+                PowerForgeReleaseProgressPhase.Packages,
+                result.ModulePackagePlans.Length,
+                "Publishing validated module-owned NuGet packages");
+            try
+            {
+                result.ModulePackagePublications = new ModulePackageReleaseCheckpointService(logger: _logger)
+                    .PublishNuGet(
+                        configPath,
+                        spec,
+                        result.ModulePackagePlans,
+                        result.ReleaseAssetEntries,
+                        requireStagedAssets: HasAfterStagingValidation(spec),
+                        remotePublishAttempted: () => ValidatePostBuildSourceState(request),
+                        progress: null,
+                        cancellationToken: request.CancellationToken);
+                request.Progress?.PhaseCompleted(
+                    PowerForgeReleaseProgressPhase.Packages,
+                    $"{result.ModulePackagePublications.Length} module package lane(s) published");
+            }
+            catch (Exception exception)
+            {
+                request.Progress?.PhaseFailed(PowerForgeReleaseProgressPhase.Packages, exception.Message);
+                result.Success = false;
+                result.ErrorMessage = exception.Message;
+                return result;
+            }
+        }
+
         if (deferredModulePublishRequest is not null &&
             !request.PlanOnly &&
             !request.ValidateOnly)
@@ -997,12 +1070,6 @@ internal sealed partial class PowerForgeReleaseService
 
         if (!request.PlanOnly && !request.ValidateOnly && !explicitAppleAction)
         {
-            ValidatePostBuildSourceState(request);
-            PopulateReleaseOutputs(spec, request, configDirectory, result, sharedReleaseVersion);
-            result.ToolGitHubReleasePlans = BuildToolGitHubReleasePlans(spec, result);
-            GenerateWingetOutputs(spec, request, configDirectory, result);
-            IncludeWingetOutputsInReleaseAssets(result);
-            RewriteReleaseSummaryFiles(result);
             if (publishUnifiedGitHub)
             {
                 ValidatePostBuildSourceState(request);
@@ -2637,7 +2704,9 @@ internal sealed partial class PowerForgeReleaseService
                 if (uploadMutationMonitor is not null && uploadSnapshot is not null)
                 {
                     uploadMutationMonitor.ValidateNoChanges(
-                        () => uploadSnapshot.ValidateUnchanged(approvedArchiveSha256!));
+                        () => uploadSnapshot.ValidateUnchanged(
+                            approvedArchiveSha256!,
+                            allowExpectedScratchDirectoryMutation: true));
                 }
                 else
                 {

--- a/PowerForge/Services/PowerForgeReleaseValidationService.cs
+++ b/PowerForge/Services/PowerForgeReleaseValidationService.cs
@@ -104,14 +104,7 @@ internal sealed class PowerForgeReleaseValidationService
                 ?? throw new InvalidOperationException($"Unable to start staged-release validation '{actionName}'.");
             using var cancellationRegistration = cancellationToken.Register(() =>
             {
-                try
-                {
-#if NET472
-                    process.Kill();
-#else
-                    process.Kill(entireProcessTree: true);
-#endif
-                }
+                try { KillProcessTree(process); }
                 catch { }
             });
             var standardOutput = process.StandardOutput.ReadToEndAsync();
@@ -125,7 +118,7 @@ internal sealed class PowerForgeReleaseValidationService
                     continue;
 
                 timedOut = true;
-                try { process.Kill(); } catch { }
+                try { KillProcessTree(process); } catch { }
                 process.WaitForExit();
                 break;
             }
@@ -161,6 +154,31 @@ internal sealed class PowerForgeReleaseValidationService
             startInfo.EnvironmentVariables.Remove(name);
         else
             startInfo.EnvironmentVariables[name] = value;
+    }
+
+    private static void KillProcessTree(Process process)
+    {
+        if (process.HasExited)
+            return;
+
+#if NET472
+        if (Path.DirectorySeparatorChar == '\\')
+        {
+            using var taskKill = Process.Start(new ProcessStartInfo
+            {
+                FileName = "taskkill.exe",
+                Arguments = $"/PID {process.Id} /T /F",
+                UseShellExecute = false,
+                CreateNoWindow = true
+            });
+            taskKill?.WaitForExit();
+            return;
+        }
+
+        process.Kill();
+#else
+        process.Kill(entireProcessTree: true);
+#endif
     }
 
     private static string ResolvePowerShellExecutable(bool preferWindowsPowerShell)

--- a/PowerForge/Services/PowerForgeReleaseValidationService.cs
+++ b/PowerForge/Services/PowerForgeReleaseValidationService.cs
@@ -1,0 +1,187 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+
+namespace PowerForge;
+
+/// <summary>
+/// Runs consumer-owned validation against the complete staged release.
+/// </summary>
+internal sealed class PowerForgeReleaseValidationService
+{
+    private static readonly JsonSerializerOptions ContextJsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private readonly ILogger _logger;
+
+    internal PowerForgeReleaseValidationService(ILogger logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    internal PowerForgeReleaseValidationResult Run(
+        PowerForgeReleaseValidationAction action,
+        PowerForgeReleaseValidationContext context,
+        string configurationDirectory,
+        CancellationToken cancellationToken)
+    {
+        if (action is null)
+            throw new ArgumentNullException(nameof(action));
+        if (context is null)
+            throw new ArgumentNullException(nameof(context));
+        if (string.IsNullOrWhiteSpace(configurationDirectory))
+            throw new ArgumentException("Configuration directory is required.", nameof(configurationDirectory));
+        if (string.IsNullOrWhiteSpace(action.FilePath))
+            throw new InvalidOperationException("A staged-release validation action requires FilePath.");
+        if (action.TimeoutSeconds <= 0)
+            throw new InvalidOperationException("A staged-release validation action TimeoutSeconds must be greater than zero.");
+
+        var scriptPath = ResolvePath(configurationDirectory, action.FilePath);
+        if (!File.Exists(scriptPath))
+            throw new FileNotFoundException($"Staged-release validation script was not found: {scriptPath}", scriptPath);
+
+        var workingDirectory = string.IsNullOrWhiteSpace(action.WorkingDirectory)
+            ? configurationDirectory
+            : ResolvePath(configurationDirectory, action.WorkingDirectory!);
+        if (!Directory.Exists(workingDirectory))
+            throw new DirectoryNotFoundException($"Staged-release validation working directory was not found: {workingDirectory}");
+
+        var actionName = string.IsNullOrWhiteSpace(action.Name)
+            ? Path.GetFileNameWithoutExtension(scriptPath)
+            : action.Name!.Trim();
+        var contextDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge",
+            "release-validation",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(contextDirectory);
+        var contextPath = Path.Combine(contextDirectory, "context.json");
+        context.ActionName = actionName;
+        context.ContextPath = contextPath;
+        File.WriteAllText(contextPath, JsonSerializer.Serialize(context, ContextJsonOptions), new UTF8Encoding(false));
+
+        try
+        {
+            var executable = ResolvePowerShellExecutable(action.PreferWindowsPowerShell);
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = executable,
+                WorkingDirectory = workingDirectory,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+#if NET472
+            startInfo.Arguments = $"-NoLogo -NoProfile -NonInteractive -File \"{scriptPath}\"";
+#else
+            foreach (var argument in new[] { "-NoLogo", "-NoProfile", "-NonInteractive", "-File", scriptPath })
+                startInfo.ArgumentList.Add(argument);
+#endif
+            ProcessStartInfoEncoding.TryApplyUtf8(startInfo);
+            foreach (var entry in action.Environment ?? new Dictionary<string, string?>())
+            {
+                if (string.IsNullOrWhiteSpace(entry.Key))
+                    continue;
+                if (entry.Value is null)
+                    startInfo.EnvironmentVariables.Remove(entry.Key.Trim());
+                else
+                    startInfo.EnvironmentVariables[entry.Key.Trim()] = entry.Value;
+            }
+
+            startInfo.EnvironmentVariables["POWERFORGE_CONTEXT"] = contextPath;
+            startInfo.EnvironmentVariables["POWERFORGE_RELEASE_STAGE"] = context.Stage;
+            startInfo.EnvironmentVariables["POWERFORGE_RELEASE_VERSION"] = context.ResolvedVersion;
+            SetEnvironmentValue(startInfo, "POWERFORGE_RELEASE_MANIFEST", context.ReleaseManifestPath);
+            SetEnvironmentValue(startInfo, "POWERFORGE_RELEASE_CHECKSUMS", context.ReleaseChecksumsPath);
+            SetEnvironmentValue(startInfo, "POWERFORGE_RELEASE_STAGING_ROOT", context.StagingRoot);
+            SetEnvironmentValue(startInfo, "POWERFORGE_MODULE_STAGING_PATH", context.ModuleStagingPath);
+
+            _logger.Info($"Running staged-release validation '{actionName}'.");
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException($"Unable to start staged-release validation '{actionName}'.");
+            using var cancellationRegistration = cancellationToken.Register(() =>
+            {
+                try
+                {
+#if NET472
+                    process.Kill();
+#else
+                    process.Kill(entireProcessTree: true);
+#endif
+                }
+                catch { }
+            });
+            var standardOutput = process.StandardOutput.ReadToEndAsync();
+            var standardError = process.StandardError.ReadToEndAsync();
+            var deadline = DateTime.UtcNow.AddSeconds(action.TimeoutSeconds);
+            var timedOut = false;
+            while (!process.WaitForExit(100))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (DateTime.UtcNow < deadline)
+                    continue;
+
+                timedOut = true;
+                try { process.Kill(); } catch { }
+                process.WaitForExit();
+                break;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var stdout = standardOutput.GetAwaiter().GetResult();
+            var stderr = standardError.GetAwaiter().GetResult();
+            var result = new PowerForgeReleaseValidationResult
+            {
+                Name = actionName,
+                Succeeded = !timedOut && process.ExitCode == 0,
+                ExitCode = timedOut ? -1 : process.ExitCode,
+                Executable = executable,
+                FilePath = scriptPath,
+                WorkingDirectory = workingDirectory,
+                StdOut = stdout,
+                StdErr = stderr,
+                TimedOut = timedOut
+            };
+            if (result.Succeeded)
+                _logger.Success($"Staged-release validation '{actionName}' completed successfully.");
+            return result;
+        }
+        finally
+        {
+            try { Directory.Delete(contextDirectory, recursive: true); } catch { }
+        }
+    }
+
+    private static void SetEnvironmentValue(ProcessStartInfo startInfo, string name, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            startInfo.EnvironmentVariables.Remove(name);
+        else
+            startInfo.EnvironmentVariables[name] = value;
+    }
+
+    private static string ResolvePowerShellExecutable(bool preferWindowsPowerShell)
+    {
+        if (Path.DirectorySeparatorChar == '\\' && preferWindowsPowerShell)
+        {
+            var windowsPowerShell = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.System),
+                "WindowsPowerShell",
+                "v1.0",
+                "powershell.exe");
+            if (File.Exists(windowsPowerShell))
+                return windowsPowerShell;
+        }
+
+        return "pwsh";
+    }
+
+    private static string ResolvePath(string baseDirectory, string path)
+        => Path.GetFullPath(Path.IsPathRooted(path)
+            ? path
+            : Path.Combine(baseDirectory, path));
+
+}

--- a/PowerForge/Services/ProjectBuildPublishHostService.cs
+++ b/PowerForge/Services/ProjectBuildPublishHostService.cs
@@ -118,8 +118,69 @@ public sealed class ProjectBuildPublishHostService
             GitHubPrimaryProject = TrimOrNull(config.GitHubPrimaryProject),
             GitHubTagConflictPolicy = TrimOrNull(config.GitHubTagConflictPolicy),
             PublishFailFast = config.PublishFailFast ?? true,
-            SkipDuplicate = config.SkipDuplicate ?? true
+            SkipDuplicate = config.SkipDuplicate ?? true,
+            IncludeSymbols = config.IncludeSymbols ?? false
         };
+    }
+
+    /// <summary>
+    /// Publishes the exact package files recorded in an existing release result without rebuilding them.
+    /// </summary>
+    internal NuGetPackagePublishResult PublishNuGet(
+        ProjectBuildPublishHostConfiguration configuration,
+        DotNetRepositoryReleaseResult release,
+        string? repositoryRoot = null,
+        Action? remotePublishAttempted = null,
+        IProjectBuildProgressReporter? progress = null)
+    {
+        FrameworkCompatibility.NotNull(configuration, nameof(configuration));
+        FrameworkCompatibility.NotNull(release, nameof(release));
+        if (!configuration.PublishNuget)
+            throw new InvalidOperationException("NuGet publishing is not enabled for this package lane.");
+        if (string.IsNullOrWhiteSpace(configuration.PublishApiKey))
+            throw new InvalidOperationException("PublishApiKey is required when package NuGet publishing is enabled.");
+
+        var configDirectory = Path.GetDirectoryName(configuration.ConfigPath);
+        if (string.IsNullOrWhiteSpace(configDirectory))
+            throw new InvalidOperationException($"Unable to resolve the configuration directory for '{configuration.ConfigPath}'.");
+        var source = DotNetRepositoryReleaseService.ResolvePublishSource(
+            configuration.PublishSource,
+            string.IsNullOrWhiteSpace(repositoryRoot) ? configDirectory : repositoryRoot!,
+            nuGetConfigSearchRoot: configDirectory);
+        release.PublishSource = source;
+        var publishSymbolsSeparately = configuration.IncludeSymbols &&
+            DotNetRepositoryReleaseService.IsLocalPublishSource(source);
+        var packages = DotNetRepositoryReleaseService.GetPackagesForPublish(
+            release.Projects,
+            includeSymbolPackages: publishSymbolsSeparately);
+        if (packages.Length == 0)
+            throw new InvalidOperationException("The package release checkpoint contains no package artifacts to publish.");
+
+        _logger.Info($"Publishing {packages.Length} existing package(s) from the staged release checkpoint.");
+        var publish = new NuGetPackagePublishService(
+            _logger,
+            workingDirectory: configDirectory).ExecutePackages(
+            packages,
+            configuration.PublishApiKey!,
+            source,
+            configuration.SkipDuplicate,
+            configuration.PublishFailFast,
+            suppressCompanionSymbols: !configuration.IncludeSymbols || publishSymbolsSeparately,
+            remotePublishAttempted: remotePublishAttempted,
+            progress: progress);
+
+        DotNetRepositoryReleaseService.ApplyPublishedNuGetArtifactOutcomes(
+            release,
+            publish,
+            publishSymbolsSeparately,
+            configuration.SkipDuplicate);
+        if (!publish.Success)
+        {
+            release.Success = false;
+            release.ErrorMessage = publish.ErrorMessage ?? "One or more packages failed to publish.";
+        }
+
+        return publish;
     }
 
     /// <summary>

--- a/PowerForge/Services/ProjectBuildPublishHostService.cs
+++ b/PowerForge/Services/ProjectBuildPublishHostService.cs
@@ -131,7 +131,8 @@ public sealed class ProjectBuildPublishHostService
         DotNetRepositoryReleaseResult release,
         string? repositoryRoot = null,
         Action? remotePublishAttempted = null,
-        IProjectBuildProgressReporter? progress = null)
+        IProjectBuildProgressReporter? progress = null,
+        CancellationToken cancellationToken = default)
     {
         FrameworkCompatibility.NotNull(configuration, nameof(configuration));
         FrameworkCompatibility.NotNull(release, nameof(release));
@@ -167,7 +168,8 @@ public sealed class ProjectBuildPublishHostService
             configuration.PublishFailFast,
             suppressCompanionSymbols: !configuration.IncludeSymbols || publishSymbolsSeparately,
             remotePublishAttempted: remotePublishAttempted,
-            progress: progress);
+            progress: progress,
+            cancellationToken: cancellationToken);
 
         DotNetRepositoryReleaseService.ApplyPublishedNuGetArtifactOutcomes(
             release,

--- a/Schemas/powerforge.release.schema.json
+++ b/Schemas/powerforge.release.schema.json
@@ -96,6 +96,32 @@
         }
       }
     },
+    "Validation": {
+      "type": [ "object", "null" ],
+      "additionalProperties": false,
+      "properties": {
+        "AfterStaging": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [ "FilePath" ],
+            "properties": {
+              "Enabled": { "type": "boolean" },
+              "Name": { "type": [ "string", "null" ] },
+              "FilePath": { "type": "string", "minLength": 1 },
+              "WorkingDirectory": { "type": [ "string", "null" ] },
+              "Environment": {
+                "type": "object",
+                "additionalProperties": { "type": [ "string", "null" ] }
+              },
+              "TimeoutSeconds": { "type": "integer", "minimum": 1 },
+              "PreferWindowsPowerShell": { "type": "boolean" }
+            }
+          }
+        }
+      }
+    },
     "GitHub": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
## Summary

PowerForge is the shared release owner for projects that combine PowerShell modules, NuGet packages, and portable tools. This change makes that release path fail closed and reusable:

- preserves complete restore and source-provenance coverage across filtered runtime matrices, bundles, renamed executables, and retained nested outputs;
- preserves Unix executable permissions in Linux and macOS archives;
- classifies module-produced primary and symbol packages from current-run evidence and stages them under the package layout;
- plans signed module/package outputs without invoking signing handlers or certificate discovery in WhatIf mode;
- validates the complete staged release before any registry or GitHub publication;
- publishes immutable private snapshots of the exact validated NuGet bytes, with cancellation propagated through active and remaining pushes;
- requires legacy module wrappers to support the complete deferred Build/Publish checkpoint contract;
- publishes module-owned NuGet and PowerShell Gallery lanes before per-tool or unified GitHub releases;
- honors request-level staging roots and terminates validation process trees on timeout or cancellation.

## Ownership and release order

This repository owns the reusable release behavior. [EventViewerX](https://github.com/EvotecIT/EventViewerX) remains a thin consumer that declares its module, NuGet, CLI, staging, and validation inputs.

Merge and release the PowerForge owner first. EventViewerX can then pin the public three-part owner version before its eventual 4.0 publication. Neither project is published by this PR.

## Validation

- Five focused signed-planning regression tests pass.
- Before rebasing, the narrowed release/package owner suite passed all 651 tests.
- After rebasing onto current `main`, the release-only suite passes 304/304 and the deterministic provenance/release integration set passes 6/6.
- The dedicated locked-restore and provenance gate passes.
- A local PowerForge module build succeeds without signing or publication.
- A final downstream no-publish rehearsal against exact owner head `8ced70a5` produced one PowerShell module ZIP, six NuGet packages, twelve cross-platform CLI ZIPs, and six metadata assets in one 25-asset manifest; all 26 recorded SHA-256 entries matched independently.
- One independent read-only review and its single targeted confirmation were completed; all validated in-scope findings are addressed.
