### PR TITLE
Normalize Linux root capacity probes

### DIFF
--- a/.github/scripts/expand-linux-runner-root.sh
+++ b/.github/scripts/expand-linux-runner-root.sh
@@ -78,9 +78,9 @@ flock -n 9 || fail "Another Linux root-capacity operation is already running on 
 worker_count="$(pgrep -xc Runner.Worker || true)"
 [[ "$worker_count" -eq 1 ]] || fail "Expected exactly this workflow's Runner.Worker process; found $worker_count."
 
-root_source="$(findmnt -n -o SOURCE /)"
-root_filesystem="$(findmnt -n -o FSTYPE /)"
-root_major_minor="$(findmnt -n -o MAJ:MIN /)"
+root_source="$(trim "$(findmnt -n -o SOURCE /)")"
+root_filesystem="$(trim "$(findmnt -n -o FSTYPE /)")"
+root_major_minor="$(trim "$(findmnt -n -o MAJ:MIN /)")"
 [[ -n "$root_source" && -n "$root_major_minor" ]] || fail "Unable to resolve the root filesystem device."
 [[ "$root_filesystem" == "ext4" ]] || fail "Expected the verified ext4 root filesystem; found '$root_filesystem'."
 

--- a/PowerForge.Tests/LinuxRunnerRootCapacityWorkflowTests.cs
+++ b/PowerForge.Tests/LinuxRunnerRootCapacityWorkflowTests.cs
@@ -50,6 +50,9 @@ public sealed class LinuxRunnerRootCapacityWorkflowTests
         Assert.Contains("RUNNER_NAME\" == \"$expected_runner_name", script, StringComparison.Ordinal);
         Assert.Contains("pgrep -xc Runner.Worker", script, StringComparison.Ordinal);
         Assert.Contains("flock -n 9", script, StringComparison.Ordinal);
+        Assert.Contains("root_source=\"$(trim \"$(findmnt -n -o SOURCE /)\")\"", script, StringComparison.Ordinal);
+        Assert.Contains("root_filesystem=\"$(trim \"$(findmnt -n -o FSTYPE /)\")\"", script, StringComparison.Ordinal);
+        Assert.Contains("root_major_minor=\"$(trim \"$(findmnt -n -o MAJ:MIN /)\")\"", script, StringComparison.Ordinal);
         Assert.Contains("Expected the verified ext4 root filesystem", script, StringComparison.Ordinal);
         Assert.Contains("Expected exactly one LVM logical volume", script, StringComparison.Ordinal);
         Assert.Contains("must contain exactly one physical volume", script, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

- normalize fixed-width whitespace from `findmnt` before comparing the root source, filesystem, and major:minor identity
- lock that normalization into the capacity-workflow contract tests

The first live dry run failed closed on all six runners because `findmnt` padded the major:minor value with trailing spaces. No storage command ran. This keeps the exact-device guard while comparing normalized probe values.

## Validation

- Bash syntax validation
- ShellCheck
- focused Linux runner root-capacity workflow tests
