### PR TITLE
Resolve GitHub CLI on public release runners

### DIFF
--- a/.github/workflows/pspublishmodule-public-release.yml
+++ b/.github/workflows/pspublishmodule-public-release.yml
@@ -49,6 +49,25 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Resolve GitHub CLI
+        shell: pwsh
+        run: |
+          $command = Get-Command gh -ErrorAction SilentlyContinue
+          if ($null -ne $command) {
+              $ghPath = [string] $command.Source
+          } else {
+              $ghPath = Join-Path $env:ProgramFiles 'GitHub CLI\gh.exe'
+          }
+          if (-not (Test-Path -LiteralPath $ghPath -PathType Leaf)) {
+              throw "GitHub CLI was not found in PATH or at '$ghPath'."
+          }
+          $ghDirectory = Split-Path -Parent ([IO.Path]::GetFullPath($ghPath))
+          $ghDirectory | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          & $ghPath --version
+          if ($LASTEXITCODE -ne 0) {
+              throw "GitHub CLI failed to start from '$ghPath'."
+          }
+
       - name: Verify actor and immutable main commit
         shell: pwsh
         env:


### PR DESCRIPTION
## Summary

- resolve GitHub CLI from the runner PATH when available
- fall back to the standard Windows installation under `%ProgramFiles%`
- add the resolved directory to `GITHUB_PATH` for every subsequent release step
- fail before release work when GitHub CLI is absent or cannot start

## Why

The protected public-release workflow reached its self-hosted Windows runner but failed before the immutable-commit check because `gh` was installed outside the runner service PATH. The release workflow uses `gh` for permission verification, release-branch and pull-request operations, and final publication verification.

Failed run: https://github.com/EvotecIT/PSPublishModule/actions/runs/34229910743

## Validation

- `git diff --check` passes
- the fallback executable is present locally at `C:\Program Files\GitHub CLI\gh.exe` and reports GitHub CLI 2.97.0
- an independent read-only workflow review found no P0-P3 issues
- the step invokes the resolved executable directly for its own validation and exports only its parent directory for later steps

## Release recovery

After this PR merges, rerun the guarded 3.0.136 Prepare operation against the new exact main commit.