### PR TITLE
Support multiple App Store listing locales

### DIFF
--- a/Docs/PSPublishModule.AppleRelease.md
+++ b/Docs/PSPublishModule.AppleRelease.md
@@ -1063,6 +1063,49 @@ to the app-level resource rather than an App Store version. Use one config per a
 the unified release applies every matching locale once per unique app id even when iOS and macOS
 targets share that app, and fails when a selected app has no matching config.
 
+## Multiple Listing Languages
+
+Use one version metadata file per app, platform, and locale. `AppleApps.MetadataConfigPaths`
+can include several languages for the same platform; preparation applies every matching
+file and rejects duplicate locales before remote release work. `UseReleaseVersion: true`
+binds each file to the selected marketing version. Explicit version IDs must agree across
+all metadata and screenshot mappings for a target.
+
+```json
+{
+  "AppleApps": {
+    "MetadataConfigPaths": [
+      "store/en-US/ios.json",
+      "store/pl/ios.json",
+      "store/en-US/macos.json",
+      "store/pl/macos.json"
+    ],
+    "AppInfoConfigPaths": [
+      "store/en-US/app-info.json",
+      "store/pl/app-info.json"
+    ]
+  }
+}
+```
+
+This fragment belongs alongside the app targets and credentials in the release config.
+App Information is shared across platform versions, so list each app/locale only once.
+Both sync services create a localization when it is missing. App Information creation
+requires a localized `name`; other supplied fields are sent with the create request.
+An existing localization is updated using its existing resource ID.
+
+An editable App Information resource can receive a new title or language while the previous
+live resource retains its released metadata. Locked resources still in review must already
+match, and a locked-only app cannot receive new or changed metadata. Create the next editable
+version before preparing those changes.
+
+For .NET callers, `AppStoreConnectReleasePreparationRequest.MetadataSpecs` accepts multiple
+locales alongside the existing single `MetadataSpec`. `MetadataResults` returns all results;
+`Metadata` retains the first result for single-locale callers. Each sync result reports
+`CreatedLocalization`; `Before` is null when there was no prior localization. These operations
+prepare metadata only; submission and public release remain separate, explicitly authorized
+actions.
+
 ## Screenshot Upload Flow
 
 Screenshot upload uses App Store Connect's asset reservation flow:

--- a/PowerForge.Tests/AppStoreConnectClientTests.AppInfoMetadata.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.AppInfoMetadata.cs
@@ -123,7 +123,7 @@ public sealed partial class AppStoreConnectClientTests
                       "type": "appInfoLocalizations",
                       "attributes": {
                         "locale": "en-US",
-                        "privacyPolicyUrl": "https://tactra.dev/privacy/"
+                        "privacyPolicyUrl": "https://previous.example/privacy/"
                       }
                     }
                   ]
@@ -175,7 +175,7 @@ public sealed partial class AppStoreConnectClientTests
         });
 
         Assert.Equal("info-editable", result.AppInfo.Id);
-        Assert.Equal("https://old.example/privacy/", result.Before.PrivacyPolicyUrl);
+        Assert.Equal("https://old.example/privacy/", result.Before!.PrivacyPolicyUrl);
         Assert.Equal("https://tactra.dev/privacy/", result.After.PrivacyPolicyUrl);
         Assert.Equal(new[] { "privacyPolicyUrl" }, result.UpdatedFields);
         Assert.Contains("appInfos/info-editable/appInfoLocalizations", handler.RequestUris[2].ToString(), StringComparison.Ordinal);
@@ -263,7 +263,7 @@ public sealed partial class AppStoreConnectClientTests
             });
 
         Assert.Empty(result.UpdatedFields);
-        Assert.Equal(result.Before.Id, result.After.Id);
+        Assert.Equal(result.Before!.Id, result.After.Id);
         Assert.Equal(3, handler.RequestUris.Count);
         Assert.All(handler.Methods, method => Assert.Equal(HttpMethod.Get, method));
     }

--- a/PowerForge.Tests/AppStoreConnectClientTests.LocalizationCreation.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.LocalizationCreation.cs
@@ -1,0 +1,141 @@
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class AppStoreConnectClientTests
+{
+    [Fact]
+    public async Task ReleasePreparation_SyncsExistingAndMissingVersionLocales()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK, """{"data":[{"type":"appStoreVersions","id":"version-2","attributes":{"versionString":"2.0","platform":"IOS"}}]}"""),
+            new SequenceResponse(HttpStatusCode.OK, """{"data":[{"type":"appStoreVersionLocalizations","id":"english","attributes":{"locale":"en-US","description":"Old"}}]}"""),
+            new SequenceResponse(HttpStatusCode.OK, """{"data":{"type":"appStoreVersionLocalizations","id":"english","attributes":{"locale":"en-US","description":"English"}}}"""),
+            new SequenceResponse(HttpStatusCode.OK, """{"data":[]}"""),
+            new SequenceResponse(HttpStatusCode.Created, """{"data":{"type":"appStoreVersionLocalizations","id":"polish","attributes":{"locale":"pl","description":"Polski"}}}"""));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var result = await new AppStoreConnectReleasePreparationService(client).PrepareAsync(new()
+        {
+            AppId = "app-1", VersionString = "2.0", CreateVersion = false, SelectBuild = false,
+            MetadataSpecs = new[]
+            {
+                VersionListing("en-US", "English"), VersionListing("pl", "Polski")
+            }
+        });
+
+        Assert.Equal(2, result.MetadataResults.Length);
+        Assert.Same(result.MetadataResults[0], result.Metadata);
+        Assert.False(result.MetadataResults[0].CreatedLocalization);
+        Assert.Equal("Old", result.MetadataResults[0].Before!.Description);
+        Assert.True(result.MetadataResults[1].CreatedLocalization);
+        Assert.Null(result.MetadataResults[1].Before);
+        Assert.Equal("Polski", result.MetadataResults[1].After.Description);
+        Assert.All(result.MetadataResults, value => Assert.Equal("version-2", value.Version.Id));
+        Assert.Equal(HttpMethod.Patch, handler.Methods[2]);
+        Assert.Equal(HttpMethod.Post, handler.Methods[4]);
+        Assert.Equal("/v1/appStoreVersionLocalizations", handler.RequestUris[4].AbsolutePath);
+        using var body = JsonDocument.Parse(handler.RequestBodies[4]!);
+        var data = body.RootElement.GetProperty("data");
+        Assert.Equal("pl", data.GetProperty("attributes").GetProperty("locale").GetString());
+        Assert.False(data.GetProperty("attributes").TryGetProperty("keywords", out _));
+        var parent = data.GetProperty("relationships").GetProperty("appStoreVersion").GetProperty("data");
+        Assert.Equal("appStoreVersions", parent.GetProperty("type").GetString());
+        Assert.Equal("version-2", parent.GetProperty("id").GetString());
+    }
+
+    [Theory]
+    [InlineData("duplicate")]
+    [InlineData("version-id")]
+    [InlineData("platform")]
+    [InlineData("empty-locale")]
+    public async Task ReleasePreparation_RejectsInvalidLocaleBatchBeforeRemoteWork(string defect)
+    {
+        var handler = new SequenceHandler();
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var first = VersionListing("en-US", "English");
+        var second = VersionListing("pl", "Polski");
+        switch (defect)
+        {
+            case "duplicate": second.Locale = " EN-us "; break;
+            case "version-id": first.VersionId = "one"; second.VersionId = "two"; break;
+            case "platform": second.Platform = ApplePlatform.macOS; break;
+            case "empty-locale": second.Locale = " "; break;
+        }
+        var exception = await Record.ExceptionAsync(() => new AppStoreConnectReleasePreparationService(client).PrepareAsync(new()
+        {
+            AppId = "app-1", VersionString = "2.0", CreateVersion = true, SelectBuild = false,
+            MetadataSpec = first, MetadataSpecs = new[] { second }
+        }));
+        Assert.NotNull(exception);
+        Assert.True(exception is ArgumentException or InvalidOperationException);
+        Assert.Empty(handler.Methods);
+    }
+
+    [Fact]
+    public async Task AppInfoSync_CreatesMissingEditableLocaleBesideReleasedRecord_ThenConverges()
+    {
+        const string infos = """{"data":[{"type":"appInfos","id":"live","attributes":{"state":"READY_FOR_DISTRIBUTION"}},{"type":"appInfos","id":"editable","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}""";
+        const string localization = """{"type":"appInfoLocalizations","id":"info-pl","attributes":{"locale":"pl","name":"Smart Home","subtitle":"Sterowanie"}}""";
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK, infos),
+            new SequenceResponse(HttpStatusCode.OK, """{"data":[]}"""),
+            new SequenceResponse(HttpStatusCode.OK, """{"data":[]}"""),
+            new SequenceResponse(HttpStatusCode.Created, "{\"data\":" + localization + "}"),
+            new SequenceResponse(HttpStatusCode.OK, infos),
+            new SequenceResponse(HttpStatusCode.OK, """{"data":[]}"""),
+            new SequenceResponse(HttpStatusCode.OK, "{\"data\":[" + localization + "]}"));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var service = new AppStoreConnectAppInfoMetadataSyncService(client);
+        var request = new AppStoreConnectAppInfoMetadataSyncRequest
+        {
+            Spec = new() { AppId = "app-1", Locale = "pl", Metadata = new() { Name = "Smart Home", Subtitle = "Sterowanie" } }
+        };
+
+        var created = await service.SyncAsync(request);
+        var converged = await service.SyncAsync(request);
+
+        Assert.True(created.CreatedLocalization);
+        Assert.Null(created.Before);
+        Assert.Equal("editable", created.AppInfo.Id);
+        Assert.Equal("info-pl", created.After.Id);
+        Assert.False(converged.CreatedLocalization);
+        Assert.Empty(converged.UpdatedFields);
+        Assert.Single(handler.Methods, method => method != HttpMethod.Get);
+        Assert.Equal(HttpMethod.Post, handler.Methods[3]);
+        Assert.Equal("/v1/appInfoLocalizations", handler.RequestUris[3].AbsolutePath);
+        using var body = JsonDocument.Parse(handler.RequestBodies[3]!);
+        var data = body.RootElement.GetProperty("data");
+        Assert.Equal("pl", data.GetProperty("attributes").GetProperty("locale").GetString());
+        Assert.Equal("Smart Home", data.GetProperty("attributes").GetProperty("name").GetString());
+        var parent = data.GetProperty("relationships").GetProperty("appInfo").GetProperty("data");
+        Assert.Equal("appInfos", parent.GetProperty("type").GetString());
+        Assert.Equal("editable", parent.GetProperty("id").GetString());
+    }
+
+    [Theory]
+    [InlineData("READY_FOR_DISTRIBUTION")]
+    [InlineData("IN_REVIEW")]
+    public async Task AppInfoSync_DoesNotCreateLocaleInLockedResource(string state)
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK, "{\"data\":[{\"type\":\"appInfos\",\"id\":\"locked\",\"attributes\":{\"state\":\"" + state + "\"}}]}"),
+            new SequenceResponse(HttpStatusCode.OK, """{"data":[]}"""));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => new AppStoreConnectAppInfoMetadataSyncService(client).SyncAsync(new()
+        {
+            Spec = new() { AppId = "app-1", Locale = "pl", Metadata = new() { Name = "Smart Home" } }
+        }));
+        Assert.All(handler.Methods, method => Assert.Equal(HttpMethod.Get, method));
+    }
+
+    private static AppStoreConnectVersionMetadataSpec VersionListing(string locale, string description)
+        => new() { AppId = "app-1", Locale = locale, UseReleaseVersion = true, Metadata = new() { Description = description } };
+}

--- a/PowerForge.Tests/AppStoreConnectClientTests.LocalizationCreation.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.LocalizationCreation.cs
@@ -77,10 +77,15 @@ public sealed partial class AppStoreConnectClientTests
         Assert.Empty(handler.Methods);
     }
 
-    [Fact]
-    public async Task AppInfoSync_CreatesMissingEditableLocaleBesideReleasedRecord_ThenConverges()
+    [Theory]
+    [InlineData("READY_FOR_SALE")]
+    [InlineData("READY_FOR_DISTRIBUTION")]
+    [InlineData("REMOVED_FROM_SALE")]
+    [InlineData("DEVELOPER_REMOVED_FROM_SALE")]
+    [InlineData("REPLACED_WITH_NEW_VERSION")]
+    public async Task AppInfoSync_CreatesMissingEditableLocaleBesideReleasedRecord_ThenConverges(string state)
     {
-        const string infos = """{"data":[{"type":"appInfos","id":"live","attributes":{"state":"READY_FOR_DISTRIBUTION"}},{"type":"appInfos","id":"editable","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}""";
+        var infos = """{"data":[{"type":"appInfos","id":"live","attributes":{"state":"STATE"}},{"type":"appInfos","id":"editable","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}""".Replace("STATE", state);
         const string localization = """{"type":"appInfoLocalizations","id":"info-pl","attributes":{"locale":"pl","name":"Smart Home","subtitle":"Sterowanie"}}""";
         var handler = new SequenceHandler(
             new SequenceResponse(HttpStatusCode.OK, infos),
@@ -121,6 +126,9 @@ public sealed partial class AppStoreConnectClientTests
 
     [Theory]
     [InlineData("READY_FOR_DISTRIBUTION")]
+    [InlineData("REMOVED_FROM_SALE")]
+    [InlineData("DEVELOPER_REMOVED_FROM_SALE")]
+    [InlineData("REPLACED_WITH_NEW_VERSION")]
     [InlineData("IN_REVIEW")]
     public async Task AppInfoSync_DoesNotCreateLocaleInLockedResource(string state)
     {

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.VersionMetadata.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.VersionMetadata.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class PowerForgeReleaseServiceTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Execute_AppleMetadata_ResolvesEveryLocaleAndRejectsDuplicates(bool duplicate)
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Sample.xcodeproj", "1.2.0", "9");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var locales = new[] { "en-US", "pl", "de-DE", "es-ES", "fr-FR", "it", "nl-NL", "sv", "da", "no", "cs", "pt-BR" };
+            var paths = new List<string>();
+            foreach (var platform in new[] { ApplePlatform.iOS, ApplePlatform.macOS })
+            {
+                foreach (var locale in locales)
+                {
+                    var filename = $"metadata-{platform}-{locale}.json";
+                    paths.Add(filename);
+                    File.WriteAllText(Path.Combine(root, filename), JsonSerializer.Serialize(new AppStoreConnectVersionMetadataSpec
+                    {
+                        AppId = "1234567890", Platform = platform, UseReleaseVersion = true,
+                        Locale = duplicate && locale == "pl" ? " EN-us " : locale,
+                        Metadata = new() { Description = $"Description: {platform}/{locale}" }
+                    }));
+                }
+            }
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Apps[0].Name = "iOS";
+            spec.AppleApps.Apps[0].ProjectPath = "Sample.xcodeproj";
+            spec.AppleApps.Apps[0].Scheme = "Sample";
+            spec.AppleApps.Apps[0].AppStoreConnectAppId = "1234567890";
+            spec.AppleApps.Apps[0].BundleId = "com.example.smart-home";
+            spec.AppleApps.Archive = false;
+            spec.AppleApps.SyncMetadata = true;
+            spec.AppleApps.MetadataConfigPaths = paths.ToArray();
+            spec.AppleApps.Apps = new[]
+            {
+                spec.AppleApps.Apps[0],
+                new AppleAppConfiguration
+                {
+                    Name = "Mac", BundleId = "com.example.smart-home", Platform = ApplePlatform.macOS,
+                    ProjectPath = "Sample.xcodeproj", Scheme = "Sample", AppStoreConnectAppId = "1234567890"
+                }
+            };
+            var requests = new List<AppStoreConnectReleasePreparationRequest>();
+            var service = CreateAppleAutomationService(
+                request => CreateReleaseState(request, "VALID"),
+                prepareAppleDistribution: request =>
+                {
+                    requests.Add(request);
+                    return CreateSuccessfulPreparation(request);
+                });
+            var result = service.Execute(spec, new PowerForgeReleaseRequest
+            {
+                ConfigPath = Path.Combine(root, "powerforge.release.json")
+            });
+
+            if (duplicate)
+            {
+                Assert.False(result.Success);
+                Assert.Empty(requests);
+                Assert.Contains("Multiple App Store metadata configs", result.AppleReceipt!.ErrorMessage);
+            }
+            else
+            {
+                Assert.True(result.Success, result.ErrorMessage ?? result.AppleReceipt?.ErrorMessage);
+                Assert.Equal(2, requests.Count);
+                foreach (var request in requests)
+                {
+                    Assert.Equal(locales, request.MetadataSpecs.Select(value => value.Locale));
+                    Assert.All(request.MetadataSpecs, value => Assert.Equal(request.Platform, value.Platform));
+                    Assert.Equal("1.2.0", request.VersionString);
+                }
+            }
+        }
+        finally { TryDelete(root); }
+    }
+}

--- a/PowerForge/Models/AppStoreConnectAppInfoMetadataModels.cs
+++ b/PowerForge/Models/AppStoreConnectAppInfoMetadataModels.cs
@@ -99,8 +99,11 @@ public sealed class AppStoreConnectAppInfoMetadataSyncResult
     /// <summary>Matched editable resource, or one locked resource retained after convergence was proven.</summary>
     public AppStoreConnectAppInformationInfo AppInfo { get; set; } = new();
 
-    /// <summary>Localization before the metadata update.</summary>
-    public AppStoreConnectAppInfoLocalizationInfo Before { get; set; } = new();
+    /// <summary>Localization before the metadata update; null when this sync created it.</summary>
+    public AppStoreConnectAppInfoLocalizationInfo? Before { get; set; }
+
+    /// <summary>Whether this sync created a previously missing localization.</summary>
+    public bool CreatedLocalization { get; set; }
 
     /// <summary>Localization after the metadata update.</summary>
     public AppStoreConnectAppInfoLocalizationInfo After { get; set; } = new();

--- a/PowerForge/Models/AppStoreConnectReleasePreparationModels.cs
+++ b/PowerForge/Models/AppStoreConnectReleasePreparationModels.cs
@@ -35,6 +35,9 @@ public sealed class AppStoreConnectReleasePreparationRequest
     /// <summary>Optional localized metadata sync configuration to run after the version exists.</summary>
     public AppStoreConnectVersionMetadataSpec? MetadataSpec { get; set; }
 
+    /// <summary>Additional localized version metadata configurations. Locale values must be unique across this array and MetadataSpec.</summary>
+    public AppStoreConnectVersionMetadataSpec[] MetadataSpecs { get; set; } = Array.Empty<AppStoreConnectVersionMetadataSpec>();
+
     /// <summary>App-level metadata sync configurations to apply once per app.</summary>
     public AppStoreConnectAppInfoMetadataSpec[] AppInfoMetadataSpecs { get; set; } = Array.Empty<AppStoreConnectAppInfoMetadataSpec>();
 
@@ -95,8 +98,11 @@ public sealed class AppStoreConnectReleasePreparationResult
     /// <summary>Screenshot sync result when screenshots were configured.</summary>
     public AppStoreConnectScreenshotSyncResult? Screenshots { get; set; }
 
-    /// <summary>Metadata sync result when metadata was configured.</summary>
+    /// <summary>First metadata sync result, retained for single-localization callers. MetadataResults contains every locale.</summary>
     public AppStoreConnectVersionMetadataSyncResult? Metadata { get; set; }
+
+    /// <summary>Version metadata sync results for every configured locale, in configuration order.</summary>
+    public AppStoreConnectVersionMetadataSyncResult[] MetadataResults { get; set; } = Array.Empty<AppStoreConnectVersionMetadataSyncResult>();
 
     /// <summary>App-level metadata sync results when App Information metadata was configured.</summary>
     public AppStoreConnectAppInfoMetadataSyncResult[] AppInfoMetadataResults { get; set; } = Array.Empty<AppStoreConnectAppInfoMetadataSyncResult>();

--- a/PowerForge/Models/AppStoreConnectVersionMetadataModels.cs
+++ b/PowerForge/Models/AppStoreConnectVersionMetadataModels.cs
@@ -69,8 +69,11 @@ public sealed class AppStoreConnectVersionMetadataSyncResult
     /// <summary>Matched App Store version.</summary>
     public AppStoreConnectVersionInfo Version { get; set; } = new();
 
-    /// <summary>Localization before the metadata update.</summary>
-    public AppStoreConnectVersionLocalizationInfo Before { get; set; } = new();
+    /// <summary>Localization before the metadata update; null when this sync created it.</summary>
+    public AppStoreConnectVersionLocalizationInfo? Before { get; set; }
+
+    /// <summary>Whether this sync created a previously missing localization.</summary>
+    public bool CreatedLocalization { get; set; }
 
     /// <summary>Localization after the metadata update.</summary>
     public AppStoreConnectVersionLocalizationInfo After { get; set; } = new();

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -474,6 +474,7 @@ internal sealed class PowerForgeAppleReleaseOptions
 
     public string? MetadataConfigPath { get; set; }
 
+    /// <summary>Version metadata files, with one file per app, platform, and locale.</summary>
     public string[] MetadataConfigPaths { get; set; } = Array.Empty<string>();
 
     public string? AppInfoConfigPath { get; set; }
@@ -631,6 +632,7 @@ internal sealed class PowerForgeAppleReleasePlan
 
     public string? MetadataConfigPath { get; set; }
 
+    /// <summary>Version metadata files, with one file per app, platform, and locale.</summary>
     public string[] MetadataConfigPaths { get; set; } = Array.Empty<string>();
 
     public string? AppInfoConfigPath { get; set; }

--- a/PowerForge/Services/AppStoreConnectAppInfoMetadataSyncService.cs
+++ b/PowerForge/Services/AppStoreConnectAppInfoMetadataSyncService.cs
@@ -124,7 +124,7 @@ public sealed class AppStoreConnectAppInfoMetadataSyncService
 
         var mismatched = appInfos
             .Where(appInfo => !IsEditable(appInfo))
-            // A previous live version is not the target of an editable version's new metadata.
+            // A previous released version is not the target of an editable version's new metadata.
             // Locked in-flight reviews still have to converge before shared changes proceed.
             .Where(appInfo => selected is null || !IsEditable(selected) || !IsReleased(appInfo))
             .Where(appInfo => localizations[appInfo.Id] is not { } current || GetChangedFields(current, spec.Metadata).Length > 0)
@@ -188,7 +188,10 @@ public sealed class AppStoreConnectAppInfoMetadataSyncService
     private static bool IsReleased(AppStoreConnectAppInformationInfo appInfo)
         => GetState(appInfo) is { } state &&
            (string.Equals(state, "READY_FOR_SALE", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(state, "READY_FOR_DISTRIBUTION", StringComparison.OrdinalIgnoreCase));
+            string.Equals(state, "READY_FOR_DISTRIBUTION", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(state, "REMOVED_FROM_SALE", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(state, "DEVELOPER_REMOVED_FROM_SALE", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(state, "REPLACED_WITH_NEW_VERSION", StringComparison.OrdinalIgnoreCase));
 
     private static string? GetState(AppStoreConnectAppInformationInfo appInfo)
         => string.IsNullOrWhiteSpace(appInfo.State) ? appInfo.AppStoreState : appInfo.State;

--- a/PowerForge/Services/AppStoreConnectAppInfoMetadataSyncService.cs
+++ b/PowerForge/Services/AppStoreConnectAppInfoMetadataSyncService.cs
@@ -28,7 +28,7 @@ public sealed class AppStoreConnectAppInfoMetadataSyncService
 
     /// <summary>
     /// Applies localized metadata to the editable App Information localization for an app,
-    /// or proves that every locked resource already matches without issuing a mutation.
+    /// creates the localization when missing, or proves convergence without mutating locked resources.
     /// </summary>
     public async Task<AppStoreConnectAppInfoMetadataSyncResult> SyncAsync(
         AppStoreConnectAppInfoMetadataSyncRequest request,
@@ -42,27 +42,32 @@ public sealed class AppStoreConnectAppInfoMetadataSyncService
         if (string.IsNullOrWhiteSpace(spec.Locale))
             throw new ArgumentException("Spec.Locale is required.", nameof(request));
 
+        if (spec.Metadata is null)
+            throw new ArgumentException("Spec.Metadata is required.", nameof(request));
+
         var appInfos = await _client.GetAppInfosAsync(spec.AppId, limit: 50, cancellationToken).ConfigureAwait(false);
         var appInfo = ResolveAppInfo(spec, appInfos);
         var localizations = await LoadAppInfoLocalizationsAsync(spec, appInfos, cancellationToken).ConfigureAwait(false);
-        AssertLockedAppInfoConverged(spec, appInfos, localizations);
-        if (appInfo is null)
-            return CreateConvergedResult(appInfos, localizations);
+        AssertLockedAppInfoConverged(spec, appInfos, localizations, appInfo);
+        if (appInfo is null || !IsEditable(appInfo))
+            return CreateConvergedResult(appInfo ?? appInfos[0], localizations);
 
         var localization = localizations[appInfo.Id];
 
-        var updatedFields = GetChangedFields(localization, spec.Metadata);
-        var updated = updatedFields.Length == 0
-            ? localization
-            : await _client.UpdateAppInfoLocalizationAsync(
-                localization.Id,
-                spec.Metadata,
-                cancellationToken).ConfigureAwait(false);
+        var updatedFields = localization is null
+            ? AppStoreConnectClient.GetSuppliedAppInfoLocalizationFields(spec.Metadata)
+            : GetChangedFields(localization, spec.Metadata);
+        var updated = localization is null
+            ? await _client.CreateAppInfoLocalizationAsync(appInfo.Id, spec.Locale, spec.Metadata, cancellationToken).ConfigureAwait(false)
+            : updatedFields.Length == 0
+                ? localization
+                : await _client.UpdateAppInfoLocalizationAsync(localization.Id, spec.Metadata, cancellationToken).ConfigureAwait(false);
 
         return new AppStoreConnectAppInfoMetadataSyncResult
         {
             AppInfo = appInfo,
             Before = localization,
+            CreatedLocalization = localization is null,
             After = updated,
             UpdatedFields = updatedFields
         };
@@ -88,12 +93,12 @@ public sealed class AppStoreConnectAppInfoMetadataSyncService
         return null;
     }
 
-    private async Task<Dictionary<string, AppStoreConnectAppInfoLocalizationInfo>> LoadAppInfoLocalizationsAsync(
+    private async Task<Dictionary<string, AppStoreConnectAppInfoLocalizationInfo?>> LoadAppInfoLocalizationsAsync(
         AppStoreConnectAppInfoMetadataSpec spec,
         AppStoreConnectAppInformationInfo[] appInfos,
         CancellationToken cancellationToken)
     {
-        var localizations = new Dictionary<string, AppStoreConnectAppInfoLocalizationInfo>(StringComparer.OrdinalIgnoreCase);
+        var localizations = new Dictionary<string, AppStoreConnectAppInfoLocalizationInfo?>(StringComparer.OrdinalIgnoreCase);
         foreach (var appInfo in appInfos)
         {
             var localization = (await _client.GetAppInfoLocalizationsAsync(
@@ -103,11 +108,6 @@ public sealed class AppStoreConnectAppInfoMetadataSyncService
                     cancellationToken)
                 .ConfigureAwait(false))
                 .FirstOrDefault();
-            if (localization is null)
-            {
-                throw new InvalidOperationException(
-                    $"App Information localization '{spec.Locale}' was not found for resource '{appInfo.Id}'.");
-            }
             localizations.Add(appInfo.Id, localization);
         }
         return localizations;
@@ -116,25 +116,29 @@ public sealed class AppStoreConnectAppInfoMetadataSyncService
     private static void AssertLockedAppInfoConverged(
         AppStoreConnectAppInfoMetadataSpec spec,
         AppStoreConnectAppInformationInfo[] appInfos,
-        IReadOnlyDictionary<string, AppStoreConnectAppInfoLocalizationInfo> localizations)
+        IReadOnlyDictionary<string, AppStoreConnectAppInfoLocalizationInfo?> localizations,
+        AppStoreConnectAppInformationInfo? selected)
     {
         if (appInfos.Length == 0)
             throw CreateNoEditableAppInfoException(spec.AppId, appInfos);
 
         var mismatched = appInfos
             .Where(appInfo => !IsEditable(appInfo))
-            .Where(appInfo => GetChangedFields(localizations[appInfo.Id], spec.Metadata).Length > 0)
+            // A previous live version is not the target of an editable version's new metadata.
+            // Locked in-flight reviews still have to converge before shared changes proceed.
+            .Where(appInfo => selected is null || !IsEditable(selected) || !IsReleased(appInfo))
+            .Where(appInfo => localizations[appInfo.Id] is not { } current || GetChangedFields(current, spec.Metadata).Length > 0)
             .ToArray();
         if (mismatched.Length > 0)
             throw CreateNoEditableAppInfoException(spec.AppId, appInfos);
     }
 
     private static AppStoreConnectAppInfoMetadataSyncResult CreateConvergedResult(
-        AppStoreConnectAppInformationInfo[] appInfos,
-        IReadOnlyDictionary<string, AppStoreConnectAppInfoLocalizationInfo> localizations)
+        AppStoreConnectAppInformationInfo retained,
+        IReadOnlyDictionary<string, AppStoreConnectAppInfoLocalizationInfo?> localizations)
     {
-        var retained = appInfos[0];
-        var localization = localizations[retained.Id];
+        var localization = localizations[retained.Id]
+            ?? throw new InvalidOperationException("The retained App Information localization is missing.");
         return new AppStoreConnectAppInfoMetadataSyncResult
         {
             AppInfo = retained,
@@ -153,7 +157,7 @@ public sealed class AppStoreConnectAppInfoMetadataSyncService
             ? "none"
             : string.Join(", ", appInfos.Select(info => GetState(info) ?? "unknown"));
         return new InvalidOperationException(
-            $"App Information metadata cannot converge for app '{appId}' because one or more locked resources do not already match the requested metadata. Current states: {states}. Align the locked resources before applying shared App Information changes.");
+            $"App Information metadata cannot converge for app '{appId}' because one or more locked resources do not already match the requested metadata. Current states: {states}. Create an editable App Store version, or wait for in-review resources to settle, before applying shared App Information changes.");
     }
 
     private static string[] GetChangedFields(
@@ -180,6 +184,11 @@ public sealed class AppStoreConnectAppInfoMetadataSyncService
         var state = GetState(appInfo);
         return state is not null && EditableStates.Contains(state);
     }
+
+    private static bool IsReleased(AppStoreConnectAppInformationInfo appInfo)
+        => GetState(appInfo) is { } state &&
+           (string.Equals(state, "READY_FOR_SALE", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(state, "READY_FOR_DISTRIBUTION", StringComparison.OrdinalIgnoreCase));
 
     private static string? GetState(AppStoreConnectAppInformationInfo appInfo)
         => string.IsNullOrWhiteSpace(appInfo.State) ? appInfo.AppStoreState : appInfo.State;

--- a/PowerForge/Services/AppStoreConnectClient.AppInfoMetadata.cs
+++ b/PowerForge/Services/AppStoreConnectClient.AppInfoMetadata.cs
@@ -94,6 +94,46 @@ public sealed partial class AppStoreConnectClient
         return ParseAppInfoLocalization(data);
     }
 
+    /// <summary>
+    /// Creates a localization under the specified App Information resource.
+    /// Only supplied metadata fields are sent; the locale identifies the new localization.
+    /// </summary>
+    public async Task<AppStoreConnectAppInfoLocalizationInfo> CreateAppInfoLocalizationAsync(
+        string parentId,
+        string locale,
+        AppStoreConnectAppInfoLocalizationUpdate metadata,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(parentId))
+            throw new ArgumentException("Parent resource id is required.", nameof(parentId));
+        if (string.IsNullOrWhiteSpace(locale))
+            throw new ArgumentException("Locale is required.", nameof(locale));
+        if (metadata is null)
+            throw new ArgumentNullException(nameof(metadata));
+        if (string.IsNullOrWhiteSpace(metadata.Name))
+            throw new ArgumentException("A localized app name is required to create App Information localization.", nameof(metadata));
+
+        var attributes = BuildAppInfoLocalizationAttributes(metadata);
+        attributes.Add("locale", locale.Trim());
+        var body = new
+        {
+            data = new
+            {
+                type = "appInfoLocalizations",
+                attributes,
+                relationships = new
+                {
+                    appInfo = new { data = new { type = "appInfos", id = parentId.Trim() } }
+                }
+            }
+        };
+        using var doc = await SendJsonAsync(HttpMethod.Post, "appInfoLocalizations", body, cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("App Store Connect API request returned no response body.");
+        if (!doc.RootElement.TryGetProperty("data", out var data) || data.ValueKind == JsonValueKind.Null)
+            throw new InvalidOperationException("App Store Connect API request returned no data.");
+        return ParseAppInfoLocalization(data);
+    }
+
     internal static string[] GetSuppliedAppInfoLocalizationFields(AppStoreConnectAppInfoLocalizationUpdate update)
         => BuildAppInfoLocalizationAttributes(update).Keys.ToArray();
 

--- a/PowerForge/Services/AppStoreConnectClient.VersionMetadata.cs
+++ b/PowerForge/Services/AppStoreConnectClient.VersionMetadata.cs
@@ -45,6 +45,44 @@ public sealed partial class AppStoreConnectClient
         return ParseVersionLocalization(data);
     }
 
+    /// <summary>
+    /// Creates a localization under the specified App Store version resource.
+    /// Only supplied metadata fields are sent; the locale identifies the new localization.
+    /// </summary>
+    public async Task<AppStoreConnectVersionLocalizationInfo> CreateVersionLocalizationAsync(
+        string parentId,
+        string locale,
+        AppStoreConnectVersionLocalizationUpdate metadata,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(parentId))
+            throw new ArgumentException("Parent resource id is required.", nameof(parentId));
+        if (string.IsNullOrWhiteSpace(locale))
+            throw new ArgumentException("Locale is required.", nameof(locale));
+        if (metadata is null)
+            throw new ArgumentNullException(nameof(metadata));
+
+        var attributes = BuildLocalizationAttributes(metadata);
+        attributes.Add("locale", locale.Trim());
+        var body = new
+        {
+            data = new
+            {
+                type = "appStoreVersionLocalizations",
+                attributes,
+                relationships = new
+                {
+                    appStoreVersion = new { data = new { type = "appStoreVersions", id = parentId.Trim() } }
+                }
+            }
+        };
+        using var doc = await SendJsonAsync(HttpMethod.Post, "appStoreVersionLocalizations", body, cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("App Store Connect API request returned no response body.");
+        if (!doc.RootElement.TryGetProperty("data", out var data) || data.ValueKind == JsonValueKind.Null)
+            throw new InvalidOperationException("App Store Connect API request returned no data.");
+        return ParseVersionLocalization(data);
+    }
+
     internal static string[] GetSuppliedLocalizationFields(AppStoreConnectVersionLocalizationUpdate update)
         => BuildLocalizationAttributes(update).Keys.ToArray();
 

--- a/PowerForge/Services/AppStoreConnectReleasePreparationService.Metadata.cs
+++ b/PowerForge/Services/AppStoreConnectReleasePreparationService.Metadata.cs
@@ -1,0 +1,55 @@
+namespace PowerForge;
+
+public sealed partial class AppStoreConnectReleasePreparationService
+{
+    private static AppStoreConnectVersionMetadataSpec[] ResolveMetadataSpecs(AppStoreConnectReleasePreparationRequest request)
+    {
+        var specs = new List<AppStoreConnectVersionMetadataSpec>();
+        if (request.MetadataSpec is not null)
+            specs.Add(request.MetadataSpec);
+        specs.AddRange(request.MetadataSpecs ?? Array.Empty<AppStoreConnectVersionMetadataSpec>());
+        var locales = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var spec in specs)
+        {
+            if (spec is null || string.IsNullOrWhiteSpace(spec.Locale) || spec.Metadata is null)
+                throw new ArgumentException("Every metadata spec must declare a locale and metadata object.", nameof(request));
+            if (!locales.Add(spec.Locale.Trim()))
+                throw new ArgumentException($"Multiple metadata specs declare locale '{spec.Locale.Trim()}'.", nameof(request));
+            if (AppStoreConnectClient.GetSuppliedLocalizationFields(spec.Metadata).Length == 0)
+                throw new ArgumentException("Every metadata spec must supply at least one metadata field.", nameof(request));
+            // Validate every target before any version creation or build selection can mutate Apple.
+            CreateMetadataSpecForVersion(spec, request.AppId.Trim(), request.VersionString?.Trim() ?? string.Empty, request.Platform, string.Empty);
+        }
+        return specs.ToArray();
+    }
+
+    private static AppStoreConnectVersionMetadataSpec CreateMetadataSpecForVersion(
+        AppStoreConnectVersionMetadataSpec source,
+        string appId,
+        string versionString,
+        ApplePlatform platform,
+        string versionId)
+    {
+        if (!string.IsNullOrWhiteSpace(source.AppId) &&
+            !string.Equals(source.AppId.Trim(), appId, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Metadata config AppId '{source.AppId}' does not match release app id '{appId}'.");
+        var sourceVersionString = string.IsNullOrWhiteSpace(source.VersionString) ? null : source.VersionString!.Trim();
+        if (sourceVersionString is not null &&
+            !string.Equals(sourceVersionString, versionString, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Metadata config VersionString '{source.VersionString}' does not match release version '{versionString}'.");
+        if (source.Platform != platform)
+            throw new InvalidOperationException($"Metadata config Platform '{source.Platform}' does not match release platform '{platform}'.");
+
+        return new AppStoreConnectVersionMetadataSpec
+        {
+            AppId = appId,
+            VersionString = versionString,
+            VersionId = versionId,
+            UseReleaseVersion = false,
+            Platform = platform,
+            Locale = source.Locale.Trim(),
+            Metadata = source.Metadata
+        };
+    }
+
+}

--- a/PowerForge/Services/AppStoreConnectReleasePreparationService.cs
+++ b/PowerForge/Services/AppStoreConnectReleasePreparationService.cs
@@ -3,7 +3,7 @@ namespace PowerForge;
 /// <summary>
 /// Prepares App Store Connect Distribution metadata for an uploaded Apple app build.
 /// </summary>
-public sealed class AppStoreConnectReleasePreparationService
+public sealed partial class AppStoreConnectReleasePreparationService
 {
     private readonly AppStoreConnectClient _client;
 
@@ -27,9 +27,10 @@ public sealed class AppStoreConnectReleasePreparationService
             throw new ArgumentNullException(nameof(request));
         if (string.IsNullOrWhiteSpace(request.AppId))
             throw new ArgumentException("AppId is required.", nameof(request));
+        var metadataSpecs = ResolveMetadataSpecs(request);
         var requiresVersion = request.CreateVersion ||
                               request.SelectBuild ||
-                              request.MetadataSpec is not null ||
+                              metadataSpecs.Length > 0 ||
                               request.ScreenshotSpec is not null ||
                               request.CheckReadiness;
         if (requiresVersion && string.IsNullOrWhiteSpace(request.VersionString))
@@ -166,15 +167,15 @@ public sealed class AppStoreConnectReleasePreparationService
             }
         }
 
-        AppStoreConnectVersionMetadataSyncResult? metadata = null;
-        if (request.MetadataSpec is not null)
+        var metadataResults = new List<AppStoreConnectVersionMetadataSyncResult>();
+        foreach (var sourceSpec in metadataSpecs)
         {
             await AuthorizeFirstRemoteMutationAsync().ConfigureAwait(false);
-            var metadataSpec = CreateMetadataSpecForVersion(request.MetadataSpec, appId, versionString, request.Platform, version!.Id);
-            metadata = await new AppStoreConnectVersionMetadataSyncService(_client).SyncAsync(
+            var metadataSpec = CreateMetadataSpecForVersion(sourceSpec, appId, versionString, request.Platform, version!.Id);
+            metadataResults.Add(await new AppStoreConnectVersionMetadataSyncService(_client).SyncAsync(
                 new AppStoreConnectVersionMetadataSyncRequest { Spec = metadataSpec },
-                cancellationToken).ConfigureAwait(false);
-            messages.Add("Synchronized App Store version metadata.");
+                cancellationToken).ConfigureAwait(false));
+            messages.Add($"Synchronized App Store version metadata for locale '{metadataSpec.Locale}'.");
         }
 
         var appInfoMetadataResults = new List<AppStoreConnectAppInfoMetadataSyncResult>();
@@ -239,7 +240,8 @@ public sealed class AppStoreConnectReleasePreparationService
             SelectedBuild = selectedBuild,
             PreviousBuildId = previousBuildId,
             Screenshots = screenshots,
-            Metadata = metadata,
+            Metadata = metadataResults.FirstOrDefault(),
+            MetadataResults = metadataResults.ToArray(),
             AppInfoMetadataResults = appInfoMetadataResults.ToArray(),
             Readiness = readiness,
             Messages = messages.ToArray()
@@ -253,6 +255,7 @@ public sealed class AppStoreConnectReleasePreparationService
                 request.ScreenshotSpec?.VersionId,
                 request.MetadataSpec?.VersionId
             }
+            .Concat((request.MetadataSpecs ?? Array.Empty<AppStoreConnectVersionMetadataSpec>()).Select(static spec => spec.VersionId))
             .Where(static value => !string.IsNullOrWhiteSpace(value))
             .Select(static value => value!.Trim())
             .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -302,35 +305,6 @@ public sealed class AppStoreConnectReleasePreparationService
         };
     }
 
-    private static AppStoreConnectVersionMetadataSpec CreateMetadataSpecForVersion(
-        AppStoreConnectVersionMetadataSpec source,
-        string appId,
-        string versionString,
-        ApplePlatform platform,
-        string versionId)
-    {
-        if (!string.IsNullOrWhiteSpace(source.AppId) &&
-            !string.Equals(source.AppId.Trim(), appId, StringComparison.OrdinalIgnoreCase))
-            throw new InvalidOperationException($"Metadata config AppId '{source.AppId}' does not match release app id '{appId}'.");
-        var sourceVersionString = string.IsNullOrWhiteSpace(source.VersionString) ? null : source.VersionString!.Trim();
-        if (sourceVersionString is not null &&
-            !string.Equals(sourceVersionString, versionString, StringComparison.OrdinalIgnoreCase))
-            throw new InvalidOperationException($"Metadata config VersionString '{source.VersionString}' does not match release version '{versionString}'.");
-        if (source.Platform != platform)
-            throw new InvalidOperationException($"Metadata config Platform '{source.Platform}' does not match release platform '{platform}'.");
-
-        return new AppStoreConnectVersionMetadataSpec
-        {
-            AppId = appId,
-            VersionString = versionString,
-            VersionId = versionId,
-            UseReleaseVersion = false,
-            Platform = platform,
-            Locale = source.Locale,
-            Metadata = source.Metadata
-        };
-    }
-
     private static AppStoreConnectAppInfoMetadataSpec CreateAppInfoMetadataSpec(
         AppStoreConnectAppInfoMetadataSpec source,
         string appId)
@@ -343,7 +317,7 @@ public sealed class AppStoreConnectReleasePreparationService
         {
             AppId = appId,
             AppInfoId = source.AppInfoId,
-            Locale = source.Locale,
+            Locale = source.Locale.Trim(),
             Metadata = source.Metadata
         };
     }

--- a/PowerForge/Services/AppStoreConnectVersionMetadataSyncService.cs
+++ b/PowerForge/Services/AppStoreConnectVersionMetadataSyncService.cs
@@ -36,23 +36,25 @@ public sealed class AppStoreConnectVersionMetadataSyncService
         if (string.IsNullOrWhiteSpace(spec.Locale))
             throw new ArgumentException("Spec.Locale is required.", nameof(request));
 
+        if (spec.Metadata is null || AppStoreConnectClient.GetSuppliedLocalizationFields(spec.Metadata).Length == 0)
+            throw new ArgumentException("Spec.Metadata must supply at least one metadata field.", nameof(request));
+
         var version = await ResolveVersionAsync(spec, cancellationToken).ConfigureAwait(false);
         var localization = (await _client.GetVersionLocalizationsAsync(
             version.Id,
             spec.Locale,
             limit: 10,
-            cancellationToken).ConfigureAwait(false)).FirstOrDefault()
-            ?? throw new InvalidOperationException($"Localization '{spec.Locale}' was not found for App Store version '{version.Id}'.");
+            cancellationToken).ConfigureAwait(false)).FirstOrDefault();
 
-        var updated = await _client.UpdateVersionLocalizationAsync(
-            localization.Id,
-            spec.Metadata,
-            cancellationToken).ConfigureAwait(false);
+        var updated = localization is null
+            ? await _client.CreateVersionLocalizationAsync(version.Id, spec.Locale, spec.Metadata, cancellationToken).ConfigureAwait(false)
+            : await _client.UpdateVersionLocalizationAsync(localization.Id, spec.Metadata, cancellationToken).ConfigureAwait(false);
 
         return new AppStoreConnectVersionMetadataSyncResult
         {
             Version = version,
             Before = localization,
+            CreatedLocalization = localization is null,
             After = updated,
             UpdatedFields = AppStoreConnectClient.GetSuppliedLocalizationFields(spec.Metadata)
         };

--- a/PowerForge/Services/PowerForgeReleaseService.AppInfoMetadata.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppInfoMetadata.cs
@@ -17,7 +17,7 @@ internal sealed partial class PowerForgeReleaseService
         foreach (var spec in requested)
         {
             var result = observed.SingleOrDefault(value =>
-                string.Equals(value.After.Locale, spec.Locale, StringComparison.OrdinalIgnoreCase));
+                string.Equals(value.After.Locale, spec.Locale.Trim(), StringComparison.OrdinalIgnoreCase));
             if (result is null ||
                 string.IsNullOrWhiteSpace(result.AppInfo.Id) ||
                 string.IsNullOrWhiteSpace(result.After.Id))

--- a/PowerForge/Services/PowerForgeReleaseService.VersionMetadata.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.VersionMetadata.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+
+namespace PowerForge;
+
+internal sealed partial class PowerForgeReleaseService
+{
+    private static (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)[] LoadAppleMetadataSpecs(PowerForgeAppleReleasePlan plan)
+    {
+        var paths = new List<string>();
+        if (!string.IsNullOrWhiteSpace(plan.MetadataConfigPath))
+            paths.Add(plan.MetadataConfigPath!);
+        paths.AddRange(plan.MetadataConfigPaths.Where(static path => !string.IsNullOrWhiteSpace(path)));
+
+        return paths
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(path =>
+            {
+                var json = ReadApprovedMutationInputText(plan, path);
+                var spec = JsonSerializer.Deserialize<AppStoreConnectVersionMetadataSpec>(json, CreateJsonOptions())
+                    ?? throw new InvalidOperationException($"Unable to deserialize App Store version metadata config: {path}");
+                return (spec, path);
+            })
+            .ToArray();
+    }
+
+    private static void ValidateAppleMetadataPreflight(
+        (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath) configured)
+    {
+        if (string.IsNullOrWhiteSpace(configured.Spec.Locale))
+        {
+            throw new InvalidOperationException(
+                $"App Store version metadata config must declare Locale: {configured.ConfigPath}");
+        }
+        if (configured.Spec.Metadata is null)
+        {
+            throw new InvalidOperationException(
+                $"App Store version metadata config must declare a Metadata object: {configured.ConfigPath}");
+        }
+    }
+
+    private static (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)[] ResolveMatchingMetadataSpecs(
+        (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)[] specs,
+        PowerForgeAppleAppReleaseTargetPlan app,
+        string marketingVersion,
+        bool required = false)
+    {
+        var matches = specs
+            .Where(candidate => MetadataSpecMatches(candidate.Spec, app, marketingVersion))
+            .ToArray();
+        var duplicateLocale = matches.GroupBy(candidate => candidate.Spec.Locale?.Trim() ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(group => group.Count() > 1);
+        if (duplicateLocale is not null)
+            throw new InvalidOperationException($"Multiple App Store metadata configs match Apple app '{app.Name}' version '{marketingVersion}' platform '{app.Platform}' locale '{duplicateLocale.Key}'.");
+        if (matches.Length == 0 && required)
+        {
+            throw new InvalidOperationException(
+                $"No App Store metadata config matches Apple app '{app.Name}' " +
+                $"(AppStoreConnectAppId '{app.AppStoreConnectAppId}', platform '{app.Platform}', version '{marketingVersion}').");
+        }
+
+        return matches;
+    }
+
+    private static bool MetadataSpecMatches(
+        AppStoreConnectVersionMetadataSpec spec,
+        PowerForgeAppleAppReleaseTargetPlan app,
+        string marketingVersion)
+    {
+        var appIdMatches = string.IsNullOrWhiteSpace(spec.AppId) ||
+                           string.Equals(spec.AppId.Trim(), app.AppStoreConnectAppId, StringComparison.OrdinalIgnoreCase);
+        var specVersionString = string.IsNullOrWhiteSpace(spec.VersionString) ? null : spec.VersionString!.Trim();
+        var versionMatches = (spec.UseReleaseVersion && specVersionString is null) ||
+                             string.Equals(specVersionString, marketingVersion, StringComparison.OrdinalIgnoreCase);
+        return appIdMatches && versionMatches && spec.Platform == app.Platform;
+    }
+}

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -2312,7 +2312,7 @@ internal sealed partial class PowerForgeReleaseService
             (AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)?>();
         var metadataByApp = new Dictionary<
             PowerForgeAppleAppReleaseTargetPlan,
-            (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)?>();
+            (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)[]>();
         var resumedByApp = new Dictionary<PowerForgeAppleAppReleaseTargetPlan, bool>();
         var governancePlansByAppId = new Dictionary<string, AppStoreConnectGovernancePlan>(StringComparer.OrdinalIgnoreCase);
         var preflightAttempted = new HashSet<PowerForgeAppleAppReleaseTargetPlan>();
@@ -2420,18 +2420,18 @@ internal sealed partial class PowerForgeReleaseService
                 if (plan.SyncScreenshots && matchingScreenshotSpec is not null)
                     ValidateAppleScreenshotPreflight(matchingScreenshotSpec.Value, plan.SourceCommit);
 
-                var matchingMetadataSpec = plan.SyncMetadata &&
+                var matchingMetadataSpecs = plan.SyncMetadata &&
                                            ShouldRunAppleShipAppStoreStep(plan, app) &&
                                            app.DistributionRoute == AppleDistributionRoute.AppStore
-                    ? ResolveMatchingMetadataSpec(
+                    ? ResolveMatchingMetadataSpecs(
                         metadataSpecs,
                         app,
                         valuesByApp[app].MarketingVersion,
                         required: true)
-                    : null;
-                metadataByApp[app] = matchingMetadataSpec;
-                if (matchingMetadataSpec is not null)
-                    ValidateAppleMetadataPreflight(matchingMetadataSpec.Value);
+                    : Array.Empty<(AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)>();
+                metadataByApp[app] = matchingMetadataSpecs;
+                foreach (var matchingMetadataSpec in matchingMetadataSpecs)
+                    ValidateAppleMetadataPreflight(matchingMetadataSpec);
 
                 if (plan.CheckGovernance &&
                     UsesAppStoreConnect(app) &&
@@ -2750,7 +2750,7 @@ internal sealed partial class PowerForgeReleaseService
                     ? valuesByApp[app]
                     : (MarketingVersion: string.Empty, BuildNumber: string.Empty);
                 var matchingScreenshotSpec = screenshotsByApp[app];
-                var matchingMetadataSpec = metadataByApp[app];
+                var matchingMetadataSpecs = metadataByApp[app];
                 result.Distribution = _prepareAppleDistribution(new AppStoreConnectReleasePreparationRequest
                 {
                     Credential = CreateAppStoreConnectCredential(plan),
@@ -2762,7 +2762,7 @@ internal sealed partial class PowerForgeReleaseService
                     SelectBuild = plan.PrepareDistribution && plan.SelectBuildForDistribution,
                     RequireValidBuild = !plan.AllowUnprocessedDistributionBuild,
                     ScreenshotSpec = plan.SyncScreenshots ? matchingScreenshotSpec?.Spec : null,
-                    MetadataSpec = matchingMetadataSpec?.Spec,
+                    MetadataSpecs = matchingMetadataSpecs.Select(static value => value.Spec).ToArray(),
                     AppInfoMetadataSpecs = appInfoMetadataSpecs,
                     ReplaceScreenshots = plan.ReplaceScreenshots,
                     ExpectedSourceCommit = plan.SourceCommit,
@@ -2783,9 +2783,7 @@ internal sealed partial class PowerForgeReleaseService
                         }
                         : null,
                     BaseDirectory = matchingScreenshotSpec is null
-                        ? matchingMetadataSpec is null
-                            ? plan.ProjectRoot
-                            : Path.GetDirectoryName(matchingMetadataSpec.Value.ConfigPath) ?? plan.ProjectRoot
+                        ? plan.ProjectRoot
                         : Path.GetDirectoryName(matchingScreenshotSpec.Value.ConfigPath) ?? plan.ProjectRoot
                 });
                 if (appInfoMetadataSpecs.Length > 0)
@@ -3127,25 +3125,6 @@ internal sealed partial class PowerForgeReleaseService
             .ToArray();
     }
 
-    private static (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)[] LoadAppleMetadataSpecs(PowerForgeAppleReleasePlan plan)
-    {
-        var paths = new List<string>();
-        if (!string.IsNullOrWhiteSpace(plan.MetadataConfigPath))
-            paths.Add(plan.MetadataConfigPath!);
-        paths.AddRange(plan.MetadataConfigPaths.Where(static path => !string.IsNullOrWhiteSpace(path)));
-
-        return paths
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .Select(path =>
-            {
-                var json = ReadApprovedMutationInputText(plan, path);
-                var spec = JsonSerializer.Deserialize<AppStoreConnectVersionMetadataSpec>(json, CreateJsonOptions())
-                    ?? throw new InvalidOperationException($"Unable to deserialize App Store version metadata config: {path}");
-                return (spec, path);
-            })
-            .ToArray();
-    }
-
     private static Dictionary<string, AppStoreConnectGovernanceSpec> LoadAppleGovernanceSpecs(PowerForgeAppleReleasePlan plan)
     {
         var paths = new List<string>();
@@ -3182,21 +3161,6 @@ internal sealed partial class PowerForgeReleaseService
             .Distinct(StringComparer.OrdinalIgnoreCase);
         throw new InvalidOperationException(
             $"Screenshot preflight failed for '{configured.ConfigPath}': {string.Join(" ", messages)}");
-    }
-
-    private static void ValidateAppleMetadataPreflight(
-        (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath) configured)
-    {
-        if (string.IsNullOrWhiteSpace(configured.Spec.Locale))
-        {
-            throw new InvalidOperationException(
-                $"App Store version metadata config must declare Locale: {configured.ConfigPath}");
-        }
-        if (configured.Spec.Metadata is null)
-        {
-            throw new InvalidOperationException(
-                $"App Store version metadata config must declare a Metadata object: {configured.ConfigPath}");
-        }
     }
 
     private static (AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)? ResolveMatchingScreenshotSpec(
@@ -3249,40 +3213,6 @@ internal sealed partial class PowerForgeReleaseService
             ScreenshotSets = source.ScreenshotSets,
             Quality = source.Quality
         };
-
-    private static (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)? ResolveMatchingMetadataSpec(
-        (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)[] specs,
-        PowerForgeAppleAppReleaseTargetPlan app,
-        string marketingVersion,
-        bool required = false)
-    {
-        var matches = specs
-            .Where(candidate => MetadataSpecMatches(candidate.Spec, app, marketingVersion))
-            .ToArray();
-        if (matches.Length > 1)
-            throw new InvalidOperationException($"Multiple App Store metadata configs match Apple app '{app.Name}' version '{marketingVersion}' platform '{app.Platform}'.");
-        if (matches.Length == 0 && required)
-        {
-            throw new InvalidOperationException(
-                $"No App Store metadata config matches Apple app '{app.Name}' " +
-                $"(AppStoreConnectAppId '{app.AppStoreConnectAppId}', platform '{app.Platform}', version '{marketingVersion}').");
-        }
-
-        return matches.Length == 0 ? null : matches[0];
-    }
-
-    private static bool MetadataSpecMatches(
-        AppStoreConnectVersionMetadataSpec spec,
-        PowerForgeAppleAppReleaseTargetPlan app,
-        string marketingVersion)
-    {
-        var appIdMatches = string.IsNullOrWhiteSpace(spec.AppId) ||
-                           string.Equals(spec.AppId.Trim(), app.AppStoreConnectAppId, StringComparison.OrdinalIgnoreCase);
-        var specVersionString = string.IsNullOrWhiteSpace(spec.VersionString) ? null : spec.VersionString!.Trim();
-        var versionMatches = (spec.UseReleaseVersion && specVersionString is null) ||
-                             string.Equals(specVersionString, marketingVersion, StringComparison.OrdinalIgnoreCase);
-        return appIdMatches && versionMatches && spec.Platform == app.Platform;
-    }
 
     private static string NormalizeAppleArchiveProjectPath(string projectPath, string appName)
     {
@@ -5720,7 +5650,7 @@ internal sealed partial class PowerForgeReleaseService
                     result.Distribution.SelectedBuild,
                     result.Distribution.PreviousBuildId,
                     ScreenshotSetCount = result.Distribution.Screenshots?.ScreenshotSets.Length ?? 0,
-                    MetadataUpdatedFields = result.Distribution.Metadata?.UpdatedFields ?? Array.Empty<string>(),
+                    MetadataUpdatedFields = result.Distribution.MetadataResults.SelectMany(static value => value.UpdatedFields).Distinct(StringComparer.OrdinalIgnoreCase).ToArray(),
                     AppInfoMetadataUpdatedFields = result.Distribution.AppInfoMetadataResults
                         .SelectMany(metadata => metadata.UpdatedFields)
                         .Distinct(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
App Store release preparation previously rejected multiple version-metadata files for the same app/platform and failed when the requested localization did not exist. It now prepares every configured locale and creates missing version and App Information localizations through the Apple API.

`MetadataConfigPaths` supports one file per app/platform/locale, with duplicate locales and conflicting targets rejected before remote preparation. Results include every localization while preserving the single-result property for existing callers. A new `CreatedLocalization` flag distinguishes creation, with `Before = null` when there was no prior resource.

Editable App Information can receive a new title or language while an older live record retains its released metadata. Locked records still in review must converge, and locked-only records are never mutated. This enables a private downstream consumer to declare 12 listing languages for iOS and macOS; the shared change must be available before its release configuration adopts the new behavior.

Validation: 176 focused App Store client/app-information/release tests pass, including a 12-language two-platform batch, creation and repeat convergence, and rejection before remote work. The .NET Framework 4.7.2 build and .NET 8 module build pass. The wider selected suite passed 767 tests; its eight macOS temporary-path failures all passed when rerun using the physical `/private/tmp` path. A private consumer validates all 24 listings and the rebuilt CLI produces its read-only Prepare plan. Independent local review found no actionable issues. No live Apple mutation was performed.
