### PR TITLE
Clarify generated benchmark comparison results

### DIFF
--- a/PowerForge.Tests/BenchmarkServicesTests.MarkdownTieTolerance.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.MarkdownTieTolerance.cs
@@ -108,9 +108,9 @@ New-BenchmarkSuite 'ties' -OutputRoot '{{escapedRoot}}' {
             }
         });
 
-        Assert.Contains("| baseline narrowly faster | Current | Run | 1.00x (100ms) | 1.04x (104ms) | Managed tied with Other |", markdown);
-        Assert.Contains("| baseline narrowly slower | Current | Run | 1.00x (104ms) | 0.96x (100ms) | Managed tied with Other |", markdown);
-        Assert.Contains("| baseline materially slower | Current | Run | 1.00x (106ms) | 0.94x (100ms) | Managed slower than Other |", markdown);
+        Assert.Contains("| baseline narrowly faster | Current | Run | 1.00x (100ms) | 1.04x (104ms) | Fastest: Managed, Other (tie) |", markdown);
+        Assert.Contains("| baseline narrowly slower | Current | Run | 1.00x (104ms) | 0.96x (100ms) | Fastest: Other, Managed (tie) |", markdown);
+        Assert.Contains("| baseline materially slower | Current | Run | 1.00x (106ms) | 0.94x (100ms) | Fastest: Other |", markdown);
     }
 
     [Fact]
@@ -142,7 +142,7 @@ New-BenchmarkSuite 'ties' -OutputRoot '{{escapedRoot}}' {
             }
         });
 
-        Assert.Contains("Managed slower than Other", markdown);
+        Assert.Contains("Fastest: Other", markdown);
         Assert.DoesNotContain("tied", markdown, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/PowerForge.Tests/BenchmarkServicesTests.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.cs
@@ -370,7 +370,7 @@ public sealed partial class BenchmarkServicesTests
         });
 
         Assert.Contains("| Scenario | Variables | Host | Operation | Managed | ModuleFast | Result |", markdown);
-        Assert.Contains("| SingleModule | ModuleName=PSScriptAnalyzer | Core-7.6.3 | Install | 1.00x (1.00s) | 1.50x (1.50s) | Managed fastest |", markdown);
+        Assert.Contains("| SingleModule | ModuleName=PSScriptAnalyzer | Core-7.6.3 | Install | 1.00x (1.00s) | 1.50x (1.50s) | Fastest: Managed |", markdown);
         Assert.DoesNotContain("Baseline Value", markdown, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -434,8 +434,8 @@ public sealed partial class BenchmarkServicesTests
         });
 
         Assert.Contains("| Scenario | Variables | Host | Operation | Metric | Managed | Other | Result |", markdown);
-        Assert.Contains("| case | Rows=10 | Current | Run | MedianMs | 1.00x (10ms) | 2.00x (20ms) | Managed fastest |", markdown);
-        Assert.Contains("| case | Rows=20 | Current | Run | P95Ms | 1.00x (15ms) | 2.00x (30ms) | Managed fastest |", markdown);
+        Assert.Contains("| case | Rows=10 | Current | Run | MedianMs | 1.00x (10ms) | 2.00x (20ms) | Fastest: Managed |", markdown);
+        Assert.Contains("| case | Rows=20 | Current | Run | P95Ms | 1.00x (15ms) | 2.00x (30ms) | Fastest: Managed |", markdown);
     }
 
     [Fact]
@@ -494,8 +494,8 @@ public sealed partial class BenchmarkServicesTests
         });
 
         Assert.Contains("| Scenario | Host | Operation | Baseline | Managed | Other | Result |", markdown);
-        Assert.Contains("| case | Current | Run | Managed | 1.00x (10ms) | 2.00x (20ms) | Managed fastest |", markdown);
-        Assert.Contains("| case | Current | Run | Other | 0.50x (10ms) | 1.00x (20ms) | Other slower than Managed |", markdown);
+        Assert.Contains("| case | Current | Run | Managed | 1.00x (10ms) | 2.00x (20ms) | Fastest: Managed |", markdown);
+        Assert.Contains("| case | Current | Run | Other | 0.50x (10ms) | 1.00x (20ms) | Fastest: Managed |", markdown);
     }
 
     [Fact]
@@ -532,7 +532,7 @@ public sealed partial class BenchmarkServicesTests
         });
 
         Assert.Contains("| Scenario | Variables | Host | Operation | Managed | Other | Result |", markdown);
-        Assert.Contains("| Cold | ModuleName=PSScriptAnalyzer | Current | Run | 1.00x (10ms) | 2.00x (20ms) | Managed fastest |", markdown);
+        Assert.Contains("| Cold | ModuleName=PSScriptAnalyzer | Current | Run | 1.00x (10ms) | 2.00x (20ms) | Fastest: Managed |", markdown);
     }
 
     [Fact]
@@ -566,7 +566,7 @@ public sealed partial class BenchmarkServicesTests
             }
         });
 
-        Assert.Contains("| case | Current | Run | 1.00x (10ms) | Skipped | Managed only successful |", markdown);
+        Assert.Contains("| case | Current | Run | 1.00x (10ms) | Skipped | Only Managed measured; others skipped |", markdown);
         Assert.DoesNotContain("Failed", markdown, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -601,8 +601,48 @@ public sealed partial class BenchmarkServicesTests
             }
         });
 
-        Assert.Contains("| case | Current | Run | RowsPerSecond | 1.00x (1000) | 1.20x (1200) | Managed baseline |", markdown);
+        Assert.Contains("| case | Current | Run | RowsPerSecond | 1.00x (1000) | 1.20x (1200) | Reference: Managed |", markdown);
         Assert.DoesNotContain("1.00s", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MarkdownRenderer_RendersSingleEngineRowsAsMeasurements()
+    {
+        var markdown = new BenchmarkMarkdownRenderer().RenderComparisonTable(new[]
+        {
+            new BenchmarkComparisonRow
+            {
+                Scenario = "parse",
+                Operation = "Run",
+                Engine = "EvtxECmd",
+                Host = "Current",
+                BaselineEngine = "EvtxECmd",
+                Metric = "MedianMs",
+                Status = "Succeeded",
+                Actual = 17530,
+                Baseline = 17530,
+                Ratio = 1
+            },
+            new BenchmarkComparisonRow
+            {
+                Scenario = "parse",
+                Operation = "Run",
+                Engine = "EvtxECmd",
+                Host = "Current",
+                BaselineEngine = "EvtxECmd",
+                Metric = "OutputBytes",
+                Status = "Succeeded",
+                Actual = 0,
+                Baseline = 0
+            }
+        });
+
+        Assert.Contains("| Scenario | Host | Operation | Metric | EvtxECmd |", markdown);
+        Assert.Contains("| parse | Current | Run | MedianMs | 17.53s |", markdown);
+        Assert.Contains("| parse | Current | Run | OutputBytes | 0 |", markdown);
+        Assert.DoesNotContain("Result", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("1.00x", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("successful", markdown, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -671,7 +711,7 @@ public sealed partial class BenchmarkServicesTests
         Assert.Single(output);
         var text = File.ReadAllText(readme);
         Assert.Contains("Other", text, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Managed", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Reference: Managed", text, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("old", text, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/PowerForge/Services/Benchmarks/BenchmarkMarkdownRenderer.cs
+++ b/PowerForge/Services/Benchmarks/BenchmarkMarkdownRenderer.cs
@@ -65,6 +65,8 @@ public sealed class BenchmarkMarkdownRenderer
             .OrderBy(engine => !includeBaseline && string.Equals(engine, primaryBaseline, StringComparison.OrdinalIgnoreCase) ? 0 : 1)
             .ThenBy(engine => engine, StringComparer.OrdinalIgnoreCase)
             .ToArray();
+        var hasExternalBaseline = baselines.Any(baseline => !engines.Contains(baseline, StringComparer.OrdinalIgnoreCase));
+        var isComparison = engines.Length > 1 || hasExternalBaseline;
 
         markdown.Append("| Scenario |");
         if (includeVariables) markdown.Append(" Variables |");
@@ -76,7 +78,7 @@ public sealed class BenchmarkMarkdownRenderer
         if (includeBaseline) markdown.Append(" Baseline |");
         foreach (var engine in engines)
             markdown.Append(' ').Append(Cell(engine)).Append(" |");
-        markdown.AppendLine(" Result |");
+        markdown.AppendLine(isComparison ? " Result |" : string.Empty);
 
         markdown.Append("| --- |");
         if (includeVariables) markdown.Append(" --- |");
@@ -88,7 +90,7 @@ public sealed class BenchmarkMarkdownRenderer
         if (includeBaseline) markdown.Append(" --- |");
         foreach (var _ in engines)
             markdown.Append(" ---: |");
-        markdown.AppendLine(" --- |");
+        markdown.AppendLine(isComparison ? " --- |" : string.Empty);
 
         foreach (var group in rows
                      .GroupBy(r => string.Join("\u001f", r.Scenario, FormatVariables(r.Variables), r.Operation, r.Host, r.Os, r.RunMode, r.Metric, r.BaselineEngine, r.TieTolerance.ToString("G17", CultureInfo.InvariantCulture)), StringComparer.Ordinal)
@@ -121,10 +123,17 @@ public sealed class BenchmarkMarkdownRenderer
             foreach (var engine in engines)
             {
                 byEngine.TryGetValue(engine, out var row);
-                markdown.Append(' ').Append(Cell(FormatComparisonValue(row))).Append(" |");
+                markdown.Append(' ').Append(Cell(FormatComparisonValue(row, isComparison))).Append(" |");
             }
-            markdown.AppendLine(
-                $" {Cell(FormatComparisonResult(baseline, first.Metric, group))} |");
+            if (isComparison)
+            {
+                markdown.AppendLine(
+                    $" {Cell(FormatComparisonResult(baseline, first.Metric, group, engines))} |");
+            }
+            else
+            {
+                markdown.AppendLine();
+            }
         }
 
         return markdown.ToString().TrimEnd() + Environment.NewLine;
@@ -133,7 +142,7 @@ public sealed class BenchmarkMarkdownRenderer
     private static string DisplayScenario(BenchmarkComparisonRow row)
         => row.Scenario;
 
-    private static string FormatComparisonValue(BenchmarkComparisonRow? row)
+    private static string FormatComparisonValue(BenchmarkComparisonRow? row, bool includeRatio)
     {
         if (row is null)
             return "n/a";
@@ -148,27 +157,61 @@ public sealed class BenchmarkMarkdownRenderer
         var value = BenchmarkComparisonSemantics.IsDurationMetric(row.Metric)
             ? FormatDuration(row.Actual.Value)
             : Number(row.Actual.Value);
-        return $"{ratio} ({value})";
+        return includeRatio ? $"{ratio} ({value})" : value;
     }
 
-    private static string FormatComparisonResult(string baseline, string? metric, IEnumerable<BenchmarkComparisonRow> rows)
+    private static string FormatComparisonResult(
+        string baseline,
+        string? metric,
+        IEnumerable<BenchmarkComparisonRow> rows,
+        IReadOnlyCollection<string> engines)
     {
         if (!BenchmarkComparisonSemantics.IsDurationMetric(metric))
-            return $"{baseline} baseline";
+            return $"Reference: {baseline}";
 
-        var successful = rows
+        var materializedRows = rows.ToArray();
+        var successful = materializedRows
             .Where(static row => row.Actual.HasValue)
             .OrderBy(static row => row.Actual!.Value)
             .ToArray();
         if (successful.Length == 0)
-            return "No successful rows";
+        {
+            return materializedRows.All(static row => string.Equals(row.Status, "Skipped", StringComparison.OrdinalIgnoreCase))
+                ? "No lanes measured"
+                : "No lanes succeeded";
+        }
+
+        if (successful.Length == 1)
+        {
+            var successfulEngine = successful[0].Engine;
+            if (engines.Count == 1
+                && !string.Equals(successfulEngine, baseline, StringComparison.OrdinalIgnoreCase)
+                && successful[0].Baseline.HasValue)
+            {
+                return $"Reference: {baseline}";
+            }
+            var unsuccessful = materializedRows.Where(static row => !row.Actual.HasValue).ToArray();
+            if (materializedRows.Length < engines.Count)
+            {
+                return $"Only {successfulEngine} measured";
+            }
+            if (unsuccessful.All(static row => string.Equals(row.Status, "Skipped", StringComparison.OrdinalIgnoreCase)))
+            {
+                return $"Only {successfulEngine} measured; others skipped";
+            }
+            return $"Only {successfulEngine} succeeded";
+        }
 
         var fastest = successful[0];
-        var baselineSucceeded = successful.Any(row => string.Equals(row.Engine, baseline, StringComparison.OrdinalIgnoreCase));
-        if (!baselineSucceeded)
-            return $"{baseline} failed";
-        if (successful.Length == 1)
-            return $"{baseline} only successful";
+        var baselineRow = materializedRows.FirstOrDefault(row => string.Equals(row.Engine, baseline, StringComparison.OrdinalIgnoreCase));
+        if (baselineRow?.Actual is null)
+        {
+            return baselineRow is null
+                ? $"Reference {baseline} not measured; fastest: {fastest.Engine}"
+                : string.Equals(baselineRow.Status, "Skipped", StringComparison.OrdinalIgnoreCase)
+                    ? $"Reference {baseline} skipped; fastest: {fastest.Engine}"
+                    : $"Reference {baseline} failed; fastest: {fastest.Engine}";
+        }
 
         var tieTolerance = Math.Max(0, successful[0].TieTolerance);
         if (tieTolerance > 0)
@@ -177,17 +220,13 @@ public sealed class BenchmarkMarkdownRenderer
                 .Where(row => row.Actual!.Value <= fastest.Actual!.Value * (1 + tieTolerance))
                 .Select(row => row.Engine)
                 .ToArray();
-            if (tiedEngines.Any(engine => string.Equals(engine, baseline, StringComparison.OrdinalIgnoreCase)) && tiedEngines.Length > 1)
+            if (tiedEngines.Length > 1)
             {
-                var peers = tiedEngines.Where(engine => !string.Equals(engine, baseline, StringComparison.OrdinalIgnoreCase));
-                return $"{baseline} tied with {string.Join(", ", peers)}";
+                return $"Fastest: {string.Join(", ", tiedEngines)} (tie)";
             }
         }
 
-        if (string.Equals(fastest.Engine, baseline, StringComparison.OrdinalIgnoreCase))
-            return $"{baseline} fastest";
-
-        return $"{baseline} slower than {fastest.Engine}";
+        return $"Fastest: {fastest.Engine}";
     }
 
     private static bool IsDefaultDurationMetric(string? metric)


### PR DESCRIPTION
## Summary

- render a one-engine benchmark as a plain measurement instead of a `1.00x` comparison with an `only successful` verdict
- name the fastest measured lane directly in multi-engine duration tables
- distinguish skipped lanes from failed lanes and label non-duration ratios as reference values

## Why

Generated benchmark tables should explain what was measured without implying that an undeclared engine failed. This keeps comparison semantics in PowerForge so consuming repositories do not need their own wording rules.

## Validation

- `dotnet test PowerForge.Tests\PowerForge.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~PowerForge.Tests.BenchmarkServicesTests"` (457 passed)
- full-suite run was attempted but stopped after unrelated existing failures across Apple, publish, web, and temporary-directory tests; the complete benchmark-service slice passed independently

## Downstream

EventViewerX will consume this behavior for its generated performance tables after the next public PSPublishModule release.
