### PR TITLE
Fix provider package license metadata and CI process capture

### DIFF
--- a/PowerForge.PowerShell.ProviderSdk/PowerShellCompilationProviderPackageBuilder.cs
+++ b/PowerForge.PowerShell.ProviderSdk/PowerShellCompilationProviderPackageBuilder.cs
@@ -268,7 +268,8 @@ public sealed class PowerShellCompilationProviderPackageBuilder
         var dependencies = string.Join(string.Empty, manifest.Dependencies
             .OrderBy(static dependency => dependency.PackageId, StringComparer.Ordinal)
             .Select(static dependency => $"<dependency id=\"{Xml(dependency.PackageId)}\" version=\"[{Xml(dependency.Version)}]\" />"));
-        return $"<?xml version=\"1.0\" encoding=\"utf-8\"?><package><metadata><id>{Xml(manifest.PackageId)}</id><version>{Xml(manifest.PackageVersion)}</version><authors>{Xml(manifest.Publisher)}</authors><description>PowerForge PowerShell compilation provider metadata.</description><license type=\"expression\">{Xml(manifest.LicenseExpression)}</license><dependencies><group targetFramework=\"net8.0\">{dependencies}</group></dependencies></metadata></package>";
+        var licenseUrl = "https://licenses.nuget.org/" + Uri.EscapeDataString(manifest.LicenseExpression);
+        return $"<?xml version=\"1.0\" encoding=\"utf-8\"?><package><metadata><id>{Xml(manifest.PackageId)}</id><version>{Xml(manifest.PackageVersion)}</version><authors>{Xml(manifest.Publisher)}</authors><description>PowerForge PowerShell compilation provider metadata.</description><license type=\"expression\">{Xml(manifest.LicenseExpression)}</license><licenseUrl>{Xml(licenseUrl)}</licenseUrl><dependencies><group targetFramework=\"net8.0\">{dependencies}</group></dependencies></metadata></package>";
     }
 
     private static string Xml(string value) => System.Security.SecurityElement.Escape(value) ?? string.Empty;

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -513,36 +513,54 @@ public sealed partial class DotNetPublishPipelineRunnerHardeningTests
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
+    [Trait("Category", "DotNetPublishPrGate")]
     public void RunProcessWithTimeout_PreservesUnterminatedOutputWithInheritedHandles(bool useStandardError)
     {
-        if (!DotNetPublishPipelineRunner.IsWindows())
-            return;
-
         var method = typeof(DotNetPublishPipelineRunner).GetMethod(
             "RunProcessWithTimeout",
             BindingFlags.Static | BindingFlags.NonPublic);
         Assert.NotNull(method);
         var stopwatch = Stopwatch.StartNew();
+        string fileName;
+        string[] arguments;
+        if (DotNetPublishPipelineRunner.IsWindows())
+        {
+            fileName = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+                "PowerShell",
+                "7",
+                "pwsh.exe");
+            arguments =
+            [
+                "-NoProfile",
+                "-Command",
+                "$descendant = Start-Process -FilePath $env:ComSpec -ArgumentList '/d','/c','ping 127.0.0.1 -n 11 >nul' -NoNewWindow -PassThru; " +
+                "[Console]::Out.WriteLine('descendant-pid=' + $descendant.Id); " +
+                (useStandardError
+                    ? "[Console]::Error.Write('parent-complete')"
+                    : "[Console]::Out.Write('parent-complete')")
+            ];
+        }
+        else
+        {
+            fileName = "/bin/sh";
+            arguments =
+            [
+                "-c",
+                "sleep 10 & descendant=$!; printf 'descendant-pid=%s\\n' \"$descendant\"; " +
+                (useStandardError
+                    ? "printf parent-complete >&2"
+                    : "printf parent-complete")
+            ];
+        }
 
         var raw = method!.Invoke(
             null,
             new object[]
             {
-                Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
-                    "PowerShell",
-                    "7",
-                    "pwsh.exe"),
+                fileName,
                 Environment.CurrentDirectory,
-                new[]
-                {
-                    "-NoProfile",
-                    "-Command",
-                    "Start-Process -FilePath $env:ComSpec -ArgumentList '/d','/c','ping 127.0.0.1 -n 11 >nul' -NoNewWindow; " +
-                    (useStandardError
-                        ? "[Console]::Error.Write('parent-complete')"
-                        : "[Console]::Out.Write('parent-complete')")
-                },
+                arguments,
                 TimeSpan.FromSeconds(2),
                 CancellationToken.None
             });
@@ -555,13 +573,80 @@ public sealed partial class DotNetPublishPipelineRunnerHardeningTests
         var stderr = (string)resultType.GetField("Item3")!.GetValue(raw)!;
         var timedOut = (bool)resultType.GetField("Item4")!.GetValue(raw)!;
 
-        Assert.False(timedOut);
-        Assert.Equal(0, exitCode);
-        Assert.Contains(
-            "parent-complete",
-            useStandardError ? stderr : stdout,
-            StringComparison.Ordinal);
-        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), stopwatch.Elapsed.ToString());
+        string? processIdLine = stdout
+            .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault(line => line.StartsWith("descendant-pid=", StringComparison.Ordinal));
+        Assert.NotNull(processIdLine);
+        Assert.True(int.TryParse(processIdLine!["descendant-pid=".Length..], out int processId));
+
+        using var descendant = Process.GetProcessById(processId);
+        try
+        {
+            Assert.False(descendant.HasExited);
+            Assert.False(timedOut);
+            Assert.Equal(0, exitCode);
+            Assert.Contains(
+                "parent-complete",
+                useStandardError ? stderr : stdout,
+                StringComparison.Ordinal);
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), stopwatch.Elapsed.ToString());
+        }
+        finally
+        {
+            try
+            {
+                if (!descendant.HasExited)
+                {
+                    descendant.Kill(entireProcessTree: true);
+                    descendant.WaitForExit(5000);
+                }
+            }
+            catch
+            {
+                // best effort test cleanup
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void RunProcessWithTimeout_TimesOutContinuouslyWritingUnixProcess()
+    {
+        if (DotNetPublishPipelineRunner.IsWindows())
+            return;
+
+        var method = typeof(DotNetPublishPipelineRunner).GetMethod(
+            "RunProcessWithTimeout",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        var stopwatch = Stopwatch.StartNew();
+
+        var raw = method!.Invoke(
+            null,
+            new object[]
+            {
+                "/bin/sh",
+                Environment.CurrentDirectory,
+                new[]
+                {
+                    "-c",
+                    "(sleep 3; kill -TERM $$) & while :; do printf 'continuous-output-0123456789\\n'; done"
+                },
+                TimeSpan.FromMilliseconds(200),
+                CancellationToken.None
+            });
+
+        stopwatch.Stop();
+        Assert.NotNull(raw);
+        var resultType = raw!.GetType();
+        var exitCode = (int)resultType.GetField("Item1")!.GetValue(raw)!;
+        var stderr = (string)resultType.GetField("Item3")!.GetValue(raw)!;
+        var timedOut = (bool)resultType.GetField("Item4")!.GetValue(raw)!;
+
+        Assert.True(timedOut);
+        Assert.Equal(-1, exitCode);
+        Assert.Contains("timed out", stderr, StringComparison.OrdinalIgnoreCase);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(2), stopwatch.Elapsed.ToString());
     }
 
     [Fact]

--- a/PowerForge.Tests/PowerShellCompilationProviderPackageTests.cs
+++ b/PowerForge.Tests/PowerShellCompilationProviderPackageTests.cs
@@ -196,6 +196,23 @@ public sealed partial class PowerShellCompilationProviderPackageTests
     }
 
     [Fact]
+    public void BuilderEmitsNuGetHostedLicenseUrlForOlderClients()
+    {
+        using var fixture = ProviderFixture.Create();
+        fixture.Manifest.LicenseExpression = "MIT OR Apache-2.0";
+        var packagePath = fixture.PackagePath("provider.nupkg");
+
+        fixture.BuildPackage("provider.nupkg");
+
+        using var archive = ZipFile.OpenRead(packagePath);
+        var entry = Assert.Single(archive.Entries, static item => item.Name.EndsWith(".nuspec", StringComparison.Ordinal));
+        using var reader = new StreamReader(entry.Open(), Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        var nuspec = reader.ReadToEnd();
+        Assert.Contains("<license type=\"expression\">MIT OR Apache-2.0</license>", nuspec, StringComparison.Ordinal);
+        Assert.Contains("<licenseUrl>https://licenses.nuget.org/MIT%20OR%20Apache-2.0</licenseUrl>", nuspec, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ReaderRejectsPreviousProviderAbiInsteadOfInferringExternalOperationSemantics()
     {
         using var fixture = ProviderFixture.Create();

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.OutputCapture.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.OutputCapture.cs
@@ -54,29 +54,66 @@ public sealed partial class DotNetPublishPipelineRunner
         }
     }
 
-    private static Task ReadRedirectedOutputAsync(
+    // Start each reader on its own thread so the caller can arm the process
+    // timeout even when a Unix pipe keeps completing reads synchronously. The
+    // thread exits at the first asynchronous read; the continuation then
+    // completes normally without occupying a worker for the process lifetime.
+    private static Task StartRedirectedOutputReader(
         StreamReader reader,
         RedirectedOutputCapture capture)
-        => Task.Run(async () =>
+    {
+        var completion = new TaskCompletionSource<object?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() =>
         {
-            var buffer = new char[4096];
-            try
-            {
-                int count;
-                while ((count = await reader.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0)
-                    capture.Append(buffer, count);
-            }
-            catch (IOException)
-            {
-                // Disposing an inherited redirected stream ends the bounded read.
-            }
-            catch (ObjectDisposedException)
-            {
-                // Disposing an inherited redirected stream ends the bounded read.
-            }
-            catch (InvalidOperationException)
-            {
-                // The asynchronous reader can report disposal as an invalid operation.
-            }
-        });
+            _ = CompleteRedirectedOutputReaderAsync(reader, capture, completion);
+        })
+        {
+            IsBackground = true,
+            Name = "PowerForge redirected output reader"
+        };
+        thread.Start();
+        return completion.Task;
+    }
+
+    private static async Task CompleteRedirectedOutputReaderAsync(
+        StreamReader reader,
+        RedirectedOutputCapture capture,
+        TaskCompletionSource<object?> completion)
+    {
+        try
+        {
+            await ReadRedirectedOutputAsync(reader, capture).ConfigureAwait(false);
+            completion.TrySetResult(null);
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
+    }
+
+    private static async Task ReadRedirectedOutputAsync(
+        StreamReader reader,
+        RedirectedOutputCapture capture)
+    {
+        var buffer = new char[4096];
+        try
+        {
+            int count;
+            while ((count = await reader.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0)
+                capture.Append(buffer, count);
+        }
+        catch (IOException)
+        {
+            // Disposing an inherited redirected stream ends the bounded read.
+        }
+        catch (ObjectDisposedException)
+        {
+            // Disposing an inherited redirected stream ends the bounded read.
+        }
+        catch (InvalidOperationException)
+        {
+            // The asynchronous reader can report disposal as an invalid operation.
+        }
+    }
 }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.cs
@@ -1023,8 +1023,8 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             var stdoutCapture = new RedirectedOutputCapture();
             var stderrCapture = new RedirectedOutputCapture();
-            Task stdoutRead = ReadRedirectedOutputAsync(p.StandardOutput, stdoutCapture);
-            Task stderrRead = ReadRedirectedOutputAsync(p.StandardError, stderrCapture);
+            Task stdoutRead = StartRedirectedOutputReader(p.StandardOutput, stdoutCapture);
+            Task stderrRead = StartRedirectedOutputReader(p.StandardError, stderrCapture);
 
             var timeoutMs = ToTimeoutMilliseconds(timeout.Value);
             bool exited = p.WaitForExit(timeoutMs);


### PR DESCRIPTION
## Summary

- add the NuGet-hosted compatibility license URL to custom PowerShell provider packages
- URL-encode compound SPDX expressions before using them as the license path
- start bounded stdout and stderr capture independently so low-core agents cannot miss process output before the drain deadline
- cover the generated package metadata plus inherited-handle and continuous-writer process behavior on Windows and Unix

## Why

Runtime provider projects replace the SDK-generated package with a deterministic package built by `PowerShellCompilationProviderPackageBuilder`. That replacement preserved the modern license expression but omitted the compatibility `licenseUrl` normally generated by the NuGet SDK, causing NuGet.org to reject the package.

The failed focused CI run also exposed a repository-wide process-capture race. Redirected readers were queued through the shared thread pool while the caller synchronously waited for the child process. Under low-core load, the readers could start after the bounded drain expired, leaving MSBuild JSON incomplete and producing a misleading provenance failure. Reader startup is now independent, while the normal asynchronous read and bounded timeout behavior remain intact.

The package fix applies to both Directory.Runtime and Management.Runtime packages. The process fix applies to every bounded child-process invocation in the shared .NET publish pipeline.

## Validation

- provider-package artifact suite: 57 passed
- focused Windows process/provenance regression set: 4 passed
- Linux `DotNetPublishPrGate`: 75 passed
- independent read-only review plus targeted confirmation: no unresolved findings

## Release state

The interrupted `3.0.136` release published five packages before reaching the invalid runtime package. This PR fixes the package source; completing the remaining NuGet and GitHub publication is a separate release action after merge.
