### PR TITLE
Support shared documentation shells and API-aware site search

### DIFF
--- a/Docs/PowerForge.Web.AgentReadiness.md
+++ b/Docs/PowerForge.Web.AgentReadiness.md
@@ -236,6 +236,26 @@ large JSON indexes delivered without `Content-Encoding` as a warning. When
 Apache support is enabled, the generated managed block prefers Brotli and falls
 back to deflate for JSON if the corresponding modules are available.
 
+Visible search interfaces can call `PowerForgeWebMcpSearch.search({ query, limit })`
+to use the same generated index and ranking as the built-in WebMCP search. The
+visible interface accepts up to 100 results; agent responses retain their separate
+five-result and output-size limits. The index loads on demand and is shared by
+both interfaces. API aliases participate in ranking, so an unqualified type name
+can find its fully qualified reference entry.
+
+To include generated API types and PowerShell commands alongside content pages,
+configure output-relative API roots in the site specification:
+
+```json
+"Search": { "ApiRoots": ["api"] }
+```
+
+Generate API documentation before the final site build. The builder reads the
+generated `search.json` catalogs, links existing HTML reference pages, and updates
+the aggregate index, collection shards, language shards, and manifest together.
+Rebuilding uses the current catalogs rather than retaining old reference entries.
+The manifest reports any truncation caused by the shared index budgets.
+
 Themes with richer ranking can call `PowerForgeWebMcpSearch.bindAdapter(...)` to
 reuse their visible search implementation. If no adapter is bound, the runtime
 loads and reuses the generated index for the lifetime of the page;

--- a/Docs/PowerForge.Web.Theme.md
+++ b/Docs/PowerForge.Web.Theme.md
@@ -281,6 +281,20 @@ When rendering a page:
 3) Otherwise use theme `defaultLayout`.
 4) If layout is missing, fallback to base theme `page`.
 
+## Template exports for generated surfaces
+
+Use `TemplateExports` in `site.json` when a generated surface, such as API reference, needs the same theme navigation as a regular page:
+
+```json
+"TemplateExports": [
+  { "Name": "documentation-shell", "SourceRoute": "/docs/", "Layout": "documentation-shell" }
+]
+```
+
+The build renders the named layout with the source page's data and navigation context into `_powerforge/fragments/documentation-shell.html`. An API generation step can use that file as its `headerHtml`. The export does not create another content page or search/sitemap entry. Shared partial changes are reflected in both page and export output on the next build.
+
+The source route must identify a non-draft page included in the build, and the layout must exist. Export names must be unique lowercase letters, digits, and hyphens, starting with a letter or digit. Invalid declarations fail the build.
+
 ## Partials + components
 Partials are shared building blocks (header, footer, nav, cards, tabs).
 They should be pure HTML with placeholders or Scriban logic.

--- a/PowerForge.Tests/WebSiteApiSearchTests.cs
+++ b/PowerForge.Tests/WebSiteApiSearchTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using PowerForge.Web;
+
+namespace PowerForge.Tests;
+
+public sealed class WebSiteApiSearchTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "pf-api-search-" + Guid.NewGuid().ToString("N"));
+    private string Output => Path.Combine(_root, "out");
+    private readonly SiteSpec _spec;
+
+    public WebSiteApiSearchTests()
+    {
+        Directory.CreateDirectory(Path.Combine(_root, "content"));
+        File.WriteAllText(Path.Combine(_root, "content", "guide.md"), "---\ntitle: Guide\nslug: guide\n---\nDocument guidance.");
+        File.WriteAllText(Path.Combine(_root, "site.json"), "{}");
+        _spec = new SiteSpec
+        {
+            Name = "Search test", BaseUrl = "https://example.test",
+            Collections = [new CollectionSpec { Name = "docs", Input = "content", Output = "/" }],
+            Search = new SearchSpec { ApiRoots = ["api"] }
+        };
+    }
+
+    [Fact]
+    public void Build_IncludesApiAndCommandsAsHtmlLinksAndRefreshesChangedCatalogs()
+    {
+        WriteCatalog("word", """[{"title":"WordDocument","slug":"worddocument","kind":"Class","summary":"Create Word files.","aliases":["DocumentFactory"]}]""", "worddocument");
+        WriteCatalog("powershell", """[{"title":"New-OfficeWord","slug":"new-officeword","kind":"Cmdlet","summary":"Create a document."}]""", "new-officeword");
+        Build();
+        var entries = ReadIndex();
+        Assert.Contains(entries, entry => entry.Url == "/guide");
+        var word = Assert.Single(entries, entry => entry.Title == "WordDocument");
+        Assert.Equal("/api/word/worddocument/", word.Url);
+        Assert.Contains("DocumentFactory", word.SearchText);
+        Assert.Equal("en", word.Language);
+        Assert.Equal("powershell", Assert.Single(entries, entry => entry.Title == "New-OfficeWord").Collection);
+        Assert.Equal(entries.Length, JsonDocument.Parse(File.ReadAllText(Path.Combine(Output, "search", "manifest.json"))).RootElement.GetProperty("entryCount").GetInt32());
+
+        File.WriteAllText(Path.Combine(Output, "api", "word", "search.json"), "[]");
+        Build();
+        Assert.DoesNotContain(ReadIndex(), entry => entry.Title == "WordDocument");
+        Assert.Single(ReadIndex(), entry => entry.Title == "New-OfficeWord");
+    }
+
+    [Fact]
+    public void Build_OnlyIndexesExistingHtmlAndDeduplicatesOverlappingRoots()
+    {
+        WriteCatalog("word", """[{"title":"WordDocument","slug":"worddocument","kind":"Class"},{"title":"Missing","slug":"missing"},{"title":"Unsafe","slug":"../outside"}]""", "worddocument");
+        _spec.Search!.ApiRoots = ["api", "api/word"];
+        Build();
+        Assert.Single(ReadIndex(), entry => entry.Collection == "api");
+    }
+
+    [Fact]
+    public void Build_IndexesReferenceOnlySitesAndClearsRemovedReferences()
+    {
+        File.Delete(Path.Combine(_root, "content", "guide.md"));
+        WriteCatalog("word", """[{"title":"WordDocument","slug":"worddocument","kind":"Class"}]""", "worddocument");
+        Build();
+        Assert.Equal("WordDocument", Assert.Single(ReadIndex()).Title);
+        File.WriteAllText(Path.Combine(Output, "api", "word", "search.json"), "[]");
+        Build();
+        Assert.Empty(ReadIndex());
+    }
+
+    [Fact]
+    public void Build_RejectsApiRootsOutsideTheOutput()
+    {
+        _spec.Search!.ApiRoots = ["../outside"];
+        Assert.Throws<ArgumentException>(Build);
+    }
+
+    private void WriteCatalog(string name, string json, string slug)
+    {
+        var path = Path.Combine(Output, "api", name);
+        Directory.CreateDirectory(Path.Combine(path, slug));
+        File.WriteAllText(Path.Combine(path, slug, "index.html"), "<h1>Reference</h1>");
+        File.WriteAllText(Path.Combine(path, "search.json"), json);
+    }
+    private void Build() => WebSiteBuilder.Build(_spec, WebSitePlanner.Plan(_spec, Path.Combine(_root, "site.json")), Output);
+    private SearchIndexEntry[] ReadIndex() => JsonSerializer.Deserialize<SearchIndexEntry[]>(File.ReadAllText(Path.Combine(Output, "search", "index.json")), new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+    public void Dispose() => Directory.Delete(_root, recursive: true);
+}

--- a/PowerForge.Tests/WebSiteTemplateExportTests.cs
+++ b/PowerForge.Tests/WebSiteTemplateExportTests.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using PowerForge.Web;
+
+namespace PowerForge.Tests;
+
+public sealed class WebSiteTemplateExportTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "pf-template-export-" + Guid.NewGuid().ToString("N"));
+    private readonly SiteSpec _spec;
+    private readonly string _partial;
+    private string Output => Path.Combine(_root, "_site");
+    private string Fragment => Path.Combine(Output, "_powerforge", "fragments", "docs-shell.html");
+
+    public WebSiteTemplateExportTests()
+    {
+        Directory.CreateDirectory(Path.Combine(_root, "content", "pages"));
+        File.WriteAllText(Path.Combine(_root, "content", "pages", "guide.md"), "---\ntitle: Guide\nlayout: page\n---\n\nGuide content.");
+        var theme = Path.Combine(_root, "themes", "test");
+        Directory.CreateDirectory(Path.Combine(theme, "layouts"));
+        Directory.CreateDirectory(Path.Combine(theme, "partials"));
+        File.WriteAllText(Path.Combine(theme, "theme.json"), """{"name":"test","engine":"scriban","defaultLayout":"page"}""");
+        File.WriteAllText(Path.Combine(theme, "layouts", "page.html"), """{{ include "shared" }}<main>{{ content }}</main>""");
+        File.WriteAllText(Path.Combine(theme, "layouts", "shell.html"), """{{ include "shared" }}<aside>{{ page.title }} {{ current_path }}</aside>""");
+        _partial = Path.Combine(theme, "partials", "shared.html");
+        File.WriteAllText(_partial, "<header>Shared navigation</header>");
+        File.WriteAllText(Path.Combine(_root, "site.json"), "{}");
+        _spec = new SiteSpec
+        {
+            Name = "Export test", BaseUrl = "https://example.test", DefaultTheme = "test", ThemesRoot = "themes",
+            Collections = [new CollectionSpec { Name = "pages", Input = "content/pages", Output = "/" }],
+            TemplateExports = [new TemplateExportSpec { Name = "docs-shell", SourceRoute = "/guide/", Layout = "shell" }]
+        };
+    }
+
+    [Fact]
+    public void Build_ExportsTheSharedThemeWithoutCreatingSearchOrSitemapPages()
+    {
+        Build();
+        Assert.Equal("<header>Shared navigation</header><aside>Guide /guide</aside>", File.ReadAllText(Fragment).Trim());
+        var pageHtml = File.ReadAllText(Path.Combine(Output, "guide", "index.html"));
+        Assert.Contains("<main>", pageHtml);
+        Assert.Contains("Guide content.</p>", pageHtml);
+        using var index = JsonDocument.Parse(File.ReadAllText(Path.Combine(Output, "search", "index.json")));
+        Assert.Single(index.RootElement.EnumerateArray());
+        Assert.DoesNotContain("docs-shell", File.ReadAllText(Path.Combine(Output, "_powerforge", "sitemap-entries.json")));
+
+        var unchanged = Build();
+        Assert.DoesNotContain("_powerforge/fragments/docs-shell.html", unchanged.UpdatedFiles);
+        File.WriteAllText(_partial, "<header>Updated navigation</header>");
+        Build();
+        Assert.Contains("Updated navigation", File.ReadAllText(Fragment));
+        Assert.Contains("Updated navigation", File.ReadAllText(Path.Combine(Output, "guide", "index.html")));
+    }
+
+    [Theory]
+    [InlineData("../outside")]
+    [InlineData("nested/file")]
+    [InlineData("UpperCase")]
+    [InlineData("")]
+    public void Build_RejectsNamesThatAreNotPortableArtifactNames(string name)
+    {
+        _spec.TemplateExports[0].Name = name;
+        Assert.Throws<InvalidOperationException>(() => Build());
+    }
+
+    [Fact]
+    public void Build_RejectsUnknownSourceAndMissingLayoutInsteadOfRenderingFallbackContent()
+    {
+        _spec.TemplateExports[0].SourceRoute = "/missing/";
+        Assert.Throws<InvalidOperationException>(() => Build());
+        _spec.TemplateExports[0].SourceRoute = "/guide/";
+        _spec.TemplateExports[0].Layout = "missing-layout";
+        Assert.Throws<InvalidOperationException>(() => Build());
+    }
+
+    [Fact]
+    public void ExportedFragments_AreNotPublicPagesInSitemapsOrAudits()
+    {
+        Build();
+        var sitemap = WebSitemapGenerator.Generate(new WebSitemapOptions {
+            SiteRoot = Output, BaseUrl = _spec.BaseUrl, IncludeTextFiles = false
+        });
+        var xml = System.Xml.Linq.XDocument.Load(sitemap.OutputPath);
+        var routes = xml.Descendants(System.Xml.Linq.XName.Get("loc", "http://www.sitemaps.org/schemas/sitemap/0.9"))
+            .Select(element => element.Value).ToArray();
+        Assert.Contains("https://example.test/guide/", routes);
+        Assert.DoesNotContain(routes, route => route.Contains("/fragments/", StringComparison.Ordinal));
+        Assert.Equal(1, WebSeoDoctor.Analyze(new WebSeoDoctorOptions { SiteRoot = Output }).PageCount);
+        Assert.Equal(1, WebSiteAuditor.Audit(new WebAuditOptions { SiteRoot = Output }).PageCount);
+    }
+
+    private WebBuildResult Build() => WebSiteBuilder.Build(_spec, WebSitePlanner.Plan(_spec, Path.Combine(_root, "site.json")), Output);
+    public void Dispose() => Directory.Delete(_root, recursive: true);
+}

--- a/PowerForge.Web/Assets/WebMcp/site-search.v1.js
+++ b/PowerForge.Web/Assets/WebMcp/site-search.v1.js
@@ -77,6 +77,7 @@
       if (!url || seen[url]) return;
 
       var title = normalizeText(item.title);
+      var aliases = toArray(item.aliases).map(normalizeText);
       var haystack = normalizeText([
         item.title,
         item.description,
@@ -84,6 +85,7 @@
         item.searchText,
         item.collection,
         item.kind,
+        aliases.join(' '),
         toArray(item.tags).join(' '),
         toArray(item.categories).join(' ')
       ].join(' '));
@@ -91,6 +93,7 @@
 
       var score = 0;
       if (title === normalizedQuery) score += 120;
+      else if (aliases.indexOf(normalizedQuery) >= 0) score += 110;
       else if (title.indexOf(normalizedQuery) === 0) score += 80;
       else if (title.indexOf(normalizedQuery) >= 0) score += 50;
       if (haystack.indexOf(normalizedQuery) >= 0) score += 30;
@@ -302,6 +305,15 @@
   };
   api.normalizeText = normalizeText;
   api.searchEntries = searchEntries;
+  // The visible search UI shares the same index and ranking, with its own page size.
+  api.search = function (request) {
+    request = request || {};
+    return genericSearch({
+      query: boundedText(request.query, 200).trim(),
+      limit: boundedInteger(request.limit, 20, 1, 100),
+      signal: request.signal
+    });
+  };
   api.dispose = function () {
     if (registrationController) registrationController.abort();
     registrationController = null;

--- a/PowerForge.Web/Models/SearchIndexEntry.cs
+++ b/PowerForge.Web/Models/SearchIndexEntry.cs
@@ -5,6 +5,8 @@ public sealed class SearchIndexEntry
 {
     /// <summary>Display title.</summary>
     public string Title { get; set; } = string.Empty;
+    /// <summary>Alternative display names, such as an unqualified API type name.</summary>
+    public string[] Aliases { get; set; } = Array.Empty<string>();
     /// <summary>Destination URL.</summary>
     public string Url { get; set; } = string.Empty;
     /// <summary>Optional description.</summary>

--- a/PowerForge.Web/Models/SearchSpec.cs
+++ b/PowerForge.Web/Models/SearchSpec.cs
@@ -1,0 +1,11 @@
+namespace PowerForge.Web;
+
+/// <summary>Sources included alongside content pages in the site-wide search index.</summary>
+public sealed class SearchSpec
+{
+    /// <summary>
+    /// Output-relative API documentation roots whose generated search.json catalogs are included.
+    /// Generate API documentation before the final site build so reference entries are current.
+    /// </summary>
+    public string[] ApiRoots { get; set; } = Array.Empty<string>();
+}

--- a/PowerForge.Web/Models/SiteSpec.cs
+++ b/PowerForge.Web/Models/SiteSpec.cs
@@ -44,6 +44,10 @@ public sealed class SiteSpec
 
     /// <summary>Output format configuration.</summary>
     public OutputsSpec? Outputs { get; set; }
+    /// <summary>Additional generated reference sources for the site-wide search index.</summary>
+    public SearchSpec? Search { get; set; }
+    /// <summary>Named theme layouts exported as build fragments without creating public content routes.</summary>
+    public TemplateExportSpec[] TemplateExports { get; set; } = Array.Empty<TemplateExportSpec>();
     /// <summary>Pagination defaults for section/taxonomy pages.</summary>
     public PaginationSpec? Pagination { get; set; }
     /// <summary>Feed generation settings for RSS outputs.</summary>

--- a/PowerForge.Web/Models/TemplateExportSpec.cs
+++ b/PowerForge.Web/Models/TemplateExportSpec.cs
@@ -1,0 +1,12 @@
+namespace PowerForge.Web;
+
+/// <summary>Renders a theme layout using an existing page's content, data, and navigation context.</summary>
+public sealed class TemplateExportSpec
+{
+    /// <summary>Unique lowercase name used for the file under <c>_powerforge/fragments/{name}.html</c>.</summary>
+    public string Name { get; set; } = string.Empty;
+    /// <summary>Canonical route of a non-draft page included in this build, for example <c>/docs/</c>.</summary>
+    public string SourceRoute { get; set; } = string.Empty;
+    /// <summary>Theme layout to render instead of the source page's normal layout.</summary>
+    public string Layout { get; set; } = string.Empty;
+}

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.TypeIndexing.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.TypeIndexing.cs
@@ -194,7 +194,7 @@ public static partial class WebApiDocsGenerator
         return linked;
     }
 
-    private static string StripCrefTokens(string? text)
+    internal static string StripCrefTokens(string? text)
     {
         if (string.IsNullOrWhiteSpace(text)) return string.Empty;
         var cleaned = CrefTokenRegex.Replace(text, match =>

--- a/PowerForge.Web/Services/WebSeoDoctor.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.cs
@@ -14,7 +14,8 @@ public static partial class WebSeoDoctor
         "*.head.html",
         "**/*.head.html",
         "**/api-fragments/**",
-        "api-fragments/**"
+        "api-fragments/**",
+        "_powerforge/fragments/**"
     };
 
     private static readonly string[] DefaultHtmlExtensions = { ".html", ".htm" };

--- a/PowerForge.Web/Services/WebSiteAuditor.Constants.cs
+++ b/PowerForge.Web/Services/WebSiteAuditor.Constants.cs
@@ -11,7 +11,7 @@ public static partial class WebSiteAuditor
         "*.head.html",
         "**/*.head.html",
         "**/api-fragments/**",
-        "api-fragments/**"
+        "api-fragments/**",
+        "_powerforge/fragments/**"
     };
 }
-

--- a/PowerForge.Web/Services/WebSiteBuilder.ApiSearch.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.ApiSearch.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace PowerForge.Web;
+
+public static partial class WebSiteBuilder
+{
+    private static void AppendApiSearchEntries(SiteSpec spec, string outputRoot, List<SearchIndexEntry> entries)
+    {
+        var root = Path.GetFullPath(outputRoot);
+        var rootPrefix = root.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        var seen = entries.Select(entry => entry.Url).ToHashSet(StringComparer.Ordinal);
+        foreach (var apiRoot in spec.Search?.ApiRoots ?? Array.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(apiRoot) || Path.IsPathRooted(apiRoot))
+                throw new ArgumentException("Search.ApiRoots must contain output-relative directories.");
+            var directory = Path.GetFullPath(Path.Combine(root, apiRoot));
+            if (!directory.StartsWith(rootPrefix, comparison))
+                throw new ArgumentException("Search.ApiRoots must stay within the site output directory.");
+            if (!Directory.Exists(directory)) continue;
+
+            var options = new EnumerationOptions { RecurseSubdirectories = true, AttributesToSkip = FileAttributes.ReparsePoint };
+            foreach (var catalogPath in Directory.EnumerateFiles(directory, "search.json", options).Order(StringComparer.Ordinal))
+            {
+                using var catalog = JsonDocument.Parse(File.ReadAllText(catalogPath));
+                if (catalog.RootElement.ValueKind != JsonValueKind.Array)
+                    throw new InvalidDataException($"API search catalog must be an array: {catalogPath}");
+                var catalogDirectory = Path.GetDirectoryName(catalogPath)!;
+                var catalogRoute = "/" + Path.GetRelativePath(root, catalogDirectory).Replace('\\', '/').Trim('/') + "/";
+                foreach (var item in catalog.RootElement.EnumerateArray())
+                {
+                    var slug = ApiSearchString(item, "slug");
+                    if (!Regex.IsMatch(slug, "^[A-Za-z0-9_-]+$")) continue;
+                    // Generated catalogs link JSON payloads; visible search must link the HTML reference.
+                    var route = File.Exists(Path.Combine(catalogDirectory, slug, "index.html"))
+                        ? catalogRoute + slug + "/"
+                        : File.Exists(Path.Combine(catalogDirectory, slug + ".html")) ? catalogRoute + slug + ".html" : null;
+                    if (route is null || !seen.Add(route)) continue;
+                    var title = ApiSearchString(item, "title");
+                    if (string.IsNullOrWhiteSpace(title)) continue;
+                    var summary = WebApiDocsGenerator.StripCrefTokens(ApiSearchString(item, "summary"));
+                    var kind = ApiSearchString(item, "kind");
+                    var aliasNames = item.TryGetProperty("aliases", out var aliases) && aliases.ValueKind == JsonValueKind.Array
+                        ? aliases.EnumerateArray().Where(value => value.ValueKind == JsonValueKind.String).Select(value => value.GetString()!).ToArray()
+                        : Array.Empty<string>();
+                    entries.Add(new SearchIndexEntry
+                    {
+                        Title = title,
+                        Aliases = aliasNames,
+                        Url = route,
+                        Description = summary.Length > 400 ? summary[..400] : summary,
+                        Collection = kind.Equals("Cmdlet", StringComparison.OrdinalIgnoreCase) ? "powershell" : "api",
+                        Kind = kind.ToLowerInvariant(),
+                        Weight = 1,
+                        Language = NormalizeLanguageToken(spec.Localization?.DefaultLanguage ?? "en"),
+                        SearchText = string.Join(' ', title, string.Join(' ', aliasNames), summary, ApiSearchString(item, "namespace")),
+                        Tags = new[] { ApiSearchString(item, "namespace") }.Where(value => value.Length > 0).ToArray()
+                    });
+                }
+            }
+        }
+    }
+
+    private static string ApiSearchString(JsonElement item, string property) =>
+        item.ValueKind == JsonValueKind.Object && item.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString() ?? string.Empty
+            : string.Empty;
+}

--- a/PowerForge.Web/Services/WebSiteBuilder.DataAndDiagnostics.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.DataAndDiagnostics.cs
@@ -650,7 +650,7 @@ public static partial class WebSiteBuilder
 
     private static void WriteSearchIndex(SiteSpec spec, string outputRoot, IReadOnlyList<ContentItem> items)
     {
-        if (items.Count == 0) return;
+        if (items.Count == 0 && spec.Search?.ApiRoots.Length is not > 0) return;
 
         var entries = new List<SearchIndexEntry>();
         foreach (var item in items)
@@ -679,9 +679,15 @@ public static partial class WebSiteBuilder
                 Meta = BuildSearchMeta(item)
             });
         }
-        if (entries.Count == 0)
+        AppendApiSearchEntries(spec, outputRoot, entries);
+        if (entries.Count == 0 && spec.Search?.ApiRoots.Length is not > 0)
             return;
 
+        WriteSearchArtifacts(spec, outputRoot, entries);
+    }
+
+    private static void WriteSearchArtifacts(SiteSpec spec, string outputRoot, List<SearchIndexEntry> entries)
+    {
         entries = entries
             .OrderByDescending(static entry => entry.Weight)
             .ThenBy(static entry => entry.Title, StringComparer.OrdinalIgnoreCase)

--- a/PowerForge.Web/Services/WebSiteBuilder.OutputRendering.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.OutputRendering.cs
@@ -56,7 +56,8 @@ public static partial class WebSiteBuilder
         IReadOnlyDictionary<string, ProjectSpec> projectMap,
         MenuSpec[] menuSpecs,
         IReadOnlyList<OutputRuntime> outputs,
-        string alternateHeadLinksHtml)
+        string alternateHeadLinksHtml,
+        string? layoutOverride = null)
     {
         var pageTimer = Stopwatch.StartNew();
         var renderCache = BuildRenderCacheScope.Value ?? CreateBuildRenderCache(spec, rootPath);
@@ -72,7 +73,7 @@ public static partial class WebSiteBuilder
         Func<string, string?>? partialResolver = null;
         if (!string.IsNullOrWhiteSpace(themeRoot) && Directory.Exists(themeRoot))
         {
-            var layoutName = item.Template ?? item.Layout ?? manifest?.DefaultLayout ?? "base";
+            var layoutName = layoutOverride ?? item.Template ?? item.Layout ?? manifest?.DefaultLayout ?? "base";
             var layoutPath = loader.ResolveLayoutPath(themeRoot, manifest, layoutName);
             if (!string.IsNullOrWhiteSpace(layoutPath))
             {
@@ -82,6 +83,9 @@ public static partial class WebSiteBuilder
                     assetSlotTemplateKind = AssetSlotTemplateKind.Scriban;
             }
         }
+
+        if (layoutOverride is not null && themeTemplate is null)
+            throw new InvalidOperationException($"Template export layout '{layoutOverride}' was not found in the selected theme.");
 
         if (themeTemplate is not null && themeRoot is not null)
         {

--- a/PowerForge.Web/Services/WebSiteBuilder.TemplateExports.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.TemplateExports.cs
@@ -1,0 +1,39 @@
+namespace PowerForge.Web;
+
+public static partial class WebSiteBuilder
+{
+    private static void WriteTemplateExports(
+        string outputRoot,
+        SiteSpec spec,
+        string rootPath,
+        IReadOnlyList<ContentItem> items,
+        IReadOnlyDictionary<string, object?> data,
+        IReadOnlyDictionary<string, ProjectSpec> projectMap,
+        MenuSpec[] menuSpecs)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var export in spec.TemplateExports ?? Array.Empty<TemplateExportSpec>())
+        {
+            if (export is null || string.IsNullOrWhiteSpace(export.Name) ||
+                !export.Name.All(static c => c is >= 'a' and <= 'z' or >= '0' and <= '9' or '-') ||
+                export.Name[0] == '-' || !names.Add(export.Name))
+                throw new InvalidOperationException("Template exports require unique lowercase names containing only letters, digits, and hyphens, starting with a letter or digit.");
+            if (string.IsNullOrWhiteSpace(export.Layout) || string.IsNullOrWhiteSpace(export.SourceRoute))
+                throw new InvalidOperationException($"Template export '{export.Name}' requires a layout and source route.");
+
+            var source = items.FirstOrDefault(item => !item.Draft &&
+                string.Equals(NormalizeRouteForMatch(item.OutputPath), NormalizeRouteForMatch(export.SourceRoute), StringComparison.Ordinal));
+            if (source is null)
+                throw new InvalidOperationException($"Template export '{export.Name}' source route '{export.SourceRoute}' is not included in this build.");
+
+            var effectiveData = ResolveDataForProject(data, source.ProjectSlug);
+            var formats = ResolveOutputFormats(spec, source);
+            var outputs = ResolveOutputRuntime(spec, source, formats);
+            var html = RenderHtmlPage(outputRoot, spec, rootPath, source, items, effectiveData, projectMap, menuSpecs,
+                outputs, string.Empty, export.Layout);
+            var target = Path.Combine(outputRoot, "_powerforge", "fragments", export.Name + ".html");
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            WriteAllTextIfChanged(target, html);
+        }
+    }
+}

--- a/PowerForge.Web/Services/WebSiteBuilder.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.cs
@@ -207,6 +207,7 @@ public static partial class WebSiteBuilder
                 }
             }
 
+            WriteTemplateExports(outDir, spec, plan.RootPath, renderItems, data, projectMap, menuSpecs);
             ReportProgress("writing navigation/search/diagnostic outputs");
             WriteSiteNavData(spec, outDir, menuSpecs);
             WriteSearchIndex(spec, outDir, renderItems);

--- a/PowerForge.Web/Services/WebSitemapGenerator.cs
+++ b/PowerForge.Web/Services/WebSitemapGenerator.cs
@@ -167,7 +167,8 @@ public static partial class WebSitemapGenerator
         "*.head.html",
         "**/*.head.html",
         "api-fragments/**",
-        "**/api-fragments/**"
+        "**/api-fragments/**",
+        "_powerforge/fragments/**"
     };
 
     private static readonly string[] RobotsNoIndexNames = { "robots", "googlebot", "bingbot", "slurp" };

--- a/Schemas/powerforge.web.sitespec.schema.json
+++ b/Schemas/powerforge.web.sitespec.schema.json
@@ -8,6 +8,27 @@
     "$schema": { "type": "string" },
     "SchemaVersion": { "type": "integer", "minimum": 1 },
     "Name": { "type": "string" },
+    "Search": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ApiRoots": { "type": "array", "items": { "type": "string", "minLength": 1 }, "description": "Output-relative API documentation roots to include in site-wide search. Generate APIs before the final site build." }
+      }
+    },
+    "TemplateExports": {
+      "type": "array",
+      "description": "Render theme layouts to _powerforge/fragments/{Name}.html using existing page contexts, without creating content routes.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["Name", "SourceRoute", "Layout"],
+        "properties": {
+          "Name": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+          "SourceRoute": { "type": "string", "minLength": 1 },
+          "Layout": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
     "BaseUrl": { "type": "string" },
     "Extends": {
       "oneOf": [


### PR DESCRIPTION
Generated API documentation can now reuse the website's navigation and footer, and API symbols can appear in the same search results as regular pages. Template exports render shared fragments from the site's normal theme context; API search adds configured API roots and symbol aliases to the common search index. The visible search interface and WebMCP use the same search implementation.

Fragment outputs are excluded from public sitemap and page audits. Documentation and focused tests cover the new configuration and generated outputs.

This is the shared engine change for the [OfficeIMO website PR #2462](https://github.com/EvotecIT/OfficeIMO/pull/2462). Its website workflows will pin this source commit; merge this owner change before the website consumer PR.

Validation: 220 focused PowerForge tests passed, covering template exports, API search, WebMCP, sitemap canonicalization, and SEO audits.

