### PR TITLE
Add guarded Linux runner root capacity workflow

### DIFF
--- a/.github/scripts/expand-linux-runner-root.sh
+++ b/.github/scripts/expand-linux-runner-root.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+apply="${APPLY:-false}"
+confirmation="${CONFIRMATION:-}"
+expected_pv="${EXPECTED_PV:-/dev/sda3}"
+expected_runner_name="${EXPECTED_RUNNER_NAME:-}"
+expected_disk_bytes="${EXPECTED_DISK_BYTES:-136365211648}"
+expected_partition_bytes="${EXPECTED_PARTITION_BYTES:-133088411648}"
+expected_initial_lv_bytes="${EXPECTED_INITIAL_LV_BYTES:-66542632960}"
+expected_initial_fs_bytes="${EXPECTED_INITIAL_FS_BYTES:-65174941696}"
+profile_tolerance_bytes="${PROFILE_TOLERANCE_BYTES:-16777216}"
+minimum_initial_vg_free_bytes="${MINIMUM_INITIAL_VG_FREE_BYTES:-64424509440}"
+maximum_initial_vg_free_bytes="${MAXIMUM_INITIAL_VG_FREE_BYTES:-73014444032}"
+minimum_expanded_lv_bytes="${MINIMUM_EXPANDED_LV_BYTES:-130000000000}"
+minimum_expanded_fs_bytes="${MINIMUM_EXPANDED_FS_BYTES:-128000000000}"
+confirmation_phrase="EXPAND-ALL-LINUX-RUNNER-ROOTS"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+to_integer_bytes() {
+  awk -v value="$1" 'BEGIN { printf "%.0f", value }'
+}
+
+within_tolerance() {
+  local actual="$1"
+  local expected="$2"
+  local tolerance="$3"
+  (( actual >= expected - tolerance && actual <= expected + tolerance ))
+}
+
+[[ "$(uname -s)" == "Linux" ]] || fail "This operation supports Linux only."
+[[ "$EUID" -eq 0 ]] || fail "Root privileges are required; current uid is $EUID."
+[[ "$apply" == "true" || "$apply" == "false" ]] || fail "APPLY must be exactly 'true' or 'false'."
+[[ -n "${RUNNER_NAME:-}" ]] || fail "RUNNER_NAME is required."
+[[ -n "$expected_runner_name" ]] || fail "EXPECTED_RUNNER_NAME is required."
+[[ "$RUNNER_NAME" == "$expected_runner_name" ]] || fail "Scheduled runner '$RUNNER_NAME' does not match matrix target '$expected_runner_name'."
+case "$RUNNER_NAME" in
+  github-runner-linux|github-runner-linux-01|github-runner-linux-02|github-runner-linux-03|github-runner-linux-04|github-runner-linux-05) ;;
+  *) fail "Runner '$RUNNER_NAME' is not in the approved runner allowlist." ;;
+esac
+
+for numeric_value in \
+  "$expected_disk_bytes" \
+  "$expected_partition_bytes" \
+  "$expected_initial_lv_bytes" \
+  "$expected_initial_fs_bytes" \
+  "$profile_tolerance_bytes" \
+  "$minimum_initial_vg_free_bytes" \
+  "$maximum_initial_vg_free_bytes" \
+  "$minimum_expanded_lv_bytes" \
+  "$minimum_expanded_fs_bytes"; do
+  [[ "$numeric_value" =~ ^[0-9]+$ ]] || fail "Capacity profile values must be non-negative integers."
+done
+
+for command_name in awk df findmnt flock lsblk lvextend lvs mkdir pgrep pvs readlink resize2fs stat uname; do
+  command -v "$command_name" >/dev/null 2>&1 || fail "Required command '$command_name' is unavailable."
+done
+
+lock_directory="/run/powerforge-linux-root-capacity"
+if [[ ! -d "$lock_directory" ]]; then
+  mkdir --mode=0700 "$lock_directory" 2>/dev/null || [[ -d "$lock_directory" ]] || fail "Unable to create the operation-lock directory."
+fi
+[[ "$(stat -Lc '%u:%g:%a' "$lock_directory")" == "0:0:700" ]] || fail "Operation-lock directory ownership or mode is unsafe."
+exec 9>"$lock_directory/operation.lock"
+flock -n 9 || fail "Another Linux root-capacity operation is already running on this host."
+
+worker_count="$(pgrep -xc Runner.Worker || true)"
+[[ "$worker_count" -eq 1 ]] || fail "Expected exactly this workflow's Runner.Worker process; found $worker_count."
+
+root_source="$(findmnt -n -o SOURCE /)"
+root_filesystem="$(findmnt -n -o FSTYPE /)"
+root_major_minor="$(findmnt -n -o MAJ:MIN /)"
+[[ -n "$root_source" && -n "$root_major_minor" ]] || fail "Unable to resolve the root filesystem device."
+[[ "$root_filesystem" == "ext4" ]] || fail "Expected the verified ext4 root filesystem; found '$root_filesystem'."
+
+matching_lvs=()
+matching_vgs=()
+matching_lv_names=()
+matching_lv_sizes=()
+while IFS='|' read -r raw_lv_path raw_vg_name raw_lv_name raw_lv_size; do
+  lv_path="$(trim "$raw_lv_path")"
+  vg_name="$(trim "$raw_vg_name")"
+  lv_name="$(trim "$raw_lv_name")"
+  lv_size="$(to_integer_bytes "$(trim "$raw_lv_size")")"
+  [[ -n "$lv_path" && -e "$lv_path" ]] || continue
+  candidate_major_minor="$(lsblk -dn -o MAJ:MIN "$lv_path" 2>/dev/null | awk 'NF { print $1; exit }')"
+  if [[ "$candidate_major_minor" == "$root_major_minor" ]]; then
+    matching_lvs+=("$lv_path")
+    matching_vgs+=("$vg_name")
+    matching_lv_names+=("$lv_name")
+    matching_lv_sizes+=("$lv_size")
+  fi
+done < <(lvs --noheadings --separator '|' --units b --nosuffix -o lv_path,vg_name,lv_name,lv_size)
+
+[[ "${#matching_lvs[@]}" -eq 1 ]] || fail "Expected exactly one LVM logical volume for root major:minor '$root_major_minor'; found ${#matching_lvs[@]}."
+lv_path="${matching_lvs[0]}"
+vg_name="${matching_vgs[0]}"
+lv_name="${matching_lv_names[0]}"
+lv_size_bytes="${matching_lv_sizes[0]}"
+
+matching_pvs=()
+matching_pv_sizes=()
+while IFS='|' read -r raw_pv_name raw_vg_name raw_pv_size; do
+  pv_name="$(trim "$raw_pv_name")"
+  candidate_vg="$(trim "$raw_vg_name")"
+  pv_size="$(to_integer_bytes "$(trim "$raw_pv_size")")"
+  if [[ "$candidate_vg" == "$vg_name" ]]; then
+    matching_pvs+=("$pv_name")
+    matching_pv_sizes+=("$pv_size")
+  fi
+done < <(pvs --noheadings --separator '|' --units b --nosuffix -o pv_name,vg_name,pv_size)
+
+[[ "${#matching_pvs[@]}" -eq 1 ]] || fail "Volume group '$vg_name' must contain exactly one physical volume; found ${#matching_pvs[@]}."
+actual_pv="$(readlink -f "${matching_pvs[0]}")"
+pv_size_bytes="${matching_pv_sizes[0]}"
+expected_pv_resolved="$(readlink -f "$expected_pv")"
+[[ -n "$expected_pv_resolved" && "$actual_pv" == "$expected_pv_resolved" ]] || fail "Root volume group '$vg_name' uses '$actual_pv', not expected '$expected_pv'."
+
+pv_type="$(lsblk -dn -o TYPE "$actual_pv" | awk 'NF { print $1; exit }')"
+pv_parent="$(lsblk -dn -o PKNAME "$actual_pv" | awk 'NF { print $1; exit }')"
+[[ "$pv_type" == "part" ]] || fail "Expected '$actual_pv' to be a partition; found type '$pv_type'."
+[[ "/dev/$pv_parent" == "/dev/sda" ]] || fail "Expected '$actual_pv' to belong to /dev/sda; found parent '/dev/$pv_parent'."
+
+disk_bytes="$(lsblk -bdn -o SIZE /dev/sda | awk 'NF { print $1; exit }')"
+partition_bytes="$(lsblk -bdn -o SIZE "$actual_pv" | awk 'NF { print $1; exit }')"
+[[ "$disk_bytes" =~ ^[0-9]+$ && "$partition_bytes" =~ ^[0-9]+$ ]] || fail "Unable to read disk and partition sizes."
+[[ "$disk_bytes" -eq "$expected_disk_bytes" ]] || fail "Disk size '$disk_bytes' does not match verified profile '$expected_disk_bytes'."
+[[ "$partition_bytes" -eq "$expected_partition_bytes" ]] || fail "Partition size '$partition_bytes' does not match verified profile '$expected_partition_bytes'."
+within_tolerance "$pv_size_bytes" "$partition_bytes" "$profile_tolerance_bytes" || fail "PV size '$pv_size_bytes' is outside the verified partition-size tolerance."
+
+vg_free_raw="$(vgs --noheadings --units b --nosuffix -o vg_free "$vg_name" | awk 'NF { print $1; exit }')"
+vg_free_bytes="$(to_integer_bytes "$vg_free_raw")"
+[[ "$vg_free_bytes" =~ ^[0-9]+$ ]] || fail "Unable to read free bytes for volume group '$vg_name'."
+
+root_before_bytes="$(df -B1 --output=size / | awk 'NR == 2 { print $1 }')"
+[[ "$root_before_bytes" =~ ^[0-9]+$ ]] || fail "Unable to read the root filesystem size."
+
+echo "Runner: $RUNNER_NAME"
+echo "Root: source=$root_source filesystem=$root_filesystem major_minor=$root_major_minor"
+echo "LVM: pv=$actual_pv vg=$vg_name lv=$lv_name lv_path=$lv_path"
+echo "Capacity bytes: disk=$disk_bytes partition=$partition_bytes pv=$pv_size_bytes vg_free=$vg_free_bytes lv=$lv_size_bytes filesystem=$root_before_bytes"
+
+state=""
+if (( vg_free_bytes >= minimum_initial_vg_free_bytes && vg_free_bytes <= maximum_initial_vg_free_bytes )) &&
+   within_tolerance "$lv_size_bytes" "$expected_initial_lv_bytes" "$profile_tolerance_bytes" &&
+   within_tolerance "$root_before_bytes" "$expected_initial_fs_bytes" "$profile_tolerance_bytes"; then
+  state="ready"
+elif (( vg_free_bytes < 64 * 1024 * 1024 && lv_size_bytes >= minimum_expanded_lv_bytes )); then
+  if (( root_before_bytes >= minimum_expanded_fs_bytes )); then
+    state="filesystem-expanded"
+  elif within_tolerance "$root_before_bytes" "$expected_initial_fs_bytes" "$profile_tolerance_bytes" ||
+       (( root_before_bytes > expected_initial_fs_bytes && root_before_bytes < minimum_expanded_fs_bytes )); then
+    state="filesystem-recovery"
+  fi
+fi
+
+[[ -n "$state" ]] || fail "Capacity state is outside the verified initial, recovery, and completed profiles."
+
+if [[ "$apply" == "false" ]]; then
+  if [[ "$state" == "ready" ]]; then
+    echo "Dry run: the LV can consume the verified free extents, then ext4 can grow to the LV boundary."
+  elif [[ "$state" == "filesystem-recovery" ]]; then
+    echo "Dry run: the LV is already expanded and ext4 can safely resume growth to the LV boundary."
+  else
+    echo "Dry run: the LV and ext4 filesystem are expanded; apply will idempotently verify ext4 against the LV boundary."
+  fi
+  exit 0
+fi
+
+[[ "$confirmation" == "$confirmation_phrase" ]] || fail "Apply requires confirmation phrase '$confirmation_phrase'."
+
+if [[ "$state" == "ready" ]]; then
+  lvextend --extents '+100%FREE' "$lv_path"
+fi
+
+resize2fs "$lv_path"
+
+vg_free_after_raw="$(vgs --noheadings --units b --nosuffix -o vg_free "$vg_name" | awk 'NF { print $1; exit }')"
+vg_free_after_bytes="$(to_integer_bytes "$vg_free_after_raw")"
+lv_size_after_raw="$(lvs --noheadings --units b --nosuffix -o lv_size "$lv_path" | awk 'NF { print $1; exit }')"
+lv_size_after_bytes="$(to_integer_bytes "$lv_size_after_raw")"
+root_after_bytes="$(df -B1 --output=size / | awk 'NR == 2 { print $1 }')"
+[[ "$vg_free_after_bytes" =~ ^[0-9]+$ && "$lv_size_after_bytes" =~ ^[0-9]+$ && "$root_after_bytes" =~ ^[0-9]+$ ]] || fail "Unable to verify capacity after expansion."
+(( vg_free_after_bytes < 64 * 1024 * 1024 )) || fail "Volume group still has at least 64 MiB free after expansion."
+(( lv_size_after_bytes >= minimum_expanded_lv_bytes )) || fail "Logical volume did not reach the verified expanded-size range."
+(( root_after_bytes >= minimum_expanded_fs_bytes )) || fail "Root filesystem did not reach the verified expanded-size range."
+
+echo "Expansion verified: lv_bytes=$lv_size_after_bytes filesystem_bytes_before=$root_before_bytes filesystem_bytes_after=$root_after_bytes vg_free_bytes_after=$vg_free_after_bytes"
+df -h /
+lsblk -o NAME,TYPE,FSTYPE,SIZE,MOUNTPOINTS /dev/sda

--- a/.github/workflows/linux-runner-root-capacity.yml
+++ b/.github/workflows/linux-runner-root-capacity.yml
@@ -1,0 +1,102 @@
+name: Linux Runner Root Capacity
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Expand each verified Linux runner root (true/false)"
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      confirmation:
+        description: "For apply=true, enter EXPAND-ALL-LINUX-RUNNER-ROOTS"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: linux-runner-root-capacity-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  validate-root:
+    if: ${{ github.repository == 'EvotecIT/PSPublishModule' }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - name: github-runner-linux
+            labels: '["self-hosted","linux","runner-github-runner-linux"]'
+          - name: github-runner-linux-01
+            labels: '["self-hosted","linux","runner-github-runner-linux-01"]'
+          - name: github-runner-linux-02
+            labels: '["self-hosted","linux","runner-github-runner-linux-02"]'
+          - name: github-runner-linux-03
+            labels: '["self-hosted","linux","runner-github-runner-linux-03"]'
+          - name: github-runner-linux-04
+            labels: '["self-hosted","linux","runner-github-runner-linux-04"]'
+          - name: github-runner-linux-05
+            labels: '["self-hosted","linux","runner-github-runner-linux-05"]'
+    name: ${{ matrix.runner.name }} / validate root capacity
+    runs-on: ${{ fromJSON(matrix.runner.labels) }}
+    steps:
+      - name: Check out PSPublishModule
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Validate root expansion plan
+        shell: bash
+        env:
+          APPLY: "false"
+          EXPECTED_RUNNER_NAME: ${{ matrix.runner.name }}
+          EXPECTED_PV: /dev/sda3
+          EXPECTED_DISK_BYTES: "136365211648"
+          EXPECTED_PARTITION_BYTES: "133088411648"
+          EXPECTED_INITIAL_LV_BYTES: "66542632960"
+          EXPECTED_INITIAL_FS_BYTES: "65174941696"
+        run: bash ./.github/scripts/expand-linux-runner-root.sh
+
+  expand-root:
+    if: ${{ inputs.apply == 'true' && needs.validate-root.result == 'success' }}
+    needs: validate-root
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - name: github-runner-linux
+            labels: '["self-hosted","linux","runner-github-runner-linux"]'
+          - name: github-runner-linux-01
+            labels: '["self-hosted","linux","runner-github-runner-linux-01"]'
+          - name: github-runner-linux-02
+            labels: '["self-hosted","linux","runner-github-runner-linux-02"]'
+          - name: github-runner-linux-03
+            labels: '["self-hosted","linux","runner-github-runner-linux-03"]'
+          - name: github-runner-linux-04
+            labels: '["self-hosted","linux","runner-github-runner-linux-04"]'
+          - name: github-runner-linux-05
+            labels: '["self-hosted","linux","runner-github-runner-linux-05"]'
+    name: ${{ matrix.runner.name }} / expand root capacity
+    runs-on: ${{ fromJSON(matrix.runner.labels) }}
+    steps:
+      - name: Check out PSPublishModule
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Expand root volume
+        shell: bash
+        env:
+          APPLY: "true"
+          CONFIRMATION: ${{ inputs.confirmation }}
+          EXPECTED_RUNNER_NAME: ${{ matrix.runner.name }}
+          EXPECTED_PV: /dev/sda3
+          EXPECTED_DISK_BYTES: "136365211648"
+          EXPECTED_PARTITION_BYTES: "133088411648"
+          EXPECTED_INITIAL_LV_BYTES: "66542632960"
+          EXPECTED_INITIAL_FS_BYTES: "65174941696"
+        run: bash ./.github/scripts/expand-linux-runner-root.sh

--- a/PowerForge.Tests/LinuxRunnerRootCapacityWorkflowTests.cs
+++ b/PowerForge.Tests/LinuxRunnerRootCapacityWorkflowTests.cs
@@ -1,0 +1,140 @@
+using YamlDotNet.Serialization;
+
+namespace PowerForge.Tests;
+
+public sealed class LinuxRunnerRootCapacityWorkflowTests
+{
+    private static readonly KeyValuePair<string, string>[] ExpectedRunners =
+    {
+        new("github-runner-linux", "[\"self-hosted\",\"linux\",\"runner-github-runner-linux\"]"),
+        new("github-runner-linux-01", "[\"self-hosted\",\"linux\",\"runner-github-runner-linux-01\"]"),
+        new("github-runner-linux-02", "[\"self-hosted\",\"linux\",\"runner-github-runner-linux-02\"]"),
+        new("github-runner-linux-03", "[\"self-hosted\",\"linux\",\"runner-github-runner-linux-03\"]"),
+        new("github-runner-linux-04", "[\"self-hosted\",\"linux\",\"runner-github-runner-linux-04\"]"),
+        new("github-runner-linux-05", "[\"self-hosted\",\"linux\",\"runner-github-runner-linux-05\"]")
+    };
+
+    [Fact]
+    public void WorkflowIsManualOnlyAndRequiresFleetValidationBeforeApply()
+    {
+        var workflow = ReadWorkflow();
+        var triggers = Mapping(workflow["on"]);
+        var jobs = Mapping(workflow["jobs"]);
+
+        Assert.Equal(new[] { "workflow_dispatch" }, triggers.Keys.Cast<string>());
+        Assert.Equal(new[] { "validate-root", "expand-root" }, jobs.Keys.Cast<string>());
+
+        var validationJob = Mapping(jobs["validate-root"]);
+        var applyJob = Mapping(jobs["expand-root"]);
+        Assert.Equal(ExpectedRunners, ReadMatrixRunners(validationJob));
+        Assert.Equal(ExpectedRunners, ReadMatrixRunners(applyJob));
+        Assert.Equal("validate-root", applyJob["needs"]);
+        Assert.Equal("${{ inputs.apply == 'true' && needs.validate-root.result == 'success' }}", applyJob["if"]);
+        Assert.Equal("${{ fromJSON(matrix.runner.labels) }}", validationJob["runs-on"]);
+        Assert.Equal("${{ fromJSON(matrix.runner.labels) }}", applyJob["runs-on"]);
+
+        AssertPinnedCheckout(validationJob);
+        AssertPinnedCheckout(applyJob);
+        AssertCapacityStep(validationJob, "Validate root expansion plan", "false", expectedConfirmation: null);
+        AssertCapacityStep(applyJob, "Expand root volume", "true", "${{ inputs.confirmation }}");
+    }
+
+    [Fact]
+    public void ExpansionScriptFailsClosedAndHasAConvergentExt4RecoveryPath()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var scriptPath = Path.Combine(repoRoot, ".github", "scripts", "expand-linux-runner-root.sh");
+        var script = File.ReadAllText(scriptPath);
+
+        Assert.Contains("[[ \"$EUID\" -eq 0 ]]", script, StringComparison.Ordinal);
+        Assert.Contains("RUNNER_NAME\" == \"$expected_runner_name", script, StringComparison.Ordinal);
+        Assert.Contains("pgrep -xc Runner.Worker", script, StringComparison.Ordinal);
+        Assert.Contains("flock -n 9", script, StringComparison.Ordinal);
+        Assert.Contains("Expected the verified ext4 root filesystem", script, StringComparison.Ordinal);
+        Assert.Contains("Expected exactly one LVM logical volume", script, StringComparison.Ordinal);
+        Assert.Contains("must contain exactly one physical volume", script, StringComparison.Ordinal);
+        Assert.Contains("EXPECTED_PV:-/dev/sda3", script, StringComparison.Ordinal);
+        Assert.Contains("EXPECTED_DISK_BYTES:-136365211648", script, StringComparison.Ordinal);
+        Assert.Contains("EXPECTED_PARTITION_BYTES:-133088411648", script, StringComparison.Ordinal);
+        Assert.Contains("EXPECTED_INITIAL_LV_BYTES:-66542632960", script, StringComparison.Ordinal);
+        Assert.Contains("EXPECTED_INITIAL_FS_BYTES:-65174941696", script, StringComparison.Ordinal);
+        Assert.Contains("state=\"filesystem-recovery\"", script, StringComparison.Ordinal);
+        Assert.Contains("state=\"filesystem-expanded\"", script, StringComparison.Ordinal);
+        Assert.Contains("lvextend --extents '+100%FREE'", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("lvextend --resizefs", script, StringComparison.Ordinal);
+        Assert.Contains("resize2fs \"$lv_path\"", script, StringComparison.Ordinal);
+        Assert.Contains("minimum_expanded_fs_bytes", script, StringComparison.Ordinal);
+    }
+
+    private static IDictionary<object, object> ReadWorkflow()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var workflowPath = Path.Combine(repoRoot, ".github", "workflows", "linux-runner-root-capacity.yml");
+        return new DeserializerBuilder().Build().Deserialize<IDictionary<object, object>>(File.ReadAllText(workflowPath));
+    }
+
+    private static IDictionary<object, object> Mapping(object value)
+        => Assert.IsAssignableFrom<IDictionary<object, object>>(value);
+
+    private static IReadOnlyList<KeyValuePair<string, string>> ReadMatrixRunners(IDictionary<object, object> job)
+    {
+        var strategy = Mapping(job["strategy"]);
+        var matrix = Mapping(strategy["matrix"]);
+        var runners = Assert.IsAssignableFrom<IEnumerable<object>>(matrix["runner"]);
+        return runners.Select(value =>
+        {
+            var runner = Mapping(value);
+            return new KeyValuePair<string, string>(
+                Assert.IsType<string>(runner["name"]),
+                Assert.IsType<string>(runner["labels"]));
+        }).ToArray();
+    }
+
+    private static void AssertPinnedCheckout(IDictionary<object, object> job)
+    {
+        var steps = Assert.IsAssignableFrom<IEnumerable<object>>(job["steps"]);
+        var checkout = steps.Select(Mapping).Single(step => Equals(step["name"], "Check out PSPublishModule"));
+        Assert.Equal("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", checkout["uses"]);
+    }
+
+    private static void AssertCapacityStep(
+        IDictionary<object, object> job,
+        string stepName,
+        string expectedApply,
+        string? expectedConfirmation)
+    {
+        var steps = Assert.IsAssignableFrom<IEnumerable<object>>(job["steps"]);
+        var step = steps.Select(Mapping).Single(candidate => Equals(candidate["name"], stepName));
+        var environment = Mapping(step["env"]);
+        Assert.Equal("bash", step["shell"]);
+        Assert.Equal("bash ./.github/scripts/expand-linux-runner-root.sh", step["run"]);
+        Assert.Equal(expectedApply, environment["APPLY"]);
+        Assert.Equal("${{ matrix.runner.name }}", environment["EXPECTED_RUNNER_NAME"]);
+        Assert.Equal("/dev/sda3", environment["EXPECTED_PV"]);
+        Assert.Equal("136365211648", environment["EXPECTED_DISK_BYTES"]);
+        Assert.Equal("133088411648", environment["EXPECTED_PARTITION_BYTES"]);
+        Assert.Equal("66542632960", environment["EXPECTED_INITIAL_LV_BYTES"]);
+        Assert.Equal("65174941696", environment["EXPECTED_INITIAL_FS_BYTES"]);
+        if (expectedConfirmation is null)
+            Assert.False(environment.ContainsKey("CONFIRMATION"));
+        else
+            Assert.Equal(expectedConfirmation, environment["CONFIRMATION"]);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "PSPublishModule.sln")) &&
+                Directory.Exists(Path.Combine(current.FullName, ".github")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate the PSPublishModule repository root.");
+    }
+}


### PR DESCRIPTION
## Summary

- add a manual-only workflow for the six owned Linux self-hosted runners
- require a successful fleet-wide validation matrix before any apply job can start
- bind each matrix leg to the exact runner name and the observed ext4/LVM capacity profile
- pin checkout by full commit SHA and hold a root-owned host lock during inspection and mutation
- grow the LV and ext4 filesystem as separate, retry-safe operations so an interrupted resize converges on rerun

The workflow accepts only the verified `/dev/sda` → `/dev/sda3` → single-PV root-LV layout. Apply requires an explicit confirmation phrase; drifted, partial, concurrent, non-root, or unknown-runner states fail closed. An already-expanded LV is handled by an idempotent `resize2fs` pass rather than being treated as complete from a coarse size threshold.

## Validation

- Bash syntax validation
- ShellCheck
- focused workflow-contract tests, including trigger shape, fleet matrices, dependency ordering, pinned action, exact labels, capacity inputs, and recovery wiring
