### PR TITLE
Improve cross-platform runner storage retention

### DIFF
--- a/.github/actions/github-housekeeping/action.yml
+++ b/.github/actions/github-housekeeping/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: Optional runner free-disk threshold override in GiB.
     required: false
     default: ""
+  runner-tool-cache-path:
+    description: Optional explicit runner tool cache path.
+    required: false
+    default: ""
   report-path:
     description: Optional JSON report output path relative to the workspace.
     required: false
@@ -86,6 +90,7 @@ runs:
         INPUT_CONFIG_PATH: ${{ inputs['config-path'] }}
         INPUT_APPLY: ${{ inputs.apply }}
         INPUT_RUNNER_MIN_FREE_GB: ${{ inputs['runner-min-free-gb'] }}
+        RUNNER_TOOL_CACHE: ${{ inputs['runner-tool-cache-path'] }}
         GITHUB_TOKEN: ${{ inputs['github-token'] != '' && inputs['github-token'] || github.token }}
         POWERFORGE_GITHUB_HOUSEKEEPING_REPORT_PATH: ${{ inputs['report-path'] }}
         POWERFORGE_GITHUB_HOUSEKEEPING_SUMMARY_PATH: ${{ inputs['summary-path'] }}

--- a/.github/workflows/powerforge-github-runner-housekeeping.yml
+++ b/.github/workflows/powerforge-github-runner-housekeeping.yml
@@ -189,6 +189,7 @@ jobs:
           apply: ${{ inputs.apply && 'true' || 'false' }}
           github-token: ${{ secrets['github-token'] != '' && secrets['github-token'] || github.token }}
           runner-min-free-gb: ${{ steps.resolved.outputs.runner_min_free_gb }}
+          runner-tool-cache-path: ${{ runner.tool_cache }}
           report-path: ${{ steps.resolved.outputs.report_path }}
           summary-path: ${{ steps.resolved.outputs.summary_path }}
 

--- a/.powerforge/runner-housekeeping.json
+++ b/.powerforge/runner-housekeeping.json
@@ -16,8 +16,8 @@
     "WorkspacesRetentionDays": 0,
     "CleanWorkspaces": true,
     "ToolCacheRetentionDays": 30,
-    "DotNetRootPath": "/usr/share/dotnet",
     "PruneDotNetSdks": true,
-    "DotNetSdkVersionsToKeepPerMajorMinor": 1
+    "DotNetSdkVersionsToKeepPerMajorMinor": 1,
+    "CleanWindowsComponentStore": true
   }
 }

--- a/PowerForge.Cli/Program.Command.GitHub.cs
+++ b/PowerForge.Cli/Program.Command.GitHub.cs
@@ -11,7 +11,7 @@ internal static partial class Program
     private const string GitHubCachesPruneUsage = "Usage: powerforge github caches prune [--repo <owner/repo>] [--api-base-url <Url>] [--token-env <ENV>] [--token <TOKEN>] [--key <pattern[,pattern...]>] [--exclude <pattern[,pattern...]>] [--keep <N>] [--max-age-days <N>] [--max-delete <N>] [--dry-run|--apply] [--fail-on-delete-error] [--output json]";
     private const string GitHubContentSyncUsage = "Usage: powerforge github content sync [--config <file>] [--login <LOGIN>] [--graphql-endpoint <URL>] [--token-env <ENV>] [--token <TOKEN>] [--restrict-output-root <path>] [--output json]";
     private const string GitHubHousekeepingUsage = "Usage: powerforge github housekeeping [--config <file>] [--repo <owner/repo>] [--api-base-url <Url>] [--token-env <ENV>] [--token <TOKEN>] [--runner-min-free-gb <N>] [--dry-run|--apply] [--output json]";
-    private const string GitHubRunnerCleanupUsage = "Usage: powerforge github runner cleanup [--runner-temp <path>] [--work-root <path>] [--runner-root <path>] [--diag-root <path>] [--tool-cache <path>] [--dotnet-root <path>] [--min-free-gb <N>] [--aggressive-threshold-gb <N>] [--diag-retention-days <N>] [--actions-retention-days <N>] [--workspaces-retention-days|--workspace-retention-days <N>] [--tool-cache-retention-days <N>] [--dotnet-sdk-retain <N>] [--dry-run|--apply] [--aggressive] [--allow-sudo] [--clean-workspaces] [--prune-dotnet-sdks] [--skip-diagnostics] [--skip-runner-temp] [--skip-actions-cache] [--skip-workspaces] [--skip-tool-cache] [--skip-dotnet-cache] [--skip-dotnet-sdk-prune] [--skip-docker] [--no-docker-volumes] [--output json] (when conflicting cleanup/skip flags are provided, the later flag wins)";
+    private const string GitHubRunnerCleanupUsage = "Usage: powerforge github runner cleanup [--runner-temp <path>] [--work-root <path>] [--runner-root <path>] [--diag-root <path>] [--tool-cache <path>] [--dotnet-root <path>] [--min-free-gb <N>] [--aggressive-threshold-gb <N>] [--diag-retention-days <N>] [--actions-retention-days <N>] [--workspaces-retention-days|--workspace-retention-days <N>] [--tool-cache-retention-days <N>] [--dotnet-sdk-retain <N>] [--dry-run|--apply] [--aggressive] [--allow-sudo] [--clean-workspaces] [--prune-dotnet-sdks] [--clean-windows-component-store] [--skip-diagnostics] [--skip-runner-temp] [--skip-actions-cache] [--skip-workspaces] [--skip-tool-cache] [--skip-dotnet-cache] [--skip-dotnet-sdk-prune] [--skip-windows-component-store] [--skip-docker] [--no-docker-volumes] [--output json] (when conflicting cleanup/skip flags are provided, the later flag wins)";
     private const string GitHubRunnerStorageUsage = "Usage: powerforge github runner storage [--runner-root <path>] --state-root <external-path> --work-root <external-path> [--core-simulator-path <path>] [--launch-agent <plist>] [--core-simulator-size-gb <N>] [--external-storage-wait-seconds <N>] [--dry-run|--apply] [--output json]";
 
     private static int CommandGitHub(string[] filteredArgs, CliOptions cli, ILogger logger)
@@ -680,6 +680,9 @@ internal static partial class Program
                 case "--prune-dotnet-sdks":
                     spec.PruneDotNetSdks = true;
                     break;
+                case "--clean-windows-component-store":
+                    spec.CleanWindowsComponentStore = true;
+                    break;
                 case "--skip-diagnostics":
                     spec.CleanDiagnostics = false;
                     break;
@@ -701,6 +704,9 @@ internal static partial class Program
                     break;
                 case "--skip-dotnet-sdk-prune":
                     spec.PruneDotNetSdks = false;
+                    break;
+                case "--skip-windows-component-store":
+                    spec.CleanWindowsComponentStore = false;
                     break;
                 case "--skip-docker":
                     spec.PruneDocker = false;

--- a/PowerForge.Cli/Program.Helpers.cs
+++ b/PowerForge.Cli/Program.Helpers.cs
@@ -80,7 +80,8 @@ internal static partial class Program
                                      [--fail-on-delete-error] [--output json]
       powerforge github runner cleanup [--runner-temp <path>] [--work-root <path>] [--runner-root <path>] [--diag-root <path>] [--tool-cache <path>] [--dotnet-root <path>]
                                       [--min-free-gb <N>] [--aggressive-threshold-gb <N>] [--dotnet-sdk-retain <N>] [--dry-run|--apply] [--aggressive] [--allow-sudo]
-                                      [--prune-dotnet-sdks] [--skip-diagnostics] [--skip-runner-temp] [--skip-actions-cache] [--skip-tool-cache] [--skip-dotnet-cache] [--skip-dotnet-sdk-prune]
+                                      [--prune-dotnet-sdks] [--clean-windows-component-store] [--skip-diagnostics] [--skip-runner-temp] [--skip-actions-cache] [--skip-tool-cache] [--skip-dotnet-cache]
+                                      [--skip-dotnet-sdk-prune] [--skip-windows-component-store]
                                       [--skip-docker] [--no-docker-volumes] [--output json]
       powerforge homeassistant release prepare --repo <owner/name> --pr-number <N> [--repository-root <path>] [--merge-sha <sha>] [--workflow-run-id <N>] [--apply]
       powerforge homeassistant release build --repository-root <path> --release-version <X.Y.Z> --release-commit <sha>

--- a/PowerForge.Tests/GitHubRunnerHousekeepingWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubRunnerHousekeepingWorkflowTests.cs
@@ -24,7 +24,13 @@ public sealed class GitHubRunnerHousekeepingWorkflowTests
         Assert.Contains(".powerforge/runner-housekeeping.json", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("runner-min-free-gb", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("report-artifact-name", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("runner-tool-cache-path: ${{ runner.tool_cache }}", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("actions: write", workflowYaml, StringComparison.Ordinal);
+
+        var actionPath = Path.Combine(repoRoot, ".github", "actions", "github-housekeeping", "action.yml");
+        var actionYaml = File.ReadAllText(actionPath);
+        Assert.Contains("runner-tool-cache-path:", actionYaml, StringComparison.Ordinal);
+        Assert.Contains("RUNNER_TOOL_CACHE: ${{ inputs['runner-tool-cache-path'] }}", actionYaml, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -74,7 +80,8 @@ public sealed class GitHubRunnerHousekeepingWorkflowTests
         Assert.Equal(0, runner.GetProperty("WorkspacesRetentionDays").GetInt32());
         Assert.True(runner.GetProperty("PruneDotNetSdks").GetBoolean());
         Assert.Equal(1, runner.GetProperty("DotNetSdkVersionsToKeepPerMajorMinor").GetInt32());
-        Assert.Equal("/usr/share/dotnet", runner.GetProperty("DotNetRootPath").GetString());
+        Assert.True(runner.GetProperty("CleanWindowsComponentStore").GetBoolean());
+        Assert.False(runner.TryGetProperty("DotNetRootPath", out _));
     }
 
     private static string FindRepoRoot()

--- a/PowerForge.Tests/PowerForgeCliRunnerHousekeepingTests.cs
+++ b/PowerForge.Tests/PowerForgeCliRunnerHousekeepingTests.cs
@@ -70,19 +70,20 @@ public sealed class PowerForgeCliRunnerHousekeepingTests
 
     private static async Task<(int ExitCode, string StdOut, string StdErr)> RunCliAsync(string workingDirectory, string arguments)
     {
-        using var process = new Process
+        var startInfo = new ProcessStartInfo
         {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = "dotnet",
-                Arguments = arguments,
-                WorkingDirectory = workingDirectory,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            }
+            FileName = "dotnet",
+            Arguments = arguments,
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
         };
+        startInfo.Environment["DOTNET_CLI_USE_MSBUILD_SERVER"] = "0";
+        startInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
+
+        using var process = new Process { StartInfo = startInfo };
 
         process.Start();
         var stdoutTask = process.StandardOutput.ReadToEndAsync();

--- a/PowerForge.Tests/RunnerHousekeepingServiceTests.cs
+++ b/PowerForge.Tests/RunnerHousekeepingServiceTests.cs
@@ -104,6 +104,56 @@ public sealed class RunnerHousekeepingServiceTests
     }
 
     [Fact]
+    public void Clean_DryRun_PlansWindowsComponentStoreCleanupOnlyOnWindows()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var runnerRoot = Path.Combine(root, "runner");
+            var workRoot = Path.Combine(runnerRoot, "_work");
+            var runnerTemp = Path.Combine(workRoot, "_temp");
+            Directory.CreateDirectory(runnerTemp);
+
+            var service = new RunnerHousekeepingService(new NullLogger());
+            var result = service.Clean(new RunnerHousekeepingSpec
+            {
+                RunnerTempPath = runnerTemp,
+                RunnerRootPath = runnerRoot,
+                WorkRootPath = workRoot,
+                MinFreeGb = null,
+                DryRun = true,
+                Aggressive = true,
+                CleanDiagnostics = false,
+                CleanRunnerTemp = false,
+                CleanActionsCache = false,
+                CleanWorkspaces = false,
+                CleanToolCache = false,
+                ClearDotNetCaches = false,
+                PruneDotNetSdks = false,
+                CleanWindowsComponentStore = true,
+                PruneDocker = false
+            });
+
+            var step = Assert.Single(result.Steps);
+            Assert.Equal("windows-component-store", step.Id);
+            if (OperatingSystem.IsWindows())
+            {
+                Assert.False(step.Skipped);
+                Assert.True(step.DryRun);
+                Assert.Equal("dism /Online /Cleanup-Image /StartComponentCleanup /NoRestart", step.Command);
+            }
+            else
+            {
+                Assert.True(step.Skipped);
+            }
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Clean_Apply_RemovesOldRepositoryWorkspacesButKeepsCurrentAndInternalDirectories()
     {
         var root = CreateSandbox();
@@ -601,6 +651,75 @@ public sealed class RunnerHousekeepingServiceTests
     public void IsPackageOwnershipProbeFailureFatal_FailsClosedOnUnexpectedErrors(int exitCode, bool expected)
     {
         Assert.Equal(expected, RunnerHousekeepingService.IsPackageOwnershipProbeFailureFatal(exitCode));
+    }
+
+    [Fact]
+    public void SelectWindowsPackageOwnedSdkDirectories_ProtectsOnlyRegisteredInstalledVersions()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.RunnerHousekeepingWindowsSdkSelection");
+        var directories = new[]
+        {
+            Path.Combine(root, "3.1.426"),
+            Path.Combine(root, "8.0.413"),
+            Path.Combine(root, "8.0.424"),
+            Path.Combine(root, "9.0.304"),
+            Path.Combine(root, "10.0.100-preview.1")
+        };
+
+        var result = RunnerHousekeepingService.SelectWindowsPackageOwnedSdkDirectories(
+            directories,
+            new[]
+            {
+                "Microsoft .NET Core SDK 3.1.426 (x64)",
+                "Microsoft .NET SDK 8.0.413 (x64)",
+                "Microsoft .NET SDK 9.0.304 (x64)",
+                "Microsoft .NET Runtime - 9.0.8 (x64)",
+                "Unrelated package 8.0.424"
+            });
+
+        Assert.Equal(
+            new[]
+            {
+                Path.GetFullPath(Path.Combine(root, "3.1.426")),
+                Path.GetFullPath(Path.Combine(root, "8.0.413")),
+                Path.GetFullPath(Path.Combine(root, "9.0.304"))
+            },
+            result.OrderBy(path => path, StringComparer.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("Microsoft .NET Core SDK 3.1.426 (x64)", true, "3.1.426")]
+    [InlineData("Microsoft .NET SDK 8.0.413 (x64)", true, "8.0.413")]
+    [InlineData("Microsoft .NET SDK 10.0.100", true, "10.0.100")]
+    [InlineData("Microsoft .NET SDK 10.0.100-preview.1 (x64)", false, null)]
+    [InlineData("Microsoft .NET Runtime - 8.0.19 (x64)", false, null)]
+    [InlineData("Microsoft .NET SDK 08.0.413 (x64)", false, null)]
+    public void TryParseWindowsRegisteredSdkVersion_RequiresCanonicalSdkPackageName(string displayName, bool expected, string? expectedVersion)
+    {
+        Assert.Equal(expected, RunnerHousekeepingService.TryParseWindowsRegisteredSdkVersion(displayName, out var version));
+        Assert.Equal(expectedVersion, version);
+    }
+
+    [Fact]
+    public void SelectDotNetSdkDirectoriesToPrune_PreservesLegacyWindowsPackageOwnedSdk()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.RunnerHousekeepingLegacyWindowsSdkSelection");
+        var installedDirectories = new[]
+        {
+            Path.Combine(root, "3.1.425"),
+            Path.Combine(root, "3.1.426")
+        };
+        var packageOwnedDirectories = RunnerHousekeepingService.SelectWindowsPackageOwnedSdkDirectories(
+            installedDirectories,
+            new[] { "Microsoft .NET Core SDK 3.1.425 (x64)" });
+
+        var result = RunnerHousekeepingService.SelectDotNetSdkDirectoriesToPrune(
+            installedDirectories,
+            activeVersion: string.Empty,
+            packageOwnedDirectories,
+            versionsToKeepPerMajorMinor: 1);
+
+        Assert.Empty(result);
     }
 
     [Theory]

--- a/PowerForge/Models/GitHubHousekeeping.cs
+++ b/PowerForge/Models/GitHubHousekeeping.cs
@@ -253,9 +253,14 @@ public sealed class GitHubHousekeepingRunnerSpec
     public bool ClearDotNetCaches { get; set; } = true;
 
     /// <summary>
-    /// Enables conservative pruning of superseded unowned stable SDK directories on Debian-family Linux runners.
+    /// Enables conservative pruning of superseded unowned stable SDK directories on Linux and Windows runners.
     /// </summary>
     public bool PruneDotNetSdks { get; set; }
+
+    /// <summary>
+    /// Enables non-resetting Windows component-store cleanup during aggressive cleanup.
+    /// </summary>
+    public bool CleanWindowsComponentStore { get; set; }
 
     /// <summary>
     /// Enables Docker prune.

--- a/PowerForge/Models/RunnerHousekeeping.cs
+++ b/PowerForge/Models/RunnerHousekeeping.cs
@@ -117,10 +117,17 @@ public sealed class RunnerHousekeepingSpec
     public bool ClearDotNetCaches { get; set; } = true;
 
     /// <summary>
-    /// When true on Debian-family Linux runners, superseded unowned stable SDK directories under
-    /// <c>DOTNET_ROOT/sdk</c> are pruned during aggressive cleanup.
+    /// When true, superseded unowned stable SDK directories under <c>DOTNET_ROOT/sdk</c> are pruned
+    /// during aggressive cleanup. Linux package ownership is detected with <c>dpkg-query</c>; Windows
+    /// package ownership is detected through registered uninstall metadata.
     /// </summary>
     public bool PruneDotNetSdks { get; set; }
+
+    /// <summary>
+    /// When true on Windows runners, DISM performs a non-resetting component-store cleanup during
+    /// aggressive cleanup. Installed update rollback remains available.
+    /// </summary>
+    public bool CleanWindowsComponentStore { get; set; }
 
     /// <summary>
     /// When true, <c>docker system prune</c> is executed during aggressive cleanup.

--- a/PowerForge/Services/GitHubHousekeepingService.cs
+++ b/PowerForge/Services/GitHubHousekeepingService.cs
@@ -173,6 +173,7 @@ public sealed class GitHubHousekeepingService
                 CleanToolCache = spec.Runner.CleanToolCache,
                 ClearDotNetCaches = spec.Runner.ClearDotNetCaches,
                 PruneDotNetSdks = spec.Runner.PruneDotNetSdks,
+                CleanWindowsComponentStore = spec.Runner.CleanWindowsComponentStore,
                 PruneDocker = spec.Runner.PruneDocker,
                 IncludeDockerVolumes = spec.Runner.IncludeDockerVolumes,
                 AllowSudo = spec.Runner.AllowSudo

--- a/PowerForge/Services/RunnerHousekeepingService.DotNet.cs
+++ b/PowerForge/Services/RunnerHousekeepingService.DotNet.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.Win32;
 
 namespace PowerForge;
 
@@ -30,8 +31,10 @@ public sealed partial class RunnerHousekeepingService
         const string id = "dotnet-sdk-prune";
         const string title = "Prune superseded dotnet SDKs";
 
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            return SkippedStep(id, title, "SDK pruning is supported only on Linux runners.");
+        var isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        if (!isLinux && !isWindows)
+            return SkippedStep(id, title, "SDK pruning is supported only on Linux and Windows runners.");
 
         if (string.IsNullOrWhiteSpace(dotNetRootPath))
             return SkippedStep(id, title, "DOTNET_ROOT is not configured.");
@@ -43,9 +46,6 @@ public sealed partial class RunnerHousekeepingService
         if (!CommandExists("dotnet"))
             return SkippedStep(id, title, "dotnet is not available on PATH; active SDK cannot be protected.");
 
-        if (!CommandExists("dpkg-query"))
-            return SkippedStep(id, title, "SDK pruning currently supports Debian-family Linux runners; dpkg-query is unavailable.");
-
         var versionProbe = RunProcess("dotnet", new[] { "--version" }, activeSdkProbePath);
         var activeVersion = versionProbe.ExitCode == 0 ? versionProbe.StdOut.Trim() : string.Empty;
         if (!Version.TryParse(activeVersion, out _))
@@ -56,20 +56,31 @@ public sealed partial class RunnerHousekeepingService
             .ToArray();
         var protectedDirectories = new HashSet<string>(GetPathStringComparer());
 
-        foreach (var directory in installedDirectories)
+        if (isLinux)
         {
-            var markerPath = Path.Combine(directory, "dotnet.dll");
-            if (!File.Exists(markerPath))
-            {
-                protectedDirectories.Add(directory);
-                continue;
-            }
+            if (!CommandExists("dpkg-query"))
+                return SkippedStep(id, title, "SDK pruning currently supports Debian-family Linux runners; dpkg-query is unavailable.");
 
-            var ownershipProbe = RunProcess("dpkg-query", new[] { "-S", markerPath }, sdkRoot);
-            if (ownershipProbe.ExitCode == 0)
-                protectedDirectories.Add(directory);
-            else if (IsPackageOwnershipProbeFailureFatal(ownershipProbe.ExitCode))
-                return SkippedStep(id, title, $"dpkg-query failed with exit code {ownershipProbe.ExitCode}; no SDKs were pruned.");
+            foreach (var directory in installedDirectories)
+            {
+                var markerPath = Path.Combine(directory, "dotnet.dll");
+                if (!File.Exists(markerPath))
+                {
+                    protectedDirectories.Add(directory);
+                    continue;
+                }
+
+                var ownershipProbe = RunProcess("dpkg-query", new[] { "-S", markerPath }, sdkRoot);
+                if (ownershipProbe.ExitCode == 0)
+                    protectedDirectories.Add(directory);
+                else if (IsPackageOwnershipProbeFailureFatal(ownershipProbe.ExitCode))
+                    return SkippedStep(id, title, $"dpkg-query failed with exit code {ownershipProbe.ExitCode}; no SDKs were pruned.");
+            }
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                 && !TryGetWindowsPackageOwnedSdkDirectories(installedDirectories, out protectedDirectories))
+        {
+            return SkippedStep(id, title, "Unable to inspect registered Windows SDK packages; no SDKs were pruned.");
         }
 
         var targets = SelectDotNetSdkDirectoriesToPrune(
@@ -132,6 +143,96 @@ public sealed partial class RunnerHousekeepingService
     }
 
     internal static bool IsPackageOwnershipProbeFailureFatal(int exitCode) => exitCode is not (0 or 1);
+
+#if NET8_0_OR_GREATER
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
+    private static bool TryGetWindowsPackageOwnedSdkDirectories(
+        IEnumerable<string> installedDirectories,
+        out HashSet<string> protectedDirectories)
+    {
+        protectedDirectories = new HashSet<string>(GetPathStringComparer());
+        try
+        {
+            var displayNames = new List<string>();
+            foreach (var view in new[] { RegistryView.Registry64, RegistryView.Registry32 })
+            {
+                using var localMachine = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, view);
+                using var uninstall = localMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall");
+                if (uninstall is null)
+                    continue;
+
+                foreach (var subKeyName in uninstall.GetSubKeyNames())
+                {
+                    using var subKey = uninstall.OpenSubKey(subKeyName);
+                    if (subKey?.GetValue("DisplayName") is string displayName)
+                        displayNames.Add(displayName);
+                }
+            }
+
+            protectedDirectories = SelectWindowsPackageOwnedSdkDirectories(installedDirectories, displayNames);
+            return true;
+        }
+        catch
+        {
+            protectedDirectories.Clear();
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Maps registered Windows SDK package display names to their corresponding SDK directories.
+    /// Unregistered directories installed by dotnet-install remain eligible for normal retention selection.
+    /// </summary>
+    internal static HashSet<string> SelectWindowsPackageOwnedSdkDirectories(
+        IEnumerable<string> installedDirectories,
+        IEnumerable<string> registeredDisplayNames)
+    {
+        if (installedDirectories is null) throw new ArgumentNullException(nameof(installedDirectories));
+        if (registeredDisplayNames is null) throw new ArgumentNullException(nameof(registeredDisplayNames));
+
+        var registeredVersions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var displayName in registeredDisplayNames)
+        {
+            if (TryParseWindowsRegisteredSdkVersion(displayName, out var version))
+                registeredVersions.Add(version!);
+        }
+
+        return new HashSet<string>(
+            installedDirectories
+                .Where(path => registeredVersions.Contains(Path.GetFileName(path)))
+                .Select(Path.GetFullPath),
+            GetPathStringComparer());
+    }
+
+    /// <summary>
+    /// Extracts a canonical SDK version from a Windows package display name.
+    /// </summary>
+    internal static bool TryParseWindowsRegisteredSdkVersion(string? displayName, out string? version)
+    {
+        var prefixes = new[]
+        {
+            "Microsoft .NET SDK ",
+            "Microsoft .NET Core SDK "
+        };
+        version = null;
+        if (string.IsNullOrWhiteSpace(displayName))
+            return false;
+
+        var normalizedDisplayName = displayName!;
+        var prefix = prefixes.FirstOrDefault(candidate => normalizedDisplayName.StartsWith(candidate, StringComparison.OrdinalIgnoreCase));
+        if (prefix is null)
+            return false;
+
+        var remainder = normalizedDisplayName.Substring(prefix.Length);
+        var separator = remainder.IndexOf(' ');
+        var candidate = separator < 0 ? remainder : remainder.Substring(0, separator);
+        if (!TryParseStableSdkVersion(candidate, out _))
+            return false;
+
+        version = candidate;
+        return true;
+    }
 
     internal static bool TryParseStableSdkVersion(string? value, out Version? version)
     {

--- a/PowerForge/Services/RunnerHousekeepingService.Windows.cs
+++ b/PowerForge/Services/RunnerHousekeepingService.Windows.cs
@@ -1,0 +1,26 @@
+using System.Runtime.InteropServices;
+
+namespace PowerForge;
+
+public sealed partial class RunnerHousekeepingService
+{
+    private RunnerHousekeepingStepResult CleanWindowsComponentStore(string workingDirectory, bool dryRun)
+    {
+        const string id = "windows-component-store";
+        const string title = "Cleanup Windows component store";
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return SkippedStep(id, title, "Windows component-store cleanup is supported only on Windows runners.");
+
+        if (!CommandExists("dism"))
+            return SkippedStep(id, title, "dism.exe is unavailable.");
+
+        return RunCommand(
+            id,
+            title,
+            "dism",
+            new[] { "/Online", "/Cleanup-Image", "/StartComponentCleanup", "/NoRestart" },
+            workingDirectory,
+            dryRun);
+    }
+}

--- a/PowerForge/Services/RunnerHousekeepingService.cs
+++ b/PowerForge/Services/RunnerHousekeepingService.cs
@@ -135,6 +135,13 @@ public sealed partial class RunnerHousekeepingService
                     allowSudo: normalized.AllowSudo));
             }
 
+            if (normalized.CleanWindowsComponentStore)
+            {
+                steps.Add(CleanWindowsComponentStore(
+                    workingDirectory: normalized.WorkRootPath,
+                    dryRun: normalized.DryRun));
+            }
+
             if (normalized.PruneDocker)
             {
                 var args = normalized.IncludeDockerVolumes
@@ -240,6 +247,7 @@ public sealed partial class RunnerHousekeepingService
         public bool CleanToolCache { get; set; }
         public bool ClearDotNetCaches { get; set; }
         public bool PruneDotNetSdks { get; set; }
+        public bool CleanWindowsComponentStore { get; set; }
         public bool PruneDocker { get; set; }
         public bool IncludeDockerVolumes { get; set; }
         public bool AllowSudo { get; set; }
@@ -291,6 +299,7 @@ public sealed partial class RunnerHousekeepingService
             CleanToolCache = spec.CleanToolCache,
             ClearDotNetCaches = spec.ClearDotNetCaches,
             PruneDotNetSdks = spec.PruneDotNetSdks,
+            CleanWindowsComponentStore = spec.CleanWindowsComponentStore,
             PruneDocker = spec.PruneDocker,
             IncludeDockerVolumes = spec.IncludeDockerVolumes,
             AllowSudo = spec.AllowSudo

--- a/Schemas/github.housekeeping.schema.json
+++ b/Schemas/github.housekeeping.schema.json
@@ -152,7 +152,11 @@
         "ClearDotNetCaches": { "type": "boolean" },
         "PruneDotNetSdks": {
           "type": "boolean",
-          "description": "Prunes superseded unowned stable SDKs during aggressive cleanup on Debian-family Linux runners."
+          "description": "Prunes superseded unowned stable SDKs during aggressive cleanup on Linux and Windows runners."
+        },
+        "CleanWindowsComponentStore": {
+          "type": "boolean",
+          "description": "Runs non-resetting DISM component-store cleanup during aggressive cleanup on Windows runners."
         },
         "PruneDocker": { "type": "boolean" },
         "IncludeDockerVolumes": { "type": "boolean" },


### PR DESCRIPTION
## Summary

- pass GitHub's resolved runner tool-cache path into the canonical PowerForge housekeeping action so the existing 30-day retention policy reaches the real cache on Windows and Linux
- resolve SDK cleanup from the runner's actual `DOTNET_ROOT`, extend safe pruning to Windows, and preserve active, prerelease, unknown-layout, and package-managed SDKs while retaining the newest configured versions per major/minor line
- add opt-in, non-resetting Windows component-store cleanup that runs only during aggressive below-threshold maintenance
- keep the model, CLI, JSON schema, reusable action, workflow, and focused tests aligned

## Why

The 20 GiB free-space threshold is an operational floor, not a storage target. Runner disks can hover near that floor because tool caches, superseded SDKs, and the Windows component store were outside or only partially inside the effective cleanup path. This closes those ownership gaps while keeping destructive SDK cleanup fail-closed.

## Validation

- `dotnet build PowerForge\\PowerForge.csproj -c Release` (`net472`, `net8.0`, `net10.0`)
- 41 focused runner-housekeeping, workflow, and CLI tests
- final Windows dry run against the installed SDK and registry layout; package ownership protected, two unowned superseded SDKs planned, and DISM rendered with `/StartComponentCleanup /NoRestart`
- independent destructive-path review plus targeted confirmation of the legacy `.NET Core SDK` MSI ownership regression