### PR TITLE
Add durable server data backup support

### DIFF
--- a/.github/actions/powerforge-server-backup/Invoke-PowerForgeServerBackup.ps1
+++ b/.github/actions/powerforge-server-backup/Invoke-PowerForgeServerBackup.ps1
@@ -4,78 +4,8 @@ param()
 
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
-
-function Assert-LastExitCode {
-    param([Parameter(Mandatory)][string] $Operation)
-
-    if ($LASTEXITCODE -ne 0) {
-        throw "$Operation failed with exit code $LASTEXITCODE."
-    }
-}
-
-function Invoke-GitWithRetry {
-    param(
-        [Parameter(Mandatory)][string] $Operation,
-        [Parameter(Mandatory)][string[]] $Arguments,
-        [string] $ResetPath,
-        [ValidateRange(1, 5)][int] $MaxAttempts = 3,
-        [ValidateRange(0, 60)][int] $RetryDelaySeconds = 5
-    )
-
-    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
-        if (-not [string]::IsNullOrWhiteSpace($ResetPath) -and (Test-Path -LiteralPath $ResetPath)) {
-            Remove-Item -LiteralPath $ResetPath -Recurse -Force
-        }
-
-        & git @Arguments
-        $exitCode = $LASTEXITCODE
-        if ($exitCode -eq 0) {
-            return
-        }
-        if ($attempt -lt $MaxAttempts) {
-            Write-Warning "$Operation failed with exit code $exitCode; retrying ($attempt/$MaxAttempts)."
-            Start-Sleep -Seconds ($attempt * $RetryDelaySeconds)
-        }
-    }
-
-    if (-not [string]::IsNullOrWhiteSpace($ResetPath) -and (Test-Path -LiteralPath $ResetPath)) {
-        Remove-Item -LiteralPath $ResetPath -Recurse -Force
-    }
-    throw "$Operation failed after $MaxAttempts attempts with exit code $exitCode."
-}
-
-function Write-ActionOutput {
-    param(
-        [Parameter(Mandatory)][string] $Name,
-        [Parameter(Mandatory)][AllowEmptyString()][string] $Value
-    )
-
-    "$Name=$Value" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-}
-
-function Write-CaptureFailureDiagnostic {
-    param([Parameter(Mandatory)][string] $CaptureRoot)
-
-    foreach ($name in @('plain-files.stderr.txt', 'encrypted-secrets.stderr.txt')) {
-        $path = Join-Path $CaptureRoot $name
-        if (-not (Test-Path -LiteralPath $path -PathType Leaf) -or (Get-Item -LiteralPath $path).Length -eq 0) {
-            continue
-        }
-
-        # Only tar/encryption stderr is surfaced. Command captures may contain sensitive service output.
-        $diagnostic = ((Get-Content -LiteralPath $path -TotalCount 40) -join [Environment]::NewLine)
-        $diagnostic = $diagnostic -replace '[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]', '?'
-        if ($diagnostic.Length -gt 4096) {
-            $diagnostic = $diagnostic.Substring(0, 4096) + [Environment]::NewLine + '[truncated]'
-        }
-        $stopToken = [Guid]::NewGuid().ToString('N')
-        Write-Host "::group::PowerForge capture diagnostic: $name"
-        Write-Host "::stop-commands::$stopToken"
-        Write-Host $diagnostic
-        Write-Host "::$stopToken::"
-        Write-Host '::endgroup::'
-    }
-}
+. (Join-Path $PSScriptRoot 'PowerForgeBackupSupport.ps1')
+. (Join-Path $PSScriptRoot 'PowerForgeBackupCatalog.ps1')
 
 if ($env:RUNNER_OS -ne 'Linux') {
     throw 'PowerForge server backup requires a Linux runner.'
@@ -334,6 +264,8 @@ exec /usr/bin/ssh -F "${POWERFORGE_SERVER_SSH_CONFIG:?}" "$@"
         Remove-Item -LiteralPath $stale.FullName -Recurse -Force
     }
 
+    Update-BackupCatalog -TargetRoot $targetRoot -TargetRelative $backupPath -KeepLatestInTree $keepLatestInTree
+
     git -C $checkout config user.name 'PowerForge Server Backup'
     Assert-LastExitCode 'Configuring the backup Git author'
     git -C $checkout config user.email 'powerforge-backup@users.noreply.github.com'
@@ -353,11 +285,11 @@ exec /usr/bin/ssh -F "${POWERFORGE_SERVER_SSH_CONFIG:?}" "$@"
             'origin',
             "+refs/heads/${backupBranch}:refs/remotes/origin/${backupBranch}"
         )
-        git -C $checkout rebase "origin/$backupBranch"
-        if ($LASTEXITCODE -ne 0) {
-            git -C $checkout rebase --abort 2>$null
-            throw 'Rebasing the backup publication failed.'
-        }
+        $generatedCatalogPaths = @(
+            "$($backupPath.TrimEnd('/'))/LATEST.txt",
+            "$($backupPath.TrimEnd('/'))/index.json"
+        )
+        Invoke-BackupPublicationRebase -Checkout $checkout -Upstream "origin/$backupBranch" -GeneratedCatalogPaths $generatedCatalogPaths
 
         $captures = @(Get-ChildItem -LiteralPath $targetRoot -Directory |
             Where-Object Name -Match '^\d{8}T\d{6}Z-\d+-\d+$' |
@@ -365,6 +297,7 @@ exec /usr/bin/ssh -F "${POWERFORGE_SERVER_SSH_CONFIG:?}" "$@"
         foreach ($stale in @($captures | Select-Object -Skip $keepLatestInTree)) {
             Remove-Item -LiteralPath $stale.FullName -Recurse -Force
         }
+        Update-BackupCatalog -TargetRoot $targetRoot -TargetRelative $backupPath -KeepLatestInTree $keepLatestInTree
         git -C $checkout add -- $backupPath
         Assert-LastExitCode 'Restaging retained backup captures'
 

--- a/.github/actions/powerforge-server-backup/PowerForgeBackupCatalog.ps1
+++ b/.github/actions/powerforge-server-backup/PowerForgeBackupCatalog.ps1
@@ -1,0 +1,98 @@
+function Get-BackupCaptureDirectory {
+    param([Parameter(Mandatory)][string] $TargetRoot)
+
+    if (-not (Test-Path -LiteralPath $TargetRoot -PathType Container)) {
+        return @()
+    }
+
+    $captures = @(Get-ChildItem -LiteralPath $TargetRoot -Directory -Force -ErrorAction Stop |
+        Where-Object Name -Match '^(?:\d{14}|\d{8}T\d{6}Z-\d+-\d+)$' |
+        Sort-Object Name -Descending)
+    foreach ($capture in $captures) {
+        if (($capture.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+            throw "Backup capture directory must not be a link: $($capture.FullName)"
+        }
+    }
+
+    $captures
+}
+
+function Get-BackupFileSummary {
+    param(
+        [Parameter(Mandatory)][string] $CapturePath,
+        [Parameter(Mandatory)][string] $FilePath
+    )
+
+    $relative = [IO.Path]::GetRelativePath($CapturePath, $FilePath).Replace('\', '/')
+    if ($relative.StartsWith('../', [StringComparison]::Ordinal) -or
+        [IO.Path]::IsPathRooted($relative)) {
+        throw "Backup file escaped its capture directory: $FilePath"
+    }
+
+    $item = Get-Item -LiteralPath $FilePath -Force
+    if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "Backup capture files must not be links: $FilePath"
+    }
+    [ordered]@{
+        name      = $relative
+        sizeBytes = $item.Length
+        sha256    = (Get-FileHash -LiteralPath $item.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+    }
+}
+
+function Update-BackupCatalog {
+    param(
+        [Parameter(Mandatory)][string] $TargetRoot,
+        [Parameter(Mandatory)][string] $TargetRelative,
+        [Parameter(Mandatory)][int] $KeepLatestInTree
+    )
+
+    $captures = @(Get-BackupCaptureDirectory -TargetRoot $TargetRoot)
+    if ($captures.Count -eq 0) {
+        throw "Backup target does not contain a completed capture: $TargetRoot"
+    }
+
+    $entries = foreach ($capture in $captures) {
+        $unsafeLink = Get-ChildItem -LiteralPath $capture.FullName -Recurse -Force -ErrorAction Stop |
+            Where-Object { ($_.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0 } |
+            Select-Object -First 1
+        if ($null -ne $unsafeLink) {
+            throw "Backup capture content must not contain links: $($unsafeLink.FullName)"
+        }
+
+        $summaryPath = Join-Path $capture.FullName 'capture-summary.json'
+        $metadataPath = Join-Path $capture.FullName 'capture-metadata.json'
+        $summary = if (Test-Path -LiteralPath $summaryPath -PathType Leaf) {
+            Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json
+        }
+        $metadata = if (Test-Path -LiteralPath $metadataPath -PathType Leaf) {
+            Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json
+        }
+        $createdAtUtc = if ($metadata -and $null -ne $metadata.capturedAtUtc) {
+            ([DateTimeOffset]$metadata.capturedAtUtc).ToUniversalTime().ToString('O')
+        } elseif ($capture.Name -match '^(\d{4})(\d{2})(\d{2})T?(\d{2})(\d{2})(\d{2})Z?') {
+            '{0}-{1}-{2}T{3}:{4}:{5}Z' -f $Matches[1], $Matches[2], $Matches[3], $Matches[4], $Matches[5], $Matches[6]
+        }
+
+        [ordered]@{
+            stamp        = $capture.Name
+            path         = "$($TargetRelative.TrimEnd('/'))/$($capture.Name)"
+            createdAtUtc = $createdAtUtc
+            commandCount = if ($summary) { @($summary.commandResults).Count } else { 0 }
+            warningCount = if ($summary) { @($summary.warnings).Count } else { 0 }
+            files        = @(Get-ChildItem -LiteralPath $capture.FullName -File -Recurse -Force |
+                Sort-Object FullName |
+                ForEach-Object { Get-BackupFileSummary -CapturePath $capture.FullName -FilePath $_.FullName })
+        }
+    }
+
+    $latest = $captures[0].Name
+    Set-Content -LiteralPath (Join-Path $TargetRoot 'LATEST.txt') -Value $latest -Encoding utf8NoBOM
+    [ordered]@{
+        schemaVersion = 1
+        updatedAtUtc  = [DateTimeOffset]::UtcNow.ToString('O')
+        latest        = $latest
+        retention     = [ordered]@{ keepLatestInTree = $KeepLatestInTree }
+        captures      = @($entries)
+    } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath (Join-Path $TargetRoot 'index.json') -Encoding utf8NoBOM
+}

--- a/.github/actions/powerforge-server-backup/PowerForgeBackupSupport.ps1
+++ b/.github/actions/powerforge-server-backup/PowerForgeBackupSupport.ps1
@@ -1,0 +1,103 @@
+function Assert-LastExitCode {
+    param([Parameter(Mandatory)][string] $Operation)
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Operation failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Invoke-GitWithRetry {
+    param(
+        [Parameter(Mandatory)][string] $Operation,
+        [Parameter(Mandatory)][string[]] $Arguments,
+        [string] $ResetPath,
+        [ValidateRange(1, 5)][int] $MaxAttempts = 3,
+        [ValidateRange(0, 60)][int] $RetryDelaySeconds = 5
+    )
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        if (-not [string]::IsNullOrWhiteSpace($ResetPath) -and (Test-Path -LiteralPath $ResetPath)) {
+            Remove-Item -LiteralPath $ResetPath -Recurse -Force
+        }
+
+        & git @Arguments
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -eq 0) {
+            return
+        }
+        if ($attempt -lt $MaxAttempts) {
+            Write-Warning "$Operation failed with exit code $exitCode; retrying ($attempt/$MaxAttempts)."
+            Start-Sleep -Seconds ($attempt * $RetryDelaySeconds)
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($ResetPath) -and (Test-Path -LiteralPath $ResetPath)) {
+        Remove-Item -LiteralPath $ResetPath -Recurse -Force
+    }
+    throw "$Operation failed after $MaxAttempts attempts with exit code $exitCode."
+}
+
+function Invoke-BackupPublicationRebase {
+    param(
+        [Parameter(Mandatory)][string] $Checkout,
+        [Parameter(Mandatory)][string] $Upstream,
+        [Parameter(Mandatory)][string[]] $GeneratedCatalogPaths
+    )
+
+    & git -C $Checkout rebase $Upstream
+    while ($LASTEXITCODE -ne 0) {
+        $unmerged = @(& git -C $Checkout diff --name-only --diff-filter=U)
+        if ($LASTEXITCODE -ne 0 -or $unmerged.Count -eq 0) {
+            & git -C $Checkout rebase --abort 2>$null
+            throw 'Rebasing the backup publication failed without a resolvable file conflict.'
+        }
+
+        $unexpected = @($unmerged | Where-Object { $_ -notin $GeneratedCatalogPaths })
+        if ($unexpected.Count -ne 0) {
+            & git -C $Checkout rebase --abort 2>$null
+            throw "Rebasing the backup publication conflicted outside generated catalogs: $($unexpected -join ', ')"
+        }
+
+        # During a rebase HEAD is the refreshed upstream. Preserve its generated catalogs;
+        # the caller regenerates both files from the combined capture tree immediately after.
+        & git -C $Checkout restore --source=HEAD --staged --worktree -- @unmerged
+        if ($LASTEXITCODE -ne 0) {
+            & git -C $Checkout rebase --abort 2>$null
+            throw 'Restoring upstream generated catalogs during backup rebase failed.'
+        }
+        & git -C $Checkout -c core.editor=true rebase --continue
+    }
+}
+
+function Write-ActionOutput {
+    param(
+        [Parameter(Mandatory)][string] $Name,
+        [Parameter(Mandatory)][AllowEmptyString()][string] $Value
+    )
+
+    "$Name=$Value" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+}
+
+function Write-CaptureFailureDiagnostic {
+    param([Parameter(Mandatory)][string] $CaptureRoot)
+
+    foreach ($name in @('plain-files.stderr.txt', 'encrypted-secrets.stderr.txt')) {
+        $path = Join-Path $CaptureRoot $name
+        if (-not (Test-Path -LiteralPath $path -PathType Leaf) -or (Get-Item -LiteralPath $path).Length -eq 0) {
+            continue
+        }
+
+        # Only tar/encryption stderr is surfaced. Command captures may contain sensitive service output.
+        $diagnostic = ((Get-Content -LiteralPath $path -TotalCount 40) -join [Environment]::NewLine)
+        $diagnostic = $diagnostic -replace '[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]', '?'
+        if ($diagnostic.Length -gt 4096) {
+            $diagnostic = $diagnostic.Substring(0, 4096) + [Environment]::NewLine + '[truncated]'
+        }
+        $stopToken = [Guid]::NewGuid().ToString('N')
+        Write-Host "::group::PowerForge capture diagnostic: $name"
+        Write-Host "::stop-commands::$stopToken"
+        Write-Host $diagnostic
+        Write-Host "::$stopToken::"
+        Write-Host '::endgroup::'
+    }
+}

--- a/Deployment/Linux/powerforge-server-backup-pull.sh
+++ b/Deployment/Linux/powerforge-server-backup-pull.sh
@@ -99,7 +99,8 @@ while (($# > 0)); do
 done
 
 [[ "$remote" =~ ^[A-Za-z_][A-Za-z0-9_-]{0,31}@[A-Za-z0-9][A-Za-z0-9.-]{0,252}$ ]] || die 'remote must be a fixed user@host value'
-[[ "$remote_root" =~ ^/[A-Za-z0-9._/-]*/$ && "$remote_root" != *'//'* ]] || die 'remote root must be an absolute path ending in /'
+[[ "$remote_root" == '/' || ( "$remote_root" =~ ^/[A-Za-z0-9._/-]*/$ && "$remote_root" != *'//'* ) ]] ||
+  die 'remote root must be an absolute path ending in /'
 [[ ! "$remote_root" =~ (^|/)\.{1,2}(/|$) ]] || die 'remote root contains a traversal segment'
 assert_local_path "$destination"
 assert_local_path "$identity"
@@ -164,6 +165,7 @@ cleanup() {
   for temporary in "${verification_temps[@]:-}" "$remote_listing" "$remote_manifest"; do
     [[ -n "$temporary" && "$temporary" == "$destination/"* && -f "$temporary" && ! -L "$temporary" ]] && rm -f -- "$temporary"
   done
+  return 0
 }
 trap cleanup EXIT INT TERM
 

--- a/Deployment/Linux/powerforge-server-backup-pull.sh
+++ b/Deployment/Linux/powerforge-server-backup-pull.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+export PATH
+
+log() {
+  printf 'powerforge-server-backup-pull: %s\n' "$*" >&2
+}
+
+die() {
+  log "$*"
+  exit 1
+}
+
+require_command() {
+  local name="$1" resolved
+  resolved="$(command -v -- "$name" 2>/dev/null || true)"
+  [[ -n "$resolved" && "$resolved" == /* ]] || die "required command is unavailable: $name"
+  printf '%s\n' "$resolved"
+}
+
+assert_local_path() {
+  local path="$1"
+  [[ "$path" =~ ^/[A-Za-z0-9._/-]+$ ]] || die "unsafe local path: $path"
+  [[ "$path" != '/' && "$path" != *'//'* && "$path" != */ ]] || die "local path must be a dedicated exact path: $path"
+  [[ ! "$path" =~ (^|/)\.{1,2}(/|$) ]] || die "local path contains a traversal segment: $path"
+}
+
+verify_snapshot() {
+  local snapshot="$1" unsafe entry relative expected actual manifest_sha
+  [[ -d "$snapshot" && ! -L "$snapshot" ]] || die "snapshot directory is unsafe: $snapshot"
+  [[ "$($readlink_bin -f -- "$snapshot")" == "$snapshot" ]] || die "snapshot directory is not canonical: $snapshot"
+  [[ -f "$snapshot/READY" && ! -L "$snapshot/READY" ]] || die "snapshot is not ready: $snapshot"
+  [[ -f "$snapshot/SHA256SUMS" && ! -L "$snapshot/SHA256SUMS" ]] || die "snapshot checksum manifest is missing or unsafe: $snapshot"
+  [[ -f "$snapshot/recovery.tar.gz.age" && ! -L "$snapshot/recovery.tar.gz.age" ]] ||
+    die "snapshot encrypted bundle is missing or unsafe: $snapshot"
+
+  unsafe="$(find "$snapshot" -mindepth 1 ! -type f ! -type d -print -quit)"
+  [[ -z "$unsafe" ]] || die "snapshot contains a link or special entry: $unsafe"
+  while IFS= read -r -d '' entry; do
+    relative="${entry#"$snapshot/"}"
+    [[ "$relative" != *$'\n'* && "$relative" != *$'\r'* && "$relative" != *\\* ]] ||
+      die "snapshot path cannot be represented safely in SHA256SUMS: $relative"
+  done < <(find "$snapshot" -mindepth 1 -print0)
+
+  expected="$($mktemp_bin "$destination/.verify-expected.XXXXXXXX")"
+  actual="$($mktemp_bin "$destination/.verify-actual.XXXXXXXX")"
+  verification_temps+=("$expected" "$actual")
+  (
+    cd "$snapshot"
+    # shellcheck disable=SC2016 # The program is evaluated by awk, not Bash.
+    "$awk_bin" '
+      length($0) < 67 || substr($0, 1, 64) !~ /^[a-f0-9]{64}$/ || substr($0, 65, 2) != "  " { exit 1 }
+      { print substr($0, 67) }
+    ' SHA256SUMS | "$sort_bin" >"$expected"
+    find . -type f ! -name SHA256SUMS ! -name READY ! -name VERIFIED -print | "$sort_bin" >"$actual"
+    "$cmp_bin" -s "$expected" "$actual"
+    "$sha256_bin" -c SHA256SUMS >/dev/null
+  ) || die "snapshot tree or checksum verification failed: $snapshot"
+  [[ "$(head -n 1 "$snapshot/recovery.tar.gz.age")" == 'age-encryption.org/v1' ]] ||
+    die "snapshot age header is invalid: $snapshot"
+  manifest_sha="$($sha256_bin "$snapshot/SHA256SUMS" | cut -d ' ' -f 1)"
+  printf 'verifiedAtUtc=%s\nmanifestSha256=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$manifest_sha" >"$snapshot/VERIFIED"
+  chmod 0600 "$snapshot/VERIFIED"
+  rm -f -- "$expected" "$actual"
+}
+
+has_current_verification() {
+  local snapshot="$1" recorded current
+  [[ -f "$snapshot/VERIFIED" && ! -L "$snapshot/VERIFIED" && -f "$snapshot/SHA256SUMS" ]] || return 1
+  recorded="$(sed -n 's/^manifestSha256=//p' "$snapshot/VERIFIED")"
+  current="$($sha256_bin "$snapshot/SHA256SUMS" | cut -d ' ' -f 1)"
+  [[ "$recorded" =~ ^[a-f0-9]{64}$ && "$recorded" == "$current" ]]
+}
+
+remote=''
+remote_root='/'
+destination=''
+identity=''
+known_hosts=''
+port='22'
+keep_recent='56'
+keep_weekly='8'
+keep_monthly='12'
+
+while (($# > 0)); do
+  case "$1" in
+    --remote) remote="${2:-}"; shift 2 ;;
+    --remote-root) remote_root="${2:-}"; shift 2 ;;
+    --destination) destination="${2:-}"; shift 2 ;;
+    --identity) identity="${2:-}"; shift 2 ;;
+    --known-hosts) known_hosts="${2:-}"; shift 2 ;;
+    --port) port="${2:-}"; shift 2 ;;
+    --keep-recent) keep_recent="${2:-}"; shift 2 ;;
+    --keep-weekly) keep_weekly="${2:-}"; shift 2 ;;
+    --keep-monthly) keep_monthly="${2:-}"; shift 2 ;;
+    *) die "unsupported argument: $1" ;;
+  esac
+done
+
+[[ "$remote" =~ ^[A-Za-z_][A-Za-z0-9_-]{0,31}@[A-Za-z0-9][A-Za-z0-9.-]{0,252}$ ]] || die 'remote must be a fixed user@host value'
+[[ "$remote_root" =~ ^/[A-Za-z0-9._/-]*/$ && "$remote_root" != *'//'* ]] || die 'remote root must be an absolute path ending in /'
+[[ ! "$remote_root" =~ (^|/)\.{1,2}(/|$) ]] || die 'remote root contains a traversal segment'
+assert_local_path "$destination"
+assert_local_path "$identity"
+assert_local_path "$known_hosts"
+[[ "${EUID}" -eq 0 ]] || die 'destination pull must run as root'
+umask 0077
+[[ -f "$identity" && ! -L "$identity" ]] || die "SSH identity is missing or unsafe: $identity"
+[[ -f "$known_hosts" && ! -L "$known_hosts" ]] || die "known-hosts file is missing or unsafe: $known_hosts"
+if [[ ! "$port" =~ ^[0-9]+$ ]] || ((port < 1 || port > 65535)); then
+  die 'SSH port must be from 1 through 65535'
+fi
+for value in "$keep_recent" "$keep_weekly" "$keep_monthly"; do
+  [[ "$value" =~ ^[0-9]+$ ]] || die 'retention counts must be non-negative integers'
+done
+((keep_recent >= 1 && keep_recent <= 1000)) || die 'keep-recent must be from 1 through 1000'
+((keep_weekly <= 260 && keep_monthly <= 120)) || die 'weekly or monthly retention is unreasonably large'
+
+rsync_bin="$(require_command rsync)"
+ssh_bin="$(require_command ssh)"
+sha256_bin="$(require_command sha256sum)"
+date_bin="$(require_command date)"
+readlink_bin="$(require_command readlink)"
+stat_bin="$(require_command stat)"
+flock_bin="$(require_command flock)"
+mktemp_bin="$(require_command mktemp)"
+awk_bin="$(require_command awk)"
+sort_bin="$(require_command sort)"
+cmp_bin="$(require_command cmp)"
+readonly rsync_bin ssh_bin sha256_bin date_bin readlink_bin stat_bin flock_bin mktemp_bin awk_bin sort_bin cmp_bin
+
+readonly marker="$destination/.powerforge-server-backup-root"
+[[ -d "$destination" && ! -L "$destination" ]] || die "destination must be an existing non-link directory: $destination"
+[[ "$($readlink_bin -f -- "$destination")" == "$destination" ]] || die "destination must be a canonical physical path: $destination"
+[[ -f "$marker" && ! -L "$marker" && "$(tr -d '\r\n' <"$marker")" == 'powerforge-server-backup-v1' ]] ||
+  die "destination marker is missing or invalid: $marker"
+[[ "$($stat_bin -c '%u:%a' "$destination")" == '0:700' ]] || die 'destination must be owned by root with mode 0700'
+[[ "$($stat_bin -c '%u:%a' "$marker")" == '0:600' ]] || die 'destination marker must be owned by root with mode 0600'
+snapshots_root="$destination/snapshots"
+if [[ -e "$snapshots_root" || -L "$snapshots_root" ]]; then
+  [[ -d "$snapshots_root" && ! -L "$snapshots_root" && "$($readlink_bin -f -- "$snapshots_root")" == "$snapshots_root" ]] ||
+    die 'existing snapshot root must be a canonical non-link directory'
+fi
+install -d -m 0700 -o root -g root "$snapshots_root"
+[[ ! -L "$snapshots_root" && "$($readlink_bin -f -- "$snapshots_root")" == "$snapshots_root" ]] ||
+  die 'snapshot root must be a canonical non-link directory'
+
+lock_file="$destination/.pull.lock"
+[[ ! -e "$lock_file" || ( -f "$lock_file" && ! -L "$lock_file" ) ]] || die 'pull lock path is unsafe'
+exec 9>"$lock_file"
+"$flock_bin" -n 9 || die 'another backup pull is already running'
+chown root:root "$lock_file"
+chmod 0600 "$lock_file"
+
+current_partial=''
+remote_listing=''
+remote_manifest=''
+verification_temps=()
+cleanup() {
+  if [[ -n "${current_partial:-}" && "$current_partial" == "$snapshots_root/.partial-"* && -d "$current_partial" && ! -L "$current_partial" ]]; then
+    rm -rf -- "$current_partial"
+  fi
+  for temporary in "${verification_temps[@]:-}" "$remote_listing" "$remote_manifest"; do
+    [[ -n "$temporary" && "$temporary" == "$destination/"* && -f "$temporary" && ! -L "$temporary" ]] && rm -f -- "$temporary"
+  done
+}
+trap cleanup EXIT INT TERM
+
+export RSYNC_RSH="$ssh_bin -p $port -i $identity -o UserKnownHostsFile=$known_hosts -o StrictHostKeyChecking=yes -o IdentitiesOnly=yes -o BatchMode=yes"
+remote_listing="$($mktemp_bin "$destination/.remote-list.XXXXXXXX")"
+"$rsync_bin" --list-only "$remote:${remote_root}snapshots/" >"$remote_listing"
+mapfile -t remote_stamps < <(
+  # shellcheck disable=SC2016 # The program is evaluated by awk, not Bash.
+  "$awk_bin" '$1 ~ /^d/ && $NF ~ /^[0-9]{8}T[0-9]{6}Z\/?$/ { name=$NF; sub(/\/$/, "", name); print name }' "$remote_listing" |
+    "$sort_bin"
+)
+(( ${#remote_stamps[@]} > 0 )) || die 'remote export does not contain a completed snapshot'
+
+verified_now=0
+for stamp in "${remote_stamps[@]}"; do
+  snapshot="$snapshots_root/$stamp"
+  if [[ -e "$snapshot" ]]; then
+    [[ -d "$snapshot" && ! -L "$snapshot" && "$($readlink_bin -f -- "$snapshot")" == "$snapshot" ]] ||
+      die "existing snapshot path is unsafe: $snapshot"
+    remote_manifest="$destination/.remote-sha-${stamp}-$$"
+    "$rsync_bin" "$remote:${remote_root}snapshots/$stamp/SHA256SUMS" "$remote_manifest"
+    "$cmp_bin" -s "$remote_manifest" "$snapshot/SHA256SUMS" || die "remote snapshot changed after local publication: $stamp"
+    rm -f -- "$remote_manifest"
+    remote_manifest=''
+    verify_snapshot "$snapshot"
+  else
+    current_partial="$snapshots_root/.partial-${stamp}-$$"
+    install -d -m 0700 -o root -g root "$current_partial"
+    rsync_args=(--archive --hard-links --no-links --no-devices --no-specials --partial --delay-updates)
+    previous="$(find "$snapshots_root" -mindepth 1 -maxdepth 1 -type d -name '????????T??????Z' -print | "$sort_bin" | tail -n 1)"
+    if [[ -n "$previous" && -d "$previous" && ! -L "$previous" ]]; then
+      rsync_args+=("--link-dest=$previous")
+    fi
+    "$rsync_bin" "${rsync_args[@]}" "$remote:${remote_root}snapshots/$stamp/" "$current_partial/"
+    verify_snapshot "$current_partial"
+    mv -- "$current_partial" "$snapshot"
+    current_partial=''
+  fi
+  verified_now=$((verified_now + 1))
+done
+
+mapfile -t snapshots < <(find "$snapshots_root" -mindepth 1 -maxdepth 1 -type d -name '????????T??????Z' -print | "$sort_bin" -r)
+declare -A keep=()
+for ((index = 0; index < ${#snapshots[@]} && index < keep_recent; index++)); do
+  keep["${snapshots[$index]}"]=1
+done
+
+weekly_kept=0
+declare -A weeks=()
+for ((index = keep_recent; index < ${#snapshots[@]} && weekly_kept < keep_weekly; index++)); do
+  snapshot="${snapshots[$index]}"
+  stamp="${snapshot##*/}"
+  calendar_date="${stamp:0:4}-${stamp:4:2}-${stamp:6:2}"
+  week="$($date_bin -u -d "$calendar_date" +%G-%V 2>/dev/null || true)"
+  [[ "$week" =~ ^[0-9]{4}-[0-9]{2}$ ]] || die 'date command cannot calculate ISO retention weeks'
+  if [[ -z "${weeks[$week]:-}" ]]; then
+    weeks["$week"]=1
+    keep["$snapshot"]=1
+    weekly_kept=$((weekly_kept + 1))
+  fi
+done
+
+monthly_kept=0
+declare -A months=()
+for ((index = keep_recent; index < ${#snapshots[@]} && monthly_kept < keep_monthly; index++)); do
+  snapshot="${snapshots[$index]}"
+  stamp="${snapshot##*/}"
+  month="${stamp:0:6}"
+  if [[ -z "${months[$month]:-}" ]]; then
+    months["$month"]=1
+    keep["$snapshot"]=1
+    monthly_kept=$((monthly_kept + 1))
+  fi
+done
+
+removed=0
+for snapshot in "${snapshots[@]}"; do
+  [[ -n "${keep[$snapshot]:-}" ]] && continue
+  verify_snapshot "$snapshot"
+  has_current_verification "$snapshot" || { log "retaining unverified snapshot: $snapshot"; continue; }
+  [[ "$snapshot" == "$snapshots_root/"????????T??????Z && -d "$snapshot" && ! -L "$snapshot" ]] ||
+    die "refusing to prune unsafe snapshot path: $snapshot"
+  [[ "$($readlink_bin -f -- "$snapshot")" == "$snapshot" && "$($readlink_bin -f -- "${snapshot%/*}")" == "$snapshots_root" ]] ||
+    die "refusing to prune snapshot outside the canonical destination: $snapshot"
+  rm -rf -- "$snapshot"
+  removed=$((removed + 1))
+done
+
+latest="${snapshots[0]:-}"
+if [[ -z "$latest" ]] || ! has_current_verification "$latest"; then
+  die 'no verified durable snapshot is available after pull'
+fi
+printf 'latest=%s\nverifiedNow=%s\nremoved=%s\n' "${latest##*/}" "$verified_now" "$removed" >"$destination/health.txt"
+chmod 0600 "$destination/health.txt"
+log "pull complete; latest=${latest##*/}, verified=$verified_now, pruned=$removed"
+
+trap - EXIT INT TERM
+cleanup

--- a/Deployment/Linux/powerforge-server-data-capture.sh
+++ b/Deployment/Linux/powerforge-server-data-capture.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+export PATH
+
+log() {
+  printf 'powerforge-server-data-capture: %s\n' "$*" >&2
+}
+
+die() {
+  log "$*"
+  exit 1
+}
+
+require_command() {
+  local name="$1" resolved
+  resolved="$(command -v -- "$name" 2>/dev/null || true)"
+  [[ -n "$resolved" && "$resolved" == /* ]] || die "required command is unavailable: $name"
+  printf '%s\n' "$resolved"
+}
+
+assert_identifier() {
+  [[ "$1" =~ ^[A-Za-z0-9_][A-Za-z0-9_-]{0,63}$ ]] || die "unsafe identifier: $1"
+}
+
+assert_unix_identity() {
+  [[ "$1" =~ ^[A-Za-z_][A-Za-z0-9_-]{0,31}$ ]] || die "unsafe Unix identity: $1"
+}
+
+assert_database_name() {
+  [[ "$1" =~ ^[A-Za-z_][A-Za-z0-9_]{0,62}$ ]] || die "unsafe PostgreSQL database name: $1"
+}
+
+assert_absolute_path() {
+  local path="$1"
+  [[ "$path" =~ ^/[A-Za-z0-9._/-]+$ ]] || die "unsafe absolute path: $path"
+  [[ "$path" != '/' && "$path" != *'//'* && "$path" != */ ]] || die "path must be a dedicated exact path: $path"
+  [[ ! "$path" =~ (^|/)\.{1,2}(/|$) ]] || die "path contains a traversal segment: $path"
+}
+
+assert_dedicated_export_root() {
+  case "$1" in
+    /etc|/home|/root|/srv|/var|/var/lib) die "export root must be a dedicated directory below a system data root: $1" ;;
+  esac
+}
+
+paths_overlap() {
+  [[ "$1" == "$2" || "$1" == "$2/"* || "$2" == "$1/"* ]]
+}
+
+[[ "${EUID}" -eq 0 ]] || die 'capture must run as root'
+[[ "$#" -eq 1 ]] || die 'usage: powerforge-server-data-capture <server-recovery-manifest.json>'
+umask 0027
+
+readonly manifest="$1"
+[[ -f "$manifest" && ! -L "$manifest" ]] || die "manifest must be a regular file: $manifest"
+
+jq_bin="$(require_command jq)"
+age_bin="$(require_command age)"
+tar_bin="$(require_command tar)"
+rsync_bin="$(require_command rsync)"
+sha256_bin="$(require_command sha256sum)"
+pg_dump_bin="$(require_command pg_dump)"
+pg_dumpall_bin="$(require_command pg_dumpall)"
+pg_restore_bin="$(require_command pg_restore)"
+psql_bin="$(require_command psql)"
+runuser_bin="$(require_command runuser)"
+flock_bin="$(require_command flock)"
+mktemp_bin="$(require_command mktemp)"
+stat_bin="$(require_command stat)"
+readlink_bin="$(require_command readlink)"
+readonly jq_bin age_bin tar_bin rsync_bin sha256_bin pg_dump_bin pg_dumpall_bin pg_restore_bin psql_bin runuser_bin flock_bin mktemp_bin stat_bin readlink_bin
+
+manifest_uid="$($stat_bin -c '%u' "$manifest")"
+manifest_mode="$($stat_bin -c '%a' "$manifest")"
+[[ "$manifest_uid" == '0' ]] || die 'manifest must be owned by root'
+(( (8#$manifest_mode & 0022) == 0 )) || die 'manifest must not be group- or world-writable'
+
+"$jq_bin" -e '
+  .schemaVersion == 2 and
+  (.durableBackup | type == "object") and
+  (.durableBackup.databases | type == "array" and length > 0) and
+  (.durableBackup.encryptedFiles | type == "array" and length > 0) and
+  (.durableBackup.artifactStores | type == "array" and length > 0)
+' "$manifest" >/dev/null || die 'manifest does not contain a complete schema-v2 durableBackup contract'
+
+export_root="$($jq_bin -er '.durableBackup.exportRoot' "$manifest")"
+export_group="$($jq_bin -er '.durableBackup.exportGroup' "$manifest")"
+recipient="$($jq_bin -er '.durableBackup.recipient' "$manifest")"
+retention_hours="$($jq_bin -er '.durableBackup.stagingRetentionHours' "$manifest")"
+assert_absolute_path "$export_root"
+assert_dedicated_export_root "$export_root"
+assert_unix_identity "$export_group"
+[[ "$recipient" =~ ^age1[a-z0-9]+$ ]] || die 'durable backup requires a literal age public recipient'
+if [[ ! "$retention_hours" =~ ^[0-9]+$ ]] || ((retention_hours < 24 || retention_hours > 720)); then
+  die 'staging retention must be from 24 through 720 hours'
+fi
+getent group "$export_group" >/dev/null || die "export group does not exist: $export_group"
+
+export_parent="${export_root%/*}"
+[[ -n "$export_parent" ]] || export_parent='/'
+[[ -d "$export_parent" && ! -L "$export_parent" && "$($readlink_bin -f -- "$export_parent")" == "$export_parent" ]] ||
+  die 'export root parent must be a canonical non-link directory'
+if [[ -e "$export_root" || -L "$export_root" ]]; then
+  [[ -d "$export_root" && ! -L "$export_root" && "$($readlink_bin -f -- "$export_root")" == "$export_root" ]] ||
+    die 'existing export root must be a canonical non-link directory'
+fi
+if [[ -e "$export_root/snapshots" || -L "$export_root/snapshots" ]]; then
+  [[ -d "$export_root/snapshots" && ! -L "$export_root/snapshots" && "$($readlink_bin -f -- "$export_root/snapshots")" == "$export_root/snapshots" ]] ||
+    die 'existing export snapshot root must be a canonical non-link directory'
+fi
+install -d -m 0750 -o root -g "$export_group" "$export_root" "$export_root/snapshots"
+[[ -d "$export_root" && ! -L "$export_root" && "$($readlink_bin -f -- "$export_root")" == "$export_root" ]] ||
+  die 'export root must be a canonical non-link directory'
+[[ -d "$export_root/snapshots" && ! -L "$export_root/snapshots" && "$($readlink_bin -f -- "$export_root/snapshots")" == "$export_root/snapshots" ]] ||
+  die 'export snapshot root must be a canonical non-link directory'
+exec 9>"$export_root/.capture.lock"
+"$flock_bin" -n 9 || die 'another durable capture is already running'
+
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+readonly stamp
+[[ "$stamp" =~ ^[0-9]{8}T[0-9]{6}Z$ ]] || die 'unable to generate a safe UTC capture stamp'
+partial="$export_root/snapshots/.partial-${stamp}-$$"
+final="$export_root/snapshots/$stamp"
+checksum_temp="$export_root/.checksums-${stamp}-$$"
+work=''
+[[ ! -e "$partial" && ! -e "$final" ]] || die "capture path already exists: $final"
+
+cleanup() {
+  if [[ -n "${partial:-}" && "$partial" == "$export_root/snapshots/.partial-"* && -d "$partial" ]]; then
+    if [[ ! -L "$partial" && "$($readlink_bin -f -- "${partial%/*}")" == "$export_root/snapshots" ]]; then
+      rm -rf -- "$partial"
+    else
+      log "refusing to clean unsafe partial capture path: $partial"
+    fi
+  fi
+  if [[ -n "${checksum_temp:-}" && "$checksum_temp" == "$export_root/.checksums-"* && -f "$checksum_temp" ]]; then
+    rm -f -- "$checksum_temp"
+  fi
+  if [[ -n "${work:-}" && "$work" == /var/tmp/powerforge-server-data-capture.* && -d "$work" ]]; then
+    rm -rf -- "$work"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+install -d -m 0750 -o root -g "$export_group" "$partial"
+install -d -m 0750 -o root -g "$export_group" "$partial/artifacts"
+work="$($mktemp_bin -d /var/tmp/powerforge-server-data-capture.XXXXXXXX)"
+[[ "$work" == /var/tmp/powerforge-server-data-capture.* && -d "$work" && ! -L "$work" ]] ||
+  die 'unable to create a safe database staging directory'
+chown postgres:postgres "$work"
+chmod 0700 "$work"
+install -d -m 0700 -o postgres -g postgres "$work/databases"
+
+database_ids=()
+while IFS=$'\t' read -r id provider database required; do
+  assert_identifier "$id"
+  [[ "$provider" == 'postgresql' ]] || die "unsupported database provider for $id: $provider"
+  assert_database_name "$database"
+  [[ "$required" == 'true' || "$required" == 'false' ]] || die "invalid required flag for database: $id"
+
+  if ! "$runuser_bin" -u postgres -- "$psql_bin" -Atqc "select 1 from pg_database where datname = '$database'" | grep -qx '1'; then
+    [[ "$required" == 'false' ]] && { log "optional database is absent: $database"; continue; }
+    die "required PostgreSQL database is absent: $database"
+  fi
+
+  dump_path="$work/databases/$id.dump"
+  "$runuser_bin" -u postgres -- "$pg_dump_bin" --format=custom --no-owner --no-privileges --file="$dump_path" --dbname="$database"
+  [[ -s "$dump_path" ]] || die "PostgreSQL dump is empty: $database"
+  "$pg_restore_bin" --list "$dump_path" >/dev/null || die "PostgreSQL dump cannot be listed: $database"
+  database_ids+=("$id")
+done < <("$jq_bin" -r '.durableBackup.databases[] | [.id, .provider, .database, (.required // false)] | @tsv' "$manifest")
+(( ${#database_ids[@]} > 0 )) || die 'durable capture did not produce any database dump'
+
+"$runuser_bin" -u postgres -- "$pg_dumpall_bin" --globals-only >"$work/databases/postgresql-globals.sql"
+[[ -s "$work/databases/postgresql-globals.sql" ]] || die 'PostgreSQL globals dump is empty'
+
+tar_args=(-C "$work" databases)
+encrypted_paths=()
+while IFS=$'\t' read -r path required; do
+  assert_absolute_path "$path"
+  [[ "$required" == 'true' || "$required" == 'false' ]] || die "invalid required flag for encrypted file: $path"
+  encrypted_paths+=("$path")
+  if [[ ! -e "$path" && ! -L "$path" ]]; then
+    [[ "$required" == 'false' ]] && { log "optional encrypted path is absent: $path"; continue; }
+    die "required encrypted path is absent: $path"
+  fi
+  [[ -f "$path" && ! -L "$path" ]] || die "encrypted path must be a regular non-link file: $path"
+  [[ "$($readlink_bin -f -- "$path")" == "$path" ]] || die "encrypted path must be canonical: $path"
+  tar_args+=(-C / "${path#/}")
+done < <("$jq_bin" -r '.durableBackup.encryptedFiles[] | [.target, (.required // false)] | @tsv' "$manifest")
+
+"$tar_bin" -czf - "${tar_args[@]}" | "$age_bin" -r "$recipient" -o "$partial/recovery.tar.gz.age"
+[[ -s "$partial/recovery.tar.gz.age" ]] || die 'encrypted recovery bundle is empty'
+
+previous="$(find "$export_root/snapshots" -mindepth 1 -maxdepth 1 -type d -name '????????T??????Z' -print | sort | tail -n 1)"
+artifact_ids=()
+while IFS=$'\t' read -r id source required; do
+  assert_identifier "$id"
+  assert_absolute_path "$source"
+  [[ "$required" == 'true' || "$required" == 'false' ]] || die "invalid required flag for artifact store: $id"
+  paths_overlap "$source" "$export_root" &&
+    die "artifact store overlaps durable export root: $source and $export_root"
+  for encrypted_path in "${encrypted_paths[@]}"; do
+    paths_overlap "$encrypted_path" "$source" &&
+      die "encrypted path overlaps plaintext artifact store: $encrypted_path and $source"
+  done
+  if [[ ! -d "$source" || -L "$source" ]]; then
+    [[ "$required" == 'false' ]] && { log "optional artifact store is absent: $source"; continue; }
+    die "required artifact store is absent or unsafe: $source"
+  fi
+  [[ "$($readlink_bin -f -- "$source")" == "$source" ]] || die "artifact store must be canonical: $source"
+  unsafe_source_entry="$(find "$source" -mindepth 1 ! -type f ! -type d -print -quit)"
+  [[ -z "$unsafe_source_entry" ]] || die "artifact store contains a link or special entry: $unsafe_source_entry"
+
+  destination="$partial/artifacts/$id"
+  install -d -m 0750 -o root -g "$export_group" "$destination"
+  # Ownership and modes are normalized after capture. Ignoring those source attributes lets
+  # --link-dest reuse immutable bytes from the preceding root:export snapshot.
+  rsync_args=(--archive --hard-links --no-owner --no-group --no-perms --no-links --no-devices --no-specials --delete-delay)
+  if [[ -n "$previous" && -d "$previous/artifacts/$id" ]]; then
+    rsync_args+=("--link-dest=$previous/artifacts/$id")
+  fi
+  "$rsync_bin" "${rsync_args[@]}" "$source/" "$destination/"
+  artifact_ids+=("$id")
+done < <("$jq_bin" -r '.durableBackup.artifactStores[] | [.id, .path, (.required // false)] | @tsv' "$manifest")
+(( ${#artifact_ids[@]} > 0 )) || die 'durable capture did not export any artifact store'
+
+unsafe_snapshot_entry="$(find "$partial" -mindepth 1 ! -type f ! -type d -print -quit)"
+[[ -z "$unsafe_snapshot_entry" ]] || die "snapshot contains a link or special entry: $unsafe_snapshot_entry"
+while IFS= read -r -d '' snapshot_entry; do
+  relative_entry="${snapshot_entry#"$partial/"}"
+  [[ "$relative_entry" != *$'\n'* && "$relative_entry" != *$'\r'* && "$relative_entry" != *\\* ]] ||
+    die "snapshot path cannot be represented safely in SHA256SUMS: $relative_entry"
+done < <(find "$partial" -mindepth 1 -print0)
+
+database_json="$($jq_bin -c '[.durableBackup.databases[] | {id, provider, database, required: (.required // false)}]' "$manifest")"
+artifact_json="$($jq_bin -c '[.durableBackup.artifactStores[] | {id, path, required: (.required // false)}]' "$manifest")"
+manifest_sha="$($sha256_bin "$manifest" | awk '{print $1}')"
+# shellcheck disable=SC2016 # jq variables are intentionally evaluated by jq, not Bash.
+"$jq_bin" -n \
+  --arg capturedAtUtc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg sourceManifestSha256 "$manifest_sha" \
+  --argjson databases "$database_json" \
+  --argjson artifactStores "$artifact_json" \
+  '{schemaVersion:1,capturedAtUtc:$capturedAtUtc,sourceManifestSha256:$sourceManifestSha256,databases:$databases,artifactStores:$artifactStores}' \
+  >"$partial/metadata.json"
+
+rm -rf -- "$work"
+work=''
+chown -R "root:$export_group" "$partial"
+find "$partial" -type d -exec chmod 0750 {} +
+find "$partial" -type f -exec chmod 0640 {} +
+(
+  cd "$partial"
+  find . -type f ! -name SHA256SUMS ! -name READY -print0 |
+    sort -z |
+    xargs -0 "$sha256_bin" >"$checksum_temp"
+  mv -- "$checksum_temp" SHA256SUMS
+  "$sha256_bin" -c SHA256SUMS >/dev/null
+)
+printf 'ready\n' >"$partial/READY"
+chown "root:$export_group" "$partial/READY" "$partial/SHA256SUMS"
+chmod 0640 "$partial/READY" "$partial/SHA256SUMS"
+mv -T -- "$partial" "$final"
+partial=''
+log "completed durable snapshot $stamp"
+
+retention_minutes=$((retention_hours * 60))
+mapfile -d '' expired < <(find "$export_root/snapshots" -mindepth 1 -maxdepth 1 -type d -name '????????T??????Z' -mmin "+$retention_minutes" -print0)
+snapshot_count="$(find "$export_root/snapshots" -mindepth 1 -maxdepth 1 -type d -name '????????T??????Z' -print | wc -l)"
+for expired_path in "${expired[@]}"; do
+  ((snapshot_count > 2)) || break
+  [[ "$expired_path" == "$export_root/snapshots/"????????T??????Z && -d "$expired_path" && ! -L "$expired_path" ]] ||
+    die "refusing to prune unsafe capture path: $expired_path"
+  [[ "$($readlink_bin -f -- "$expired_path")" == "$expired_path" && "$($readlink_bin -f -- "${expired_path%/*}")" == "$export_root/snapshots" ]] ||
+    die "refusing to prune capture outside the canonical export root: $expired_path"
+  rm -rf -- "$expired_path"
+  snapshot_count=$((snapshot_count - 1))
+done
+
+trap - EXIT INT TERM

--- a/Docs/PowerForge.Web.ServerRecovery.md
+++ b/Docs/PowerForge.Web.ServerRecovery.md
@@ -1,6 +1,6 @@
 # PowerForge.Web Server Recovery
 
-Last updated: 2026-07-18
+Last updated: 2026-09-05
 
 This document defines the reusable PowerForge pattern for rebuilding a Linux-hosted static website from source control, encrypted secrets, and a site-owned recovery manifest.
 
@@ -165,6 +165,24 @@ Encrypted capture requires an explicit recipient such as an age or GPG public ke
 
 Mark capture entries with `required: true` when a successful recovery depends on them. Plain archives containing a required entry remain strict, while an all-optional plain archive retains best-effort missing-file behavior. Remote encrypted capture preflights every required entry and includes each optional entry only when it exists, so one absent optional secret cannot discard otherwise valid encrypted recovery state.
 
+## Durable Application Data
+
+Git-backed recovery captures are appropriate for configuration and small encrypted secrets. They are not the storage owner for mutable databases or large binary stores. A schema-v2 manifest may therefore add a `durableBackup` contract that declares:
+
+- one dedicated root-owned export directory and a read-only export group
+- PostgreSQL databases written as custom-format dumps and checked with `pg_restore --list`
+- exact files that must be included only inside an age-encrypted recovery bundle
+- immutable artifact stores copied into timestamped snapshots with hard-link reuse
+- the short staging retention period on the source server
+
+`Deployment/Linux/powerforge-server-data-capture.sh` executes that contract as root. It accepts only a root-owned manifest that is not group- or world-writable, validates identifiers and exact paths without evaluating manifest text, creates its database work area outside the export tree, and publishes a snapshot only after encryption, metadata generation, SHA-256 calculation, and an immediate checksum verification succeed. A final atomic rename and `READY` marker distinguish complete snapshots from interrupted work. The source server retains at least two complete snapshots even when the configured staging window has expired.
+
+The export directory is staging, not disaster recovery. Put the matching pull job on a second failure domain. `Deployment/Linux/powerforge-server-backup-pull.sh` uses a fixed SSH identity, a pinned known-hosts file, and batch-only strict host-key checking. Pair it with a forced read-only `rrsync` key rooted at the export directory; the source server then holds no credential that can write to or delete the destination. The pull verifies every declared hash and the age header before adding `VERIFIED`, never deletes remote data, and prunes only locally verified timestamped snapshots. Its default policy keeps 56 recent snapshots, eight additional weekly restore points, and twelve additional monthly restore points.
+
+The destination must be prepared deliberately with a mode-600 marker containing `powerforge-server-backup-v1` at `.powerforge-server-backup-root`. This marker prevents a missing mount or mistyped destination from turning retention into a broad filesystem cleanup. The runtime also requires Bash, rsync, SSH, SHA-256 tools, and a `date` implementation that can calculate ISO weeks with `date -u -d <date> +%G-%V`.
+
+Checksum and age-header validation proves that the transported ciphertext matches the source snapshot; it does not prove that the decryption identity is available or that application restore steps still work. Keep the age private identity outside the source server and run a periodic isolated restore drill: decrypt `recovery.tar.gz.age`, re-run `pg_restore --list` for each dump, restore into disposable database names, compare expected schema/data checks, and validate representative artifact hashes before deleting the drill environment.
+
 ## Bootstrap Stages
 
 The engine should plan and run these stages:
@@ -254,7 +272,7 @@ concurrency:
   cancel-in-progress: false
 ```
 
-The action requires remote age encryption, a non-empty plain archive, a non-empty encrypted archive, a warning-free capture summary, exact source/engine/run provenance, and SHA-256 checksums before it clones the backup repository. It commits a timestamped directory under `backupTarget.path`, applies `backupTarget.retention.keepLatestInTree`, and retries fetch/rebase/push races without uploading recovery material as a GitHub Actions artifact. The older `keepLatest` property remains a compatibility alias.
+The action requires remote age encryption, a non-empty plain archive, a non-empty encrypted archive, a warning-free capture summary, exact source/engine/run provenance, and SHA-256 checksums before it clones the backup repository. It commits a timestamped directory under `backupTarget.path`, applies `backupTarget.retention.keepLatestInTree`, and retries fetch/rebase/push races without uploading recovery material as a GitHub Actions artifact. After retention, and again after any rebase, it regenerates `LATEST.txt` and `index.json` from the captures actually present in the checkout. The catalog hashes every nested artifact rather than assuming a fixed top-level file set, so consumers cannot silently keep selecting an old capture. The older `keepLatest` property remains a compatibility alias.
 
 This setting deliberately controls only the captures visible in the current Git tree. Git history is preserved, so it is not a data-destruction or repository-size retention policy. Use a separately reviewed history rewrite or a non-Git backup backend if historical deletion is required.
 

--- a/PowerForge.Tests/GitHubServerBackupActionTests.cs
+++ b/PowerForge.Tests/GitHubServerBackupActionTests.cs
@@ -57,16 +57,18 @@ public sealed class GitHubServerBackupActionTests
     public void Action_ShouldSurfaceBoundedArchiveDiagnosticsWithoutPrintingCommandCaptures()
     {
         var script = ReadRepoFile(".github", "actions", "powerforge-server-backup", "Invoke-PowerForgeServerBackup.ps1");
+        var support = ReadRepoFile(".github", "actions", "powerforge-server-backup", "PowerForgeBackupSupport.ps1");
 
         Assert.Contains("Write-CaptureFailureDiagnostic", script, StringComparison.Ordinal);
-        Assert.Contains("plain-files.stderr.txt", script, StringComparison.Ordinal);
-        Assert.Contains("encrypted-secrets.stderr.txt", script, StringComparison.Ordinal);
-        Assert.Contains("-TotalCount 40", script, StringComparison.Ordinal);
-        Assert.Contains("$diagnostic.Length -gt 4096", script, StringComparison.Ordinal);
-        Assert.Contains("::stop-commands::$stopToken", script, StringComparison.Ordinal);
-        Assert.Contains("[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F]", script, StringComparison.Ordinal);
-        Assert.DoesNotContain("commands/*.stderr", script, StringComparison.Ordinal);
-        Assert.DoesNotContain("commands\\*.stderr", script, StringComparison.Ordinal);
+        Assert.Contains("PowerForgeBackupSupport.ps1", script, StringComparison.Ordinal);
+        Assert.Contains("plain-files.stderr.txt", support, StringComparison.Ordinal);
+        Assert.Contains("encrypted-secrets.stderr.txt", support, StringComparison.Ordinal);
+        Assert.Contains("-TotalCount 40", support, StringComparison.Ordinal);
+        Assert.Contains("$diagnostic.Length -gt 4096", support, StringComparison.Ordinal);
+        Assert.Contains("::stop-commands::$stopToken", support, StringComparison.Ordinal);
+        Assert.Contains("[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F]", support, StringComparison.Ordinal);
+        Assert.DoesNotContain("commands/*.stderr", support, StringComparison.Ordinal);
+        Assert.DoesNotContain("commands\\*.stderr", support, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -86,12 +88,59 @@ public sealed class GitHubServerBackupActionTests
     }
 
     [Fact]
+    public void Action_ShouldPublishACatalogThatSelectsAndHashesTheNewestCapture()
+    {
+        var script = ReadRepoFile(".github", "actions", "powerforge-server-backup", "Invoke-PowerForgeServerBackup.ps1");
+        var catalog = ReadRepoFile(".github", "actions", "powerforge-server-backup", "PowerForgeBackupCatalog.ps1");
+
+        Assert.Contains("PowerForgeBackupCatalog.ps1", script, StringComparison.Ordinal);
+        Assert.Contains("function Update-BackupCatalog", catalog, StringComparison.Ordinal);
+        Assert.Contains("LATEST.txt", catalog, StringComparison.Ordinal);
+        Assert.Contains("index.json", catalog, StringComparison.Ordinal);
+        Assert.Contains("Get-FileHash", catalog, StringComparison.Ordinal);
+        Assert.Contains("keepLatestInTree", catalog, StringComparison.Ordinal);
+        Assert.Contains("ReparsePoint", catalog, StringComparison.Ordinal);
+        Assert.Contains("Update-BackupCatalog -TargetRoot $targetRoot", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BackupCatalog_ShouldSelectLatestAndHashEveryCaptureArtifact()
+    {
+        var testScript = GetRepoPath("PowerForge.Tests", "Scripts", "Test-BackupCatalog.ps1");
+        var startInfo = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "pwsh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add("-NoLogo");
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-NonInteractive");
+        startInfo.ArgumentList.Add("-File");
+        startInfo.ArgumentList.Add(testScript);
+
+        using var process = System.Diagnostics.Process.Start(startInfo);
+        Assert.NotNull(process);
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await process.WaitForExitAsync(timeout.Token);
+
+        Assert.True(
+            process.ExitCode == 0,
+            $"Backup catalog contract failed with exit code {process.ExitCode}.{Environment.NewLine}{await standardOutput}{Environment.NewLine}{await standardError}");
+    }
+
+    [Fact]
     public void Action_ShouldBoundAndRetryPrivateBackupGitTransport()
     {
         var script = ReadRepoFile(".github", "actions", "powerforge-server-backup", "Invoke-PowerForgeServerBackup.ps1");
+        var support = ReadRepoFile(".github", "actions", "powerforge-server-backup", "PowerForgeBackupSupport.ps1");
 
-        Assert.Contains("function Invoke-GitWithRetry", script, StringComparison.Ordinal);
-        Assert.Contains("[ValidateRange(1, 5)][int] $MaxAttempts = 3", script, StringComparison.Ordinal);
+        Assert.Contains("PowerForgeBackupSupport.ps1", script, StringComparison.Ordinal);
+        Assert.Contains("function Invoke-GitWithRetry", support, StringComparison.Ordinal);
+        Assert.Contains("[ValidateRange(1, 5)][int] $MaxAttempts = 3", support, StringComparison.Ordinal);
         Assert.Contains("'--depth', '1'", script, StringComparison.Ordinal);
         Assert.Contains("'--no-tags'", script, StringComparison.Ordinal);
         Assert.Contains("-ResetPath $backupCheckout", script, StringComparison.Ordinal);

--- a/PowerForge.Tests/Scripts/Test-BackupCatalog.ps1
+++ b/PowerForge.Tests/Scripts/Test-BackupCatalog.ps1
@@ -1,0 +1,54 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
+$catalogScript = Join-Path $repositoryRoot '.github/actions/powerforge-server-backup/PowerForgeBackupCatalog.ps1'
+. $catalogScript
+
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) "powerforge-backup-catalog-$([Guid]::NewGuid().ToString('N'))"
+$targetRoot = Join-Path $testRoot 'backups/example'
+try {
+    $legacyCapture = Join-Path $targetRoot '20260904102030'
+    $workflowCapture = Join-Path $targetRoot '20260905T102030Z-12345-1'
+    New-Item -ItemType Directory -Path (Join-Path $legacyCapture 'commands'), (Join-Path $workflowCapture 'commands') -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $legacyCapture 'plain-files.tar.gz') -Value 'legacy' -Encoding utf8NoBOM
+    Set-Content -LiteralPath (Join-Path $legacyCapture 'capture-summary.json') -Value '{"commandResults":[],"warnings":[]}' -Encoding utf8NoBOM
+    Set-Content -LiteralPath (Join-Path $workflowCapture 'plain-files.tar.gz') -Value 'current' -Encoding utf8NoBOM
+    Set-Content -LiteralPath (Join-Path $workflowCapture 'commands/0000-example.out.txt') -Value 'captured' -Encoding utf8NoBOM
+    Set-Content -LiteralPath (Join-Path $workflowCapture 'capture-summary.json') -Value '{"commandResults":[{"id":"example","success":true}],"warnings":[]}' -Encoding utf8NoBOM
+    Set-Content -LiteralPath (Join-Path $workflowCapture 'capture-metadata.json') -Value '{"capturedAtUtc":"2026-09-05T10:20:31.0000000+00:00"}' -Encoding utf8NoBOM
+
+    Update-BackupCatalog -TargetRoot $targetRoot -TargetRelative 'backups/example' -KeepLatestInTree 24
+
+    $latest = (Get-Content -LiteralPath (Join-Path $targetRoot 'LATEST.txt') -Raw).Trim()
+    if ($latest -ne '20260905T102030Z-12345-1') {
+        throw "LATEST.txt selected an unexpected capture: $latest"
+    }
+
+    $index = Get-Content -LiteralPath (Join-Path $targetRoot 'index.json') -Raw | ConvertFrom-Json
+    if ($index.latest -ne $latest -or @($index.captures).Count -ne 2) {
+        throw 'The backup index did not include both supported capture-name formats.'
+    }
+    if ($index.retention.keepLatestInTree -ne 24) {
+        throw 'The backup index did not record current-tree retention.'
+    }
+
+    $current = @($index.captures | Where-Object stamp -eq $latest)
+    if ($current.Count -ne 1 -or $current[0].createdAtUtc -ne '2026-09-05T10:20:31.0000000+00:00') {
+        throw 'The backup index did not preserve capture metadata time.'
+    }
+    if ($current[0].commandCount -ne 1 -or $current[0].warningCount -ne 0) {
+        throw 'The backup index did not summarize command results.'
+    }
+    $indexedCommand = @($current[0].files | Where-Object name -eq 'commands/0000-example.out.txt')
+    if ($indexedCommand.Count -ne 1 -or $indexedCommand[0].sizeBytes -le 0 -or $indexedCommand[0].sha256 -notmatch '^[a-f0-9]{64}$') {
+        throw 'The backup index did not hash nested capture artifacts.'
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $testRoot) {
+        Remove-Item -LiteralPath $testRoot -Recurse -Force
+    }
+}

--- a/PowerForge.Tests/Scripts/Test-GitWithRetry.ps1
+++ b/PowerForge.Tests/Scripts/Test-GitWithRetry.ps1
@@ -4,23 +4,8 @@ param()
 $ErrorActionPreference = 'Stop'
 
 $repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
-$actionScript = Join-Path $repositoryRoot '.github/actions/powerforge-server-backup/Invoke-PowerForgeServerBackup.ps1'
-$tokens = $null
-$parseErrors = $null
-$ast = [System.Management.Automation.Language.Parser]::ParseFile($actionScript, [ref]$tokens, [ref]$parseErrors)
-if ($parseErrors.Count -gt 0) {
-    throw "Unable to parse the server backup action: $($parseErrors[0].Message)"
-}
-
-$functionAst = $ast.Find({
-        param($node)
-        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
-        $node.Name -eq 'Invoke-GitWithRetry'
-    }, $true)
-if ($null -eq $functionAst) {
-    throw 'Invoke-GitWithRetry was not found in the server backup action.'
-}
-. ([scriptblock]::Create($functionAst.Extent.Text))
+$supportScript = Join-Path $repositoryRoot '.github/actions/powerforge-server-backup/PowerForgeBackupSupport.ps1'
+. $supportScript
 
 $testRoot = Join-Path ([IO.Path]::GetTempPath()) "powerforge-git-retry-$([Guid]::NewGuid().ToString('N'))"
 $resetPath = Join-Path $testRoot 'partial-clone'
@@ -149,6 +134,56 @@ try {
         if ($LASTEXITCODE -ne 0) {
             throw "Published history does not retain $requiredPath."
         }
+    }
+
+    $catalogRemote = Join-Path $testRoot 'catalog-remote.git'
+    $catalogSeed = Join-Path $testRoot 'catalog-seed'
+    $catalogWorkerA = Join-Path $testRoot 'catalog-worker-a'
+    $catalogWorkerB = Join-Path $testRoot 'catalog-worker-b'
+    Invoke-TestGit init --bare $catalogRemote
+    Invoke-TestGit init $catalogSeed
+    Invoke-TestGit -C $catalogSeed checkout -b main
+    Invoke-TestGit -C $catalogSeed config user.name PowerForgeTest
+    Invoke-TestGit -C $catalogSeed config user.email powerforge-test@example.invalid
+    New-Item -ItemType Directory -Path (Join-Path $catalogSeed 'server') | Out-Null
+    Set-Content -LiteralPath (Join-Path $catalogSeed 'server/LATEST.txt') -Value seed -Encoding utf8NoBOM
+    Set-Content -LiteralPath (Join-Path $catalogSeed 'server/index.json') -Value '{"latest":"seed"}' -Encoding utf8NoBOM
+    Invoke-TestGit -C $catalogSeed add server
+    Invoke-TestGit -C $catalogSeed commit -m seed
+    Invoke-TestGit -C $catalogSeed remote add origin $catalogRemote
+    Invoke-TestGit -C $catalogSeed push -u origin main
+
+    $catalogRemoteUri = ([Uri]$catalogRemote).AbsoluteUri
+    foreach ($catalogWorker in @($catalogWorkerA, $catalogWorkerB)) {
+        Invoke-TestGit clone --no-tags --single-branch --branch main $catalogRemoteUri $catalogWorker
+        Invoke-TestGit -C $catalogWorker config user.name PowerForgeTest
+        Invoke-TestGit -C $catalogWorker config user.email powerforge-test@example.invalid
+    }
+    New-Item -ItemType Directory -Path (Join-Path $catalogWorkerA 'server/capture-a') | Out-Null
+    Set-Content -LiteralPath (Join-Path $catalogWorkerA 'server/capture-a/data.txt') -Value capture-a -Encoding utf8NoBOM
+    Set-Content -LiteralPath (Join-Path $catalogWorkerA 'server/LATEST.txt') -Value capture-a -Encoding utf8NoBOM
+    Set-Content -LiteralPath (Join-Path $catalogWorkerA 'server/index.json') -Value '{"latest":"capture-a"}' -Encoding utf8NoBOM
+    Invoke-TestGit -C $catalogWorkerA add server
+    Invoke-TestGit -C $catalogWorkerA commit -m capture-a
+
+    New-Item -ItemType Directory -Path (Join-Path $catalogWorkerB 'server/capture-b') | Out-Null
+    Set-Content -LiteralPath (Join-Path $catalogWorkerB 'server/capture-b/data.txt') -Value capture-b -Encoding utf8NoBOM
+    Set-Content -LiteralPath (Join-Path $catalogWorkerB 'server/LATEST.txt') -Value capture-b -Encoding utf8NoBOM
+    Set-Content -LiteralPath (Join-Path $catalogWorkerB 'server/index.json') -Value '{"latest":"capture-b"}' -Encoding utf8NoBOM
+    Invoke-TestGit -C $catalogWorkerB add server
+    Invoke-TestGit -C $catalogWorkerB commit -m capture-b
+    Invoke-TestGit -C $catalogWorkerB push origin HEAD:main
+
+    Invoke-TestGit -C $catalogWorkerA fetch origin '+refs/heads/main:refs/remotes/origin/main'
+    Invoke-BackupPublicationRebase -Checkout $catalogWorkerA -Upstream origin/main -GeneratedCatalogPaths @('server/LATEST.txt', 'server/index.json')
+    foreach ($requiredPath in @('server/capture-a/data.txt', 'server/capture-b/data.txt')) {
+        & git -C $catalogWorkerA cat-file -e "HEAD:$requiredPath"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Catalog-only conflict resolution lost $requiredPath."
+        }
+    }
+    if ((Get-Content -LiteralPath (Join-Path $catalogWorkerA 'server/LATEST.txt') -Raw).Trim() -ne 'capture-b') {
+        throw 'Catalog-only conflict resolution did not preserve the refreshed upstream catalog.'
     }
 }
 finally {

--- a/PowerForge.Tests/ServerRecoveryDurableBackupTests.cs
+++ b/PowerForge.Tests/ServerRecoveryDurableBackupTests.cs
@@ -127,6 +127,8 @@ public sealed class ServerRecoveryDurableBackupTests
         Assert.Contains("snapshot contains a link or special entry", script, StringComparison.Ordinal);
         Assert.Contains("destination must be a canonical physical path", script, StringComparison.Ordinal);
         Assert.Contains("flock_bin", script, StringComparison.Ordinal);
+        Assert.Contains("[[ \"$remote_root\" == '/' ||", script, StringComparison.Ordinal);
+        Assert.Contains("return 0\n}\ntrap cleanup EXIT INT TERM", script, StringComparison.Ordinal);
         Assert.DoesNotContain("--delete", script, StringComparison.Ordinal);
         Assert.DoesNotContain("StrictHostKeyChecking=no", script, StringComparison.Ordinal);
     }

--- a/PowerForge.Tests/ServerRecoveryDurableBackupTests.cs
+++ b/PowerForge.Tests/ServerRecoveryDurableBackupTests.cs
@@ -1,0 +1,189 @@
+using System.Text.Json.Nodes;
+using Json.Schema;
+using PowerForge.Web.Cli;
+
+namespace PowerForge.Tests;
+
+public sealed class ServerRecoveryDurableBackupTests
+{
+    [Fact]
+    public void Validation_ShouldAcceptACompleteDurableBackupContract()
+    {
+        var manifest = CreateManifest();
+
+        var errors = WebCliCommandHandlers.ValidateServerRecoveryManifest(manifest);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Validation_ShouldRejectUnsafeOrIncompleteDurableBackupContracts()
+    {
+        var manifest = CreateManifest();
+        manifest.DurableBackup!.ExportRoot = "/var/lib";
+        manifest.DurableBackup.StagingRetentionHours = 12;
+        manifest.DurableBackup.Recipient = "not-an-age-recipient";
+        manifest.DurableBackup.Databases![0].Database = "example;drop";
+        manifest.DurableBackup.ArtifactStores![0].Path = "/var/lib/powerforge-backup-export/artifacts";
+        manifest.DurableBackup.EncryptedFiles![0].Target = "/var/lib/powerforge-backup-export/artifacts/secret.env";
+
+        var errors = WebCliCommandHandlers.ValidateServerRecoveryManifest(manifest);
+
+        Assert.Contains(errors, error => error.Contains("dedicated directory", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("24 through 720", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("literal age public recipient", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("database name", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("must not overlap", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("must not overlap artifact store", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validation_ShouldMatchRuntimeIdentityAndRecipientBoundaries()
+    {
+        var manifest = CreateManifest();
+        manifest.DurableBackup!.ExportGroup = new string('g', 33);
+        manifest.DurableBackup.Recipient = "age1";
+
+        var errors = WebCliCommandHandlers.ValidateServerRecoveryManifest(manifest);
+
+        Assert.Contains(errors, error => error.Contains("valid Linux group name", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("literal age public recipient", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Schema_ShouldAcceptTheTypedContractAndRejectUnknownFields()
+    {
+        var schema = JsonSchema.FromText(File.ReadAllText(GetRepoPath("Schemas", "powerforge.web.serverrecovery.schema.json")));
+        var valid = JsonNode.Parse("""
+            {
+              "schemaVersion": 2,
+              "name": "example",
+              "target": { "host": "example.invalid" },
+              "durableBackup": {
+                "exportRoot": "/var/lib/powerforge-backup-export",
+                "exportGroup": "powerforge-export",
+                "recipient": "age1example",
+                "stagingRetentionHours": 48,
+                "databases": [
+                  { "id": "control", "provider": "postgresql", "database": "control", "required": true }
+                ],
+                "encryptedFiles": [
+                  { "target": "/etc/example.env", "required": true, "sensitive": true }
+                ],
+                "artifactStores": [
+                  { "id": "releases", "path": "/var/lib/example-releases", "required": true }
+                ]
+              }
+            }
+            """)!;
+
+        Assert.True(schema.Evaluate(valid, new EvaluationOptions { OutputFormat = OutputFormat.List }).IsValid);
+        var missingRecipient = valid.DeepClone();
+        missingRecipient["durableBackup"]!.AsObject().Remove("recipient");
+        Assert.False(schema.Evaluate(missingRecipient, new EvaluationOptions { OutputFormat = OutputFormat.List }).IsValid);
+        var broadExportRoot = valid.DeepClone();
+        broadExportRoot["durableBackup"]!["exportRoot"] = "/var/lib";
+        Assert.False(schema.Evaluate(broadExportRoot, new EvaluationOptions { OutputFormat = OutputFormat.List }).IsValid);
+        valid["durableBackup"]!["unknown"] = true;
+        Assert.False(schema.Evaluate(valid, new EvaluationOptions { OutputFormat = OutputFormat.List }).IsValid);
+    }
+
+    [Fact]
+    public void LinuxCapture_ShouldEncryptValidatedDatabaseDumpsAndPublishAtomically()
+    {
+        var script = File.ReadAllText(GetRepoPath("Deployment", "Linux", "powerforge-server-data-capture.sh"));
+
+        Assert.Contains("pg_dump", script, StringComparison.Ordinal);
+        Assert.Contains("pg_restore", script, StringComparison.Ordinal);
+        Assert.Contains("pg_dumpall", script, StringComparison.Ordinal);
+        Assert.Contains("age_bin", script, StringComparison.Ordinal);
+        Assert.Contains("SHA256SUMS", script, StringComparison.Ordinal);
+        Assert.Contains("mv -T -- \"$partial\" \"$final\"", script, StringComparison.Ordinal);
+        Assert.Contains("--link-dest", script, StringComparison.Ordinal);
+        Assert.Contains("manifest must be owned by root", script, StringComparison.Ordinal);
+        Assert.Contains("manifest must not be group- or world-writable", script, StringComparison.Ordinal);
+        Assert.Contains("encrypted path overlaps plaintext artifact store", script, StringComparison.Ordinal);
+        Assert.Contains("artifact store overlaps durable export root", script, StringComparison.Ordinal);
+        Assert.Contains("export root must be a dedicated directory", script, StringComparison.Ordinal);
+        Assert.Contains("artifact store contains a link or special entry", script, StringComparison.Ordinal);
+        Assert.Contains("export root must be a canonical non-link directory", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("eval ", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("source \"$manifest\"", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PullRuntime_ShouldPinSshVerifyBeforeRetentionAndProtectItsRoot()
+    {
+        var script = File.ReadAllText(GetRepoPath("Deployment", "Linux", "powerforge-server-backup-pull.sh"));
+
+        Assert.Contains("StrictHostKeyChecking=yes", script, StringComparison.Ordinal);
+        Assert.Contains("IdentitiesOnly=yes", script, StringComparison.Ordinal);
+        Assert.Contains("BatchMode=yes", script, StringComparison.Ordinal);
+        Assert.Contains("sha256_bin\" -c SHA256SUMS", script, StringComparison.Ordinal);
+        Assert.Contains("age-encryption.org/v1", script, StringComparison.Ordinal);
+        Assert.Contains(".powerforge-server-backup-root", script, StringComparison.Ordinal);
+        Assert.Contains("verify_snapshot \"$snapshot\"", script, StringComparison.Ordinal);
+        Assert.Contains("has_current_verification \"$snapshot\"", script, StringComparison.Ordinal);
+        Assert.Contains("snapshot contains a link or special entry", script, StringComparison.Ordinal);
+        Assert.Contains("destination must be a canonical physical path", script, StringComparison.Ordinal);
+        Assert.Contains("flock_bin", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("--delete", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("StrictHostKeyChecking=no", script, StringComparison.Ordinal);
+    }
+
+    private static PowerForgeServerRecoveryManifest CreateManifest()
+        => new()
+        {
+            SchemaVersion = 2,
+            Name = "example",
+            Target = new PowerForgeServerTarget { Host = "example.invalid" },
+            DurableBackup = new PowerForgeServerDurableBackup
+            {
+                ExportRoot = "/var/lib/powerforge-backup-export",
+                ExportGroup = "powerforge-export",
+                Recipient = "age1example",
+                StagingRetentionHours = 48,
+                Databases =
+                [
+                    new PowerForgeServerDurableBackupDatabase
+                    {
+                        Id = "control",
+                        Provider = "postgresql",
+                        Database = "control",
+                        Required = true
+                    }
+                ],
+                EncryptedFiles =
+                [
+                    new PowerForgeServerManagedFile
+                    {
+                        Target = "/etc/example.env",
+                        Required = true,
+                        Sensitive = true
+                    }
+                ],
+                ArtifactStores =
+                [
+                    new PowerForgeServerDurableBackupArtifactStore
+                    {
+                        Id = "releases",
+                        Path = "/var/lib/example-releases",
+                        Required = true
+                    }
+                ]
+            }
+        };
+
+    private static string GetRepoPath(params string[] relativePath)
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        for (var i = 0; i < 12 && current is not null; i++)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "PowerForge", "PowerForge.csproj")))
+                return Path.Combine([current.FullName, .. relativePath]);
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate repository root.");
+    }
+}

--- a/PowerForge.Web.Cli/ServerRecoveryDurableBackupModels.cs
+++ b/PowerForge.Web.Cli/ServerRecoveryDurableBackupModels.cs
@@ -1,0 +1,27 @@
+namespace PowerForge.Web.Cli;
+
+internal sealed class PowerForgeServerDurableBackup
+{
+    public string? ExportRoot { get; set; }
+    public string? ExportGroup { get; set; }
+    public string? Recipient { get; set; }
+    public int StagingRetentionHours { get; set; }
+    public PowerForgeServerDurableBackupDatabase[]? Databases { get; set; }
+    public PowerForgeServerManagedFile[]? EncryptedFiles { get; set; }
+    public PowerForgeServerDurableBackupArtifactStore[]? ArtifactStores { get; set; }
+}
+
+internal sealed class PowerForgeServerDurableBackupDatabase
+{
+    public string? Id { get; set; }
+    public string? Provider { get; set; }
+    public string? Database { get; set; }
+    public bool Required { get; set; }
+}
+
+internal sealed class PowerForgeServerDurableBackupArtifactStore
+{
+    public string? Id { get; set; }
+    public string? Path { get; set; }
+    public bool Required { get; set; }
+}

--- a/PowerForge.Web.Cli/ServerRecoveryModels.cs
+++ b/PowerForge.Web.Cli/ServerRecoveryModels.cs
@@ -25,6 +25,7 @@ internal sealed class PowerForgeServerRecoveryManifest
     public PowerForgeServerDeploy? Deploy { get; set; }
     public PowerForgeServerVerify? Verify { get; set; }
     public PowerForgeServerBackupTarget? BackupTarget { get; set; }
+    public PowerForgeServerDurableBackup? DurableBackup { get; set; }
     public string[]? Notes { get; set; }
 }
 

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Validation.DurableBackup.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Validation.DurableBackup.cs
@@ -1,0 +1,92 @@
+namespace PowerForge.Web.Cli;
+
+internal static partial class WebCliCommandHandlers
+{
+    private static void ValidateDurableBackup(
+        PowerForgeServerDurableBackup? backup,
+        ICollection<string> errors)
+    {
+        if (backup is null)
+            return;
+
+        var exportRoot = NormalizeCapturePath(backup.ExportRoot, "durableBackup.exportRoot", errors);
+        if (exportRoot is not null)
+        {
+            if (exportRoot is "/" or "/etc" or "/home" or "/root" or "/srv" or "/var" or "/var/lib")
+                errors.Add("durableBackup.exportRoot must be a dedicated directory below a system data root.");
+            if (HasTrailingPathSeparator(backup.ExportRoot))
+                errors.Add("durableBackup.exportRoot must not end with '/'.");
+        }
+
+        if (!IsValidDurableUnixName(backup.ExportGroup))
+            errors.Add("durableBackup.exportGroup must be a valid Linux group name.");
+        if (backup.StagingRetentionHours is < 24 or > 720)
+            errors.Add("durableBackup.stagingRetentionHours must be from 24 through 720.");
+
+        var recipient = backup.Recipient;
+        if (string.IsNullOrWhiteSpace(recipient) ||
+            recipient.Length <= 4 ||
+            !recipient.StartsWith("age1", StringComparison.Ordinal) ||
+            recipient.Any(static character => !(character is >= 'a' and <= 'z' || character is >= '0' and <= '9')))
+            errors.Add("durableBackup requires a literal age public recipient in durableBackup.recipient.");
+
+        var databaseIds = new HashSet<string>(StringComparer.Ordinal);
+        var databaseNames = new HashSet<string>(StringComparer.Ordinal);
+        var databases = backup.Databases ?? Array.Empty<PowerForgeServerDurableBackupDatabase>();
+        if (databases.Length == 0)
+            errors.Add("durableBackup.databases requires at least one database.");
+        foreach (var database in databases)
+        {
+            if (string.IsNullOrWhiteSpace(database.Id) || !IsSafeIdentifier(database.Id) || !databaseIds.Add(database.Id))
+                errors.Add($"Durable backup database id '{database.Id}' is missing, unsafe, or duplicated.");
+            if (!string.Equals(database.Provider, "postgresql", StringComparison.Ordinal))
+                errors.Add($"Durable backup database '{database.Id}' provider must be postgresql.");
+            if (string.IsNullOrWhiteSpace(database.Database) ||
+                database.Database.Length > 63 ||
+                !(database.Database[0] is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or '_') ||
+                database.Database.Any(static character => !(character is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or >= '0' and <= '9' or '_')) ||
+                !databaseNames.Add(database.Database))
+                errors.Add($"Durable backup database name '{database.Database}' is missing, unsafe, or duplicated.");
+        }
+
+        var encryptedFiles = backup.EncryptedFiles ?? Array.Empty<PowerForgeServerManagedFile>();
+        if (encryptedFiles.Length == 0)
+            errors.Add("durableBackup.encryptedFiles requires at least one file.");
+        var encryptedPaths = ValidateCaptureEntries(encryptedFiles, "durableBackup.encryptedFiles", sensitive: true, errors);
+
+        var artifactIds = new HashSet<string>(StringComparer.Ordinal);
+        var artifactPaths = new HashSet<string>(StringComparer.Ordinal);
+        var artifacts = backup.ArtifactStores ?? Array.Empty<PowerForgeServerDurableBackupArtifactStore>();
+        if (artifacts.Length == 0)
+            errors.Add("durableBackup.artifactStores requires at least one immutable artifact store.");
+        foreach (var artifact in artifacts)
+        {
+            if (string.IsNullOrWhiteSpace(artifact.Id) || !IsSafeIdentifier(artifact.Id) || !artifactIds.Add(artifact.Id))
+                errors.Add($"Durable backup artifact id '{artifact.Id}' is missing, unsafe, or duplicated.");
+            var path = NormalizeCapturePath(artifact.Path, $"durableBackup.artifactStores[{artifact.Id}].path", errors);
+            if (path is null)
+                continue;
+            if (HasTrailingPathSeparator(artifact.Path) || path.IndexOfAny(['*', '?', '[']) >= 0 || !artifactPaths.Add(path))
+                errors.Add($"Durable backup artifact path '{artifact.Path}' must be exact, unique, and must not end with '/'.");
+            if (exportRoot is not null && (PathContains(exportRoot, path) || PathContains(path, exportRoot)))
+                errors.Add($"Durable backup artifact path '{path}' must not overlap durableBackup.exportRoot.");
+        }
+
+        if (exportRoot is not null && encryptedPaths.Any(path => PathContains(exportRoot, path) || PathContains(path, exportRoot)))
+            errors.Add("durableBackup.encryptedFiles must not overlap durableBackup.exportRoot.");
+        foreach (var encryptedPath in encryptedPaths)
+        {
+            foreach (var artifactPath in artifactPaths)
+            {
+                if (PathContains(encryptedPath, artifactPath) || PathContains(artifactPath, encryptedPath))
+                    errors.Add($"Durable encrypted path '{encryptedPath}' must not overlap artifact store '{artifactPath}'.");
+            }
+        }
+    }
+
+    private static bool IsValidDurableUnixName(string? value)
+        => !string.IsNullOrWhiteSpace(value) &&
+           value.Length <= 32 &&
+           (value[0] is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or '_') &&
+           value.All(static character => character is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or >= '0' and <= '9' or '_' or '-');
+}

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Validation.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Validation.cs
@@ -19,6 +19,7 @@ internal static partial class WebCliCommandHandlers
         ValidateNamedCommandText(manifest.Capture?.Commands, "capture.commands", errors);
         ValidateNamedCommandText(manifest.Deploy?.Commands, "deploy.commands", errors);
         ValidateNamedCommandText(manifest.Verify?.Commands, "verify.commands", errors);
+        ValidateDurableBackup(manifest.DurableBackup, errors);
 
         var plainFiles = manifest.Capture?.PlainFiles ?? Array.Empty<PowerForgeServerManagedFile>();
         var encryptedFiles = manifest.Capture?.EncryptedFiles ?? Array.Empty<PowerForgeServerManagedFile>();

--- a/Schemas/powerforge.web.serverrecovery.schema.json
+++ b/Schemas/powerforge.web.serverrecovery.schema.json
@@ -48,6 +48,7 @@
     "deploy": { "$ref": "#/$defs/Deploy" },
     "verify": { "$ref": "#/$defs/Verify" },
     "backupTarget": { "$ref": "#/$defs/BackupTarget" },
+    "durableBackup": { "$ref": "#/$defs/DurableBackup" },
     "notes": {
       "type": "array",
       "items": { "type": "string" }
@@ -534,6 +535,58 @@
         "via": { "type": "string" }
       },
       "required": ["url"]
+    },
+    "DurableBackup": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "exportRoot": {
+          "allOf": [
+            { "$ref": "#/$defs/AbsoluteUnixExactPath" },
+            { "not": { "enum": ["/etc", "/home", "/root", "/srv", "/var", "/var/lib"] } }
+          ]
+        },
+        "exportGroup": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_-]{0,31}$" },
+        "recipient": { "type": "string", "pattern": "^age1[a-z0-9]+$" },
+        "stagingRetentionHours": { "type": "integer", "minimum": 24, "maximum": 720 },
+        "databases": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/DurableBackupDatabase" }
+        },
+        "encryptedFiles": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/EncryptedCaptureFile" }
+        },
+        "artifactStores": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/DurableBackupArtifactStore" }
+        }
+      },
+      "required": ["exportRoot", "exportGroup", "recipient", "stagingRetentionHours", "databases", "encryptedFiles", "artifactStores"]
+    },
+    "DurableBackupDatabase": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "pattern": "^[A-Za-z0-9_][A-Za-z0-9_-]{0,63}$" },
+        "provider": { "type": "string", "enum": ["postgresql"] },
+        "database": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]{0,62}$" },
+        "required": { "type": "boolean" }
+      },
+      "required": ["id", "provider", "database"]
+    },
+    "DurableBackupArtifactStore": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "pattern": "^[A-Za-z0-9_][A-Za-z0-9_-]{0,63}$" },
+        "path": { "$ref": "#/$defs/AbsoluteUnixExactPath" },
+        "required": { "type": "boolean" }
+      },
+      "required": ["id", "path"]
     },
     "BackupTarget": {
       "type": "object",


### PR DESCRIPTION
## Summary

- add typed durable-backup contracts for PostgreSQL databases, encrypted files, immutable artifact stores, export roots, and staging retention
- add hardened Linux capture and Synology pull runtimes with manifest-bound verification, safe retention, and immutable snapshot transfer
- make the reusable GitHub backup action update its catalog safely under concurrent runs
- document the capture, transport, verification, retention, and restore boundaries

## Downstream relationship

This repository owns the reusable backup engine and schema. [EvotecIT/Website#122](https://github.com/EvotecIT/Website/pull/122) is the downstream deployment consumer: it pins this exact PowerForge commit, supplies the product manifest and thin service/task wrappers, and must land after this owner change.

## Validation

- focused durable-backup contract tests passed (16 tests)
- the real concurrent catalog-conflict regression test passed
- PowerShell backup catalog tests and ShellCheck passed
- the final capture runtime was exercised against the live product manifest and produced a checksum-verified encrypted snapshot

Local independent review covered the shared security, integrity, retention, and concurrency contracts. Its validated findings were remediated and the targeted confirmation closed the remaining defect class.
