### PR TITLE
Remove machine-specific paths from generated module loaders

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,7 @@
 
 ## Unreleased
 ### What's Changed
+- Made generated module-scoped AssemblyLoadContext loaders deterministic and removed machine-specific temporary build paths from their embedded debug metadata.
 - Added side-by-side portable modern binary payloads for PowerShell modules, allowing a .NET 8 baseline and newer targets such as .NET 10 to be packaged together, checked for a consistent command surface, and selected from packaged target metadata at runtime with a safe Standard fallback.
 - Preserved aliases declared by module scripts when binary cmdlet and alias exports are discovered during packaging.
 - Made installed-module binary conflict analysis opt-in during builds; explicit pipeline conflict validation remains available when installed-state inspection is required.

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection.PortableExecutable;
 using PowerForge;
 
 public partial class ModuleBootstrapperGeneratorTests
@@ -275,7 +276,7 @@ public partial class ModuleBootstrapperGeneratorTests
 
     [Fact]
     [Trait("Category", "Integration")]
-    public void Generate_WithNetStandard21_WritesPowerShell70CompatibleAssemblyLoadContextLoader()
+    public void Generate_WithNetStandard21_WritesPowerShell70CompatibleAssemblyLoadContextLoaderWithPortableDebugPath()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-ps70-alc-" + Guid.NewGuid().ToString("N"));
         var coreRoot = Path.Combine(root, "Lib", "Core");
@@ -300,6 +301,15 @@ public partial class ModuleBootstrapperGeneratorTests
                 ".NETCoreApp,Version=v3.1",
                 System.Text.Encoding.UTF8.GetString(File.ReadAllBytes(loaderPath)),
                 StringComparison.Ordinal);
+
+            using var stream = File.OpenRead(loaderPath);
+            using var reader = new PEReader(stream);
+            var codeView = reader.ReadDebugDirectory().Single(entry => entry.Type == DebugDirectoryEntryType.CodeView);
+            var pdbPath = reader.ReadCodeViewDebugDirectoryData(codeView).Path.Replace('\\', '/');
+            var physicalTempPath = Path.GetTempPath().Replace('\\', '/');
+
+            Assert.True(pdbPath.StartsWith("/_/", StringComparison.Ordinal), $"Expected a mapped debug path, but found '{pdbPath}'.");
+            Assert.False(pdbPath.Contains(physicalTempPath, StringComparison.OrdinalIgnoreCase), $"Debug path leaked the temporary build root: '{pdbPath}'.");
         }
         finally
         {

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -845,6 +845,8 @@ internal static partial class ModuleBootstrapperGenerator
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
     <InformationalVersion>1.0.0</InformationalVersion>
+    <Deterministic>true</Deterministic>
+    <PathMap>$(MSBuildProjectDirectory)=/_/</PathMap>
   </PropertyGroup>
 </Project>
 ";


### PR DESCRIPTION
## Summary

- generate deterministic module-scoped `AssemblyLoadContext` loader projects
- map generated build paths to `/_/` before the compiler writes CodeView metadata
- verify the actual generated PE does not retain the machine-specific temporary build root

## Why

PowerForge builds module-scoped loaders in temporary directories. Their CodeView entries could retain that absolute build path, which then traveled into packaged PowerShell modules. The mapped path keeps generated loaders portable without changing their runtime behavior or target-framework selection.

## Validation

- focused generated-loader regression test: 1 passed
- complete `ModuleBootstrapperGeneratorTests` class: 72 passed

