### PR TITLE
Check Apple metadata readiness independently of screenshot locales

### DIFF
--- a/Docs/PSPublishModule.AppleRelease.md
+++ b/Docs/PSPublishModule.AppleRelease.md
@@ -1116,6 +1116,22 @@ Direct .NET callers can supply `AppStoreConnectReleasePreparationRequest.Screens
 
 Readiness requests accept `ScreenshotSpecs` to check each locale's required display types. Combined readiness passes only when every configured locale passes, and screenshot set results identify their `Locale`. Missing localizations must be created by the version metadata synchronization before their screenshots can be uploaded.
 
+Metadata and screenshot coverage are independent. If `MetadataConfigPaths` lists 19 languages
+and `ScreenshotConfigPaths` maps only English screenshots, planning, preparation, and App Review
+submission check the metadata for all 19 languages. Screenshots are required only for the mapped
+English locale. No duplicate or relabeled screenshot mappings are needed for fallback languages.
+Readiness-only operations load the metadata locale configuration without synchronizing its text.
+The approved plan hashes every checked remote localization, so changing a secondary language's
+metadata invalidates that approval even when its screenshots fall back to English.
+
+Direct .NET callers can set `AppStoreConnectReleaseReadinessRequest.MetadataLocales` independently
+of `ScreenshotSpec` or `ScreenshotSpecs`. Metadata locales and screenshot mapping locales are
+checked together, with whitespace trimmed and duplicate locale identifiers checked once.
+Preparation also includes every locale from its applied `MetadataSpec` and `MetadataSpecs`.
+`Localizations` contains all found metadata records; a missing requested locale fails readiness.
+Without screenshot mappings, existing `RequiredScreenshotDisplayTypes` requirements still apply
+to `Locale` only. Set `RequireScreenshots = false` for a metadata-only check.
+
 ## Screenshot Upload Flow
 
 Screenshot upload uses App Store Connect's asset reservation flow:

--- a/PowerForge.Tests/AppStoreConnectClientTests.MetadataReadinessLocales.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.MetadataReadinessLocales.cs
@@ -13,7 +13,7 @@ public sealed partial class AppStoreConnectClientTests
     {
         var responses = MetadataLocaleReadinessResponses("en-US", "English", screenshots: true)
             .Concat(MetadataLocaleReadinessResponses("pl", state == "missing-description" ? null : "Polski",
-                missing: state == "missing-locale")).ToArray();
+                missing: state == "missing-locale").Skip(1)).ToArray();
         var handler = new SequenceHandler(responses);
         using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
         using var client = new AppStoreConnectClient(CreateCredential(), http);
@@ -33,7 +33,7 @@ public sealed partial class AppStoreConnectClientTests
             Assert.Equal(new[] { "en-US", "pl" }, result.Localizations.Select(value => value.Locale));
             Assert.Contains(result.Checks, check => check.Name == "pl.metadata.description" && check.Passed == (state == "ready"));
         }
-        Assert.Equal(6, handler.Methods.Count);
+        Assert.Equal(5, handler.Methods.Count);
         Assert.All(handler.Methods, method => Assert.Equal(HttpMethod.Get, method));
     }
 
@@ -66,13 +66,10 @@ public sealed partial class AppStoreConnectClientTests
             MetadataReadinessLocalization("pl", "Polski"), MetadataReadinessLocalization("pl", "Polski", single: true)
         };
         var expectedLocales = new[] { primaryLocale, "en-US", "pl" }.Distinct().ToArray();
+        responses.Add(MetadataReadinessVersion());
+        responses.Add(new(HttpStatusCode.OK, """{"data":[{"id":"build-1","type":"builds","attributes":{"version":"5","processingState":"VALID"},"relationships":{"preReleaseVersion":{"data":{"id":"train-1","type":"preReleaseVersions"}}}}],"included":[{"id":"train-1","type":"preReleaseVersions","attributes":{"version":"1.0.0","platform":"IOS"}}]}"""));
         foreach (var locale in expectedLocales)
-        {
-            // Preparation fills BuildNumber even though this check does not require a valid/selected build.
-            responses.Add(MetadataReadinessVersion());
-            responses.Add(new(HttpStatusCode.OK, """{"data":[{"id":"build-1","type":"builds","attributes":{"version":"5","processingState":"VALID"},"relationships":{"preReleaseVersion":{"data":{"id":"train-1","type":"preReleaseVersions"}}}}],"included":[{"id":"train-1","type":"preReleaseVersions","attributes":{"version":"1.0.0","platform":"IOS"}}]}"""));
             responses.Add(MetadataReadinessLocalization(locale, locale == "en-US" ? "English" : "Polski"));
-        }
         var handler = new SequenceHandler(responses.ToArray());
         using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
         using var client = new AppStoreConnectClient(CreateCredential(), http);
@@ -94,10 +91,10 @@ public sealed partial class AppStoreConnectClientTests
     {
         var build = new SequenceResponse(HttpStatusCode.OK, """{"data":[{"id":"build-1","type":"builds","attributes":{"version":"5","processingState":"VALID"},"relationships":{"preReleaseVersion":{"data":{"id":"train-1","type":"preReleaseVersions"}}}}],"included":[{"id":"train-1","type":"preReleaseVersions","attributes":{"version":"1.0.0","platform":"IOS"}}]}""");
         var responses = new List<SequenceResponse> { MetadataReadinessVersion(), build };
+        responses.Add(MetadataReadinessVersion());
+        responses.Add(build);
         foreach (var locale in new[] { "en-US", "pl" })
         {
-            responses.Add(MetadataReadinessVersion());
-            responses.Add(build);
             responses.AddRange(MetadataLocaleReadinessResponses(locale, locale == "en-US" ? "English" : null,
                 screenshots: locale == "en-US").Skip(1));
         }

--- a/PowerForge.Tests/AppStoreConnectClientTests.MetadataReadinessLocales.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.MetadataReadinessLocales.cs
@@ -1,0 +1,154 @@
+using System.Net;
+using System.Text.Json;
+
+namespace PowerForge.Tests;
+
+public sealed partial class AppStoreConnectClientTests
+{
+    [Theory]
+    [InlineData("ready")]
+    [InlineData("missing-description")]
+    [InlineData("missing-locale")]
+    public async Task ReleaseReadiness_ChecksMetadataLocalesWithoutRequiringLocalizedScreenshots(string state)
+    {
+        var responses = MetadataLocaleReadinessResponses("en-US", "English", screenshots: true)
+            .Concat(MetadataLocaleReadinessResponses("pl", state == "missing-description" ? null : "Polski",
+                missing: state == "missing-locale")).ToArray();
+        var handler = new SequenceHandler(responses);
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var result = await new AppStoreConnectReleaseReadinessService(client).CheckAsync(new()
+        {
+            AppId = "app-1", VersionString = "1.0.0", MetadataLocales = ["en-US", " pl ", "PL"],
+            RequireKeywords = false, RequireSupportUrl = false,
+            ScreenshotSpec = new() { Locale = "en-US", ScreenshotSets = [new() { ScreenshotDisplayType = "APP_IPHONE_65" }] }
+        });
+
+        Assert.Equal(state == "ready", result.IsReady);
+        Assert.Equal("en-US", Assert.Single(result.ScreenshotSets).Locale);
+        Assert.DoesNotContain(result.Checks, check => check.Name.StartsWith("pl.screenshots", StringComparison.Ordinal));
+        Assert.Contains(result.Checks, check => check.Name == "pl.localization" && check.Passed == (state != "missing-locale"));
+        if (state != "missing-locale")
+        {
+            Assert.Equal(new[] { "en-US", "pl" }, result.Localizations.Select(value => value.Locale));
+            Assert.Contains(result.Checks, check => check.Name == "pl.metadata.description" && check.Passed == (state == "ready"));
+        }
+        Assert.Equal(6, handler.Methods.Count);
+        Assert.All(handler.Methods, method => Assert.Equal(HttpMethod.Get, method));
+    }
+
+    [Fact]
+    public async Task ReleaseReadiness_MetadataOnlySelectionDoesNotImplicitlyRequireEnglish()
+    {
+        var handler = new SequenceHandler(MetadataLocaleReadinessResponses("fi", "Suomi"));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var result = await new AppStoreConnectReleaseReadinessService(client).CheckAsync(new()
+        {
+            AppId = "app-1", VersionString = "1.0.0", MetadataLocales = ["fi"],
+            RequireScreenshots = false, RequireKeywords = false, RequireSupportUrl = false
+        });
+        Assert.True(result.IsReady);
+        Assert.Equal("fi", Assert.Single(result.Localizations).Locale);
+        Assert.Empty(result.ScreenshotSets);
+        Assert.Equal(2, handler.Methods.Count);
+    }
+
+    [Theory]
+    [InlineData("en-US")]
+    [InlineData("fi")]
+    public async Task ReleasePreparation_ChecksEveryAppliedMetadataLocaleWithoutScreenshotSync(string primaryLocale)
+    {
+        var responses = new List<SequenceResponse>
+        {
+            MetadataReadinessVersion(),
+            MetadataReadinessLocalization("en-US", "English"), MetadataReadinessLocalization("en-US", "English", single: true),
+            MetadataReadinessLocalization("pl", "Polski"), MetadataReadinessLocalization("pl", "Polski", single: true)
+        };
+        var expectedLocales = new[] { primaryLocale, "en-US", "pl" }.Distinct().ToArray();
+        foreach (var locale in expectedLocales)
+        {
+            // Preparation fills BuildNumber even though this check does not require a valid/selected build.
+            responses.Add(MetadataReadinessVersion());
+            responses.Add(new(HttpStatusCode.OK, """{"data":[{"id":"build-1","type":"builds","attributes":{"version":"5","processingState":"VALID"},"relationships":{"preReleaseVersion":{"data":{"id":"train-1","type":"preReleaseVersions"}}}}],"included":[{"id":"train-1","type":"preReleaseVersions","attributes":{"version":"1.0.0","platform":"IOS"}}]}"""));
+            responses.Add(MetadataReadinessLocalization(locale, locale == "en-US" ? "English" : "Polski"));
+        }
+        var handler = new SequenceHandler(responses.ToArray());
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var result = await new AppStoreConnectReleasePreparationService(client).PrepareAsync(new()
+        {
+            AppId = "app-1", VersionString = "1.0.0", BuildNumber = "5", CreateVersion = false, SelectBuild = false,
+            MetadataSpecs = [VersionListing("en-US", "English"), VersionListing("pl", "Polski")], CheckReadiness = true,
+            ReadinessRequest = new() { Locale = primaryLocale, RequireSelectedBuild = false, RequireValidBuild = false, RequireScreenshots = false, RequireKeywords = false, RequireSupportUrl = false }
+        });
+        Assert.True(result.Readiness?.IsReady);
+        Assert.Equal(expectedLocales, result.Readiness!.Localizations.Select(value => value.Locale));
+        Assert.Equal(2, result.MetadataResults.Length);
+        Assert.Equal(2, handler.Methods.Count(method => method == HttpMethod.Patch));
+        Assert.All(handler.Methods, method => Assert.True(method == HttpMethod.Get || method == HttpMethod.Patch));
+    }
+
+    [Fact]
+    public async Task ReviewSubmission_RejectsMissingSecondaryMetadataBeforeAnyMutation()
+    {
+        var build = new SequenceResponse(HttpStatusCode.OK, """{"data":[{"id":"build-1","type":"builds","attributes":{"version":"5","processingState":"VALID"},"relationships":{"preReleaseVersion":{"data":{"id":"train-1","type":"preReleaseVersions"}}}}],"included":[{"id":"train-1","type":"preReleaseVersions","attributes":{"version":"1.0.0","platform":"IOS"}}]}""");
+        var responses = new List<SequenceResponse> { MetadataReadinessVersion(), build };
+        foreach (var locale in new[] { "en-US", "pl" })
+        {
+            responses.Add(MetadataReadinessVersion());
+            responses.Add(build);
+            responses.AddRange(MetadataLocaleReadinessResponses(locale, locale == "en-US" ? "English" : null,
+                screenshots: locale == "en-US").Skip(1));
+        }
+        var handler = new SequenceHandler(responses.ToArray());
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() => new AppStoreConnectReviewSubmissionService(client).SubmitAsync(new()
+        {
+            AppId = "app-1", VersionString = "1.0.0", BuildNumber = "5", RequireSelectedBuild = false,
+            ReadinessRequest = new()
+            {
+                MetadataLocales = ["en-US", "pl"], RequireSelectedBuild = false, RequireKeywords = false, RequireSupportUrl = false,
+                ScreenshotSpec = new() { Locale = "en-US", ScreenshotSets = [new() { ScreenshotDisplayType = "APP_IPHONE_65" }] }
+            }
+        }));
+        Assert.Contains("description is missing", error.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.All(handler.Methods, method => Assert.Equal(HttpMethod.Get, method));
+    }
+
+    [Fact]
+    public async Task ReleasePreparation_RejectsInvalidReadinessLocaleBeforeMutation()
+    {
+        var handler = new SequenceHandler();
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        await Assert.ThrowsAsync<ArgumentException>(() => new AppStoreConnectReleasePreparationService(client).PrepareAsync(new()
+        {
+            AppId = "app-1", VersionString = "1.0.0", BuildNumber = "5", CheckReadiness = true,
+            ReadinessRequest = new() { MetadataLocales = [" "] }
+        }));
+        Assert.Empty(handler.Methods);
+    }
+
+    private static SequenceResponse[] MetadataLocaleReadinessResponses(string locale, string? description, bool screenshots = false, bool missing = false)
+    {
+        var responses = new List<SequenceResponse>
+        {
+            MetadataReadinessVersion(),
+            missing ? new(HttpStatusCode.OK, """{"data":[]}""") : MetadataReadinessLocalization(locale, description)
+        };
+        if (screenshots)
+            responses.AddRange(ExistingLocaleScreenshotResponses(locale).Skip(1));
+        return responses.ToArray();
+    }
+
+    private static SequenceResponse MetadataReadinessVersion()
+        => new(HttpStatusCode.OK, """{"data":[{"id":"version-1","type":"appStoreVersions","attributes":{"versionString":"1.0.0","platform":"IOS"}}]}""");
+
+    private static SequenceResponse MetadataReadinessLocalization(string locale, string? description, bool single = false)
+    {
+        var localization = new { id = $"loc-{locale}", type = "appStoreVersionLocalizations", attributes = new { locale, description } };
+        return new(HttpStatusCode.OK, JsonSerializer.Serialize(new { data = single ? (object)localization : new[] { localization } }));
+    }
+}

--- a/PowerForge.Tests/AppStoreConnectClientTests.MetadataReadinessRegressions.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.MetadataReadinessRegressions.cs
@@ -1,0 +1,88 @@
+using System.Net;
+
+namespace PowerForge.Tests;
+
+public sealed partial class AppStoreConnectClientTests
+{
+    [Fact]
+    public async Task ReleaseReadiness_NineteenLocalesShareVersionAndBuildRequests()
+    {
+        var locales = new[] { "en-US", "pl", "de-DE", "es-ES", "fr-FR", "it", "nl-NL", "sv", "da", "no", "cs", "pt-BR", "fi", "pt-PT", "uk", "ja", "ko", "zh-Hans", "zh-Hant" };
+        var responses = new List<SequenceResponse>
+        {
+            MetadataReadinessVersion(), MetadataReadinessBuild(),
+            new(HttpStatusCode.OK, """{"data":{"id":"build-1","type":"builds"}}""")
+        };
+        foreach (var locale in locales)
+            responses.AddRange(MetadataLocaleReadinessResponses(locale, locale, screenshots: locale == "en-US").Skip(1));
+        var handler = new SequenceHandler(responses.ToArray());
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var result = await new AppStoreConnectReleaseReadinessService(client).CheckAsync(new()
+        {
+            AppId = "app-1", VersionString = "1.0.0", BuildNumber = "5", MetadataLocales = locales,
+            RequireKeywords = false, RequireSupportUrl = false,
+            ScreenshotSpec = new() { Locale = "en-US", ScreenshotSets = [new() { ScreenshotDisplayType = "APP_IPHONE_65" }] }
+        });
+        Assert.True(result.IsReady);
+        Assert.Equal(locales, result.Localizations.Select(value => value.Locale));
+        Assert.Equal("build-1", result.SelectedBuildId);
+        Assert.Equal("en-US", Assert.Single(result.ScreenshotSets).Locale);
+        Assert.Equal(24, handler.RequestUris.Count);
+        Assert.Single(handler.RequestUris, uri => uri.AbsolutePath.EndsWith("/appStoreVersions", StringComparison.Ordinal));
+        Assert.Single(handler.RequestUris, uri => uri.AbsolutePath.EndsWith("/builds", StringComparison.Ordinal));
+        Assert.Single(handler.RequestUris, uri => uri.AbsolutePath.EndsWith("/relationships/build", StringComparison.Ordinal));
+        Assert.All(handler.Methods, method => Assert.Equal(HttpMethod.Get, method));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task ReleasePreparation_AppliedMetadataPreservesLegacyScreenshotReadinessLocale(bool syncScreenshots, bool missingLocale)
+    {
+        var root = Directory.CreateTempSubdirectory("PowerForge.MetadataReadiness.");
+        try
+        {
+            var mapping = CreateLocaleMapping(root.FullName, "en-US");
+            var responses = new List<SequenceResponse>
+            {
+                MetadataReadinessLocalization("en-US", "English"), MetadataReadinessLocalization("en-US", "English", single: true)
+            };
+            if (syncScreenshots)
+                responses.AddRange(ExistingLocaleScreenshotResponses("en-US"));
+            responses.Add(MetadataReadinessVersion());
+            responses.Add(MetadataReadinessBuild());
+            responses.Add(missingLocale ? new(HttpStatusCode.OK, """{"data":[]}""") : MetadataReadinessLocalization("pl", "Polski"));
+            if (!missingLocale)
+                responses.AddRange(ExistingLocaleScreenshotResponses("pl").Skip(1));
+            responses.Add(MetadataReadinessLocalization("en-US", "English"));
+            var handler = new SequenceHandler(responses.ToArray());
+            using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+            using var client = new AppStoreConnectClient(CreateCredential(), http);
+            var metadata = VersionListing("en-US", "English");
+            metadata.VersionId = "version-1";
+            var result = await new AppStoreConnectReleasePreparationService(client).PrepareAsync(new()
+            {
+                AppId = "app-1", VersionString = "1.0.0", BuildNumber = "5", CreateVersion = false, SelectBuild = false,
+                MetadataSpec = metadata, ScreenshotSpec = syncScreenshots ? mapping.Spec : null,
+                BaseDirectory = mapping.BaseDirectory, CheckReadiness = true,
+                ReadinessRequest = new()
+                {
+                    Locale = "pl", ScreenshotSpec = syncScreenshots ? null : mapping.Spec,
+                    RequireSelectedBuild = false, RequireKeywords = false, RequireSupportUrl = false
+                }
+            });
+            Assert.Equal(!missingLocale, result.Readiness!.IsReady);
+            Assert.Contains(result.Readiness.Checks, check => check.Name == "pl.localization" && check.Passed == !missingLocale);
+            Assert.Equal("pl", Assert.Single(result.Readiness.ScreenshotSets).Locale);
+            Assert.Equal("en-US", Assert.Single(result.MetadataResults).After.Locale);
+            Assert.Equal("en-US", mapping.Spec.Locale);
+        }
+        finally { root.Delete(true); }
+    }
+
+    private static SequenceResponse MetadataReadinessBuild()
+        => new(HttpStatusCode.OK, """{"data":[{"id":"build-1","type":"builds","attributes":{"version":"5","processingState":"VALID"},"relationships":{"preReleaseVersion":{"data":{"id":"train-1","type":"preReleaseVersions"}}}}],"included":[{"id":"train-1","type":"preReleaseVersions","attributes":{"version":"1.0.0","platform":"IOS"}}]}""");
+}

--- a/PowerForge.Tests/AppStoreConnectClientTests.ScreenshotLocales.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.ScreenshotLocales.cs
@@ -95,12 +95,9 @@ public sealed partial class AppStoreConnectClientTests
     [Fact]
     public async Task ReleaseReadiness_ChecksEveryConfiguredScreenshotLocale()
     {
-        var responses = new List<SequenceResponse>();
+        var responses = new List<SequenceResponse> { MetadataReadinessVersion() };
         foreach (var locale in new[] { "en-US", "pl" })
-        {
-            responses.Add(new(HttpStatusCode.OK, """{"data":[{"id":"version-1","type":"appStoreVersions","attributes":{"versionString":"1.0.0","platform":"IOS"}}]}"""));
             responses.AddRange(ExistingLocaleScreenshotResponses(locale));
-        }
         var handler = new SequenceHandler(responses.ToArray());
         using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
         using var client = new AppStoreConnectClient(CreateCredential(), http);

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleHostedReviewRegressions.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleHostedReviewRegressions.cs
@@ -270,8 +270,11 @@ public sealed partial class PowerForgeReleaseServiceTests
         }
     }
 
-    [Fact]
-    public void ApprovedAppleMutationConfig_UsesCapturedBytesAfterSourceReplacement()
+    [Theory]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, true)]
+    public void ApprovedAppleMutationConfig_UsesCapturedBytesAfterSourceReplacement(bool syncMetadata, bool checkReadiness, bool submitForReview)
     {
         var root = CreateSandbox();
         try
@@ -284,7 +287,9 @@ public sealed partial class PowerForgeReleaseServiceTests
             var plan = new PowerForgeAppleReleasePlan
             {
                 ProjectRoot = root,
-                SyncMetadata = true,
+                SyncMetadata = syncMetadata,
+                CheckReleaseReadiness = checkReadiness,
+                SubmitForReview = submitForReview,
                 MetadataConfigPath = metadataPath,
                 ApprovedMutationInputFilesSha256 = new Dictionary<string, string>(StringComparer.Ordinal)
                 {

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleReadinessLocales.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleReadinessLocales.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace PowerForge.Tests;
 
 public sealed partial class PowerForgeReleaseServiceTests
@@ -42,7 +44,9 @@ public sealed partial class PowerForgeReleaseServiceTests
                     Platform = request.Platform,
                     IsReady = true,
                     Localization = new() { Locale = "en-US", Description = "Unchanged English description" },
-                    Localizations = [new() { Locale = "en-US", Description = "Unchanged English description" }, localizedMetadata],
+                    Localizations = request.MetadataLocales.Select(locale => locale == "pl"
+                        ? localizedMetadata
+                        : new AppStoreConnectVersionLocalizationInfo { Locale = locale, Description = "Unchanged English description" }).ToArray(),
                     Checks =
                     [
                         new AppStoreConnectReleaseReadinessCheck
@@ -54,6 +58,7 @@ public sealed partial class PowerForgeReleaseServiceTests
                     ]
                 });
             var spec = CreateAppleAutomationSpec(root, keyPath);
+            ConfigureMetadataReadinessFiles(spec, root, ["en-US", "pl"]);
             var plan = service.Execute(
                 spec,
                 new PowerForgeReleaseRequest
@@ -62,6 +67,7 @@ public sealed partial class PowerForgeReleaseServiceTests
                     PlanOnly = true,
                     AppleAction = PowerForgeAppleReleaseAction.SubmitAppReview
                 });
+            Assert.True(plan.Success, plan.ErrorMessage);
             property.SetValue(localizedMetadata, "Changed value");
 
             var execution = service.Execute(
@@ -84,4 +90,83 @@ public sealed partial class PowerForgeReleaseServiceTests
         }
     }
 
+
+    [Fact]
+    public void Execute_AppleSubmissionCarriesEveryMetadataLocaleWithOnlyEnglishScreenshots()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Sample.xcodeproj", "1.2.0", "9");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var locales = new[] { "en-US", "pl", "de-DE", "es-ES", "fr-FR", "it", "nl-NL", "sv", "da", "no", "cs", "pt-BR", "fi", "pt-PT", "uk", "ja", "ko", "zh-Hans", "zh-Hant" };
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            var app = spec.AppleApps!.Apps[0];
+            app.ProjectPath = "Sample.xcodeproj";
+            app.Scheme = "Sample";
+            app.Name = "Sample";
+            app.BundleId = "com.example.sample";
+            app.AppStoreConnectAppId = "1234567890";
+            ConfigureMetadataReadinessFiles(spec, root, locales);
+            var readinessRequests = new List<AppStoreConnectReleaseReadinessRequest>();
+            AppStoreConnectReviewSubmissionRequest? submission = null;
+            var service = CreateAppleAutomationService(request => CreateReleaseState(request, "VALID"),
+                checkAppleReleaseReadiness: (_, request) =>
+                {
+                    readinessRequests.Add(request);
+                    return CreateReadyReleaseReadiness(request);
+                },
+                submitAppleReview: request =>
+                {
+                    submission = request;
+                    return new() { AppId = request.AppId, VersionString = request.VersionString, BuildNumber = request.BuildNumber, Platform = request.Platform };
+                });
+            var request = new PowerForgeReleaseRequest
+            {
+                ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                AppleAction = PowerForgeAppleReleaseAction.SubmitAppReview, PlanOnly = true
+            };
+            var plan = service.Execute(spec, request);
+            Assert.True(plan.Success, plan.ErrorMessage);
+            request.PlanOnly = false;
+            request.AppleActionConfirmed = true;
+            request.AppleExpectedPlanSha256 = plan.AppleReceipt!.PlanSha256;
+            var result = service.Execute(spec, request);
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.NotEmpty(readinessRequests);
+            Assert.NotNull(submission?.ReadinessRequest);
+            foreach (var readiness in readinessRequests.Append(submission!.ReadinessRequest!))
+            {
+                Assert.Equal(locales, readiness.MetadataLocales);
+                Assert.Equal("en-US", readiness.ScreenshotSpec?.Locale);
+                Assert.Empty(readiness.ScreenshotSpecs);
+            }
+        }
+        finally { TryDelete(root); }
+    }
+
+    private static void ConfigureMetadataReadinessFiles(PowerForgeReleaseSpec spec, string root, string[] locales)
+    {
+        var app = spec.AppleApps!.Apps[0];
+        var metadataPaths = new List<string>();
+        foreach (var locale in locales)
+        {
+            var filename = $"metadata-{locale}.json";
+            File.WriteAllText(Path.Combine(root, filename), JsonSerializer.Serialize(new AppStoreConnectVersionMetadataSpec
+            {
+                AppId = app.AppStoreConnectAppId!, Platform = app.Platform, UseReleaseVersion = true,
+                Locale = locale, Metadata = new() { Description = $"Description for {locale}" }
+            }));
+            metadataPaths.Add(filename);
+        }
+        spec.AppleApps.MetadataConfigPaths = metadataPaths.ToArray();
+        const string screenshotPath = "screenshots-en.json";
+        File.WriteAllText(Path.Combine(root, screenshotPath), JsonSerializer.Serialize(new AppStoreConnectScreenshotSyncSpec
+        {
+            AppId = app.AppStoreConnectAppId!, Platform = app.Platform, UseReleaseVersion = true, Locale = "en-US",
+            ScreenshotSets = [new() { ScreenshotDisplayType = "APP_IPHONE_65", Path = "missing-local-files" }]
+        }));
+        spec.AppleApps.ScreenshotConfigPaths = [screenshotPath];
+    }
 }

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleReadinessLocales.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleReadinessLocales.cs
@@ -91,8 +91,10 @@ public sealed partial class PowerForgeReleaseServiceTests
     }
 
 
-    [Fact]
-    public void Execute_AppleSubmissionCarriesEveryMetadataLocaleWithOnlyEnglishScreenshots()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Execute_AppleSubmissionCarriesEveryMetadataLocaleWithOnlyEnglishScreenshots(bool changeMetadataDuringApproval)
     {
         var root = CreateSandbox();
         try
@@ -115,6 +117,13 @@ public sealed partial class PowerForgeReleaseServiceTests
                 checkAppleReleaseReadiness: (_, request) =>
                 {
                     readinessRequests.Add(request);
+                    if (changeMetadataDuringApproval && readinessRequests.Count == 2)
+                    {
+                        var path = Path.Combine(root, "metadata-pl.json");
+                        var metadata = JsonSerializer.Deserialize<AppStoreConnectVersionMetadataSpec>(File.ReadAllText(path))!;
+                        metadata.Locale = "ro";
+                        File.WriteAllText(path, JsonSerializer.Serialize(metadata));
+                    }
                     return CreateReadyReleaseReadiness(request);
                 },
                 submitAppleReview: request =>
@@ -133,6 +142,13 @@ public sealed partial class PowerForgeReleaseServiceTests
             request.AppleActionConfirmed = true;
             request.AppleExpectedPlanSha256 = plan.AppleReceipt!.PlanSha256;
             var result = service.Execute(spec, request);
+            if (changeMetadataDuringApproval)
+            {
+                Assert.False(result.Success);
+                Assert.Contains("changed after plan approval", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+                Assert.Null(submission);
+                return;
+            }
             Assert.True(result.Success, result.ErrorMessage);
             Assert.NotEmpty(readinessRequests);
             Assert.NotNull(submission?.ReadinessRequest);

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleReadinessTargetSelection.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleReadinessTargetSelection.cs
@@ -1,0 +1,83 @@
+using System.Text.Json;
+
+namespace PowerForge.Tests;
+
+public sealed partial class PowerForgeReleaseServiceTests
+{
+    [Theory]
+    [InlineData("app", true, false)]
+    [InlineData("platform", true, false)]
+    [InlineData("version", true, false)]
+    [InlineData("app", false, false)]
+    [InlineData("platform", false, false)]
+    [InlineData("version", false, false)]
+    [InlineData("app", true, true)]
+    [InlineData("platform", true, true)]
+    [InlineData("version", true, true)]
+    [InlineData("app", false, true)]
+    [InlineData("platform", false, true)]
+    [InlineData("version", false, true)]
+    public void Execute_AppleReadinessRejectsConfiguredMetadataForAnotherTarget(string mismatch, bool planOnly, bool submit)
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Sample.xcodeproj", "1.2.0", "9");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            var app = spec.AppleApps!.Apps[0];
+            app.ProjectPath = "Sample.xcodeproj";
+            app.Scheme = "Sample";
+            app.Name = "Sample";
+            app.BundleId = "com.example.sample";
+            app.AppStoreConnectAppId = "1234567890";
+            spec.AppleApps.Archive = false;
+            spec.AppleApps.Upload = false;
+            spec.AppleApps.PrepareDistribution = true;
+            spec.AppleApps.CheckReleaseReadiness = true;
+            spec.AppleApps.SyncMetadata = false;
+            ConfigureMetadataReadinessFiles(spec, root, ["en-US", "pl"]);
+            foreach (var path in spec.AppleApps.MetadataConfigPaths)
+            {
+                var absolutePath = Path.Combine(root, path);
+                var metadata = JsonSerializer.Deserialize<AppStoreConnectVersionMetadataSpec>(File.ReadAllText(absolutePath))!;
+                if (mismatch == "app") metadata.AppId = "other-app";
+                if (mismatch == "platform") metadata.Platform = ApplePlatform.macOS;
+                if (mismatch == "version")
+                {
+                    metadata.UseReleaseVersion = false;
+                    metadata.VersionString = "9.9.9";
+                }
+                File.WriteAllText(absolutePath, JsonSerializer.Serialize(metadata));
+            }
+            var readinessCalls = 0;
+            var mutationCalls = 0;
+            var service = CreateAppleAutomationService(request => CreateReleaseState(request, "VALID"),
+                checkAppleReleaseReadiness: (_, request) => { readinessCalls++; return CreateReadyReleaseReadiness(request); },
+                prepareAppleDistribution: request => { mutationCalls++; return CreateSuccessfulPreparation(request); },
+                submitAppleReview: request => { mutationCalls++; return new(); });
+            var request = new PowerForgeReleaseRequest()
+            {
+                ConfigPath = Path.Combine(root, "powerforge.release.json"), PlanOnly = planOnly,
+                AppleAction = submit ? PowerForgeAppleReleaseAction.SubmitAppReview : PowerForgeAppleReleaseAction.Configured,
+                AppleActionConfirmed = !planOnly
+            };
+            if (planOnly)
+            {
+                var error = Assert.Throws<InvalidOperationException>(() => service.Execute(spec, request));
+                Assert.Contains("No App Store metadata config matches", error.Message, StringComparison.Ordinal);
+            }
+            else
+            {
+                var result = service.Execute(spec, request);
+                Assert.False(result.Success);
+                var errors = new[] { result.ErrorMessage }.Concat(result.AppleApps.Select(value => value.ErrorMessage));
+                Assert.Contains(errors, error => error?.Contains("No App Store metadata config matches", StringComparison.Ordinal) == true);
+            }
+            Assert.Equal(0, readinessCalls);
+            Assert.Equal(0, mutationCalls);
+        }
+        finally { TryDelete(root); }
+    }
+}

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleScreenshotLocales.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleScreenshotLocales.cs
@@ -32,6 +32,8 @@ public partial class PowerForgeReleaseServiceTests
                 """);
             var polishConfigPath = Path.Combine(root, "screenshots-pl.json");
             File.WriteAllText(polishConfigPath, File.ReadAllText(screenshotConfigPath).Replace("en-US", "pl"));
+            var metadataPath = Path.Combine(root, "metadata-fi.json");
+            File.WriteAllText(metadataPath, """{"appId":"app-1","platform":"iOS","useReleaseVersion":true,"locale":"fi","metadata":{"description":"Suomi"}}""");
             var requests = new List<AppStoreConnectReleasePreparationRequest>();
 
             var service = new PowerForgeReleaseService(
@@ -67,6 +69,8 @@ public partial class PowerForgeReleaseServiceTests
                         Archive = false,
                         CheckReleaseReadiness = true,
                         SyncScreenshots = false,
+                        SyncMetadata = false,
+                        MetadataConfigPaths = [metadataPath],
                         ScreenshotConfigPaths = localeCount == 1 ? new[] { screenshotConfigPath } : new[] { screenshotConfigPath, polishConfigPath },
                         AppStoreConnectApiKeyPath = keyPath,
                         AppStoreConnectApiKeyId = "ABC123DEFG",
@@ -94,7 +98,10 @@ public partial class PowerForgeReleaseServiceTests
             Assert.True(request.CheckReadiness);
             Assert.Null(request.ScreenshotSpec);
             Assert.Empty(request.ScreenshotMappings);
+            Assert.Empty(request.MetadataSpecs);
+            Assert.Null(request.MetadataSpec);
             Assert.NotNull(request.ReadinessRequest);
+            Assert.Equal(new[] { "fi" }, request.ReadinessRequest.MetadataLocales);
             var specs = localeCount == 1 ? new[] { request.ReadinessRequest.ScreenshotSpec! } : request.ReadinessRequest.ScreenshotSpecs;
             Assert.Equal(localeCount, specs.Length);
             Assert.Equal(localeCount == 1 ? new[] { "en-US" } : new[] { "en-US", "pl" }, specs.Select(spec => spec.Locale));

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.VersionMetadata.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.VersionMetadata.cs
@@ -16,7 +16,7 @@ public sealed partial class PowerForgeReleaseServiceTests
             CreateXcodeProject(root, "Sample.xcodeproj", "1.2.0", "9");
             var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
             File.WriteAllText(keyPath, "private-key");
-            var locales = new[] { "en-US", "pl", "de-DE", "es-ES", "fr-FR", "it", "nl-NL", "sv", "da", "no", "cs", "pt-BR" };
+            var locales = new[] { "en-US", "pl", "de-DE", "es-ES", "fr-FR", "it", "nl-NL", "sv", "da", "no", "cs", "pt-BR", "fi", "pt-PT", "uk", "ja", "ko", "zh-Hans", "zh-Hant" };
             var paths = new List<string>();
             foreach (var platform in new[] { ApplePlatform.iOS, ApplePlatform.macOS })
             {

--- a/PowerForge/Models/AppStoreConnectVersionMetadataModels.cs
+++ b/PowerForge/Models/AppStoreConnectVersionMetadataModels.cs
@@ -102,6 +102,12 @@ public sealed class AppStoreConnectReleaseReadinessRequest
     /// <summary>Localization locale to check.</summary>
     public string Locale { get; set; } = "en-US";
 
+    /// <summary>
+    /// Explicit metadata locales checked alongside the screenshot mapping locales. Empty preserves
+    /// the existing locale selection. Without screenshot mappings, screenshot requirements apply only to <see cref="Locale"/>.
+    /// </summary>
+    public string[] MetadataLocales { get; set; } = Array.Empty<string>();
+
     /// <summary>Require the Distribution version to have the expected selected build.</summary>
     public bool RequireSelectedBuild { get; set; } = true;
 
@@ -144,12 +150,15 @@ public sealed class AppStoreConnectReleaseReadinessRequest
     /// <summary>Additional screenshot locales to check, each with its own required display types.</summary>
     public AppStoreConnectScreenshotSyncSpec[] ScreenshotSpecs { get; set; } = Array.Empty<AppStoreConnectScreenshotSyncSpec>();
 
-    internal AppStoreConnectReleaseReadinessRequest ForScreenshotLocale(AppStoreConnectScreenshotSyncSpec spec)
+    internal AppStoreConnectReleaseReadinessRequest ForLocale(
+        string locale, AppStoreConnectScreenshotSyncSpec? spec, bool requireScreenshots)
     {
         var result = (AppStoreConnectReleaseReadinessRequest)MemberwiseClone();
-        result.Locale = spec.Locale.Trim();
+        result.Locale = locale;
+        result.MetadataLocales = Array.Empty<string>();
         result.ScreenshotSpec = spec;
         result.ScreenshotSpecs = Array.Empty<AppStoreConnectScreenshotSyncSpec>();
+        result.RequireScreenshots = requireScreenshots;
         return result;
     }
 }

--- a/PowerForge/Services/AppStoreConnectReleasePreparationService.cs
+++ b/PowerForge/Services/AppStoreConnectReleasePreparationService.cs
@@ -28,6 +28,8 @@ public sealed partial class AppStoreConnectReleasePreparationService
         if (string.IsNullOrWhiteSpace(request.AppId))
             throw new ArgumentException("AppId is required.", nameof(request));
         var metadataSpecs = ResolveMetadataSpecs(request);
+        if (request.CheckReadiness)
+            _ = AppStoreConnectReleaseReadinessService.NormalizeMetadataLocales(request.ReadinessRequest?.MetadataLocales);
         var screenshotMappings = ResolveScreenshotMappings(request);
         var requiresVersion = request.CreateVersion ||
                               request.SelectBuild ||
@@ -188,7 +190,8 @@ public sealed partial class AppStoreConnectReleasePreparationService
                 buildNumber,
                 request.Platform,
                 screenshotMappings.Select(static mapping => mapping.Spec).ToArray(),
-                request.ScreenshotSpec is not null && screenshotMappings.Length == 1);
+                request.ScreenshotSpec is not null && screenshotMappings.Length == 1,
+                metadataSpecs.Select(static spec => spec.Locale));
             readiness = await new AppStoreConnectReleaseReadinessService(_client)
                 .CheckAsync(readinessRequest, cancellationToken)
                 .ConfigureAwait(false);
@@ -300,9 +303,16 @@ public sealed partial class AppStoreConnectReleasePreparationService
         string buildNumber,
         ApplePlatform platform,
         AppStoreConnectScreenshotSyncSpec[] screenshotSpecs,
-        bool legacySingleScreenshot)
+        bool legacySingleScreenshot,
+        IEnumerable<string> metadataLocales)
     {
         source ??= new AppStoreConnectReleaseReadinessRequest();
+        var selectedMetadataLocales = source.MetadataLocales ?? Array.Empty<string>();
+        var appliedMetadataLocales = metadataLocales.ToArray();
+        // Preserve the legacy primary metadata check when preparation adds locale selection.
+        if (selectedMetadataLocales.Length == 0 && appliedMetadataLocales.Length > 0 &&
+            screenshotSpecs.Length == 0 && source.ScreenshotSpec is null && (source.ScreenshotSpecs?.Length ?? 0) == 0)
+            selectedMetadataLocales = new[] { string.IsNullOrWhiteSpace(source.Locale) ? "en-US" : source.Locale.Trim() };
         return new AppStoreConnectReleaseReadinessRequest
         {
             AppId = appId,
@@ -310,6 +320,8 @@ public sealed partial class AppStoreConnectReleasePreparationService
             BuildNumber = buildNumber,
             Platform = platform,
             Locale = string.IsNullOrWhiteSpace(source.Locale) ? "en-US" : source.Locale.Trim(),
+            MetadataLocales = AppStoreConnectReleaseReadinessService.NormalizeMetadataLocales(
+                selectedMetadataLocales.Concat(appliedMetadataLocales)),
             RequireSelectedBuild = source.RequireSelectedBuild,
             RequireValidBuild = source.RequireValidBuild,
             RequireDescription = source.RequireDescription,
@@ -323,7 +335,7 @@ public sealed partial class AppStoreConnectReleasePreparationService
             MinimumScreenshotsPerSet = source.MinimumScreenshotsPerSet,
             RequiredScreenshotDisplayTypes = source.RequiredScreenshotDisplayTypes,
             ScreenshotSpec = legacySingleScreenshot ? screenshotSpecs[0] : screenshotSpecs.Length == 0 ? source.ScreenshotSpec : null,
-            ScreenshotSpecs = legacySingleScreenshot || screenshotSpecs.Length == 0 ? source.ScreenshotSpecs : screenshotSpecs
+            ScreenshotSpecs = legacySingleScreenshot || screenshotSpecs.Length == 0 ? source.ScreenshotSpecs ?? Array.Empty<AppStoreConnectScreenshotSyncSpec>() : screenshotSpecs
         };
     }
 }

--- a/PowerForge/Services/AppStoreConnectReleasePreparationService.cs
+++ b/PowerForge/Services/AppStoreConnectReleasePreparationService.cs
@@ -309,17 +309,28 @@ public sealed partial class AppStoreConnectReleasePreparationService
         source ??= new AppStoreConnectReleaseReadinessRequest();
         var selectedMetadataLocales = source.MetadataLocales ?? Array.Empty<string>();
         var appliedMetadataLocales = metadataLocales.ToArray();
-        // Preserve the legacy primary metadata check when preparation adds locale selection.
-        if (selectedMetadataLocales.Length == 0 && appliedMetadataLocales.Length > 0 &&
-            screenshotSpecs.Length == 0 && source.ScreenshotSpec is null && (source.ScreenshotSpecs?.Length ?? 0) == 0)
-            selectedMetadataLocales = new[] { string.IsNullOrWhiteSpace(source.Locale) ? "en-US" : source.Locale.Trim() };
+        var preserveLegacyLocale = selectedMetadataLocales.Length == 0 && appliedMetadataLocales.Length > 0 &&
+            (legacySingleScreenshot || (screenshotSpecs.Length == 0 && (source.ScreenshotSpecs?.Length ?? 0) == 0));
+        var primaryLocale = string.IsNullOrWhiteSpace(source.Locale) ? "en-US" : source.Locale.Trim();
+        var readinessScreenshotSpec = legacySingleScreenshot ? screenshotSpecs[0] : screenshotSpecs.Length == 0 ? source.ScreenshotSpec : null;
+        if (preserveLegacyLocale)
+        {
+            selectedMetadataLocales = new[] { primaryLocale };
+            // Legacy single-spec readiness used Locale for both metadata and screenshot lookup.
+            if (readinessScreenshotSpec is not null)
+                readinessScreenshotSpec = new AppStoreConnectScreenshotSyncSpec
+                {
+                    Locale = primaryLocale,
+                    ScreenshotSets = readinessScreenshotSpec.ScreenshotSets
+                };
+        }
         return new AppStoreConnectReleaseReadinessRequest
         {
             AppId = appId,
             VersionString = versionString,
             BuildNumber = buildNumber,
             Platform = platform,
-            Locale = string.IsNullOrWhiteSpace(source.Locale) ? "en-US" : source.Locale.Trim(),
+            Locale = primaryLocale,
             MetadataLocales = AppStoreConnectReleaseReadinessService.NormalizeMetadataLocales(
                 selectedMetadataLocales.Concat(appliedMetadataLocales)),
             RequireSelectedBuild = source.RequireSelectedBuild,
@@ -334,7 +345,7 @@ public sealed partial class AppStoreConnectReleasePreparationService
             RequireCompleteScreenshots = source.RequireCompleteScreenshots,
             MinimumScreenshotsPerSet = source.MinimumScreenshotsPerSet,
             RequiredScreenshotDisplayTypes = source.RequiredScreenshotDisplayTypes,
-            ScreenshotSpec = legacySingleScreenshot ? screenshotSpecs[0] : screenshotSpecs.Length == 0 ? source.ScreenshotSpec : null,
+            ScreenshotSpec = readinessScreenshotSpec,
             ScreenshotSpecs = legacySingleScreenshot || screenshotSpecs.Length == 0 ? source.ScreenshotSpecs ?? Array.Empty<AppStoreConnectScreenshotSyncSpec>() : screenshotSpecs
         };
     }

--- a/PowerForge/Services/AppStoreConnectReleaseReadinessService.Locales.cs
+++ b/PowerForge/Services/AppStoreConnectReleaseReadinessService.Locales.cs
@@ -23,13 +23,14 @@ public sealed partial class AppStoreConnectReleaseReadinessService
         if (specs.Length == 0 && (request.RequireScreenshots || locales.Count == 0))
             locales.Insert(0, request.Locale.Trim());
         var selected = locales.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        var common = await ReadCommonStateAsync(request, cancellationToken).ConfigureAwait(false);
         var results = new List<AppStoreConnectReleaseReadinessResult>();
         foreach (var locale in selected)
         {
             var spec = specs.FirstOrDefault(value => string.Equals(value.Locale.Trim(), locale, StringComparison.OrdinalIgnoreCase));
             var requireScreenshots = request.RequireScreenshots && (spec is not null ||
                 (specs.Length == 0 && string.Equals(locale, request.Locale.Trim(), StringComparison.OrdinalIgnoreCase)));
-            results.Add(await CheckAsync(request.ForLocale(locale, spec, requireScreenshots), cancellationToken).ConfigureAwait(false));
+            results.Add(await CheckLocaleAsync(request.ForLocale(locale, spec, requireScreenshots), common, cancellationToken).ConfigureAwait(false));
         }
 
         var aggregate = results[0];

--- a/PowerForge/Services/AppStoreConnectReleaseReadinessService.Locales.cs
+++ b/PowerForge/Services/AppStoreConnectReleaseReadinessService.Locales.cs
@@ -1,0 +1,49 @@
+namespace PowerForge;
+
+public sealed partial class AppStoreConnectReleaseReadinessService
+{
+    internal static string[] NormalizeMetadataLocales(IEnumerable<string>? locales)
+    {
+        var values = (locales ?? Array.Empty<string>()).ToArray();
+        if (values.Any(string.IsNullOrWhiteSpace))
+            throw new ArgumentException("Metadata locales must not contain empty values.", nameof(locales));
+        return values.Select(static locale => locale.Trim()).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+    }
+
+    private async Task<AppStoreConnectReleaseReadinessResult> CheckLocalesAsync(
+        AppStoreConnectReleaseReadinessRequest request, CancellationToken cancellationToken)
+    {
+        var metadataLocales = NormalizeMetadataLocales(request.MetadataLocales);
+        var specs = (request.ScreenshotSpec is null
+            ? Array.Empty<AppStoreConnectScreenshotSyncSpec>()
+            : new[] { request.ScreenshotSpec }).Concat(request.ScreenshotSpecs ?? Array.Empty<AppStoreConnectScreenshotSyncSpec>()).ToArray();
+        AppStoreConnectReleasePreparationService.ValidateScreenshotLocales(specs);
+        var locales = specs.Select(static spec => spec.Locale.Trim()).Concat(metadataLocales).ToList();
+        // A direct caller can still require screenshot types for its legacy Locale without a mapping.
+        if (specs.Length == 0 && (request.RequireScreenshots || locales.Count == 0))
+            locales.Insert(0, request.Locale.Trim());
+        var selected = locales.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        var results = new List<AppStoreConnectReleaseReadinessResult>();
+        foreach (var locale in selected)
+        {
+            var spec = specs.FirstOrDefault(value => string.Equals(value.Locale.Trim(), locale, StringComparison.OrdinalIgnoreCase));
+            var requireScreenshots = request.RequireScreenshots && (spec is not null ||
+                (specs.Length == 0 && string.Equals(locale, request.Locale.Trim(), StringComparison.OrdinalIgnoreCase)));
+            results.Add(await CheckAsync(request.ForLocale(locale, spec, requireScreenshots), cancellationToken).ConfigureAwait(false));
+        }
+
+        var aggregate = results[0];
+        aggregate.Localizations = results.Where(static result => result.Localization is not null)
+            .Select(static result => result.Localization!).ToArray();
+        aggregate.IsReady = results.All(static result => result.IsReady);
+        aggregate.ScreenshotSets = results.SelectMany(static result => result.ScreenshotSets).ToArray();
+        aggregate.Checks = results.SelectMany((result, index) => result.Checks.Select(check => new AppStoreConnectReleaseReadinessCheck
+        {
+            Name = selected.Length == 1 && (request.ScreenshotSpecs?.Length ?? 0) == 0
+                ? check.Name : $"{selected[index]}.{check.Name}",
+            Passed = check.Passed,
+            Message = check.Message
+        })).ToArray();
+        return aggregate;
+    }
+}

--- a/PowerForge/Services/AppStoreConnectReleaseReadinessService.cs
+++ b/PowerForge/Services/AppStoreConnectReleaseReadinessService.cs
@@ -3,7 +3,7 @@ namespace PowerForge;
 /// <summary>
 /// Checks App Store Connect Distribution readiness for one platform version.
 /// </summary>
-public sealed class AppStoreConnectReleaseReadinessService
+public sealed partial class AppStoreConnectReleaseReadinessService
 {
     private readonly AppStoreConnectClient _client;
 
@@ -31,26 +31,8 @@ public sealed class AppStoreConnectReleaseReadinessService
         if (string.IsNullOrWhiteSpace(request.Locale))
             throw new ArgumentException("Locale is required.", nameof(request));
 
-        if ((request.ScreenshotSpecs?.Length ?? 0) > 0)
-        {
-            var specs = (request.ScreenshotSpec is null
-                ? Array.Empty<AppStoreConnectScreenshotSyncSpec>()
-                : new[] { request.ScreenshotSpec }).Concat(request.ScreenshotSpecs!).ToArray();
-            AppStoreConnectReleasePreparationService.ValidateScreenshotLocales(specs);
-            var results = new List<AppStoreConnectReleaseReadinessResult>();
-            foreach (var spec in specs)
-                results.Add(await CheckAsync(request.ForScreenshotLocale(spec), cancellationToken).ConfigureAwait(false));
-            var aggregate = results[0];
-            aggregate.Localizations = results.Where(static result => result.Localization is not null)
-                .Select(static result => result.Localization!).ToArray();
-            aggregate.IsReady = results.All(static result => result.IsReady);
-            aggregate.ScreenshotSets = results.SelectMany(static result => result.ScreenshotSets).ToArray();
-            aggregate.Checks = results.SelectMany((result, index) => result.Checks.Select(check => new AppStoreConnectReleaseReadinessCheck
-            {
-                Name = $"{specs[index].Locale}.{check.Name}", Passed = check.Passed, Message = check.Message
-            })).ToArray();
-            return aggregate;
-        }
+        if ((request.MetadataLocales?.Length ?? 0) > 0 || (request.ScreenshotSpecs?.Length ?? 0) > 0)
+            return await CheckLocalesAsync(request, cancellationToken).ConfigureAwait(false);
 
         var checks = new List<AppStoreConnectReleaseReadinessCheck>();
         var version = (await _client.GetVersionsAsync(

--- a/PowerForge/Services/AppStoreConnectReleaseReadinessService.cs
+++ b/PowerForge/Services/AppStoreConnectReleaseReadinessService.cs
@@ -34,6 +34,13 @@ public sealed partial class AppStoreConnectReleaseReadinessService
         if ((request.MetadataLocales?.Length ?? 0) > 0 || (request.ScreenshotSpecs?.Length ?? 0) > 0)
             return await CheckLocalesAsync(request, cancellationToken).ConfigureAwait(false);
 
+        var common = await ReadCommonStateAsync(request, cancellationToken).ConfigureAwait(false);
+        return await CheckLocaleAsync(request, common, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<AppStoreConnectReleaseReadinessResult> ReadCommonStateAsync(
+        AppStoreConnectReleaseReadinessRequest request, CancellationToken cancellationToken)
+    {
         var checks = new List<AppStoreConnectReleaseReadinessCheck>();
         var version = (await _client.GetVersionsAsync(
             request.AppId,
@@ -47,8 +54,6 @@ public sealed partial class AppStoreConnectReleaseReadinessService
 
         AppStoreConnectBuildInfo? build = null;
         string? selectedBuildId = null;
-        AppStoreConnectVersionLocalizationInfo? localization = null;
-        var screenshotReadiness = Array.Empty<AppStoreConnectReleaseScreenshotSetReadiness>();
 
         if (version is not null)
         {
@@ -82,7 +87,26 @@ public sealed partial class AppStoreConnectReleaseReadinessService
                         : $"Build '{request.BuildNumber}' is not selected for Distribution.");
                 }
             }
+        }
+        return new AppStoreConnectReleaseReadinessResult
+        {
+            Version = version, Build = build, SelectedBuildId = selectedBuildId, Checks = checks.ToArray()
+        };
+    }
 
+    private async Task<AppStoreConnectReleaseReadinessResult> CheckLocaleAsync(
+        AppStoreConnectReleaseReadinessRequest request,
+        AppStoreConnectReleaseReadinessResult common,
+        CancellationToken cancellationToken)
+    {
+        var checks = common.Checks.ToList();
+        var version = common.Version;
+        var build = common.Build;
+        var selectedBuildId = common.SelectedBuildId;
+        AppStoreConnectVersionLocalizationInfo? localization = null;
+        var screenshotReadiness = Array.Empty<AppStoreConnectReleaseScreenshotSetReadiness>();
+        if (version is not null)
+        {
             localization = (await _client.GetVersionLocalizationsAsync(
                 version.Id,
                 request.Locale,

--- a/PowerForge/Services/AppStoreConnectReviewSubmissionService.cs
+++ b/PowerForge/Services/AppStoreConnectReviewSubmissionService.cs
@@ -189,6 +189,7 @@ public sealed class AppStoreConnectReviewSubmissionService
             BuildNumber = buildNumber,
             Platform = request.Platform,
             Locale = string.IsNullOrWhiteSpace(source.Locale) ? "en-US" : source.Locale.Trim(),
+            MetadataLocales = source.MetadataLocales,
             RequireSelectedBuild = source.RequireSelectedBuild,
             RequireValidBuild = source.RequireValidBuild,
             RequireDescription = source.RequireDescription,

--- a/PowerForge/Services/PowerForgeReleaseService.AppleVersioning.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleVersioning.cs
@@ -261,7 +261,7 @@ internal sealed partial class PowerForgeReleaseService
             var boundScreenshotSpecs = matchingScreenshotSpecs
                 .Select(value => (Spec: BindScreenshotSpec(value.Spec, app, values.MarketingVersion), value.ConfigPath)).ToArray();
             var matchingMetadataSpecs = checkReadiness
-                ? ResolveMatchingMetadataSpecs(metadataSpecs, app, values.MarketingVersion)
+                ? ResolveMatchingMetadataSpecs(metadataSpecs, app, values.MarketingVersion, required: metadataSpecs.Length > 0)
                 : Array.Empty<(AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)>();
             foreach (var configured in matchingMetadataSpecs)
                 ValidateAppleMetadataPreflight(configured);

--- a/PowerForge/Services/PowerForgeReleaseService.AppleVersioning.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleVersioning.cs
@@ -57,7 +57,7 @@ internal sealed partial class PowerForgeReleaseService
             if (!string.IsNullOrWhiteSpace(plan.ScreenshotConfigPath)) paths.Add(plan.ScreenshotConfigPath!);
             paths.AddRange(plan.ScreenshotConfigPaths);
         }
-        if (plan.SyncMetadata)
+        if (RequiresAppleMetadataSpecs(plan))
         {
             if (!string.IsNullOrWhiteSpace(plan.MetadataConfigPath)) paths.Add(plan.MetadataConfigPath!);
             paths.AddRange(plan.MetadataConfigPaths);
@@ -361,7 +361,7 @@ internal sealed partial class PowerForgeReleaseService
         {
             configuredInputs.AddRange(screenshotSpecs.Select(static configured => configured.ConfigPath));
         }
-        if (plan.SyncMetadata)
+        if (RequiresAppleMetadataSpecs(plan))
         {
             if (!string.IsNullOrWhiteSpace(plan.MetadataConfigPath))
                 configuredInputs.Add(plan.MetadataConfigPath!);

--- a/PowerForge/Services/PowerForgeReleaseService.AppleVersioning.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleVersioning.cs
@@ -138,8 +138,11 @@ internal sealed partial class PowerForgeReleaseService
                                (plan.SubmitForReview && !plan.SkipReviewReadinessCheck))
             ? LoadAppleScreenshotSpecs(plan)
             : Array.Empty<(AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)>();
+        var metadataSpecs = RequiresAppleMetadataSpecs(plan)
+            ? LoadAppleMetadataSpecs(plan)
+            : Array.Empty<(AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)>();
         var targets = plan.Apps
-            .Select(app => CreateApplePlanTarget(plan, app, versioning, screenshotSpecs))
+            .Select(app => CreateApplePlanTarget(plan, app, versioning, screenshotSpecs, metadataSpecs))
             .ToArray();
         var selectedScreenshotSpecs = ResolveSelectedAppleScreenshotSpecs(plan, screenshotSpecs);
         var mutationInputs = CreateAppleMutationInputEvidence(plan, selectedScreenshotSpecs);
@@ -175,7 +178,8 @@ internal sealed partial class PowerForgeReleaseService
         PowerForgeAppleReleasePlan plan,
         PowerForgeAppleAppReleaseTargetPlan app,
         PowerForgeAppleVersionReceipt? versioning,
-        (AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)[] screenshotSpecs)
+        (AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)[] screenshotSpecs,
+        (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)[] metadataSpecs)
     {
         var target = new PowerForgeAppleReleaseTargetReceipt
         {
@@ -255,24 +259,23 @@ internal sealed partial class PowerForgeReleaseService
             var matchingScreenshotSpecs = ResolveMatchingScreenshotSpecs(screenshotSpecs, app,
                 values.MarketingVersion, required: screenshotSpecs.Length > 0);
             var boundScreenshotSpecs = matchingScreenshotSpecs
-                .Select(value => BindScreenshotSpec(value.Spec, app, values.MarketingVersion)).ToArray();
-            var readiness = _checkAppleReleaseReadiness(
-                CreateAppStoreConnectCredential(plan),
-                new AppStoreConnectReleaseReadinessRequest
-                {
-                    AppId = app.AppStoreConnectAppId!,
-                    VersionString = values.MarketingVersion,
-                    BuildNumber = checkReadiness ? values.BuildNumber : null,
-                    Platform = app.Platform,
-                    Locale = boundScreenshotSpecs.FirstOrDefault()?.Locale ?? "en-US",
-                    ScreenshotSpec = boundScreenshotSpecs.Length == 1 ? boundScreenshotSpecs[0] : null,
-                    ScreenshotSpecs = boundScreenshotSpecs.Length > 1 ? boundScreenshotSpecs : Array.Empty<AppStoreConnectScreenshotSyncSpec>(),
-                    RequireSelectedBuild = checkReadiness,
-                    RequireValidBuild = checkReadiness,
-                    RequireDescription = checkReadiness,
-                    RequireKeywords = checkReadiness,
-                    RequireSupportUrl = checkReadiness
-                });
+                .Select(value => (Spec: BindScreenshotSpec(value.Spec, app, values.MarketingVersion), value.ConfigPath)).ToArray();
+            var matchingMetadataSpecs = checkReadiness
+                ? ResolveMatchingMetadataSpecs(metadataSpecs, app, values.MarketingVersion)
+                : Array.Empty<(AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)>();
+            foreach (var configured in matchingMetadataSpecs)
+                ValidateAppleMetadataPreflight(configured);
+            var readinessRequest = CreateAppleReadinessRequest(matchingMetadataSpecs, boundScreenshotSpecs);
+            readinessRequest.AppId = app.AppStoreConnectAppId!;
+            readinessRequest.VersionString = values.MarketingVersion;
+            readinessRequest.BuildNumber = checkReadiness ? values.BuildNumber : null;
+            readinessRequest.Platform = app.Platform;
+            readinessRequest.RequireSelectedBuild = checkReadiness;
+            readinessRequest.RequireValidBuild = checkReadiness;
+            readinessRequest.RequireDescription = checkReadiness;
+            readinessRequest.RequireKeywords = checkReadiness;
+            readinessRequest.RequireSupportUrl = checkReadiness;
+            var readiness = _checkAppleReleaseReadiness(CreateAppStoreConnectCredential(plan), readinessRequest);
             target.ScreenshotCount = readiness.ScreenshotSets.Sum(static set => set.Count);
             target.ScreenshotDeliveryStates = readiness.ScreenshotSets
                 .SelectMany(static set => set.AssetDeliveryStates)

--- a/PowerForge/Services/PowerForgeReleaseService.ReadinessLocales.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.ReadinessLocales.cs
@@ -1,0 +1,22 @@
+namespace PowerForge;
+
+internal sealed partial class PowerForgeReleaseService
+{
+    private static bool RequiresAppleMetadataSpecs(PowerForgeAppleReleasePlan plan)
+        => plan.SyncMetadata || plan.CheckReleaseReadiness || (plan.SubmitForReview && !plan.SkipReviewReadinessCheck);
+
+    private static AppStoreConnectReleaseReadinessRequest CreateAppleReadinessRequest(
+        (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)[] metadata,
+        (AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)[] screenshots)
+    {
+        return new AppStoreConnectReleaseReadinessRequest
+        {
+            Locale = screenshots.FirstOrDefault().Spec?.Locale ?? metadata.FirstOrDefault().Spec?.Locale ?? "en-US",
+            MetadataLocales = AppStoreConnectReleaseReadinessService.NormalizeMetadataLocales(metadata.Select(static value => value.Spec.Locale)),
+            ScreenshotSpec = screenshots.Length == 1 ? screenshots[0].Spec : null,
+            ScreenshotSpecs = screenshots.Length > 1
+                ? screenshots.Select(static value => value.Spec).ToArray()
+                : Array.Empty<AppStoreConnectScreenshotSyncSpec>()
+        };
+    }
+}

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -2277,7 +2277,7 @@ internal sealed partial class PowerForgeReleaseService
         var screenshotSpecs = needsScreenshotSpecs
             ? LoadAppleScreenshotSpecs(plan)
             : Array.Empty<(AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)>();
-        var metadataSpecs = plan.SyncMetadata
+        var metadataSpecs = RequiresAppleMetadataSpecs(plan)
             ? LoadAppleMetadataSpecs(plan)
             : Array.Empty<(AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)>();
         var appInfoSpecs = plan.SyncAppInfo
@@ -2362,7 +2362,7 @@ internal sealed partial class PowerForgeReleaseService
             screenshotSpecs = needsScreenshotSpecs
                 ? LoadAppleScreenshotSpecs(plan)
                 : Array.Empty<(AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)>();
-            metadataSpecs = plan.SyncMetadata
+            metadataSpecs = RequiresAppleMetadataSpecs(plan)
                 ? LoadAppleMetadataSpecs(plan)
                 : Array.Empty<(AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)>();
             appInfoSpecs = plan.SyncAppInfo
@@ -2409,14 +2409,14 @@ internal sealed partial class PowerForgeReleaseService
                     foreach (var configured in matchingScreenshotSpecs)
                         ValidateAppleScreenshotPreflight(configured, plan.SourceCommit);
 
-                var matchingMetadataSpecs = plan.SyncMetadata &&
+                var matchingMetadataSpecs = RequiresAppleMetadataSpecs(plan) &&
                                            ShouldRunAppleShipAppStoreStep(plan, app) &&
                                            app.DistributionRoute == AppleDistributionRoute.AppStore
                     ? ResolveMatchingMetadataSpecs(
                         metadataSpecs,
                         app,
                         valuesByApp[app].MarketingVersion,
-                        required: true)
+                        required: plan.SyncMetadata)
                     : Array.Empty<(AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)>();
                 metadataByApp[app] = matchingMetadataSpecs;
                 foreach (var matchingMetadataSpec in matchingMetadataSpecs)
@@ -2758,7 +2758,7 @@ internal sealed partial class PowerForgeReleaseService
                             BaseDirectory = Path.GetDirectoryName(value.ConfigPath) ?? plan.ProjectRoot
                         }).ToArray()
                         : Array.Empty<AppStoreConnectReleaseScreenshotMapping>(),
-                    MetadataSpecs = matchingMetadataSpecs.Select(static value => value.Spec).ToArray(),
+                    MetadataSpecs = plan.SyncMetadata ? matchingMetadataSpecs.Select(static value => value.Spec).ToArray() : Array.Empty<AppStoreConnectVersionMetadataSpec>(),
                     AppInfoMetadataSpecs = appInfoMetadataSpecs,
                     ReplaceScreenshots = plan.ReplaceScreenshots,
                     ExpectedSourceCommit = plan.SourceCommit,
@@ -2772,13 +2772,8 @@ internal sealed partial class PowerForgeReleaseService
                                 : StringComparer.Ordinal),
                     ExpectedScreenshotInventorySha256 = app.ExpectedScreenshotInventorySha256,
                     CheckReadiness = plan.CheckReleaseReadiness,
-                    ReadinessRequest = plan.CheckReleaseReadiness && matchingScreenshotSpecs.Length > 0
-                        ? new AppStoreConnectReleaseReadinessRequest
-                        {
-                            Locale = matchingScreenshotSpecs[0].Spec.Locale,
-                            ScreenshotSpec = matchingScreenshotSpecs.Length == 1 ? matchingScreenshotSpecs[0].Spec : null,
-                            ScreenshotSpecs = matchingScreenshotSpecs.Length > 1 ? matchingScreenshotSpecs.Select(static value => value.Spec).ToArray() : Array.Empty<AppStoreConnectScreenshotSyncSpec>()
-                        }
+                    ReadinessRequest = plan.CheckReleaseReadiness
+                        ? CreateAppleReadinessRequest(matchingMetadataSpecs, matchingScreenshotSpecs)
                         : null,
                     BaseDirectory = matchingScreenshotSpecs.Length == 1 ? Path.GetDirectoryName(matchingScreenshotSpecs[0].ConfigPath) ?? plan.ProjectRoot : plan.ProjectRoot
                 });
@@ -2844,14 +2839,9 @@ internal sealed partial class PowerForgeReleaseService
                     RequireValidBuild = !plan.AllowUnprocessedReviewBuild,
                     CheckReadiness = !plan.SkipReviewReadinessCheck,
                     RequireReady = !plan.AllowReviewSubmissionWhenNotReady,
-                    ReadinessRequest = matchingScreenshotSpecs.Length == 0
-                        ? null
-                        : new AppStoreConnectReleaseReadinessRequest
-                        {
-                            Locale = matchingScreenshotSpecs[0].Spec.Locale,
-                            ScreenshotSpec = matchingScreenshotSpecs.Length == 1 ? matchingScreenshotSpecs[0].Spec : null,
-                            ScreenshotSpecs = matchingScreenshotSpecs.Length > 1 ? matchingScreenshotSpecs.Select(static value => value.Spec).ToArray() : Array.Empty<AppStoreConnectScreenshotSyncSpec>()
-                        }
+                    ReadinessRequest = !plan.SkipReviewReadinessCheck
+                        ? CreateAppleReadinessRequest(metadataByApp[app], matchingScreenshotSpecs)
+                        : null
                 });
             }
 

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -2416,7 +2416,7 @@ internal sealed partial class PowerForgeReleaseService
                         metadataSpecs,
                         app,
                         valuesByApp[app].MarketingVersion,
-                        required: plan.SyncMetadata)
+                        required: plan.SyncMetadata || metadataSpecs.Length > 0)
                     : Array.Empty<(AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)>();
                 metadataByApp[app] = matchingMetadataSpecs;
                 foreach (var matchingMetadataSpec in matchingMetadataSpecs)


### PR DESCRIPTION
App Store readiness now checks every configured metadata language even when screenshots are supplied only in English. Previously, screenshot mappings also determined which translated descriptions and other listing fields were checked.

The shared PowerForge release pipeline carries metadata locales through planning, preparation, and App Review submission without synchronizing text during read-only checks. All checked remote localizations contribute to the approval snapshot, so a change to a secondary language invalidates an earlier approval. Direct .NET callers can select metadata locales independently of screenshot mappings. Version and build state are fetched once per readiness run, and legacy callers retain their explicitly selected metadata and screenshot locale. Configured metadata must match the target app, platform, and version; mismatched files cannot silently fall back to a default-language check.

Private downstream consumers will pin this shared change after it lands. English screenshot mappings remain sufficient; consumers do not need duplicate mappings for translated listings.

Validation: 57 focused readiness, preparation, submission, approval-hash, and captured-input tests pass. Current Windows, Linux, macOS, product smoke, dependency audit, workflow lint, and publish checks pass. Independent review and the closure audit are complete, and automatic review has settled with all addressed threads resolved. Broader local provenance tests exposed existing macOS limitations; the current Linux publish check is green. No live Apple mutation was performed.
