### PR TITLE
Preserve WebMCP runtime identity and visible search bounds

### DIFF
--- a/Docs/PowerForge.Web.AgentReadiness.md
+++ b/Docs/PowerForge.Web.AgentReadiness.md
@@ -245,6 +245,31 @@ pages use route-relative index/runtime URLs so sites hosted below an origin path
 remain functional; theme-owned pages should do the same or include the deployed
 base path explicitly.
 
+If a theme cannot reliably synchronize its visible results from the runtime's
+synthetic `input` event, it can predeclare a `renderVisibleResults(response,
+context)` function before the PowerForge runtime loads. The runtime calls it only
+after enforcing the result-count, URL, and 1,500-character response limits, and
+passes a defensive copy plus `context.signal`. The hook should render the supplied
+results rather than loading or ranking the search index again:
+
+```html
+<script>
+  window.PowerForgeWebMcpSearch = {
+    renderVisibleResults: function (response) {
+      searchInput.value = response.query;
+      renderSearchResults(response.results, response.query);
+    }
+  };
+</script>
+<script src="/assets/powerforge/webmcp-site-search.v1.js"
+        data-powerforge-webmcp defer></script>
+```
+
+The predeclared renderer replaces synthetic input dispatch. A bound search adapter
+continues to own its visible interaction unless the page also predeclares this
+renderer explicitly. Both adapters and renderers should honor the supplied abort
+signal and avoid visible changes after cancellation.
+
 The `page-tool` kind is a verification contract for a product-owned adapter;
 PowerForge does not generate its behavior. Use it only when an existing visible
 page already owns the operation. The rendered route must contain exactly one

--- a/Docs/PowerForge.Web.AgentReadiness.md
+++ b/Docs/PowerForge.Web.AgentReadiness.md
@@ -194,9 +194,10 @@ Remote verification resolves relative resources against the final page URL and
 rejects cross-origin redirects for the page, index, or runtime asset.
 
 The read-only `site-search` kind emits
-`/assets/powerforge/webmcp-site-search.v1.js`. Its script must be byte-for-byte
-the canonical embedded PowerForge runtime, and the declared index must be a
-bounded JSON array. A theme search page should expose
+`/assets/powerforge/webmcp-site-search.v1.js`. Its script must match the
+canonical embedded PowerForge runtime, allowing only LF/CRLF line-ending
+conversion by the artifact host. The declared index must be a bounded JSON
+array. A theme search page should expose
 the tool name, description, and index route on its existing search surface:
 
 ```html

--- a/Docs/PowerForge.Web.WebMcpRollout.md
+++ b/Docs/PowerForge.Web.WebMcpRollout.md
@@ -47,6 +47,9 @@ Complete in the engine and deployed on the Evotec website.
 - `agents.json` reports WebMCP only after rendered-artifact verification passes.
 - A theme can bind its existing search implementation instead of maintaining a
   second ranking engine.
+- A theme whose visible search cannot reliably react to a synthetic input event
+  can predeclare `renderVisibleResults(response, context)` and render the
+  runtime's already-normalized, bounded results without loading a second index.
 
 ### Phase 2: Public documentation portfolio
 

--- a/PowerForge.Tests/WebAgentReadinessWebMcpBudgetTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessWebMcpBudgetTests.cs
@@ -248,6 +248,31 @@ public partial class WebAgentReadinessTests
     }
 
     [Fact]
+    public void Runtime_NormalizesBeforeThemeVisibilityHookAndPreservesGenericBounds()
+    {
+        var runtime = WebSiteBuilder.GetWebMcpSiteSearchAssetContent();
+        var normalizeIndex = runtime.IndexOf("var response = normalizeResponse(result, request);", StringComparison.Ordinal);
+        var synchronizeIndex = runtime.IndexOf("await syncVisibleSearch(response, request, usesAdapter);", StringComparison.Ordinal);
+        var hookBranchIndex = runtime.IndexOf("if (renderVisibleResults) {", StringComparison.Ordinal);
+        var adapterBranchIndex = runtime.IndexOf("if (usesAdapter) return;", StringComparison.Ordinal);
+        var inputBranchIndex = runtime.IndexOf("var input = surface.querySelector", StringComparison.Ordinal);
+
+        Assert.True(normalizeIndex >= 0, "The runtime must normalize the tool response.");
+        Assert.True(synchronizeIndex > normalizeIndex, "Visible synchronization must receive only the normalized response.");
+        Assert.True(hookBranchIndex >= 0 && adapterBranchIndex > hookBranchIndex && inputBranchIndex > adapterBranchIndex,
+            "The renderer hook must replace synthetic input, while bound adapters retain their visible-search ownership.");
+        Assert.Contains("var renderVisibleResults = typeof api.renderVisibleResults === 'function'", runtime, StringComparison.Ordinal);
+        Assert.Contains("var visibleResponse = JSON.parse(JSON.stringify(response));", runtime, StringComparison.Ordinal);
+        Assert.Contains("throwIfAborted(request.signal);", runtime, StringComparison.Ordinal);
+        Assert.Contains("return renderVisibleResults(visibleResponse, { signal: request.signal });", runtime, StringComparison.Ordinal);
+        Assert.Contains("var entries = await awaitWithSignal(loadIndex(), request.signal);", runtime, StringComparison.Ordinal);
+        Assert.Contains("if (entries.length > MAX_INDEX_ENTRIES)", runtime, StringComparison.Ordinal);
+        Assert.Contains("if (total > MAX_INDEX_BYTES)", runtime, StringComparison.Ordinal);
+        Assert.Contains("var selected = source.slice(0, request.limit);", runtime, StringComparison.Ordinal);
+        Assert.Contains("if (JSON.stringify(response).length > MAX_OUTPUT_CHARACTERS)", runtime, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BehavioralObservation_ProvesRegistrationOutputBudgetAndVisibleSynchronization()
     {
         var output = new

--- a/PowerForge.Tests/WebAgentReadinessWebMcpRuntimeIdentityTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessWebMcpRuntimeIdentityTests.cs
@@ -9,7 +9,7 @@ public partial class WebAgentReadinessTests
     public async Task Scan_AcceptsCanonicalRuntimeWithPlatformLineEndings()
     {
         var handler = new RuntimeIdentityWebMcpRouteScanHandler(
-            WebSiteBuilder.GetWebMcpSiteSearchAssetContent().Replace("\n", "\r\n", StringComparison.Ordinal));
+            WebSiteBuilder.GetWebMcpSiteSearchAssetContent().ReplaceLineEndings("\r\n"));
         var result = await WebAgentReadiness.ScanAsync(new WebAgentReadinessScanOptions
         {
             BaseUrl = "https://example.test",

--- a/PowerForge.Tests/WebAgentReadinessWebMcpRuntimeIdentityTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessWebMcpRuntimeIdentityTests.cs
@@ -1,0 +1,144 @@
+using System.Net;
+using PowerForge.Web;
+
+namespace PowerForge.Tests;
+
+public partial class WebAgentReadinessTests
+{
+    [Fact]
+    public async Task Scan_AcceptsCanonicalRuntimeWithPlatformLineEndings()
+    {
+        var handler = new RuntimeIdentityWebMcpRouteScanHandler(
+            WebSiteBuilder.GetWebMcpSiteSearchAssetContent().Replace("\n", "\r\n", StringComparison.Ordinal));
+        var result = await WebAgentReadiness.ScanAsync(new WebAgentReadinessScanOptions
+        {
+            BaseUrl = "https://example.test",
+            HttpMessageHandler = handler,
+            AgentReadiness = WebMcpOnlySpec(agentsJson: false)
+        });
+
+        Assert.Contains(result.Checks, check => check.Id == "webmcp" && check.Status == "pass");
+    }
+
+    [Theory]
+    [InlineData("\r")]
+    [InlineData("\f")]
+    [InlineData("\u0085")]
+    [InlineData("\u2028")]
+    [InlineData("\u2029")]
+    public async Task Scan_RejectsOtherLineEndingSubstitutions(string replacement)
+    {
+        var handler = new RuntimeIdentityWebMcpRouteScanHandler(
+            WebSiteBuilder.GetWebMcpSiteSearchAssetContent().Replace("\n", replacement, StringComparison.Ordinal));
+        var result = await WebAgentReadiness.ScanAsync(new WebAgentReadinessScanOptions
+        {
+            BaseUrl = "https://example.test",
+            HttpMessageHandler = handler,
+            AgentReadiness = WebMcpOnlySpec(agentsJson: false)
+        });
+
+        Assert.Contains(result.Checks, check => check.Id == "webmcp" && check.Status == "fail");
+    }
+
+    [Fact]
+    public void Verify_AcceptsCanonicalRuntimeWithPlatformLineEndings()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-webmcp-runtime-line-endings-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "search"));
+        Directory.CreateDirectory(Path.Combine(root, "assets", "powerforge"));
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "search", "index.html"),
+                """
+                <!doctype html><html><body><main data-webmcp-site-search data-webmcp-tool-name="search_site" data-webmcp-tool-description="Search public documentation." data-webmcp-search-index="/search/index.json"></main>
+                <script src="/assets/powerforge/webmcp-site-search.v1.js" data-powerforge-webmcp></script></body></html>
+                """);
+            File.WriteAllText(Path.Combine(root, "search", "index.json"), "[]");
+            File.WriteAllText(
+                Path.Combine(root, "assets", "powerforge", "webmcp-site-search.v1.js"),
+                WebSiteBuilder.GetWebMcpSiteSearchAssetContent().ReplaceLineEndings("\r\n"));
+
+            var result = WebAgentReadiness.Verify(new WebAgentReadinessVerifyOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                AgentReadiness = WebMcpOnlySpec(agentsJson: false)
+            });
+
+            Assert.Contains(result.Checks, check => check.Id == "webmcp" && check.Status == "pass");
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Theory]
+    [InlineData("\r")]
+    [InlineData("\f")]
+    [InlineData("\u0085")]
+    [InlineData("\u2028")]
+    [InlineData("\u2029")]
+    public void Verify_RejectsOtherLineEndingSubstitutions(string replacement)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-webmcp-runtime-line-endings-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "search"));
+        Directory.CreateDirectory(Path.Combine(root, "assets", "powerforge"));
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "search", "index.html"),
+                """
+                <!doctype html><html><body><main data-webmcp-site-search data-webmcp-tool-name="search_site" data-webmcp-tool-description="Search public documentation." data-webmcp-search-index="/search/index.json"></main>
+                <script src="/assets/powerforge/webmcp-site-search.v1.js" data-powerforge-webmcp></script></body></html>
+                """);
+            File.WriteAllText(Path.Combine(root, "search", "index.json"), "[]");
+            File.WriteAllText(
+                Path.Combine(root, "assets", "powerforge", "webmcp-site-search.v1.js"),
+                WebSiteBuilder.GetWebMcpSiteSearchAssetContent().Replace("\n", replacement, StringComparison.Ordinal));
+
+            var result = WebAgentReadiness.Verify(new WebAgentReadinessVerifyOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                AgentReadiness = WebMcpOnlySpec(agentsJson: false)
+            });
+
+            Assert.Contains(result.Checks, check => check.Id == "webmcp" && check.Status == "fail");
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    private sealed class RuntimeIdentityWebMcpRouteScanHandler(string runtimeContent) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = request.RequestUri!.AbsolutePath switch
+            {
+                "/" => Response(HttpStatusCode.OK,
+                    "<!doctype html><html lang=\"en\"><head><title>Example</title></head><body><main><h1>Example</h1></main></body></html>",
+                    "text/html"),
+                "/sitemap.xml" => Response(HttpStatusCode.OK, "<urlset></urlset>", "application/xml"),
+                "/search/" => Response(HttpStatusCode.OK,
+                    "<!doctype html><html><body><main data-webmcp-site-search data-webmcp-tool-name=\"search_site\" data-webmcp-tool-description=\"Search public documentation.\" data-webmcp-search-index=\"/search/index.json\"></main><script src=\"/assets/powerforge/webmcp-site-search.v1.js\" data-powerforge-webmcp></script></body></html>",
+                    "text/html"),
+                "/search/index.json" => Response(HttpStatusCode.OK, "[]", "application/json"),
+                "/assets/powerforge/webmcp-site-search.v1.js" => Response(HttpStatusCode.OK,
+                    runtimeContent,
+                    "text/javascript"),
+                _ => Response(HttpStatusCode.NotFound, "not found", "text/plain")
+            };
+            response.RequestMessage = request;
+            return Task.FromResult(response);
+        }
+
+        private static HttpResponseMessage Response(HttpStatusCode statusCode, string content, string mediaType) => new(statusCode)
+        {
+            Content = new StringContent(content, System.Text.Encoding.UTF8, mediaType)
+        };
+    }
+}

--- a/PowerForge.Web/Assets/WebMcp/site-search.v1.js
+++ b/PowerForge.Web/Assets/WebMcp/site-search.v1.js
@@ -18,6 +18,9 @@
 
   var api = global.PowerForgeWebMcpSearch || {};
   var adapter = api.adapter || null;
+  var renderVisibleResults = typeof api.renderVisibleResults === 'function'
+    ? api.renderVisibleResults
+    : null;
   var registrationController = null;
   var indexPromise = null;
 
@@ -111,11 +114,30 @@
     };
   }
 
-  function syncVisibleSearch(query) {
+  function throwIfAborted(signal) {
+    if (signal && signal.aborted) {
+      throw new DOMException('The WebMCP search was cancelled.', 'AbortError');
+    }
+  }
+
+  async function syncVisibleSearch(response, request, usesAdapter) {
+    throwIfAborted(request.signal);
+
+    if (renderVisibleResults) {
+      var visibleResponse = JSON.parse(JSON.stringify(response));
+      await awaitWithSignal(Promise.resolve().then(function () {
+        throwIfAborted(request.signal);
+        return renderVisibleResults(visibleResponse, { signal: request.signal });
+      }), request.signal);
+      return;
+    }
+
+    if (usesAdapter) return;
     var input = surface.querySelector('[data-search-page-input], #pf-search-query');
-    if (!input) return;
-    input.value = query;
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    if (input) {
+      input.value = response.query;
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
   }
 
   function loadIndex() {
@@ -214,9 +236,7 @@
 
   async function genericSearch(request) {
     var entries = await awaitWithSignal(loadIndex(), request.signal);
-    var result = searchEntries(entries, request.query, request.limit);
-    syncVisibleSearch(request.query);
-    return result;
+    return searchEntries(entries, request.query, request.limit);
   }
 
   function normalizeResponse(result, request) {
@@ -260,10 +280,13 @@
       limit: boundedInteger(input.limit, DEFAULT_RESULT_LIMIT, 1, MAX_RESULT_LIMIT),
       signal: context && context.signal
     };
-    var result = adapter && typeof adapter.search === 'function'
+    var usesAdapter = Boolean(adapter && typeof adapter.search === 'function');
+    var result = usesAdapter
       ? await adapter.search(request)
       : await genericSearch(request);
-    return normalizeResponse(result, request);
+    var response = normalizeResponse(result, request);
+    await syncVisibleSearch(response, request, usesAdapter);
+    return response;
   }
 
   api.bindAdapter = function (nextAdapter) {

--- a/PowerForge.Web/Services/WebAgentReadiness.WebMcp.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.WebMcp.cs
@@ -499,7 +499,7 @@ public static partial class WebAgentReadiness
 
             if (TryResolveLocalWebMcpResourcePath(siteRoot, siteBaseUri, assetUri, out var assetPath) &&
                 File.Exists(assetPath) &&
-                string.Equals(File.ReadAllText(assetPath), canonicalRuntime, StringComparison.Ordinal))
+                MatchesCanonicalWebMcpRuntime(File.ReadAllText(assetPath), canonicalRuntime))
                 return true;
         }
 
@@ -528,7 +528,7 @@ public static partial class WebAgentReadiness
             if (asset.Success &&
                 finalAssetUri is not null &&
                 HasSameOrigin(pageUri, finalAssetUri) &&
-                string.Equals(asset.Text, canonicalRuntime, StringComparison.Ordinal))
+                MatchesCanonicalWebMcpRuntime(asset.Text, canonicalRuntime))
             {
                 return true;
             }
@@ -536,6 +536,12 @@ public static partial class WebAgentReadiness
 
         return false;
     }
+
+    private static bool MatchesCanonicalWebMcpRuntime(string candidate, string canonical) =>
+        string.Equals(
+            candidate.Replace("\r\n", "\n", StringComparison.Ordinal),
+            canonical.Replace("\r\n", "\n", StringComparison.Ordinal),
+            StringComparison.Ordinal);
 
     private static bool ScriptsResolveInsideRenderedSite(
         string siteRoot,


### PR DESCRIPTION
## Summary

- accept the canonical WebMCP site-search runtime when a static host converts LF line endings to CRLF, while rejecting every other byte-level change
- add a bounded `renderVisibleResults(response, context)` hook so theme-owned search pages can render the normalized tool response without loading or ranking a second index
- preserve existing `bindAdapter` visibility ownership, generic input synchronization, and cancellation before visible mutation
- document the ownership contract and cover the runtime bounds, synchronization order, cancellation guards, and LF/CRLF exception

## Why

Static hosting converted the deployed TestimoX runtime to CRLF, which caused a false canonical-runtime failure even though the executable content was unchanged. OfficeIMO also needs its branded search results to show exactly the response that PowerForge has already bounded and normalized; a theme-local search adapter would bypass the shared index limits.

PowerForge remains the reusable owner. [OfficeIMO](https://github.com/EvotecIT/OfficeIMO) consumes the new renderer hook in PR [#2449](https://github.com/EvotecIT/OfficeIMO/pull/2449), which should merge and deploy after this PR. The existing Evotec Website adapter continues to own its current visible-search workflow without duplicate input dispatch.

## Validation

- 134 focused WebAgentReadiness tests pass
- LF and CRLF pass local and remote identity checks; lone CR, form feed, NEL, Unicode line separator, and paragraph separator fail
- Chromium confirmed a delayed OfficeIMO index load cannot overwrite the three bounded visible cards, and manual input resumes the normal page search
- Chromium confirmed the existing Website adapter receives no duplicate input event
- Chromium confirmed cancellation immediately before synchronization returns `AbortError` without changing the visible page