### PR TITLE
Handle localized SEO metadata and unique heading anchors

### DIFF
--- a/PowerForge.Tests/WebMarkdownHeadingAnchorTests.cs
+++ b/PowerForge.Tests/WebMarkdownHeadingAnchorTests.cs
@@ -53,4 +53,16 @@ public sealed class WebMarkdownHeadingAnchorTests
 
         Assert.Equal(new[] { "privacy", "privacy-2" }, ids);
     }
+
+    [Fact]
+    public void MultilineRawHeadingsReceiveUsableAnchors()
+    {
+        var html = MarkdownRenderer.RenderToHtml("""
+            <h2>
+            <strong>プライバシー</strong>
+            </h2>
+            """);
+        var heading = Assert.Single(HtmlParser.ParseWithAngleSharp(html).QuerySelectorAll("h2"));
+        Assert.Equal("プライバシー", heading.Id);
+    }
 }

--- a/PowerForge.Tests/WebMarkdownHeadingAnchorTests.cs
+++ b/PowerForge.Tests/WebMarkdownHeadingAnchorTests.cs
@@ -1,0 +1,42 @@
+using HtmlTinkerX;
+using PowerForge.Web;
+
+namespace PowerForge.Tests;
+
+public sealed class WebMarkdownHeadingAnchorTests
+{
+    [Fact]
+    public void GeneratedAnchorsRemainUsableForNonLatinAndRepeatedHeadings()
+    {
+        var html = MarkdownRenderer.RenderToHtml("""
+            <h2>プライバシー</h2>
+            <h2>隐私</h2>
+            <h2>隐私</h2>
+            <h2>Evotecは私のホームを見ることができますか？</h2>
+            <h2>Evotecはホームを操作できますか？</h2>
+            <h2>!!!</h2>
+            """);
+        var headings = HtmlParser.ParseWithAngleSharp(html).QuerySelectorAll("h2");
+        var ids = headings.Select(heading => heading.GetAttribute("id")).ToArray();
+
+        Assert.Equal(new[] { "プライバシー", "隐私", "隐私-2", "evotec", "evotec-2", "heading" }, ids);
+        Assert.Contains("Evotecはホームを操作できますか？", html);
+    }
+
+    [Fact]
+    public void GeneratedAnchorsReserveExplicitTargetsAnywhereInTheDocument()
+    {
+        var html = MarkdownRenderer.RenderToHtml("""
+            <h2>Privacy</h2>
+            <h2 id="privacy">Authored heading</h2>
+            <div id="privacy-2">Existing target</div>
+            <h2>Privacy</h2>
+            <h2>Terms &amp; conditions</h2>
+            """);
+        var document = HtmlParser.ParseWithAngleSharp(html);
+        var ids = document.QuerySelectorAll("h2").Select(heading => heading.GetAttribute("id")).ToArray();
+
+        Assert.Equal(new[] { "privacy-3", "privacy", "privacy-4", "terms-conditions" }, ids);
+        Assert.NotNull(document.QuerySelector("div#privacy-2"));
+    }
+}

--- a/PowerForge.Tests/WebMarkdownHeadingAnchorTests.cs
+++ b/PowerForge.Tests/WebMarkdownHeadingAnchorTests.cs
@@ -36,7 +36,21 @@ public sealed class WebMarkdownHeadingAnchorTests
         var document = HtmlParser.ParseWithAngleSharp(html);
         var ids = document.QuerySelectorAll("h2").Select(heading => heading.GetAttribute("id")).ToArray();
 
-        Assert.Equal(new[] { "privacy-3", "privacy", "privacy-4", "terms-conditions" }, ids);
+        Assert.Equal(new[] { "privacy-3", "privacy", "privacy-4", "terms-amp-conditions" }, ids);
         Assert.NotNull(document.QuerySelector("div#privacy-2"));
+    }
+
+    [Fact]
+    public void RawHeadingsDoNotCollideWithMarkdownGeneratedAnchors()
+    {
+        var html = MarkdownRenderer.RenderToHtml("""
+            ## Privacy
+
+            <h2>Privacy</h2>
+            """);
+        var ids = HtmlParser.ParseWithAngleSharp(html).QuerySelectorAll("h2")
+            .Select(heading => heading.GetAttribute("id")).ToArray();
+
+        Assert.Equal(new[] { "privacy", "privacy-2" }, ids);
     }
 }

--- a/PowerForge.Tests/WebMarkdownRendererGfmTests.cs
+++ b/PowerForge.Tests/WebMarkdownRendererGfmTests.cs
@@ -342,6 +342,38 @@ public class WebMarkdownRendererGfmTests
         Assert.Contains("aria-label=\"MIT license for jquery\"", html, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void Build_TableOfContentsTargetsAssignedHeadingIds()
+    {
+        var html = BuildSinglePageSite("""
+            <h2>Privacy</h2>
+            <div id="privacy">Reserved target</div>
+            <h2>Privacy</h2>
+            <h2>隐私</h2>
+            <h3 id="Authored%23&amp;value">Terms &amp; conditions</h3>
+            """, configureRoot: root =>
+            {
+                var theme = Path.Combine(root, "themes", "t");
+                File.WriteAllText(Path.Combine(theme, "theme.json"),
+                    """{"name":"t","engine":"scriban","defaultLayout":"home"}""");
+                File.WriteAllText(Path.Combine(theme, "layouts", "home.html"),
+                    "<html><body>{{ content }}{{ toc }}</body></html>");
+            });
+        var document = HtmlTinkerX.HtmlParser.ParseWithAngleSharp(html);
+        var headings = document.QuerySelectorAll("h2, h3").ToArray();
+        var links = document.QuerySelectorAll(".pf-toc a").ToArray();
+
+        Assert.Equal(new[] { "privacy-2", "privacy-3", "隐私", "Authored%23&value" },
+            headings.Select(heading => heading.Id));
+        Assert.Equal(headings.Length, links.Length);
+        for (var index = 0; index < headings.Length; index++)
+        {
+            var target = Uri.UnescapeDataString(links[index].GetAttribute("href")![1..]);
+            Assert.Same(headings[index], document.GetElementById(target));
+            Assert.Equal(headings[index].TextContent, links[index].TextContent);
+        }
+    }
+
     private static string BuildSinglePageSite(string markdown, MarkdownSpec? markdownOptions = null, Action<string>? configureRoot = null)
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-markdown-gfm-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebReleaseHubRenderingTests.HeadingAnchors.cs
+++ b/PowerForge.Tests/WebReleaseHubRenderingTests.HeadingAnchors.cs
@@ -1,0 +1,71 @@
+using System.Text.Json;
+using HtmlTinkerX;
+
+namespace PowerForge.Tests;
+
+public partial class WebReleaseHubRenderingTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Build_ReleaseHeadingLinksRetainDistinctUnicodeAndAuthoredTargets(bool authoredHtml)
+    {
+        const string body = """
+            <h2>プライバシー</h2>
+            <h2>隐私</h2>
+            <h2>隐私</h2>
+            <h2 id="Mixed%23&amp;Value">Authored</h2>
+            <h2 id="Case">Uppercase</h2>
+            <h2 id="case">Lowercase</h2>
+            <h2 id="v1-2-0-case">Already prefixed</h2>
+            <div id="v1-2-0-隐私">Reserved non-heading target</div>
+            <p><a href="#プライバシー">プライバシー</a>
+            <a href="#%E9%9A%90%E7%A7%81">隐私</a>
+            <a href="#隐私-2">隐私</a>
+            <a href="#Mixed%2523%26Value">Authored</a>
+            <a href="#Case">Uppercase</a>
+            <a href="#case">Lowercase</a>
+            <a href="#v1-2-0-case">Already prefixed</a>
+            <a class="external" href="https://example.test/#隐私">External</a>
+            <a class="reserved" href="#v1-2-0-隐私">Reserved</a></p>
+            """;
+        var html = BuildSinglePageSite(
+            "{{< release-changelog product=\"*\" limit=\"5\" includePreview=\"true\" >}}",
+            setup: root =>
+            {
+                var data = Path.Combine(root, "data");
+                Directory.CreateDirectory(data);
+                var releases = new[] { "v1.2.0", "v1.3.0" }.Select(tag => new Dictionary<string, object>
+                {
+                    ["tag"] = tag,
+                    ["title"] = tag,
+                    ["url"] = "https://example.test/releases/" + tag,
+                    ["publishedAt"] = "2026-01-01T10:00:00Z",
+                    [authoredHtml ? "body_html" : "body_md"] = body
+                });
+                File.WriteAllText(Path.Combine(data, "release-hub.json"), JsonSerializer.Serialize(new { releases }));
+            },
+            useScribanTheme: false,
+            scribanLayoutBody: null);
+        var document = HtmlParser.ParseWithAngleSharp(html);
+        var releaseBodies = document.QuerySelectorAll(".pf-release-body");
+        Assert.Equal(2, releaseBodies.Length);
+
+        var headingIds = document.QuerySelectorAll(".pf-release-body h2").Select(heading => heading.Id).ToArray();
+        Assert.Equal(headingIds.Length, headingIds.Distinct(StringComparer.Ordinal).Count());
+        foreach (var releaseBody in releaseBodies)
+        {
+            var headings = releaseBody.QuerySelectorAll("h2");
+            var links = releaseBody.QuerySelectorAll("a:not(.external):not(.reserved)");
+            Assert.Equal(headings.Length, links.Length);
+            for (var index = 0; index < headings.Length; index++)
+            {
+                var target = Uri.UnescapeDataString(links[index].GetAttribute("href")![1..]);
+                Assert.Equal(headings[index].Id, target);
+                Assert.Single(releaseBody.QuerySelectorAll("[id]"), element => element.Id == target);
+            }
+            Assert.Equal("https://example.test/#隐私", releaseBody.QuerySelector("a.external")!.GetAttribute("href"));
+            Assert.Equal("#v1-2-0-隐私", releaseBody.QuerySelector("a.reserved")!.GetAttribute("href"));
+        }
+    }
+}

--- a/PowerForge.Tests/WebReleaseHubRenderingTests.cs
+++ b/PowerForge.Tests/WebReleaseHubRenderingTests.cs
@@ -2,7 +2,7 @@ using PowerForge.Web;
 
 namespace PowerForge.Tests;
 
-public class WebReleaseHubRenderingTests
+public partial class WebReleaseHubRenderingTests
 {
     [Fact]
     public void Build_RendersPfReleaseHelpers_FromReleaseHubData()

--- a/PowerForge.Tests/WebSeoDoctorLocalizationTests.cs
+++ b/PowerForge.Tests/WebSeoDoctorLocalizationTests.cs
@@ -14,6 +14,11 @@ public sealed class WebSeoDoctorLocalizationTests : IDisposable
     [InlineData("en", "en", true)]
     [InlineData("", "", true)]
     [InlineData("invalid language", "", true)]
+    [InlineData("ja-JP-u-ca-japanese", "", false)]
+    [InlineData("ja-JP-u-ca-japanese", "JA-jp-U-ca-JAPANESE", true)]
+    [InlineData("zh-Hant-x-site", "ja-JP-x-site", false)]
+    [InlineData("x-site-ja", "x-site-zh", false)]
+    [InlineData("i-klingon", "", false)]
     public void DuplicateIntentRespectsDeclaredLanguage(string firstLanguage, string secondLanguage, bool duplicate)
     {
         WritePage("first", firstLanguage, "Shared translated product guide", new string('a', 80));
@@ -29,6 +34,9 @@ public sealed class WebSeoDoctorLocalizationTests : IDisposable
     [InlineData("ko-KR")]
     [InlineData("zh-Hans")]
     [InlineData("ZH-hant-TW")]
+    [InlineData("ja-JP-u-ca-japanese")]
+    [InlineData("zh-Hant-x-site")]
+    [InlineData("ko-KR-x-a")]
     public void DenseLanguageDescriptionsUseTheSameMinimumInMetricsAndIssues(string language)
     {
         WritePage("guide", language, new string('家', 18), new string('家', 40));
@@ -79,6 +87,30 @@ public sealed class WebSeoDoctorLocalizationTests : IDisposable
 
         Assert.Contains(result.Issues, issue => issue.Hint == "title-short");
         Assert.Contains(result.Issues, issue => issue.Hint == "description-short");
+    }
+
+    [Fact]
+    public void DuplicateIntentBaselineKeysDistinguishLanguageAndUnicodeTitle()
+    {
+        WritePage("first-en", "en", "Shared translated product guide", new string('a', 80));
+        WritePage("second-en", "en", "Shared translated product guide", new string('a', 80));
+        var baselineKey = Assert.Single(WebSeoDoctor.Analyze(Options()).Issues,
+            issue => issue.Hint == "duplicate-title-intent").Key;
+
+        WritePage("first-nl", "nl", "Shared translated product guide", new string('a', 80));
+        WritePage("second-nl", "nl", "Shared translated product guide", new string('a', 80));
+        WritePage("first-ja", "ja", "プライバシー", new string('家', 80));
+        WritePage("second-ja", "ja", "プライバシー", new string('家', 80));
+        WritePage("third-ja", "ja", "サポート", new string('家', 80));
+        WritePage("fourth-ja", "ja", "サポート", new string('家', 80));
+
+        var keys = WebSeoDoctor.Analyze(Options()).Issues
+            .Where(issue => issue.Hint == "duplicate-title-intent")
+            .Select(issue => issue.Key).ToArray();
+
+        Assert.Equal(4, keys.Length);
+        Assert.Equal(4, keys.Distinct(StringComparer.Ordinal).Count());
+        Assert.Single(keys, key => key == baselineKey);
     }
 
     private void WritePage(string route, string language, string title, string description)

--- a/PowerForge.Tests/WebSeoDoctorLocalizationTests.cs
+++ b/PowerForge.Tests/WebSeoDoctorLocalizationTests.cs
@@ -1,0 +1,108 @@
+using PowerForge.Web;
+
+namespace PowerForge.Tests;
+
+public sealed class WebSeoDoctorLocalizationTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "pf-web-seo-localization-" + Guid.NewGuid().ToString("N"));
+
+    [Theory]
+    [InlineData("pt-BR", "pt-PT", false)]
+    [InlineData("zh-Hans", "zh-Hant", false)]
+    [InlineData("da", "nb", false)]
+    [InlineData("pt-BR", " PT-br ", true)]
+    [InlineData("en", "en", true)]
+    [InlineData("", "", true)]
+    [InlineData("invalid language", "", true)]
+    public void DuplicateIntentRespectsDeclaredLanguage(string firstLanguage, string secondLanguage, bool duplicate)
+    {
+        WritePage("first", firstLanguage, "Shared translated product guide", new string('a', 80));
+        WritePage("second", secondLanguage, "Shared translated product guide", new string('a', 80));
+
+        var result = WebSeoDoctor.Analyze(Options());
+
+        Assert.Equal(duplicate, result.Issues.Any(issue => issue.Hint == "duplicate-title-intent"));
+    }
+
+    [Theory]
+    [InlineData("ja")]
+    [InlineData("ko-KR")]
+    [InlineData("zh-Hans")]
+    [InlineData("ZH-hant-TW")]
+    public void DenseLanguageDescriptionsUseTheSameMinimumInMetricsAndIssues(string language)
+    {
+        WritePage("guide", language, new string('家', 18), new string('家', 40));
+
+        var result = WebSeoDoctor.Analyze(Options());
+
+        Assert.DoesNotContain(result.Issues, issue => issue.Category is "title" or "description");
+        Assert.False(Assert.Single(result.PageMetrics).ShortDescription);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("")]
+    [InlineData("unknown-language-value")]
+    public void OtherLanguagesKeepTheConfiguredMinimum(string language)
+    {
+        WritePage("guide", language, new string('a', 18), new string('a', 40));
+
+        var result = WebSeoDoctor.Analyze(Options());
+
+        Assert.Contains(result.Issues, issue => issue.Hint == "title-short");
+        Assert.Contains(result.Issues, issue => issue.Hint == "description-short");
+        Assert.True(Assert.Single(result.PageMetrics).ShortDescription);
+    }
+
+    [Fact]
+    public void DenseLanguageStillChecksMissingShortAndLongMetadata()
+    {
+        WritePage("missing", "ja", "", "");
+        WritePage("short", "ja", "家", "家");
+        WritePage("long", "ja", new string('家', 61), new string('家', 161));
+
+        var result = WebSeoDoctor.Analyze(Options());
+
+        foreach (var hint in new[] { "title-missing", "description-missing", "title-short", "description-short", "title-long", "description-long" })
+            Assert.Contains(result.Issues, issue => issue.Hint == hint);
+    }
+
+    [Fact]
+    public void DenseLanguageScalesCustomMinimums()
+    {
+        WritePage("guide", "ja", new string('家', 18), new string('家', 40));
+        var options = Options();
+        options.MinTitleLength = 40;
+        options.MinDescriptionLength = 100;
+
+        var result = WebSeoDoctor.Analyze(options);
+
+        Assert.Contains(result.Issues, issue => issue.Hint == "title-short");
+        Assert.Contains(result.Issues, issue => issue.Hint == "description-short");
+    }
+
+    private void WritePage(string route, string language, string title, string description)
+    {
+        var directory = Path.Combine(_root, route);
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(Path.Combine(directory, "index.html"), $"""
+            <!doctype html><html lang="{language}"><head><title>{title}</title>
+            <meta name="description" content="{description}"></head><body><h1>Guide</h1></body></html>
+            """);
+    }
+
+    private WebSeoDoctorOptions Options() => new()
+    {
+        SiteRoot = _root,
+        CheckOrphanPages = false,
+        CheckCanonical = false,
+        CheckHreflang = false,
+        CheckStructuredData = false
+    };
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+}

--- a/PowerForge.Web/Models/WebSeoDoctorOptions.cs
+++ b/PowerForge.Web/Models/WebSeoDoctorOptions.cs
@@ -38,7 +38,7 @@ public sealed class WebSeoDoctorOptions
     public bool CheckSourceMarkdownImageAlt { get; set; }
     /// <summary>Optional source content root used by source Markdown checks.</summary>
     public string? ContentRoot { get; set; }
-    /// <summary>When true, detect duplicate title intent across pages.</summary>
+    /// <summary>When true, detect duplicate title intent across pages with the same declared document language, preserving region and script distinctions.</summary>
     public bool CheckDuplicateTitles { get; set; } = true;
     /// <summary>When true, detect orphan page candidates (zero inbound links).</summary>
     public bool CheckOrphanPages { get; set; } = true;
@@ -63,11 +63,11 @@ public sealed class WebSeoDoctorOptions
     /// <summary>When true, emit warning when no JSON-LD structured data blocks are present.</summary>
     public bool RequireStructuredData { get; set; }
 
-    /// <summary>Minimum recommended title length.</summary>
+    /// <summary>Minimum recommended title length. Halved for Japanese, Korean, and Chinese document languages.</summary>
     public int MinTitleLength { get; set; } = 30;
     /// <summary>Maximum recommended title length.</summary>
     public int MaxTitleLength { get; set; } = 60;
-    /// <summary>Minimum recommended meta description length.</summary>
+    /// <summary>Minimum recommended meta description length. Halved for Japanese, Korean, and Chinese document languages.</summary>
     public int MinDescriptionLength { get; set; } = 70;
     /// <summary>Maximum recommended meta description length.</summary>
     public int MaxDescriptionLength { get; set; } = 160;

--- a/PowerForge.Web/Services/MarkdownRenderer.cs
+++ b/PowerForge.Web/Services/MarkdownRenderer.cs
@@ -137,7 +137,7 @@ internal static class MarkdownRenderer
         });
     }
 
-    private static string InjectHeadingIds(string html)
+    internal static string InjectHeadingIds(string html)
     {
         if (string.IsNullOrWhiteSpace(html))
             return string.Empty;
@@ -185,7 +185,7 @@ internal static class MarkdownRenderer
                     : (string.IsNullOrWhiteSpace(attrs) ? $" id=\"{id}\"" : $"{attrs} id=\"{id}\"");
                 return $"<h{level}{attrsWithId}>{headingHtml}</h{level}>";
             },
-            System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Compiled);
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Compiled | System.Text.RegularExpressions.RegexOptions.Singleline);
     }
 
     private static string InjectDefaultImageHints(string html, MarkdownSpec? markdown, string? sourcePath, string? siteRoot)

--- a/PowerForge.Web/Services/MarkdownRenderer.cs
+++ b/PowerForge.Web/Services/MarkdownRenderer.cs
@@ -142,6 +142,13 @@ internal static class MarkdownRenderer
         if (string.IsNullOrWhiteSpace(html))
             return string.Empty;
 
+        // Reserve authored IDs throughout the document, including headings that
+        // appear later, so generated anchors cannot take an existing target.
+        var document = HtmlTinkerX.HtmlParser.ParseWithAngleSharp(html);
+        var usedIds = document.QuerySelectorAll("[id]")
+            .Select(element => element.GetAttribute("id") ?? string.Empty)
+            .ToHashSet(StringComparer.Ordinal);
+
         return System.Text.RegularExpressions.Regex.Replace(html,
             "<h(?<level>[1-6])(?<attrs>[^>]*)>(?<text>.*?)</h\\1>",
             match =>
@@ -150,11 +157,30 @@ internal static class MarkdownRenderer
                 var attrs = match.Groups["attrs"].Value;
                 var headingHtml = NormalizeInlineCodeInHeading(match.Groups["text"].Value);
                 var text = System.Text.RegularExpressions.Regex.Replace(headingHtml, "<.*?>", string.Empty);
-                var id = Slugify(text);
                 var hasId = System.Text.RegularExpressions.Regex.IsMatch(
                     attrs,
                     "\\sid\\s*=",
                     System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.CultureInvariant);
+                var id = string.Empty;
+                if (!hasId)
+                {
+                    text = System.Net.WebUtility.HtmlDecode(text);
+                    var baseId = Slugify(text);
+                    if (string.IsNullOrEmpty(baseId))
+                    {
+                        // Retain the established ASCII anchors where possible;
+                        // all-non-Latin headings still need a usable anchor.
+                        baseId = System.Text.RegularExpressions.Regex.Replace(
+                            text.Trim().ToLowerInvariant(), @"[^\p{L}\p{N}\p{M}\s-]", string.Empty);
+                        baseId = System.Text.RegularExpressions.Regex.Replace(baseId, @"\s+", "-").Trim('-');
+                    }
+                    if (string.IsNullOrEmpty(baseId))
+                        baseId = "heading";
+                    id = baseId;
+                    var suffix = 2;
+                    while (!usedIds.Add(id))
+                        id = $"{baseId}-{suffix++}";
+                }
                 var attrsWithId = hasId
                     ? attrs
                     : (string.IsNullOrWhiteSpace(attrs) ? $" id=\"{id}\"" : $"{attrs} id=\"{id}\"");

--- a/PowerForge.Web/Services/MarkdownRenderer.cs
+++ b/PowerForge.Web/Services/MarkdownRenderer.cs
@@ -164,14 +164,13 @@ internal static class MarkdownRenderer
                 var id = string.Empty;
                 if (!hasId)
                 {
-                    text = System.Net.WebUtility.HtmlDecode(text);
                     var baseId = Slugify(text);
                     if (string.IsNullOrEmpty(baseId))
                     {
                         // Retain the established ASCII anchors where possible;
                         // all-non-Latin headings still need a usable anchor.
                         baseId = System.Text.RegularExpressions.Regex.Replace(
-                            text.Trim().ToLowerInvariant(), @"[^\p{L}\p{N}\p{M}\s-]", string.Empty);
+                            System.Net.WebUtility.HtmlDecode(text).Trim().ToLowerInvariant(), @"[^\p{L}\p{N}\p{M}\s-]", string.Empty);
                         baseId = System.Text.RegularExpressions.Regex.Replace(baseId, @"\s+", "-").Trim('-');
                     }
                     if (string.IsNullOrEmpty(baseId))

--- a/PowerForge.Web/Services/ReleaseHubRenderer.HeadingAnchors.cs
+++ b/PowerForge.Web/Services/ReleaseHubRenderer.HeadingAnchors.cs
@@ -1,0 +1,56 @@
+namespace PowerForge.Web;
+
+internal static partial class ReleaseHubRenderer
+{
+    private static string NamespaceReleaseBodyHtml(string html, string? releaseTag)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+            return string.Empty;
+
+        var prefix = Slugify(releaseTag);
+        if (string.IsNullOrWhiteSpace(prefix))
+            return html;
+
+        // Both Markdown and authored HTML use the renderer's assigned IDs.
+        // Slugifying an existing ID would lose Unicode, case, or punctuation.
+        var document = HtmlTinkerX.HtmlParser.ParseWithAngleSharp(MarkdownRenderer.InjectHeadingIds(html));
+        var headings = document.QuerySelectorAll("h1[id], h2[id], h3[id], h4[id], h5[id], h6[id]");
+        var headingSet = headings.ToHashSet();
+        var usedIds = document.QuerySelectorAll("[id]")
+            .Where(element => !headingSet.Contains(element))
+            .Select(element => element.Id ?? string.Empty)
+            .ToHashSet(StringComparer.Ordinal);
+        var remappedHeadingIds = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var heading in headings)
+        {
+            var originalId = heading.Id;
+            if (string.IsNullOrWhiteSpace(originalId))
+                continue;
+
+            var baseId = $"{prefix}-{originalId}";
+            var namespacedId = baseId;
+            var suffix = 2;
+            while (!usedIds.Add(namespacedId))
+                namespacedId = $"{baseId}-{suffix++}";
+
+            // Always prefix once here, even if an authored ID starts with the
+            // release tag. Otherwise distinct original IDs can collapse.
+            remappedHeadingIds.TryAdd(originalId, namespacedId);
+            heading.Id = namespacedId;
+        }
+
+        foreach (var link in document.QuerySelectorAll("a[href]"))
+        {
+            var href = link.GetAttribute("href") ?? string.Empty;
+            if (!href.StartsWith('#'))
+                continue;
+
+            var target = Uri.UnescapeDataString(href[1..]);
+            if (remappedHeadingIds.TryGetValue(target, out var namespacedTarget))
+                link.SetAttribute("href", "#" + Uri.EscapeDataString(namespacedTarget));
+        }
+
+        return document.Body?.InnerHtml ?? html;
+    }
+}

--- a/PowerForge.Web/Services/ReleaseHubRenderer.cs
+++ b/PowerForge.Web/Services/ReleaseHubRenderer.cs
@@ -4,18 +4,9 @@ using System.Text.RegularExpressions;
 
 namespace PowerForge.Web;
 
-internal static class ReleaseHubRenderer
+internal static partial class ReleaseHubRenderer
 {
     private const string DefaultDataPath = "release_hub";
-    private static readonly Regex HeadingWithIdRegex = new(
-        "<h(?<level>[1-6])(?<attrs>[^>]*)>(?<text>.*?)</h\\1>",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline);
-    private static readonly Regex IdAttributeRegex = new(
-        "\\sid\\s*=\\s*([\"'])(?<id>[^\"']+)\\1",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
-    private static readonly Regex FragmentLinkRegex = new(
-        "(?<prefix><a\\b[^>]*\\bhref\\s*=\\s*)(?<quote>[\"'])#(?<target>[^\"'#]+)(\\k<quote>)(?<suffix>[^>]*>)",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
     private static readonly Regex HtmlTagRegex = new(
         "<[^>]+>",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.Singleline);
@@ -552,53 +543,6 @@ internal static class ReleaseHubRenderer
         return matches;
     }
 
-    private static string NamespaceReleaseBodyHtml(string html, string? releaseTag)
-    {
-        if (string.IsNullOrWhiteSpace(html))
-            return string.Empty;
-
-        var prefix = Slugify(releaseTag);
-        if (string.IsNullOrWhiteSpace(prefix))
-            return html;
-
-        var remappedHeadingIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        var namespaced = HeadingWithIdRegex.Replace(html, match =>
-        {
-            var level = match.Groups["level"].Value;
-            var attrs = match.Groups["attrs"].Value;
-            var text = match.Groups["text"].Value;
-
-            var idMatch = IdAttributeRegex.Match(attrs);
-            var baseId = idMatch.Success
-                ? idMatch.Groups["id"].Value
-                : Slugify(Regex.Replace(text, "<.*?>", string.Empty));
-            if (string.IsNullOrWhiteSpace(baseId))
-                return match.Value;
-
-            var namespacedId = NamespaceFragment(prefix, baseId);
-            remappedHeadingIds[baseId] = namespacedId;
-            var attrsWithId = idMatch.Success
-                ? IdAttributeRegex.Replace(attrs, $" id=\"{namespacedId}\"", 1)
-                : (string.IsNullOrWhiteSpace(attrs) ? $" id=\"{namespacedId}\"" : $"{attrs} id=\"{namespacedId}\"");
-            return $"<h{level}{attrsWithId}>{text}</h{level}>";
-        });
-
-        if (remappedHeadingIds.Count == 0)
-            return namespaced;
-
-        return FragmentLinkRegex.Replace(namespaced, match =>
-        {
-            var target = match.Groups["target"].Value;
-            if (string.IsNullOrWhiteSpace(target))
-                return match.Value;
-
-            if (!remappedHeadingIds.TryGetValue(target, out var namespacedTarget))
-                return match.Value;
-
-            return $"{match.Groups["prefix"].Value}{match.Groups["quote"].Value}#{namespacedTarget}{match.Groups["quote"].Value}{match.Groups["suffix"].Value}";
-        });
-    }
-
     private static string PolishReleaseBodyHtml(string html)
     {
         if (string.IsNullOrWhiteSpace(html))
@@ -733,19 +677,6 @@ internal static class ReleaseHubRenderer
 
     private static string StripTags(string html)
         => string.IsNullOrWhiteSpace(html) ? string.Empty : HtmlTagRegex.Replace(html, string.Empty);
-
-    private static string NamespaceFragment(string prefix, string fragment)
-    {
-        var normalizedPrefix = Slugify(prefix);
-        var normalizedFragment = Slugify(fragment);
-        if (string.IsNullOrWhiteSpace(normalizedPrefix))
-            return normalizedFragment;
-        if (string.IsNullOrWhiteSpace(normalizedFragment))
-            return normalizedPrefix;
-        if (normalizedFragment.StartsWith(normalizedPrefix + "-", StringComparison.Ordinal))
-            return normalizedFragment;
-        return $"{normalizedPrefix}-{normalizedFragment}";
-    }
 
     private static string Slugify(string? value)
     {

--- a/PowerForge.Web/Services/WebSeoDoctor.Localization.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.Localization.cs
@@ -2,13 +2,26 @@ namespace PowerForge.Web;
 
 public static partial class WebSeoDoctor
 {
+    // This is a grouping token, not a language registry or hreflang validator.
+    // Preserve singleton extensions, private-use tags, and grandfathered forms.
+    private static readonly System.Text.RegularExpressions.Regex DocumentLanguageTokenPattern = new(
+        @"\A[a-z]{1,8}(?:-[a-z0-9]{1,8})*\z",
+        System.Text.RegularExpressions.RegexOptions.CultureInvariant);
+
     /// <summary>Keeps script and region subtags distinct when comparing localized page intent.</summary>
     private static string NormalizeDocumentLanguage(string? language)
     {
         var normalized = language?.Trim().ToLowerInvariant() ?? string.Empty;
-        return normalized != "x-default" && HreflangTokenPattern.IsMatch(normalized)
+        return normalized != "x-default" && DocumentLanguageTokenPattern.IsMatch(normalized)
             ? normalized
             : string.Empty;
+    }
+
+    /// <summary>Distinguishes language and Unicode titles in the ASCII baseline key space.</summary>
+    private static string DuplicateTitleKey(string language, string normalizedTitle)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(language + "\0" + normalizedTitle);
+        return "duplicate-title-" + Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(bytes));
     }
 
     /// <summary>

--- a/PowerForge.Web/Services/WebSeoDoctor.Localization.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.Localization.cs
@@ -1,0 +1,26 @@
+namespace PowerForge.Web;
+
+public static partial class WebSeoDoctor
+{
+    /// <summary>Keeps script and region subtags distinct when comparing localized page intent.</summary>
+    private static string NormalizeDocumentLanguage(string? language)
+    {
+        var normalized = language?.Trim().ToLowerInvariant() ?? string.Empty;
+        return normalized != "x-default" && HreflangTokenPattern.IsMatch(normalized)
+            ? normalized
+            : string.Empty;
+    }
+
+    /// <summary>
+    /// Dense CJK writing conveys more information per character than Latin text.
+    /// Halve the editorial minimum for those document languages, retaining the
+    /// configured maximum and the separate missing-content checks.
+    /// </summary>
+    private static int LocalizedMinimumLength(int minimum, string language)
+    {
+        var primaryLanguage = language.Split('-')[0];
+        return primaryLanguage is "ja" or "ko" or "zh"
+            ? (int)Math.Ceiling(minimum / 2d)
+            : minimum;
+    }
+}

--- a/PowerForge.Web/Services/WebSeoDoctor.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.cs
@@ -178,6 +178,9 @@ public static partial class WebSeoDoctor
             var route = ToRoute(relativePath);
             var title = NormalizeWhitespace(doc.Title);
             var description = GetMetaNameValue(doc, "description");
+            var language = NormalizeDocumentLanguage(doc.DocumentElement?.GetAttribute("lang"));
+            var pageTitleMin = LocalizedMinimumLength(titleMin, language);
+            var pageDescriptionMin = LocalizedMinimumLength(descriptionMin, language);
             var bodyText = GetVisibleBodyText(doc.Body);
             var isGeneratedApiReferencePage = options.ApplyGeneratedApiReferenceSeoProfile &&
                 IsGeneratedApiReferencePage(relativePath, doc);
@@ -213,6 +216,7 @@ public static partial class WebSeoDoctor
                 RelativePath = relativePath,
                 Route = route,
                 Title = title,
+                Language = language,
                 Description = description,
                 BodyText = bodyText,
                 CanonicalHref = canonicalLinks.FirstOrDefault() ?? string.Empty
@@ -229,7 +233,7 @@ public static partial class WebSeoDoctor
                 TitleTagCount = titleTagCount,
                 DescriptionLength = description.Length,
                 MissingDescription = string.IsNullOrWhiteSpace(description),
-                ShortDescription = !string.IsNullOrWhiteSpace(description) && description.Length < descriptionMin,
+                ShortDescription = !string.IsNullOrWhiteSpace(description) && description.Length < pageDescriptionMin,
                 LongDescription = description.Length > descriptionMax,
                 H1Count = visibleH1Count,
                 MissingH1 = visibleH1Count == 0,
@@ -250,17 +254,17 @@ public static partial class WebSeoDoctor
                 }
                 else if (!isGeneratedApiReferencePage)
                 {
-                    if (title.Length < titleMin)
+                    if (title.Length < pageTitleMin)
                     {
                         AddIssue("warning", "title", relativePath,
-                            $"title is short ({title.Length} chars). Recommended {titleMin}-{titleMax}.",
+                            $"title is short ({title.Length} chars). Recommended {pageTitleMin}-{titleMax}.",
                             "title-short");
                     }
 
                     if (title.Length > titleMax)
                     {
                         AddIssue("warning", "title", relativePath,
-                            $"title is long ({title.Length} chars). Recommended {titleMin}-{titleMax}.",
+                            $"title is long ({title.Length} chars). Recommended {pageTitleMin}-{titleMax}.",
                             "title-long");
                     }
                 }
@@ -274,17 +278,17 @@ public static partial class WebSeoDoctor
                 }
                 else if (!isGeneratedApiReferencePage)
                 {
-                    if (description.Length < descriptionMin)
+                    if (description.Length < pageDescriptionMin)
                     {
                         AddIssue("warning", "description", relativePath,
-                            $"meta description is short ({description.Length} chars). Recommended {descriptionMin}-{descriptionMax}.",
+                            $"meta description is short ({description.Length} chars). Recommended {pageDescriptionMin}-{descriptionMax}.",
                             "description-short");
                     }
 
                     if (description.Length > descriptionMax)
                     {
                         AddIssue("warning", "description", relativePath,
-                            $"meta description is long ({description.Length} chars). Recommended {descriptionMin}-{descriptionMax}.",
+                            $"meta description is long ({description.Length} chars). Recommended {pageDescriptionMin}-{descriptionMax}.",
                             "description-long");
                     }
                 }
@@ -408,9 +412,10 @@ public static partial class WebSeoDoctor
         {
             var duplicateTitleGroups = pages
                 .Where(page => !string.IsNullOrWhiteSpace(page.Title))
-                .GroupBy(page => page.Title, StringComparer.OrdinalIgnoreCase)
+                .GroupBy(page => (page.Language, Title: page.Title.ToUpperInvariant()))
                 .Where(group => group.Count() > 1)
-                .OrderBy(group => group.Key, StringComparer.OrdinalIgnoreCase)
+                .OrderBy(group => group.Key.Language, StringComparer.Ordinal)
+                .ThenBy(group => group.Key.Title, StringComparer.Ordinal)
                 .ToArray();
 
             foreach (var group in duplicateTitleGroups)
@@ -421,7 +426,7 @@ public static partial class WebSeoDoctor
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .Take(4)
                     .ToArray();
-                var title = group.Key;
+                var title = group.First().Title;
                 AddIssue("warning", "duplicate-intent", null,
                     $"duplicate title intent detected for '{title}' across {group.Count()} pages. Sample routes: {string.Join(", ", sampleRoutes)}.",
                     "duplicate-title-intent",
@@ -624,6 +629,7 @@ public static partial class WebSeoDoctor
         public string RelativePath { get; init; } = string.Empty;
         public string Route { get; init; } = "/";
         public string Title { get; init; } = string.Empty;
+        public string Language { get; init; } = string.Empty;
         public string Description { get; init; } = string.Empty;
         public string BodyText { get; init; } = string.Empty;
         public string FocusKeyphrase { get; set; } = string.Empty;

--- a/PowerForge.Web/Services/WebSeoDoctor.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.cs
@@ -430,7 +430,7 @@ public static partial class WebSeoDoctor
                 AddIssue("warning", "duplicate-intent", null,
                     $"duplicate title intent detected for '{title}' across {group.Count()} pages. Sample routes: {string.Join(", ", sampleRoutes)}.",
                     "duplicate-title-intent",
-                    title);
+                    DuplicateTitleKey(group.Key.Language, group.Key.Title));
             }
         }
 

--- a/PowerForge.Web/Services/WebSiteBuilder.DataAndDiagnostics.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.DataAndDiagnostics.cs
@@ -610,21 +610,22 @@ public static partial class WebSiteBuilder
         if (string.IsNullOrWhiteSpace(html))
             return string.Empty;
 
-        var matches = TocHeaderRegex.Matches(html);
-        if (matches.Count == 0)
+        var headings = HtmlTinkerX.HtmlParser.ParseWithAngleSharp(html).QuerySelectorAll("h2[id], h3[id]")
+            .Where(heading => !string.IsNullOrWhiteSpace(heading.Id) && !string.IsNullOrWhiteSpace(heading.TextContent))
+            .ToArray();
+        if (headings.Length == 0)
             return string.Empty;
 
         var sb = new System.Text.StringBuilder();
         sb.AppendLine("<nav class=\"pf-toc\">");
         sb.AppendLine("  <div class=\"pf-toc-title\">On this page</div>");
         sb.AppendLine("  <ul>");
-        foreach (Match match in matches)
+        foreach (var heading in headings)
         {
-            var level = match.Groups["level"].Value;
-            var text = StripTags(match.Groups["text"].Value).Trim();
-            if (string.IsNullOrWhiteSpace(text)) continue;
-            var slug = Slugify(text);
-            sb.AppendLine($"    <li class=\"pf-toc-l{level}\"><a href=\"#{slug}\">{System.Web.HttpUtility.HtmlEncode(text)}</a></li>");
+            var level = heading.LocalName[1];
+            var text = heading.TextContent.Trim();
+            var fragment = Uri.EscapeDataString(heading.Id!);
+            sb.AppendLine($"    <li class=\"pf-toc-l{level}\"><a href=\"#{fragment}\">{System.Web.HttpUtility.HtmlEncode(text)}</a></li>");
         }
         sb.AppendLine("  </ul>");
         sb.AppendLine("</nav>");

--- a/PowerForge.Web/Services/WebSiteBuilder.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.cs
@@ -20,7 +20,6 @@ public static partial class WebSiteBuilder
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
     private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
-    private static readonly Regex TocHeaderRegex = new("<h(?<level>[2-3])[^>]*>(?<text>.*?)</h\\1>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant, RegexTimeout);
     private static readonly Regex StripTagsRegex = new("<.*?>", RegexOptions.Compiled | RegexOptions.CultureInvariant, RegexTimeout);
     private static readonly Regex SnippetParagraphRegex = new("<p\\b[^>]*>(?<text>[\\s\\S]*?)</p>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant, RegexTimeout);
     private static readonly Regex HrefRegex = new("href\\s*=\\s*\"([^\"]+)\"", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant, RegexTimeout);


### PR DESCRIPTION
Multilingual websites now compare duplicate page titles within the same declared language, preserving script, region, and extension tags. Japanese, Korean, and Chinese pages use a lower minimum metadata length while retaining missing-content and maximum-length checks. Duplicate-title baseline keys distinguish both language and Unicode title; existing duplicate-title baseline entries need regeneration after review.

Generated heading anchors remain unique when non-Latin headings repeat or collapse to the same ASCII text. Explicit IDs and existing nonempty ASCII anchors are preserved. Tables of contents use the assigned heading IDs, and release headings retain distinct Unicode and authored targets when namespaced.

A private downstream website consumes these shared rendering and audit fixes. This owner change should land before the dependent website update is merged.

Validation: 118 focused SEO, Markdown, release-rendering, and pipeline tests pass. Regression tests reproduce the prior baseline and navigation defects. Desktop and mobile browser checks confirm repeated-title, Japanese, and release-specific Chinese links reach their intended headings. Independent review and targeted confirmation are complete.
