### PR TITLE
Fix build-publish project output provenance

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceRuntimeContext.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceRuntimeContext.cs
@@ -1,0 +1,144 @@
+using PowerForge;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
+{
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void ReadSourceProvenance_BuildPublishIgnoresPreexistingProjectReferenceOutputFromAnotherVersionContext()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string appDirectory = Directory.CreateDirectory(Path.Combine(root, "App")).FullName;
+            string libraryDirectory = Directory.CreateDirectory(Path.Combine(root, "Library")).FullName;
+            string appProject = Path.Combine(appDirectory, "App.csproj");
+            string libraryProject = Path.Combine(libraryDirectory, "Library.csproj");
+            File.WriteAllText(appProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net8.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup><ProjectReference Include="../Library/Library.csproj" /></ItemGroup>
+                </Project>
+                """);
+            File.WriteAllText(libraryProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+                </Project>
+                """);
+            File.WriteAllText(
+                Path.Combine(appDirectory, "Program.cs"),
+                "internal static class Program { private static void Main() { _ = Library.Value; } }");
+            File.WriteAllText(
+                Path.Combine(libraryDirectory, "Library.cs"),
+                "public static class Library { public const int Value = 1; }");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
+            RunDotNet(root, $"restore \"{appProject}\" --use-lock-file --nologo");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source and dependency locks\"");
+            RunDotNet(
+                root,
+                $"build \"{appProject}\" -c Release --no-restore --nologo -p:Version=0.1.0");
+
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Configuration = "Release",
+                NoBuildInPublish = false,
+                Targets =
+                [
+                    new DotNetPublishTargetPlan
+                    {
+                        Name = "App",
+                        ProjectPath = appProject,
+                        Publish = new DotNetPublishPublishOptions
+                        {
+                            Sign = new DotNetPublishSignOptions { Enabled = true },
+                            MsBuildProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                            {
+                                ["Version"] = "27.0.9742"
+                            }
+                        },
+                        Combinations =
+                        [
+                            new DotNetPublishTargetCombination
+                            {
+                                Framework = "net8.0",
+                                Style = DotNetPublishStyle.FrameworkDependent
+                            }
+                        ]
+                    }
+                ]
+            };
+
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(root, buildPlan: plan);
+
+            Assert.False(provenance.Dirty, string.Join(Environment.NewLine, provenance.DirtyReasons));
+            Assert.Empty(provenance.DirtyPaths);
+            Assert.True(File.Exists(Path.Combine(
+                libraryDirectory,
+                "bin",
+                "Release",
+                "net8.0",
+                "Library.dll")));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void GeneratedProjectReferenceOutputProofs_RunOnlyWhenPublishConsumesPrebuiltOutputs()
+    {
+        var target = new DotNetPublishTargetPlan
+        {
+            Name = "App",
+            ProjectPath = Path.GetFullPath(Path.Combine("src", "App", "App.csproj")),
+            Publish = new DotNetPublishPublishOptions
+            {
+                Sign = new DotNetPublishSignOptions { Enabled = true }
+            }
+        };
+        var combination = new DotNetPublishTargetCombination
+        {
+            Framework = "net8.0",
+            Runtime = "win-x64",
+            Style = DotNetPublishStyle.FrameworkDependent
+        };
+        var plan = new DotNetPublishPlan
+        {
+            NoBuildInPublish = false
+        };
+
+        Assert.False(DotNetPublishPipelineRunner.PublishConsumesPrebuiltProjectReferenceOutputs(
+            plan,
+            target,
+            combination));
+        Assert.False(DotNetPublishPipelineRunner.RequiresPrebuiltProjectReferenceOutputProof(
+            plan,
+            target,
+            combination));
+
+        plan.NoBuildInPublish = true;
+
+        Assert.True(DotNetPublishPipelineRunner.PublishConsumesPrebuiltProjectReferenceOutputs(
+            plan,
+            target,
+            combination));
+        Assert.True(DotNetPublishPipelineRunner.RequiresPrebuiltProjectReferenceOutputProof(
+            plan,
+            target,
+            combination));
+    }
+
+}

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceRuntimeContext.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceRuntimeContext.cs
@@ -189,4 +189,223 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
             combination));
     }
 
+    [Theory]
+    [InlineData("ProjectProperty")]
+    [InlineData("EnvironmentProperty")]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void ReadSourceProvenance_BuildPublishProvesEvaluatedProjectReferenceSuppression(string suppressionMode)
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string appDirectory = Directory.CreateDirectory(Path.Combine(root, "App")).FullName;
+            string libraryDirectory = Directory.CreateDirectory(Path.Combine(root, "Library")).FullName;
+            string appProject = Path.Combine(appDirectory, "App.csproj");
+            string libraryProject = Path.Combine(libraryDirectory, "Library.csproj");
+            string projectProperty = suppressionMode == "ProjectProperty"
+                ? "<BuildProjectReferences>false</BuildProjectReferences>"
+                : string.Empty;
+            File.WriteAllText(appProject, $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net8.0</TargetFramework>
+                    {projectProperty}
+                  </PropertyGroup>
+                  <ItemGroup><ProjectReference Include="../Library/Library.csproj" /></ItemGroup>
+                </Project>
+                """);
+            File.WriteAllText(libraryProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+                </Project>
+                """);
+            File.WriteAllText(
+                Path.Combine(appDirectory, "Program.cs"),
+                "internal static class Program { private static void Main() { _ = Library.Value; } }");
+            File.WriteAllText(
+                Path.Combine(libraryDirectory, "Library.cs"),
+                "public static class Library { public const int Value = 1; }");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\n");
+            RunDotNet(root, $"restore \"{appProject}\" --use-lock-file --nologo");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source and dependency locks\"");
+            RunDotNet(
+                root,
+                $"build \"{libraryProject}\" -c Release --no-restore --nologo -p:Version=0.1.0");
+
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Configuration = "Release",
+                NoBuildInPublish = false,
+                EnvironmentVariables = suppressionMode == "EnvironmentProperty"
+                    ? new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["BuildProjectReferences"] = "false"
+                    }
+                    : new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase),
+                Targets =
+                [
+                    new DotNetPublishTargetPlan
+                    {
+                        Name = "App",
+                        ProjectPath = appProject,
+                        Publish = new DotNetPublishPublishOptions
+                        {
+                            Sign = new DotNetPublishSignOptions { Enabled = true },
+                            MsBuildProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                            {
+                                ["Version"] = "27.0.9742"
+                            }
+                        },
+                        Combinations =
+                        [
+                            new DotNetPublishTargetCombination
+                            {
+                                Framework = "net8.0",
+                                Style = DotNetPublishStyle.FrameworkDependent
+                            }
+                        ]
+                    }
+                ]
+            };
+
+            DotNetPublishPipelineRunner.SourceProvenance provenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(root, buildPlan: plan);
+
+            Assert.True(provenance.Dirty);
+            Assert.Contains(provenance.DirtyReasons, reason =>
+                reason.Contains("Library.dll", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void Run_BuildPublishRejectsPrebuiltProjectReferenceOutputReplacement()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            string appDirectory = Directory.CreateDirectory(Path.Combine(root, "App")).FullName;
+            string libraryDirectory = Directory.CreateDirectory(Path.Combine(root, "Library")).FullName;
+            string appProject = Path.Combine(appDirectory, "App.csproj");
+            string libraryProject = Path.Combine(libraryDirectory, "Library.csproj");
+            string outputDirectory = Path.Combine(root, "publish");
+            File.WriteAllText(appProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net8.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup><ProjectReference Include="../Library/Library.csproj" /></ItemGroup>
+                </Project>
+                """);
+            File.WriteAllText(libraryProject, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+                </Project>
+                """);
+            File.WriteAllText(
+                Path.Combine(appDirectory, "Program.cs"),
+                "internal static class Program { private static void Main() { _ = Library.Value; } }");
+            File.WriteAllText(
+                Path.Combine(libraryDirectory, "Library.cs"),
+                "public static class Library { public const int Value = 1; }");
+            File.WriteAllText(Path.Combine(root, ".gitignore"), "bin/\nobj/\npublish/\n");
+            RunDotNet(root, $"restore \"{appProject}\" --use-lock-file --nologo");
+            RunGit(root, "add .");
+            RunGit(root, "commit -m \"approved source and dependency locks\"");
+            string revision = RunGit(root, "rev-parse HEAD").Trim();
+            RunDotNet(
+                root,
+                $"build \"{appProject}\" -c Release -f net8.0 --no-restore --nologo " +
+                $"/p:SourceRevisionId={revision} " +
+                "/p:IncludeSourceRevisionInInformationalVersion=true");
+            string libraryOutput = Path.Combine(libraryDirectory, "bin", "Release", "net8.0", "Library.dll");
+            Assert.True(File.Exists(libraryOutput), libraryOutput);
+            byte[] provenBytes = File.ReadAllBytes(libraryOutput);
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Configuration = "Release",
+                SourceRevision = revision,
+                NoBuildInPublish = false,
+                NoRestoreInPublish = true,
+                MsBuildProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["BuildProjectReferences"] = "false"
+                },
+                Targets =
+                [
+                    new DotNetPublishTargetPlan
+                    {
+                        Name = "App",
+                        ProjectPath = appProject,
+                        Publish = new DotNetPublishPublishOptions
+                        {
+                            OutputPath = outputDirectory,
+                            Style = DotNetPublishStyle.FrameworkDependent,
+                            Sign = new DotNetPublishSignOptions { Enabled = true }
+                        },
+                        Combinations =
+                        [
+                            new DotNetPublishTargetCombination
+                            {
+                                Framework = "net8.0",
+                                Runtime = string.Empty,
+                                Style = DotNetPublishStyle.FrameworkDependent
+                            }
+                        ]
+                    }
+                ],
+                Steps =
+                [
+                    new DotNetPublishStep
+                    {
+                        Kind = DotNetPublishStepKind.Publish,
+                        TargetName = "App",
+                        Framework = "net8.0",
+                        Runtime = string.Empty,
+                        Style = DotNetPublishStyle.FrameworkDependent
+                    }
+                ]
+            };
+            var runner = new DotNetPublishPipelineRunner(
+                new NullLogger(),
+                new RestoringProjectReferenceOutputRunner(libraryOutput, provenBytes));
+
+            DotNetPublishResult result = runner.Run(plan, progress: null);
+
+            Assert.False(result.Succeeded);
+            string errorMessage = result.ErrorMessage ?? string.Empty;
+            Assert.True(
+                errorMessage.Contains(
+                    "Release source changed after planning",
+                    StringComparison.OrdinalIgnoreCase) ||
+                errorMessage.Contains(
+                    "cannot access the file",
+                    StringComparison.OrdinalIgnoreCase),
+                errorMessage);
+            Assert.Equal(provenBytes, File.ReadAllBytes(libraryOutput));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
 }

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceRuntimeContext.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceRuntimeContext.cs
@@ -89,6 +89,15 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
                 "Release",
                 "net8.0",
                 "Library.dll")));
+
+            plan.MsBuildProperties["BuildProjectReferences"] = "false";
+
+            DotNetPublishPipelineRunner.SourceProvenance prebuiltProvenance =
+                DotNetPublishPipelineRunner.ReadSourceProvenance(root, buildPlan: plan);
+
+            Assert.True(prebuiltProvenance.Dirty);
+            Assert.Contains(prebuiltProvenance.DirtyReasons, reason =>
+                reason.Contains("Library.dll", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {
@@ -128,6 +137,45 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
             plan,
             target,
             combination));
+
+        plan.MsBuildProperties["BuildProjectReferences"] = "false";
+
+        Assert.True(DotNetPublishPipelineRunner.PublishConsumesPrebuiltProjectReferenceOutputs(
+            plan,
+            target,
+            combination));
+
+        plan.MsBuildProperties["BuildProjectReferences"] = "true";
+        target.Publish.MsBuildProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["BuildProjectReferences"] = "false"
+        };
+
+        Assert.True(DotNetPublishPipelineRunner.PublishConsumesPrebuiltProjectReferenceOutputs(
+            plan,
+            target,
+            combination));
+
+        target.Publish.MsBuildProperties = null;
+        target.Publish.StyleOverrides = new Dictionary<string, DotNetPublishStyleOverride>(
+            StringComparer.OrdinalIgnoreCase)
+        {
+            [DotNetPublishStyle.FrameworkDependent.ToString()] = new DotNetPublishStyleOverride
+            {
+                MsBuildProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["BuildProjectReferences"] = "false"
+                }
+            }
+        };
+
+        Assert.True(DotNetPublishPipelineRunner.PublishConsumesPrebuiltProjectReferenceOutputs(
+            plan,
+            target,
+            combination));
+
+        target.Publish.StyleOverrides = null;
+        plan.MsBuildProperties.Clear();
 
         plan.NoBuildInPublish = true;
 

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave89.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave89.cs
@@ -137,6 +137,7 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
             null,
             null,
             null,
+            true,
             true
         ]);
         object projectReference = referenceConstructor.Invoke(

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave92.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.ProjectReferenceWave92.cs
@@ -6,7 +6,6 @@ namespace PowerForge.Tests;
 public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
 {
     [Fact]
-    [Trait("Category", "DotNetPublishPrGate")]
     public void Run_NoBuildPublishReacquiresProvenanceAfterEachMatrixBuild()
     {
         string root = Directory.CreateTempSubdirectory().FullName;

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace PowerForge.Tests;
 
-[Collection(ProcessEnvironmentCollection.Name)]
 public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
 {
     [Fact]

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace PowerForge.Tests;
 
+[Collection(ProcessEnvironmentCollection.Name)]
 public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
 {
     [Fact]

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
@@ -854,7 +854,8 @@ public sealed partial class DotNetPublishPipelineRunner
             VerifiedPackageInputCatalog? verifiedPackages,
             string[] trustedBuildInfrastructureRoots,
             IReadOnlyDictionary<string, string> evaluatedProperties,
-            string? customAfterMicrosoftCommonTargets)
+            string? customAfterMicrosoftCommonTargets,
+            bool consumesPrebuiltProjectReferenceOutputs)
         {
             BuildInputs = buildInputs;
             MsBuildInputs = msBuildInputs;
@@ -872,6 +873,7 @@ public sealed partial class DotNetPublishPipelineRunner
             TrustedBuildInfrastructureRoots = trustedBuildInfrastructureRoots;
             EvaluatedProperties = evaluatedProperties;
             CustomAfterMicrosoftCommonTargets = customAfterMicrosoftCommonTargets;
+            ConsumesPrebuiltProjectReferenceOutputs = consumesPrebuiltProjectReferenceOutputs;
         }
 
         internal string[] BuildInputs { get; }
@@ -890,6 +892,7 @@ public sealed partial class DotNetPublishPipelineRunner
         internal string[] TrustedBuildInfrastructureRoots { get; }
         internal IReadOnlyDictionary<string, string> EvaluatedProperties { get; }
         internal string? CustomAfterMicrosoftCommonTargets { get; }
+        internal bool ConsumesPrebuiltProjectReferenceOutputs { get; }
     }
 
     private sealed class EvaluatedProjectReference

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
@@ -680,7 +680,8 @@ public sealed partial class DotNetPublishPipelineRunner
             IReadOnlyDictionary<string, string>? globalProperties,
             IReadOnlyDictionary<string, string?>? environmentVariables,
             IReadOnlyCollection<string>? controlledBuildEnvironmentVariableNames = null,
-            bool requiresSdkPackageEvidence = true)
+            bool requiresSdkPackageEvidence = true,
+            bool requiresPrebuiltProjectReferenceOutputProof = true)
         {
             ProjectPath = projectPath;
             TargetFramework = targetFramework;
@@ -694,6 +695,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
                 .ToArray() ?? Array.Empty<string>();
             RequiresSdkPackageEvidence = requiresSdkPackageEvidence;
+            RequiresPrebuiltProjectReferenceOutputProof = requiresPrebuiltProjectReferenceOutputProof;
         }
 
         internal string ProjectPath { get; }
@@ -704,6 +706,7 @@ public sealed partial class DotNetPublishPipelineRunner
         internal IReadOnlyDictionary<string, string?> EnvironmentVariables { get; }
         internal IReadOnlyCollection<string> ControlledBuildEnvironmentVariableNames { get; }
         internal bool RequiresSdkPackageEvidence { get; }
+        internal bool RequiresPrebuiltProjectReferenceOutputProof { get; }
 
         internal IReadOnlyDictionary<string, string> ReadEffectiveGlobalProperties()
         {
@@ -733,7 +736,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 GlobalProperties,
                 EnvironmentVariables,
                 ControlledBuildEnvironmentVariableNames,
-                RequiresSdkPackageEvidence);
+                RequiresSdkPackageEvidence,
+                RequiresPrebuiltProjectReferenceOutputProof);
 
         internal ProjectEvaluationRequest ForProject(EvaluatedProjectReference projectReference)
         {
@@ -773,7 +777,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 properties,
                 EnvironmentVariables,
                 ControlledBuildEnvironmentVariableNames,
-                requiresSdkPackageEvidence: true);
+                requiresSdkPackageEvidence: true,
+                requiresPrebuiltProjectReferenceOutputProof: RequiresPrebuiltProjectReferenceOutputProof);
         }
 
         internal string BuildVisitKey()
@@ -812,6 +817,10 @@ public sealed partial class DotNetPublishPipelineRunner
             }
             AppendProjectReferenceKeySegment(key, "SdkPackageEvidence");
             AppendProjectReferenceKeySegment(key, RequiresSdkPackageEvidence ? "Required" : "Inherited");
+            AppendProjectReferenceKeySegment(key, "PrebuiltProjectReferenceOutputProof");
+            AppendProjectReferenceKeySegment(
+                key,
+                RequiresPrebuiltProjectReferenceOutputProof ? "Required" : "NotRequired");
             return key.ToString();
         }
     }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInfrastructureProvenance.cs
@@ -707,6 +707,10 @@ public sealed partial class DotNetPublishPipelineRunner
         internal IReadOnlyCollection<string> ControlledBuildEnvironmentVariableNames { get; }
         internal bool RequiresSdkPackageEvidence { get; }
         internal bool RequiresPrebuiltProjectReferenceOutputProof { get; }
+        internal bool DisablesProjectReferenceBuilds
+            => GlobalProperties.TryGetValue("BuildProjectReferences", out string? value) &&
+               bool.TryParse(value.Trim(), out bool buildProjectReferences) &&
+               !buildProjectReferences;
 
         internal IReadOnlyDictionary<string, string> ReadEffectiveGlobalProperties()
         {

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
@@ -395,8 +395,11 @@ public sealed partial class DotNetPublishPipelineRunner
                 evaluationsByEvaluation[visitKey] = evaluation;
                 trustedBuildInfrastructureRootsByEvaluation[visitKey] =
                     evaluation.TrustedBuildInfrastructureRoots;
-                generatedProjectReferenceOutputs.AddRange(
-                    evaluation.GeneratedProjectReferenceOutputs.Select(output => (request, output)));
+                if (request.RequiresPrebuiltProjectReferenceOutputProof)
+                {
+                    generatedProjectReferenceOutputs.AddRange(
+                        evaluation.GeneratedProjectReferenceOutputs.Select(output => (request, output)));
+                }
                 if (string.IsNullOrEmpty(request.TargetFramework))
                 {
                     if (evaluation.TargetFrameworks.Length > 0)
@@ -648,7 +651,9 @@ public sealed partial class DotNetPublishPipelineRunner
                         effectiveConfiguration,
                         globalProperties: null,
                         buildPlan!.EnvironmentVariables,
-                        buildPlan.ControlledBuildEnvironmentVariableNames);
+                        buildPlan.ControlledBuildEnvironmentVariableNames,
+                        requiresPrebuiltProjectReferenceOutputProof:
+                            buildPlan.NoBuildInPublish || target.Publish?.Sign?.Enabled != true);
                     continue;
                 }
 
@@ -664,7 +669,12 @@ public sealed partial class DotNetPublishPipelineRunner
                         effectiveConfiguration,
                         properties,
                         buildPlan!.EnvironmentVariables,
-                        buildPlan.ControlledBuildEnvironmentVariableNames);
+                        buildPlan.ControlledBuildEnvironmentVariableNames,
+                        requiresPrebuiltProjectReferenceOutputProof:
+                            RequiresPrebuiltProjectReferenceOutputProof(
+                                buildPlan,
+                                target,
+                                combination));
                 }
             }
 
@@ -680,9 +690,35 @@ public sealed partial class DotNetPublishPipelineRunner
                 targetFramework: null,
                 effectiveConfiguration,
                 globalProperties: null,
-                environmentVariables: null);
+                environmentVariables: null,
+                requiresPrebuiltProjectReferenceOutputProof: true);
         }
     }
+
+    internal static bool PublishConsumesPrebuiltProjectReferenceOutputs(
+        DotNetPublishPlan plan,
+        DotNetPublishTargetPlan target,
+        DotNetPublishTargetCombination combination)
+    {
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+        if (target is null) throw new ArgumentNullException(nameof(target));
+        if (combination is null) throw new ArgumentNullException(nameof(combination));
+
+        return plan.NoBuildInPublish &&
+               !TargetUsesPublishMsiVersionProperties(
+                   plan,
+                   target.Name,
+                   combination.Framework,
+                   combination.Runtime,
+                   combination.Style);
+    }
+
+    internal static bool RequiresPrebuiltProjectReferenceOutputProof(
+        DotNetPublishPlan plan,
+        DotNetPublishTargetPlan target,
+        DotNetPublishTargetCombination combination)
+        => PublishConsumesPrebuiltProjectReferenceOutputs(plan, target, combination) ||
+           target.Publish?.Sign?.Enabled != true;
 
     private static Dictionary<string, string> BuildPublishEvaluationProperties(
         DotNetPublishPlan plan,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
@@ -395,7 +395,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 evaluationsByEvaluation[visitKey] = evaluation;
                 trustedBuildInfrastructureRootsByEvaluation[visitKey] =
                     evaluation.TrustedBuildInfrastructureRoots;
-                if (request.RequiresPrebuiltProjectReferenceOutputProof)
+                if (request.RequiresPrebuiltProjectReferenceOutputProof ||
+                    evaluation.ConsumesPrebuiltProjectReferenceOutputs)
                 {
                     generatedProjectReferenceOutputs.AddRange(
                         evaluation.GeneratedProjectReferenceOutputs.Select(output => (request, output)));
@@ -610,6 +611,16 @@ public sealed partial class DotNetPublishPipelineRunner
                         : null,
                     controlledGeneratedOutputProofs))
             {
+                if (buildPlan?.NoBuildInPublish != true)
+                {
+                    provenNoBuildPublishInputs.Add(new NoBuildPublishInput(
+                        request.BuildVisitKey(),
+                        output.OutputPath,
+                        Path.GetFileName(output.OutputPath),
+                        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+                        ComputeSha256Hex(File.ReadAllBytes(output.OutputPath)),
+                        unixFileMode: ReadControlledUnixFileMode(output.OutputPath)));
+                }
                 continue;
             }
 
@@ -789,6 +800,7 @@ public sealed partial class DotNetPublishPipelineRunner
             "-getProperty:OutDir",
             "-getProperty:TargetDir",
             "-getProperty:TargetPath",
+            "-getProperty:BuildProjectReferences",
             "-getProperty:_GlobalPropertiesToRemoveFromProjectReferences",
             "-getProperty:BaseIntermediateOutputPath",
             "-getProperty:MSBuildProjectExtensionsPath",
@@ -821,10 +833,23 @@ public sealed partial class DotNetPublishPipelineRunner
             }
             arguments.Add("-p:" + property.Key + "=" + EscapeMsBuildPropertyValue(property.Value));
         }
-        AddProjectReferenceExecutionProperties(
-            arguments,
-            request,
-            preservePublishBuildProjectReferences: false);
+        if (request.RequiresPrebuiltProjectReferenceOutputProof)
+        {
+            AddProjectReferenceExecutionProperties(
+                arguments,
+                request,
+                preservePublishBuildProjectReferences: false);
+        }
+        else if (request.GlobalProperties.TryGetValue(
+                     "BuildProjectReferences",
+                     out string? requestedBuildProjectReferences))
+        {
+            // This invocation only evaluates properties and items; it does not run a target.
+            // Preserve an explicit publish value and otherwise let project/environment
+            // evaluation reveal whether the real publish will consume prebuilt outputs.
+            arguments.Add("-p:BuildProjectReferences=" +
+                EscapeMsBuildPropertyValue(requestedBuildProjectReferences));
+        }
 
         try
         {
@@ -884,6 +909,7 @@ public sealed partial class DotNetPublishPipelineRunner
             string? msBuildToolsPath = null;
             string? msBuildSdksPath = null;
             string? customAfterMicrosoftCommonTargets = null;
+            bool evaluatedBuildProjectReferencesDisabled = false;
             if (root.TryGetProperty("Properties", out JsonElement properties))
             {
                 AddPropertyPath(properties, "BaseOutputPath", Path.GetDirectoryName(request.ProjectPath)!, generatedBuildRoots);
@@ -953,6 +979,11 @@ public sealed partial class DotNetPublishPipelineRunner
                 customAfterMicrosoftCommonTargets = ReadItemText(
                     properties,
                     "CustomAfterMicrosoftCommonTargets");
+                evaluatedBuildProjectReferencesDisabled =
+                    bool.TryParse(
+                        ReadItemText(properties, "BuildProjectReferences")?.Trim(),
+                        out bool buildProjectReferences) &&
+                    !buildProjectReferences;
                 AddSemicolonSeparatedPathValues(
                     properties,
                     "MSBuildAllProjects",
@@ -1164,8 +1195,8 @@ public sealed partial class DotNetPublishPipelineRunner
                      RequiresControlledProjectReferenceFrameworkResolution(
                          request,
                          rawReferences.Values) ||
-                     (request.RequiresPrebuiltProjectReferenceOutputProof &&
-                      request.DisablesProjectReferenceBuilds) ||
+                     request.DisablesProjectReferenceBuilds ||
+                     evaluatedBuildProjectReferencesDisabled ||
                      hasDynamicProjectReferenceTaskOutputs)
             {
                 if (!TryReadControlledResolvedProjectReferences(
@@ -1243,7 +1274,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 evaluatedProjectReferenceConditionProperties,
                 ResolveExistingCustomAfterTargets(
                     customAfterMicrosoftCommonTargets,
-                    Path.GetDirectoryName(request.ProjectPath)!));
+                    Path.GetDirectoryName(request.ProjectPath)!),
+                evaluatedBuildProjectReferencesDisabled);
             return true;
         }
         catch

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
@@ -704,13 +704,25 @@ public sealed partial class DotNetPublishPipelineRunner
         if (target is null) throw new ArgumentNullException(nameof(target));
         if (combination is null) throw new ArgumentNullException(nameof(combination));
 
-        return plan.NoBuildInPublish &&
-               !TargetUsesPublishMsiVersionProperties(
-                   plan,
-                   target.Name,
-                   combination.Framework,
-                   combination.Runtime,
-                   combination.Style);
+        Dictionary<string, string> publishProperties = BuildPublishMsBuildProperties(
+            plan,
+            target,
+            combination.Framework,
+            combination.Runtime,
+            combination.Style);
+        bool projectReferenceBuildDisabled =
+            publishProperties.TryGetValue("BuildProjectReferences", out string? value) &&
+            bool.TryParse(value.Trim(), out bool buildProjectReferences) &&
+            !buildProjectReferences;
+
+        return projectReferenceBuildDisabled ||
+               (plan.NoBuildInPublish &&
+                !TargetUsesPublishMsiVersionProperties(
+                    plan,
+                    target.Name,
+                    combination.Framework,
+                    combination.Runtime,
+                    combination.Style));
     }
 
     internal static bool RequiresPrebuiltProjectReferenceOutputProof(
@@ -1152,6 +1164,8 @@ public sealed partial class DotNetPublishPipelineRunner
                      RequiresControlledProjectReferenceFrameworkResolution(
                          request,
                          rawReferences.Values) ||
+                     (request.RequiresPrebuiltProjectReferenceOutputProof &&
+                      request.DisablesProjectReferenceBuilds) ||
                      hasDynamicProjectReferenceTaskOutputs)
             {
                 if (!TryReadControlledResolvedProjectReferences(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.BuildInputProvenance.cs
@@ -1195,8 +1195,9 @@ public sealed partial class DotNetPublishPipelineRunner
                      RequiresControlledProjectReferenceFrameworkResolution(
                          request,
                          rawReferences.Values) ||
-                     request.DisablesProjectReferenceBuilds ||
-                     evaluatedBuildProjectReferencesDisabled ||
+                     (rawReferences.Count > 0 &&
+                      (request.DisablesProjectReferenceBuilds ||
+                       evaluatedBuildProjectReferencesDisabled)) ||
                      hasDynamicProjectReferenceTaskOutputs)
             {
                 if (!TryReadControlledResolvedProjectReferences(


### PR DESCRIPTION
## Summary

- prove project-reference outputs only when the real publish consumes prebuilt binaries
- honor effective `BuildProjectReferences=false` values from publish configuration, project evaluation, or the controlled environment
- hold every proven prebuilt reference output immutable through the real signed publish
- avoid rejecting stale outputs that a normal signed publish will rebuild

## Why

A signed build-publish should accept an ignored project-reference DLL when the real publish will replace it, while still failing closed whenever MSBuild is configured to consume that DLL as a prebuilt input. PowerForge now evaluates that distinction from the effective publish context, proves consumed child outputs in its controlled checkout, and keeps the proven originals under the publication lease until the publish completes.