### PR TITLE
Exclude build-host metadata from bundled modules

### DIFF
--- a/PowerForge.Tests/ArtefactBuilderLayoutTests.cs
+++ b/PowerForge.Tests/ArtefactBuilderLayoutTests.cs
@@ -162,7 +162,11 @@ public sealed class ArtefactBuilderLayoutTests
             WriteStagingFixture(stagingRoot.FullName, moduleName);
 
             var localModulesRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "psmodules"));
-            WriteInstalledModuleFixture(localModulesRoot.FullName, dependencyName, dependencyVersion);
+            var dependencyRoot = WriteInstalledModuleFixture(localModulesRoot.FullName, dependencyName, dependencyVersion);
+            var receiptDirectory = Directory.CreateDirectory(Path.Combine(dependencyRoot, ".powerforge"));
+            File.WriteAllText(Path.Combine(receiptDirectory.FullName, "managed-module-receipt.json"), "{\"ModuleRoot\":\"C:\\\\Users\\\\Builder\"}");
+            File.WriteAllText(Path.Combine(dependencyRoot, "PSGetModuleInfo.xml"), "<Obj><S N=\"InstalledLocation\">C:\\Users\\Builder</S></Obj>");
+            File.WriteAllText(Path.Combine(dependencyRoot, "runtime.powerforge.json"), "{}");
 
             var updatedPsModulePath = string.Join(
                 Path.PathSeparator,
@@ -209,7 +213,11 @@ public sealed class ArtefactBuilderLayoutTests
                 ZipFile.ExtractToDirectory(result.OutputPath, inspectionRoot);
 
             Assert.True(File.Exists(Path.Combine(inspectionRoot, "Payload", "MainModules", moduleName, moduleName + ".psd1")));
-            Assert.True(File.Exists(Path.Combine(inspectionRoot, "Payload", "Dependencies", dependencyName, dependencyName + ".psd1")));
+            var packagedDependencyRoot = Path.Combine(inspectionRoot, "Payload", "Dependencies", dependencyName);
+            Assert.True(File.Exists(Path.Combine(packagedDependencyRoot, dependencyName + ".psd1")));
+            Assert.False(Directory.Exists(Path.Combine(packagedDependencyRoot, ".powerforge")));
+            Assert.False(File.Exists(Path.Combine(packagedDependencyRoot, "PSGetModuleInfo.xml")));
+            Assert.True(File.Exists(Path.Combine(packagedDependencyRoot, "runtime.powerforge.json")));
 
             Assert.False(Directory.Exists(Path.Combine(inspectionRoot, moduleName)));
             Assert.False(Directory.Exists(Path.Combine(inspectionRoot, dependencyName)));
@@ -308,12 +316,13 @@ public sealed class ArtefactBuilderLayoutTests
         File.WriteAllText(Path.Combine(stagingRoot, moduleName + ".psm1"), "function Get-Test { 'ok' }");
     }
 
-    private static void WriteInstalledModuleFixture(string modulesRoot, string moduleName, string moduleVersion)
+    private static string WriteInstalledModuleFixture(string modulesRoot, string moduleName, string moduleVersion)
     {
         var versionRoot = Directory.CreateDirectory(Path.Combine(modulesRoot, moduleName, moduleVersion));
         File.WriteAllText(
             Path.Combine(versionRoot.FullName, moduleName + ".psd1"),
             "@{ RootModule = '" + moduleName + ".psm1'; ModuleVersion = '" + moduleVersion + "'; GUID = '" + Guid.NewGuid().ToString() + "' }");
         File.WriteAllText(Path.Combine(versionRoot.FullName, moduleName + ".psm1"), "function Get-Dependency { 'ok' }");
+        return versionRoot.FullName;
     }
 }

--- a/PowerForge.Tests/EmbeddedModuleDependencyServiceTests.cs
+++ b/PowerForge.Tests/EmbeddedModuleDependencyServiceTests.cs
@@ -41,6 +41,47 @@ public sealed class EmbeddedModuleDependencyServiceTests
     }
 
     [Fact]
+    public void Embed_ExcludesBuildHostInstallationMetadata()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "BuiltModule"));
+            var dependencyRoot = CreateModule(root.FullName, "Microsoft.Graph.Authentication", "2.25.0");
+            var receiptDirectory = Directory.CreateDirectory(Path.Combine(dependencyRoot, ".powerforge"));
+            File.WriteAllText(Path.Combine(receiptDirectory.FullName, "managed-module-receipt.json"), "{\"ModuleRoot\":\"C:\\\\Users\\\\Builder\"}");
+            File.WriteAllText(Path.Combine(dependencyRoot, "PSGetModuleInfo.xml"), "<Obj><S N=\"InstalledLocation\">C:\\Users\\Builder</S></Obj>");
+            File.WriteAllText(Path.Combine(dependencyRoot, "runtime.powerforge.json"), "{}");
+            var provider = new Provider(new InstalledModuleMetadata(
+                "Microsoft.Graph.Authentication",
+                "2.25.0",
+                guid: null,
+                moduleBasePath: dependencyRoot));
+
+            var service = new EmbeddedModuleDependencyService(new NullLogger());
+            service.Embed(
+                moduleRoot.FullName,
+                new[] { new RequiredModuleReference("Microsoft.Graph.Authentication", requiredVersion: "2.25.0") },
+                provider);
+
+            var embeddedRoot = Path.Combine(
+                moduleRoot.FullName,
+                "Internals",
+                "Modules",
+                "Microsoft.Graph.Authentication",
+                "2.25.0");
+            Assert.False(Directory.Exists(Path.Combine(embeddedRoot, ".powerforge")));
+            Assert.False(File.Exists(Path.Combine(embeddedRoot, "PSGetModuleInfo.xml")));
+            Assert.True(File.Exists(Path.Combine(embeddedRoot, "runtime.powerforge.json")));
+            Assert.True(File.Exists(Path.Combine(embeddedRoot, "Microsoft.Graph.Authentication.psd1")));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Embed_PreservesDeclarationOrderInDependencyManifest()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge/Services/ArtefactBuilder.Api.cs
+++ b/PowerForge/Services/ArtefactBuilder.Api.cs
@@ -382,7 +382,7 @@ public sealed partial class ArtefactBuilder
                 if (installed is not null)
                 {
                     var dest = Path.Combine(destinationRoot, name);
-                    CopyDirectory(installed.ModuleBasePath, dest);
+                    CopyDirectory(installed.ModuleBasePath, dest, excludeBuildHostMetadata: true);
                     return new ArtefactModuleEntry(name, isMainModule: false, version: installed.Version, path: dest);
                 }
 
@@ -514,7 +514,7 @@ public sealed partial class ArtefactBuilder
                 throw new InvalidOperationException($"Unable to locate saved version folder under '{moduleRoot}'.");
 
             var dest = Path.Combine(destinationRoot, name);
-            CopyDirectory(versionFolder, dest);
+            CopyDirectory(versionFolder, dest, excludeBuildHostMetadata: true);
             return new ArtefactModuleEntry(name, isMainModule: false, version: resolvedVersion, path: dest);
         }
         finally

--- a/PowerForge/Services/ArtefactBuilder.FileOps.cs
+++ b/PowerForge/Services/ArtefactBuilder.FileOps.cs
@@ -10,7 +10,7 @@ namespace PowerForge;
 
 public sealed partial class ArtefactBuilder
 {
-    private static void CopyDirectory(string sourceDir, string destDir)
+    private static void CopyDirectory(string sourceDir, string destDir, bool excludeBuildHostMetadata = false)
     {
         if (!Directory.Exists(sourceDir))
             throw new DirectoryNotFoundException($"Directory not found: {sourceDir}");
@@ -23,11 +23,17 @@ public sealed partial class ArtefactBuilder
         foreach (var dir in Directory.EnumerateDirectories(sourceDir, "*", SearchOption.AllDirectories))
         {
             var rel = ComputeRelativePath(sourceDir, dir);
+            if (excludeBuildHostMetadata && ModuleDependencyPackageFilter.IsBuildHostMetadataPath(rel))
+                continue;
+
             Directory.CreateDirectory(Path.Combine(destDir, rel));
         }
         foreach (var file in Directory.EnumerateFiles(sourceDir, "*", SearchOption.AllDirectories))
         {
             var rel = ComputeRelativePath(sourceDir, file);
+            if (excludeBuildHostMetadata && ModuleDependencyPackageFilter.IsBuildHostMetadataPath(rel))
+                continue;
+
             var outPath = Path.Combine(destDir, rel);
             Directory.CreateDirectory(Path.GetDirectoryName(outPath)!);
             File.Copy(file, outPath, overwrite: true);

--- a/PowerForge/Services/EmbeddedModuleDependencyService.cs
+++ b/PowerForge/Services/EmbeddedModuleDependencyService.cs
@@ -69,7 +69,7 @@ internal sealed class EmbeddedModuleDependencyService
                 : Path.Combine(reference.ModuleName, version!);
             var destination = Path.Combine(modulesRoot, relativePath);
 
-            CopyDirectory(installed.ModuleBasePath!, destination, overwrite: true);
+            CopyDirectory(installed.ModuleBasePath!, destination, overwrite: true, excludeBuildHostMetadata: true);
             entries.Add(new EmbeddedModuleDependencyEntry
             {
                 Name = reference.ModuleName,
@@ -630,7 +630,11 @@ internal sealed class EmbeddedModuleDependencyService
         };
     }
 
-    private static void CopyDirectory(string sourceDirectory, string destinationDirectory, bool overwrite)
+    private static void CopyDirectory(
+        string sourceDirectory,
+        string destinationDirectory,
+        bool overwrite,
+        bool excludeBuildHostMetadata = false)
     {
         if (!Directory.Exists(sourceDirectory))
             throw new DirectoryNotFoundException($"Directory not found: {sourceDirectory}");
@@ -646,12 +650,18 @@ internal sealed class EmbeddedModuleDependencyService
         foreach (var directory in Directory.EnumerateDirectories(sourceDirectory, "*", SearchOption.AllDirectories))
         {
             var relative = ComputeRelativePath(sourceDirectory, directory);
+            if (excludeBuildHostMetadata && ModuleDependencyPackageFilter.IsBuildHostMetadataPath(relative))
+                continue;
+
             Directory.CreateDirectory(Path.Combine(destinationDirectory, relative));
         }
 
         foreach (var file in Directory.EnumerateFiles(sourceDirectory, "*", SearchOption.AllDirectories))
         {
             var relative = ComputeRelativePath(sourceDirectory, file);
+            if (excludeBuildHostMetadata && ModuleDependencyPackageFilter.IsBuildHostMetadataPath(relative))
+                continue;
+
             var target = Path.Combine(destinationDirectory, relative);
             Directory.CreateDirectory(Path.GetDirectoryName(target)!);
             File.Copy(file, target, overwrite: true);

--- a/PowerForge/Services/ModuleDependencyPackageFilter.cs
+++ b/PowerForge/Services/ModuleDependencyPackageFilter.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Linq;
+
+namespace PowerForge;
+
+internal static class ModuleDependencyPackageFilter
+{
+    internal static bool IsBuildHostMetadataPath(string relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath))
+            return false;
+
+        var parts = relativePath
+            .Replace('\\', '/')
+            .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        return parts.Any(static part => part.Equals(".powerforge", StringComparison.OrdinalIgnoreCase)) ||
+               (parts.Length > 0 && parts[parts.Length - 1].Equals("PSGetModuleInfo.xml", StringComparison.OrdinalIgnoreCase));
+    }
+}


### PR DESCRIPTION
## Summary

- exclude PowerForge's private `.powerforge` working directory from bundled module payloads
- exclude PowerShellGet's `PSGetModuleInfo.xml` installation metadata from bundled module payloads
- apply the same filter to embedded dependencies and both installed/downloaded `AddRequiredModules` paths
- preserve similarly named product files such as `runtime.powerforge.json`

## Why

Bundled dependencies should contain runtime module content, not build-host provenance or package-manager installation metadata. A private downstream consumer exposed both classes of files in a generated full-package archive.

## Validation

- 29 focused `PowerForge.Tests` tests passed
- installed-source artifact layout covers exact exclusions and similarly named-file preservation
- embedded dependency tests cover exact exclusions and preservation
- a rebuilt downstream full-package ZIP contained zero `.powerforge` paths and zero `PSGetModuleInfo.xml` entries
- the rebuilt downstream module imported successfully in PowerShell 7.6 and Windows PowerShell 5.1

## Release ordering

Merge and publish the PowerForge owner fix before rebuilding downstream release artifacts with the public package.