### PR TITLE
Fix release planning with pending version bindings

### DIFF
--- a/PSPublishModule/Cmdlets/InvokeProjectBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeProjectBuildCommand.cs
@@ -139,6 +139,7 @@ public sealed partial class InvokeProjectBuildCommand : PSCmdlet
                 Success = workflow.Result.Success,
                 ErrorMessage = workflow.Result.ErrorMessage
             });
+            summary.Success = workflow.Result.Success;
             var display = new DotNetRepositoryReleaseDisplayService().CreateDisplay(summary, isPlan: preparation.PlanOnly || !executeBuild);
             SpectreProjectBuildSummaryWriter.Write(display);
 

--- a/PowerForge.ConsoleShared/SpectreProjectBuildSummaryWriter.cs
+++ b/PowerForge.ConsoleShared/SpectreProjectBuildSummaryWriter.cs
@@ -23,16 +23,17 @@ internal static class SpectreProjectBuildSummaryWriter
 
         var unicode = ConsoleEncoding.ShouldRenderUnicode(AnsiConsole.Profile.Capabilities.Unicode);
         var border = unicode ? TableBorder.Rounded : TableBorder.Simple;
-        var icon = unicode ? "✅" : "*";
+        var icon = unicode ? (display.Success ? (display.IsPlan ? "ℹ" : "✅") : "❌") : "*";
+        var titleColor = display.Success ? (display.IsPlan ? "grey" : "green") : "red";
 
-        AnsiConsole.Write(new Rule($"[green]{icon} {Esc(display.Title)}[/]").LeftJustified());
+        AnsiConsole.Write(new Rule($"[{titleColor}]{icon} {Esc(display.Title)}[/]").LeftJustified());
 
         var table = new Table()
             .Border(border)
             .AddColumn(new TableColumn("Project").NoWrap())
             .AddColumn(new TableColumn("Packable").NoWrap())
             .AddColumn(new TableColumn("Version").NoWrap())
-            .AddColumn(new TableColumn("Packages").NoWrap())
+            .AddColumn(new TableColumn(display.IsPlan ? "Planned packages" : "Packages").NoWrap())
             .AddColumn(new TableColumn("Duration").RightAligned().NoWrap())
             .AddColumn(new TableColumn("Status").NoWrap())
             .AddColumn(new TableColumn("Error"));

--- a/PowerForge.Tests/ProjectBuildVersionBindingPublicationTests.cs
+++ b/PowerForge.Tests/ProjectBuildVersionBindingPublicationTests.cs
@@ -1,0 +1,105 @@
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed class ProjectBuildVersionBindingPublicationTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Execute_binding_release_can_plan_then_build_and_publish_to_local_feed(bool executeBuild)
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-binding-publish-" + Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(root.FullName, "Example.Tool"));
+            var projectPath = Path.Combine(project.FullName, "Example.Tool.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <Version>1.2.3</Version>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            var bindingPath = Path.Combine(root.FullName, "tool.txt");
+            File.WriteAllText(bindingPath, "Example.Tool@1.2.3");
+            var feed = Directory.CreateDirectory(Path.Combine(root.FullName, "feed")).FullName;
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                ExpectedVersion = "1.2.4",
+                UpdateVersions = true,
+                Pack = true,
+                Publish = true,
+                PublishApiKey = "local-test",
+                PublishSource = feed,
+                VersionSources = new[] { feed },
+                OutputPath = Path.Combine(root.FullName, "packages"),
+                VersionBindings = new[]
+                {
+                    new ProjectVersionBinding
+                    {
+                        Path = "tool.txt",
+                        Project = "Example.Tool",
+                        Pattern = @"(?<=Example\.Tool@)\d+\.\d+\.\d+"
+                    }
+                }
+            };
+            var result = new ProjectBuildWorkflowService(new NullLogger()).Execute(
+                new ProjectBuildConfiguration(),
+                root.FullName,
+                new ProjectBuildPreparedContext
+                {
+                    RootPath = root.FullName,
+                    Spec = spec,
+                    PublishNuget = true,
+                    PublishApiKey = "local-test"
+                },
+                executeBuild: executeBuild).Result;
+
+            Assert.True(result.Success, result.ErrorMessage);
+            var release = Assert.IsType<DotNetRepositoryReleaseResult>(result.Release);
+            Assert.Equal(!executeBuild, release.IsPlan);
+            Assert.Equal(!executeBuild, release.PublishOrderDeferred);
+            Assert.Equal(executeBuild ? "Example.Tool@1.2.4" : "Example.Tool@1.2.3", File.ReadAllText(bindingPath));
+            Assert.Equal(executeBuild, Directory.EnumerateFiles(feed, "*.nupkg", SearchOption.AllDirectories).Any());
+            if (executeBuild)
+                Assert.Single(release.PublishedPackages);
+            else
+            {
+                Assert.Empty(release.PublishedPackages);
+                Assert.Contains("<Version>1.2.3</Version>", File.ReadAllText(projectPath));
+                var summary = new DotNetRepositoryReleaseSummaryService().CreateSummary(release);
+                var display = new DotNetRepositoryReleaseDisplayService().CreateDisplay(summary, isPlan: true);
+                Assert.Contains(display.Totals, row => row.Label == "Publish order" && row.Value.Contains("Deferred"));
+            }
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Preview_summary_reports_planned_projects_and_overall_failure(bool success)
+    {
+        var result = new DotNetRepositoryReleaseResult { IsPlan = true, Success = success };
+        result.Projects.Add(new DotNetRepositoryProjectResult
+        {
+            ProjectName = "Example.Tool",
+            IsPackable = true,
+            Packages = new() { "Example.Tool.1.2.4.nupkg" }
+        });
+        var summary = new DotNetRepositoryReleaseSummaryService().CreateSummary(result);
+        var display = new DotNetRepositoryReleaseDisplayService().CreateDisplay(summary, isPlan: false);
+        Assert.Equal(success, display.Success);
+        Assert.True(display.IsPlan);
+        Assert.Equal(success ? "Plan" : "Plan failed", display.Title);
+        Assert.Equal("Planned", Assert.Single(display.Projects).StatusText);
+        Assert.Contains(display.Totals, row => row.Label == "Planned packages" && row.Value == "1");
+    }
+}

--- a/PowerForge/Models/DotNetRepositoryReleaseDisplayModels.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseDisplayModels.cs
@@ -5,6 +5,8 @@ namespace PowerForge;
 
 internal sealed class DotNetRepositoryReleaseDisplayModel
 {
+    internal bool Success { get; set; } = true;
+    internal bool IsPlan { get; set; }
     internal string Title { get; set; } = string.Empty;
     internal IReadOnlyList<DotNetRepositoryReleaseProjectDisplayRow> Projects { get; set; } =
         Array.Empty<DotNetRepositoryReleaseProjectDisplayRow>();

--- a/PowerForge/Models/DotNetRepositoryReleaseResult.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseResult.cs
@@ -10,6 +10,12 @@ public sealed class DotNetRepositoryReleaseResult
     /// <summary>Whether the workflow completed without fatal errors.</summary>
     public bool Success { get; set; } = true;
 
+    /// <summary>Whether this result describes a preview rather than executed operations.</summary>
+    public bool IsPlan { get; set; }
+
+    /// <summary>Whether publish ordering must be validated from artifacts during execution.</summary>
+    public bool PublishOrderDeferred { get; set; }
+
     /// <summary>Optional error message for fatal failures.</summary>
     public string? ErrorMessage { get; set; }
 

--- a/PowerForge/Models/DotNetRepositoryReleaseSummary.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseSummary.cs
@@ -8,6 +8,15 @@ namespace PowerForge;
 /// </summary>
 public sealed class DotNetRepositoryReleaseSummary
 {
+    /// <summary>Whether the summarized operation succeeded.</summary>
+    public bool Success { get; set; } = true;
+
+    /// <summary>Whether the summary describes planned operations.</summary>
+    public bool IsPlan { get; set; }
+
+    /// <summary>Whether dependency ordering will be checked from artifacts during execution.</summary>
+    public bool PublishOrderDeferred { get; set; }
+
     /// <summary>
     /// Gets or sets the per-project summary rows.
     /// </summary>
@@ -130,5 +139,8 @@ public enum DotNetRepositoryReleaseProjectStatus
     /// <summary>
     /// The project failed.
     /// </summary>
-    Failed = 2
+    Failed = 2,
+
+    /// <summary>The project was planned but no release operations were executed.</summary>
+    Planned = 3
 }

--- a/PowerForge/Services/DotNetRepositoryReleaseDisplayService.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseDisplayService.cs
@@ -13,7 +13,9 @@ internal sealed class DotNetRepositoryReleaseDisplayService
 
         return new DotNetRepositoryReleaseDisplayModel
         {
-            Title = isPlan ? "Plan" : "Summary",
+            Success = summary.Success,
+            IsPlan = isPlan || summary.IsPlan,
+            Title = isPlan || summary.IsPlan ? (summary.Success ? "Plan" : "Plan failed") : (summary.Success ? "Summary" : "Release failed"),
             Projects = summary.Projects.Select(project => new DotNetRepositoryReleaseProjectDisplayRow
             {
                 ProjectName = project.ProjectName,
@@ -27,22 +29,25 @@ internal sealed class DotNetRepositoryReleaseDisplayService
                 StatusColor = ResolveStatusColor(project.Status),
                 ErrorPreview = project.ErrorPreview
             }).ToArray(),
-            Totals = CreateTotals(summary.Totals)
+            Totals = CreateTotals(summary.Totals, isPlan || summary.IsPlan, summary.PublishOrderDeferred)
         };
     }
 
-    private static IReadOnlyList<DotNetRepositoryReleaseTotalsDisplayRow> CreateTotals(DotNetRepositoryReleaseSummaryTotals totals)
+    private static IReadOnlyList<DotNetRepositoryReleaseTotalsDisplayRow> CreateTotals(DotNetRepositoryReleaseSummaryTotals totals, bool isPlan, bool publishOrderDeferred)
     {
         var rows = new List<DotNetRepositoryReleaseTotalsDisplayRow>
         {
             Row("Projects", totals.ProjectCount),
             Row("Packable", totals.PackableCount),
             Row("Failed", totals.FailedProjectCount),
-            Row("Packages", totals.PackageCount)
+            Row(isPlan ? "Planned packages" : "Packages", totals.PackageCount)
         };
 
+        if (publishOrderDeferred)
+            rows.Add(new DotNetRepositoryReleaseTotalsDisplayRow { Label = "Publish order", Value = "Deferred until artifacts are available" });
+
         if (totals.PublishedPackageCount > 0)
-            rows.Add(Row("Published", totals.PublishedPackageCount));
+            rows.Add(Row(isPlan ? "Planned publishes" : "Published", totals.PublishedPackageCount));
         if (totals.SkippedDuplicatePackageCount > 0)
             rows.Add(Row("Skipped duplicates", totals.SkippedDuplicatePackageCount));
         if (totals.FailedPublishCount > 0)
@@ -58,6 +63,7 @@ internal sealed class DotNetRepositoryReleaseDisplayService
         {
             DotNetRepositoryReleaseProjectStatus.Ok => "Ok",
             DotNetRepositoryReleaseProjectStatus.Skipped => "Skipped",
+            DotNetRepositoryReleaseProjectStatus.Planned => "Planned",
             _ => "Fail"
         };
 
@@ -66,6 +72,7 @@ internal sealed class DotNetRepositoryReleaseDisplayService
         {
             DotNetRepositoryReleaseProjectStatus.Ok => ConsoleColor.Green,
             DotNetRepositoryReleaseProjectStatus.Skipped => ConsoleColor.Gray,
+            DotNetRepositoryReleaseProjectStatus.Planned => ConsoleColor.Gray,
             _ => ConsoleColor.Red
         };
 

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -43,6 +43,7 @@ public sealed partial class DotNetRepositoryReleaseService
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (spec is null) throw new ArgumentNullException(nameof(spec));
+            result.IsPlan = spec.WhatIf;
             spec.HasPendingVersionBindingChanges = false;
             if (string.IsNullOrWhiteSpace(spec.RootPath))
             {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PackagePublication.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PackagePublication.cs
@@ -165,9 +165,12 @@ public sealed partial class DotNetRepositoryReleaseService
 
         if (spec.WhatIf && spec.HasPendingVersionBindingChanges)
         {
-            result.Success = false;
-            result.ErrorMessage = "A safe NuGet publish order cannot be planned while version-binding files have pending WhatIf changes. Apply the version changes or build the packages, then use artifact-based ordering.";
-            return true;
+            result.PublishOrderDeferred = true;
+            const string message = "NuGet publish ordering is deferred until version bindings are applied and package artifacts are available. Execution will validate the package dependency order before publishing.";
+            _logger.Info(message);
+            progress?.PhaseStarted(ProjectBuildProgressPhase.NuGetPublish, 0, message);
+            progress?.PhaseCompleted(ProjectBuildProgressPhase.NuGetPublish, message);
+            return false;
         }
 
         var publishPlan = CreatePublishPlan(

--- a/PowerForge/Services/DotNetRepositoryReleaseSummaryService.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseSummaryService.cs
@@ -26,7 +26,7 @@ public sealed class DotNetRepositoryReleaseSummaryService
                 VersionDisplay = BuildVersionDisplay(project),
                 PackageCount = project.Packages.Count + project.SymbolPackages.Count,
                 PackageBuildDuration = project.PackageBuildDuration,
-                Status = ResolveStatus(project),
+                Status = ResolveStatus(project, result.IsPlan),
                 ErrorMessage = project.ErrorMessage?.Trim() ?? string.Empty,
                 ErrorPreview = TrimForSummary(project.ErrorMessage, maxErrorLength)
             })
@@ -34,6 +34,9 @@ public sealed class DotNetRepositoryReleaseSummaryService
 
         return new DotNetRepositoryReleaseSummary
         {
+            Success = result.Success,
+            IsPlan = result.IsPlan,
+            PublishOrderDeferred = result.PublishOrderDeferred,
             Projects = rows,
             Totals = new DotNetRepositoryReleaseSummaryTotals
             {
@@ -103,10 +106,13 @@ public sealed class DotNetRepositoryReleaseSummaryService
         return $"{project.OldVersion ?? "?"} -> {project.NewVersion ?? "?"}";
     }
 
-    private static DotNetRepositoryReleaseProjectStatus ResolveStatus(DotNetRepositoryProjectResult project)
+    private static DotNetRepositoryReleaseProjectStatus ResolveStatus(DotNetRepositoryProjectResult project, bool isPlan)
     {
         if (!string.IsNullOrWhiteSpace(project.ErrorMessage))
             return DotNetRepositoryReleaseProjectStatus.Failed;
+
+        if (isPlan && project.IsPackable)
+            return DotNetRepositoryReleaseProjectStatus.Planned;
 
         return project.IsPackable
             ? DotNetRepositoryReleaseProjectStatus.Ok


### PR DESCRIPTION
A release that updates version-bound files, such as a tool launcher pin, previously failed during Invoke-ProjectBuild's mandatory preview before it could apply those changes or build packages. Preview now records deferred NuGet publish ordering; execution still validates the built package dependency graph before pushing any package.

Preview summaries label projects and package counts as planned, expose deferred ordering, and display overall failures without a success heading.

This fixes the shared PowerForge release engine used by [OfficeIMO](https://github.com/EvotecIT/OfficeIMO). OfficeIMO needs a PSPublishModule build containing this change; no downstream configuration workaround is required.

Validation: 59 targeted tests passed, including full local-feed build/publication; the module built for net472, net8.0, and net10.0; OfficeIMO preview passed through the locally built module in PowerShell 7 and Windows PowerShell 5.1. Independent local review found no actionable defects. A broader run completed 163 tests without failures before stalling and was stopped, so that run is incomplete. Public package publication is separate from this PR.
