### PR TITLE
Honor configured Cloudflare purge modes after Pages deploys

### DIFF
--- a/.github/actions/powerforge-cloudflare-site-policy/Invoke-PowerForgeCloudflareConfiguredPurge.ps1
+++ b/.github/actions/powerforge-cloudflare-site-policy/Invoke-PowerForgeCloudflareConfiguredPurge.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = 'Stop'
+
+$arguments = @(
+    'run', '--no-build', '--no-restore', '--configuration', 'Release', '--framework', 'net10.0',
+    '--project', $env:POWERFORGE_CLOUDFLARE_CLI_PROJECT, '--',
+    'cloudflare', 'purge',
+    '--zone-id', $env:POWERFORGE_CLOUDFLARE_ZONE_ID,
+    '--token-env', 'POWERFORGE_CLOUDFLARE_API_TOKEN',
+    '--site-config', $env:POWERFORGE_CLOUDFLARE_SITE_CONFIG
+)
+if (-not [string]::IsNullOrWhiteSpace($env:POWERFORGE_CLOUDFLARE_HOSTNAME)) {
+    $arguments += @('--hostname', $env:POWERFORGE_CLOUDFLARE_HOSTNAME)
+}
+if ($env:POWERFORGE_CLOUDFLARE_DRY_RUN -eq 'true') {
+    $arguments += '--dry-run'
+}
+
+dotnet @arguments
+if ($LASTEXITCODE -ne 0) {
+    throw "Purging the configured Cloudflare scope after policy application failed with exit code $LASTEXITCODE."
+}

--- a/.github/actions/powerforge-cloudflare-site-policy/action.yml
+++ b/.github/actions/powerforge-cloudflare-site-policy/action.yml
@@ -147,9 +147,10 @@ runs:
         if ($enabled -and $env:POWERFORGE_DEPLOYMENT_JOB_ID -notmatch '^[1-9][0-9]*$') {
           throw 'Managed incremental purge requires the exact GitHub Pages deployment-job-id.'
         }
-        if ($enabled -and (-not [string]::IsNullOrWhiteSpace($env:POWERFORGE_CLOUDFLARE_HOSTNAME_OVERRIDE) -or
-                          -not [string]::IsNullOrWhiteSpace($env:POWERFORGE_CLOUDFLARE_BASE_PATH_OVERRIDE))) {
-          throw 'Managed incremental purge does not support hostname or base-path overrides; configure the canonical BaseUrl in site-config.'
+        if ($env:POWERFORGE_MANAGE_INCREMENTAL_PURGE -eq 'true' -and
+            (-not [string]::IsNullOrWhiteSpace($env:POWERFORGE_CLOUDFLARE_HOSTNAME_OVERRIDE) -or
+             -not [string]::IsNullOrWhiteSpace($env:POWERFORGE_CLOUDFLARE_BASE_PATH_OVERRIDE))) {
+          throw 'Managed purge does not support hostname or base-path overrides; configure the canonical BaseUrl in site-config.'
         }
         $relativeConfig = [IO.Path]::GetRelativePath($workspace, $siteConfig).Replace([IO.Path]::DirectorySeparatorChar, '/')
         $scopeBytes = [Text.Encoding]::UTF8.GetBytes("$($env:POWERFORGE_GITHUB_REPOSITORY_ID)|$relativeConfig")
@@ -254,6 +255,18 @@ runs:
         if ($LASTEXITCODE -ne 0) {
           throw "Purging the Cloudflare hostname after policy application failed with exit code $LASTEXITCODE."
         }
+
+    - name: Purge configured Cloudflare scope after policy application
+      if: ${{ inputs.manage-incremental-purge == 'true' && steps.incremental.outputs.enabled != 'true' }}
+      shell: pwsh
+      env:
+        POWERFORGE_CLOUDFLARE_API_TOKEN: ${{ inputs.api-token }}
+        POWERFORGE_CLOUDFLARE_CLI_PROJECT: ${{ github.action_path }}/../../../PowerForge.Web.Cli/PowerForge.Web.Cli.csproj
+        POWERFORGE_CLOUDFLARE_DRY_RUN: ${{ inputs.dry-run }}
+        POWERFORGE_CLOUDFLARE_HOSTNAME: ${{ inputs.hostname }}
+        POWERFORGE_CLOUDFLARE_SITE_CONFIG: ${{ inputs.site-config }}
+        POWERFORGE_CLOUDFLARE_ZONE_ID: ${{ inputs.zone-id }}
+      run: '& "$env:GITHUB_ACTION_PATH/Invoke-PowerForgeCloudflareConfiguredPurge.ps1"'
 
     - name: Purge changed Cloudflare URLs
       if: ${{ steps.incremental.outputs.enabled == 'true' && steps.baseline_order.outputs.stale != 'true' }}

--- a/Docs/PowerForge.Web.Cloudflare.md
+++ b/Docs/PowerForge.Web.Cloudflare.md
@@ -162,6 +162,13 @@ secrets:
   cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 ```
 
+The managed Pages job uses incremental manifest comparison only when the
+effective site profile selects `PurgeMode: "incremental"`. For another purge
+mode it applies the policy and then executes that configured purge scope. This
+matters for application entry points whose arbitrary query strings create
+separate cache keys: use `hostname` when the variants cannot be enumerated
+safely instead of leaving stale fingerprinted HTML at an old query URL.
+
 Linux deployment has two distinct credential boundaries. The narrow purge-only
 token is staged ephemerally for promotion and rollback. The broader policy token
 stays on the protected Actions runner, is used only after promotion succeeds, and

--- a/PowerForge.Tests/CloudflareIncrementalCachePurgeTests.ConfiguredPurge.cs
+++ b/PowerForge.Tests/CloudflareIncrementalCachePurgeTests.ConfiguredPurge.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace PowerForge.Tests;
+
+public sealed partial class CloudflareIncrementalCachePurgeTests
+{
+    [Theory]
+    [InlineData("files", "mode=files")]
+    [InlineData("hostname", "mode=hostname")]
+    [InlineData("everything", "mode=everything")]
+    public void ConfiguredPurgeScript_ShouldExecuteTheEffectiveProfileAsADryRun(string purgeMode, string expectedOutput)
+    {
+        if (!CommandExists("pwsh")) return;
+        var root = NewTempDirectory();
+        try
+        {
+            string siteConfig = Path.Combine(root, "site.json");
+            File.WriteAllText(siteConfig, JsonSerializer.Serialize(new
+            {
+                Name = "Configured purge test",
+                BaseUrl = "https://example.test/",
+                Cloudflare = new { PurgeMode = purgeMode }
+            }));
+
+            var startInfo = new ProcessStartInfo("pwsh")
+            {
+                WorkingDirectory = RepoPath(),
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+            startInfo.ArgumentList.Add("-NoLogo");
+            startInfo.ArgumentList.Add("-NoProfile");
+            startInfo.ArgumentList.Add("-File");
+            startInfo.ArgumentList.Add(RepoPath(
+                ".github", "actions", "powerforge-cloudflare-site-policy",
+                "Invoke-PowerForgeCloudflareConfiguredPurge.ps1"));
+            startInfo.Environment["POWERFORGE_CLOUDFLARE_API_TOKEN"] = "test-token";
+            startInfo.Environment["POWERFORGE_CLOUDFLARE_CLI_PROJECT"] = RepoPath("PowerForge.Web.Cli", "PowerForge.Web.Cli.csproj");
+            startInfo.Environment["POWERFORGE_CLOUDFLARE_DRY_RUN"] = "true";
+            startInfo.Environment["POWERFORGE_CLOUDFLARE_HOSTNAME"] = string.Empty;
+            startInfo.Environment["POWERFORGE_CLOUDFLARE_SITE_CONFIG"] = siteConfig;
+            startInfo.Environment["POWERFORGE_CLOUDFLARE_ZONE_ID"] = ZoneId;
+            DotNetTestProcessEnvironment.DisableBuildServers(startInfo);
+
+            using var process = Process.Start(startInfo)!;
+            string standardOutput = process.StandardOutput.ReadToEnd();
+            string standardError = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            Assert.True(process.ExitCode == 0, standardError + Environment.NewLine + standardOutput);
+            Assert.Contains(expectedOutput, standardOutput, StringComparison.Ordinal);
+            Assert.Contains("Dry run.", standardOutput, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/PowerForge.Tests/CloudflareIncrementalCachePurgeTests.cs
+++ b/PowerForge.Tests/CloudflareIncrementalCachePurgeTests.cs
@@ -638,6 +638,11 @@ public sealed partial class CloudflareIncrementalCachePurgeTests
         Assert.Contains("inputs.dry-run != 'true'", action, StringComparison.Ordinal);
         Assert.Contains("retention-days: 1", runWorkflow, StringComparison.Ordinal);
         Assert.Contains("Purge changed Cloudflare URLs", action, StringComparison.Ordinal);
+        Assert.Contains("Purge configured Cloudflare scope after policy application", action, StringComparison.Ordinal);
+        Assert.Contains("inputs.manage-incremental-purge == 'true' && steps.incremental.outputs.enabled != 'true'", action, StringComparison.Ordinal);
+        Assert.Contains("Invoke-PowerForgeCloudflareConfiguredPurge.ps1", action, StringComparison.Ordinal);
+        Assert.Contains("$env:POWERFORGE_MANAGE_INCREMENTAL_PURGE -eq 'true'", action, StringComparison.Ordinal);
+        Assert.Contains("Managed purge does not support hostname or base-path overrides", action, StringComparison.Ordinal);
         Assert.True(
             runWorkflow.IndexOf("Archive site artifact", StringComparison.Ordinal) <
             runWorkflow.IndexOf("Create exact deployment manifest", StringComparison.Ordinal));


### PR DESCRIPTION
## Summary

- run the configured Cloudflare purge scope after a managed GitHub Pages deployment when the site does not use incremental manifest purging
- keep incremental manifest comparison and the Linux post-policy hostname purge unchanged
- reject hostname and base-path overrides for every managed Pages purge so policy and invalidation cannot target different scopes
- cover `files`, `hostname`, and `everything` profiles through the extracted PowerShell helper and the real CLI dry-run path

## Why

The managed Pages action previously applied non-incremental site policy without purging. A site that changed fingerprinted application assets could therefore leave cached query variants pointing at removed hashes even after a successful deployment.

Sites with a bounded query contract can continue to use `incremental` plus `Cloudflare.AlwaysPurgePaths`. Sites with arbitrary query cache keys can select `hostname`; the managed Pages job now executes that configured scope after policy application.

## Validation

- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~CloudflareIncrementalCachePurgeTests|FullyQualifiedName~GitHubWebsiteLinuxDeployWorkflowTests" --no-restore`
- 48 tests passed
- independent local review completed; two P2 findings were fixed and targeted confirmation found no remaining P0-P2 issues

## Release ordering

Consumers must pin this exact PowerForge commit before changing a GitHub Pages site from incremental to hostname purging.
