### PR TITLE
Increase compiler gate timeout budget

### DIFF
--- a/.github/workflows/BuildModule.yml
+++ b/.github/workflows/BuildModule.yml
@@ -357,7 +357,7 @@ jobs:
 
       - name: Run bounded PowerShell compiler gate
         shell: pwsh
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: |
           $ErrorActionPreference = 'Stop'
           . ./Benchmarks/PowerShellCompilation/Corpus/Corpus.Runner.Common.ps1

--- a/.github/workflows/BuildModule.yml
+++ b/.github/workflows/BuildModule.yml
@@ -305,7 +305,7 @@ jobs:
         run: .\PSPublishModule.Tests.ps1
   ProductBuildSmoke:
     runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","windows"]' || '["windows-latest"]') }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       DbaClientXRoot: ${{ github.workspace }}\_dependencies\DbaClientX
 

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerCancellationTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerCancellationTests.cs
@@ -23,7 +23,11 @@ public sealed class DotNetPublishPipelineRunnerCancellationTests
             ]
         };
 
-        var execution = Task.Run(() => runner.Run(plan, progress: null, scope.Token));
+        var execution = Task.Factory.StartNew(
+            () => runner.Run(plan, progress: null, scope.Token),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
         await processRunner.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
         scope.Cancel();
 


### PR DESCRIPTION
Extends the bounded PowerShell compiler gate to 30 minutes and the enclosing product-smoke job to 90 minutes, preserving the existing gate and cleanup paths on slower hosted runners.

Also makes the pipeline cancellation contract independent of the shared test thread pool: the synchronous pipeline executes on a dedicated test thread, while the test retains its bounded startup and cancellation assertions.