### PR TITLE
Resolve deferred module package versions and preserve release signing

### DIFF
--- a/PSPublishModule/Cmdlets/InvokeModuleBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeModuleBuildCommand.cs
@@ -337,6 +337,10 @@ public sealed partial class InvokeModuleBuildCommand : PSCmdlet
     [Parameter(ParameterSetName = ParameterSetConfig, DontShow = true)]
     public SwitchParameter ReuseStaging { get; set; }
 
+    /// <summary>Marks an internal build pass as the exact local checkpoint for deferred publication.</summary>
+    [Parameter(ParameterSetName = ParameterSetConfig, DontShow = true)]
+    public SwitchParameter PowerForgeReleaseCheckpoint { get; set; }
+
     /// <summary>Optional path to a .NET project (.csproj) to publish into the module.</summary>
     [Parameter(ParameterSetName = ParameterSetModern)]
     public string? CsprojPath { get; set; }
@@ -507,6 +511,7 @@ public sealed partial class InvokeModuleBuildCommand : PSCmdlet
             InputPath = Path,
             StagingPath = StagingPath,
             ReuseStaging = ReuseStaging.IsPresent,
+            ReleaseCheckpoint = PowerForgeReleaseCheckpoint.IsPresent,
             CsprojPath = CsprojPath,
             DotNetConfiguration = DotNetConfiguration,
             DotNetFramework = DotNetFramework,

--- a/PowerForge.PowerShell/Models/ModuleBuildPreparationRequest.cs
+++ b/PowerForge.PowerShell/Models/ModuleBuildPreparationRequest.cs
@@ -24,6 +24,7 @@ internal sealed class ModuleBuildPreparationRequest
     public bool IncludeProjectPackages { get; set; } = true;
     public bool IncludeModulePublishing { get; set; } = true;
     public bool UnifiedGitHubRelease { get; set; }
+    public bool ReleaseCheckpoint { get; set; }
     public string? CertificateThumbprint { get; set; }
     public bool? SignIncludeBinaries { get; set; }
     public bool? SignIncludeInternals { get; set; }

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -63,6 +63,7 @@ internal sealed class ModuleBuildPreparationService
         var spec = new ModulePipelineSpec
         {
             UnifiedGitHubRelease = request.UnifiedGitHubRelease,
+            ReleaseCheckpoint = request.ReleaseCheckpoint,
             Build = new ModuleBuildSpec
             {
                 Name = moduleName!,
@@ -155,6 +156,7 @@ internal sealed class ModuleBuildPreparationService
     private static void ApplyConfigOverrides(ModulePipelineSpec spec, ModuleBuildPreparationRequest request)
     {
         spec.UnifiedGitHubRelease = request.UnifiedGitHubRelease;
+        spec.ReleaseCheckpoint = request.ReleaseCheckpoint;
         if (spec.Build is null)
             return;
 

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -783,7 +783,7 @@ public sealed partial class ModulePipelineRunner
             cfg.UseAsReleaseVersionSource);
         if (mode is not PackageBuildExecutionMode.PublishNuGet and not PackageBuildExecutionMode.PublishGitHub)
             MarkSynchronizedReleaseLaneAttempted(state, checkpointKey);
-        ApplyProjectBuildGateDefaults(configuration, mode, plan.GateMode);
+        ApplyProjectBuildGateDefaults(configuration, mode, plan.GateMode, plan.ReleaseCheckpoint);
         var actions = ResolveEffectiveActions(configuration);
         var request = new ProjectBuildHostRequest
         {
@@ -846,7 +846,7 @@ public sealed partial class ModulePipelineRunner
             cfg.UseAsReleaseVersionSource);
         if (mode is not PackageBuildExecutionMode.PublishNuGet and not PackageBuildExecutionMode.PublishGitHub)
             MarkSynchronizedReleaseLaneAttempted(state, checkpointKey);
-        ApplyProjectBuildGateDefaults(projectBuildConfig, mode, plan.GateMode);
+        ApplyProjectBuildGateDefaults(projectBuildConfig, mode, plan.GateMode, plan.ReleaseCheckpoint);
         var actions = ResolveEffectiveActions(projectBuildConfig);
         var configPath = Path.Combine(plan.ProjectRoot, "module.packagebuild.inline.json");
         var request = new ProjectBuildHostRequest
@@ -887,12 +887,14 @@ public sealed partial class ModulePipelineRunner
     private static void ApplyProjectBuildGateDefaults(
         ProjectBuildConfiguration target,
         PackageBuildExecutionMode mode,
-        ConfigurationGateMode? gateMode)
+        ConfigurationGateMode? gateMode,
+        bool releaseCheckpoint)
     {
         if (gateMode == ConfigurationGateMode.Build &&
             mode is PackageBuildExecutionMode.DependencyBuild or PackageBuildExecutionMode.BuildOnly)
         {
-            target.CertificateThumbprint = null;
+            if (!releaseCheckpoint)
+                target.CertificateThumbprint = null;
         }
 
         if (gateMode == ConfigurationGateMode.Documentation &&

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -557,6 +557,7 @@ public sealed partial class ModulePipelineRunner
             stagingWasGenerated: stagingWasGenerated,
             deleteGeneratedStagingAfterRun: deleteAfter,
             embeddedModules: embeddedModules);
+        plan.ReleaseCheckpoint = spec.ReleaseCheckpoint;
         ApplyReleaseSourceProtection(spec, plan, localVersioning, releaseProtection, gateMode);
         return plan;
     }

--- a/PowerForge.Tests/ModuleBuildHostServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildHostServiceTests.cs
@@ -42,6 +42,7 @@ public sealed class ModuleBuildHostServiceTests
             ModuleVersion = "3.1.0",
             StagingPath = @"C:\repo\.powerforge\staging",
             ReuseStaging = true,
+            ReleaseCheckpoint = true,
             NoDotnetBuild = true,
             NoSign = true,
             IncludeProjectPackages = false,
@@ -60,6 +61,7 @@ public sealed class ModuleBuildHostServiceTests
         Assert.Contains("$moduleBuildArguments['ModuleVersion'] = '3.1.0'", captured.CommandText!, StringComparison.Ordinal);
         Assert.Contains("$moduleBuildArguments['StagingPath'] = 'C:\\repo\\.powerforge\\staging'", captured.CommandText!, StringComparison.Ordinal);
         Assert.Contains("$moduleBuildArguments['ReuseStaging'] = $true", captured.CommandText!, StringComparison.Ordinal);
+        Assert.Contains("$moduleBuildArguments['PowerForgeReleaseCheckpoint'] = $true", captured.CommandText!, StringComparison.Ordinal);
         Assert.Contains("$moduleBuildArguments['NoDotnetBuild'] = $true", captured.CommandText!, StringComparison.Ordinal);
         Assert.Contains("$moduleBuildArguments['NoSign'] = $true", captured.CommandText!, StringComparison.Ordinal);
         Assert.Contains("$moduleBuildArguments['IncludeProjectPackages'] = $false", captured.CommandText!, StringComparison.Ordinal);

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.ConfigOverrides.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.ConfigOverrides.cs
@@ -69,6 +69,7 @@ public sealed partial class ModuleBuildPreparationServiceTests
                 CurrentPath = root.FullName,
                 ResolvePath = path => Path.IsPathRooted(path) ? path : Path.GetFullPath(Path.Combine(root.FullName, path)),
                 UnifiedGitHubRelease = true,
+                ReleaseCheckpoint = true,
                 SkipInstall = true,
                 StagingPath = Path.Combine(".powerforge", "approved-staging"),
                 DiagnosticsBaselinePath = baselinePath,
@@ -91,6 +92,7 @@ public sealed partial class ModuleBuildPreparationServiceTests
             Assert.True(prepared.PipelineSpec.Diagnostics.FailOnNewDiagnostics);
             Assert.Equal(BuildDiagnosticSeverity.Error, prepared.PipelineSpec.Diagnostics.FailOnSeverity);
             Assert.True(prepared.PipelineSpec.UnifiedGitHubRelease);
+            Assert.True(prepared.PipelineSpec.ReleaseCheckpoint);
             var publish = Assert.Single(prepared.PipelineSpec.Segments.OfType<ConfigurationPublishSegment>());
             Assert.Equal(PublishDestination.PowerShellGallery, publish.Configuration.Destination);
         }

--- a/PowerForge.Tests/ModulePipelinePackageBuildReviewTests.cs
+++ b/PowerForge.Tests/ModulePipelinePackageBuildReviewTests.cs
@@ -308,6 +308,100 @@ public sealed partial class ModulePipelinePackageBuildTests
         }
     }
 
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public void Run_GateBuild_PreservesPackageCertificateOnlyForReleaseCheckpoint(
+        bool releaseCheckpoint,
+        bool expectCertificate)
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var configPath = Path.Combine(root.FullName, "Build", "project.build.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
+            File.WriteAllText(
+                configPath,
+                """
+                {
+                  "RootPath": "Sources",
+                  "Build": true,
+                  "PublishNuget": true,
+                  "CertificateThumbprint": "ABC123"
+                }
+                """);
+
+            ProjectBuildConfiguration? capturedConfiguration = null;
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: (request, configuration, path) =>
+                {
+                    capturedConfiguration = configuration;
+                    Assert.True(request.Build);
+                    Assert.False(request.PublishNuget);
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        ConfigPath = path ?? request.ConfigPath,
+                        RootPath = root.FullName,
+                        Result = new ProjectBuildResult { Success = true }
+                    };
+                });
+
+            var spec = new ModulePipelineSpec
+            {
+                ReleaseCheckpoint = releaseCheckpoint,
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments =
+                [
+                    new ConfigurationGateSegment
+                    {
+                        Configuration = new GateConfiguration
+                        {
+                            Mode = ConfigurationGateMode.Build
+                        }
+                    },
+                    new ConfigurationProjectBuildSegment
+                    {
+                        Configuration = new ProjectBuildConfigurationReference
+                        {
+                            ConfigPath = Path.Combine("Build", "project.build.json")
+                        }
+                    }
+                ]
+            };
+
+            runner.Run(spec);
+
+            Assert.NotNull(capturedConfiguration);
+            Assert.Equal(
+                expectCertificate ? "ABC123" : null,
+                capturedConfiguration!.CertificateThumbprint);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
     [Fact]
     public void Run_HonorsReleaseBuildOrderForPackageBuildPlacement()
     {

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePackages.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePackages.cs
@@ -219,6 +219,153 @@ public sealed partial class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_ModuleOwnedPackages_PropagatesResolvedPackageVersionToValidation()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var scriptPath = Path.Combine(root, "Build-Module.ps1");
+            var releasePath = Path.Combine(root, "release.json");
+            var validationPath = Path.Combine(root, "Test-Release.ps1");
+            var manifestPath = Path.Combine(root, "Sample.psd1");
+            var packagePath = Path.Combine(root, "Sample.1.2.3.nupkg");
+            File.WriteAllText(scriptPath, "# module build");
+            File.WriteAllText(releasePath, "{}");
+            File.WriteAllText(validationPath, "# release validation");
+            File.WriteAllText(manifestPath, "@{ ModuleVersion = '1.2.X' }");
+
+            string? validationVersion = null;
+            var moduleCalls = new List<ModuleExecutionSnapshot>();
+            var service = CreateReleaseService(
+                root,
+                moduleCalls,
+                new PowerForgeToolReleaseResult { Success = true },
+                request =>
+                {
+                    if (request.RunMode != ConfigurationGateMode.Build)
+                        return;
+
+                    using var archive = System.IO.Compression.ZipFile.Open(
+                        packagePath,
+                        System.IO.Compression.ZipArchiveMode.Create);
+                    var nuspec = archive.CreateEntry("Sample.nuspec");
+                    using var writer = new StreamWriter(nuspec.Open());
+                    writer.Write("<package><metadata><id>Sample</id><version>1.2.3</version></metadata></package>");
+                },
+                runReleaseValidation: (_, context, _, _) =>
+                {
+                    validationVersion = context.ResolvedVersion;
+                    return new PowerForgeReleaseValidationResult
+                    {
+                        Name = "release",
+                        Succeeded = true,
+                        ExitCode = 0
+                    };
+                });
+            var spec = new PowerForgeReleaseSpec
+            {
+                Module = new PowerForgeModuleReleaseOptions
+                {
+                    RepositoryRoot = root,
+                    ScriptPath = scriptPath,
+                    ManifestPath = manifestPath,
+                    ModuleVersion = "1.2.X",
+                    IncludesPackages = true,
+                    ArtifactPaths = [Path.Combine(root, "Sample.{ModuleVersionWithPreRelease}.nupkg")]
+                },
+                Outputs = new PowerForgeReleaseOutputsOptions
+                {
+                    Staging = new PowerForgeReleaseStagingOptions
+                    {
+                        RootPath = Path.Combine(root, "staged")
+                    }
+                },
+                Validation = new PowerForgeReleaseValidationOptions
+                {
+                    AfterStaging =
+                    [
+                        new PowerForgeReleaseValidationAction
+                        {
+                            Name = "release",
+                            FilePath = validationPath
+                        }
+                    ]
+                }
+            };
+
+            var result = service.Execute(
+                spec,
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = releasePath,
+                    ModuleOnly = true,
+                    ModuleRunMode = ConfigurationGateMode.Publish
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal("1.2.3", result.ModulePlan!.ModuleVersion);
+            Assert.Equal("1.2.3", validationVersion);
+            Assert.Contains(packagePath, result.ModuleProducedAssets, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(2, moduleCalls.Count);
+            Assert.Equal("1.2.X", moduleCalls[0].ModuleVersion);
+            Assert.Equal("1.2.3", moduleCalls[1].ModuleVersion);
+            Assert.True(moduleCalls[0].ReleaseCheckpoint);
+            Assert.False(moduleCalls[1].ReleaseCheckpoint);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_ModuleConfig_UsesBuildVersionWhenReleaseProfileOmitsVersion()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var moduleConfigPath = Path.Combine(root, "module.json");
+            var releasePath = Path.Combine(root, "release.json");
+            File.WriteAllText(
+                moduleConfigPath,
+                """
+                {
+                  "SchemaVersion": 1,
+                  "Build": {
+                    "Name": "Sample",
+                    "SourcePath": ".",
+                    "Version": "1.2.X"
+                  },
+                  "Segments": []
+                }
+                """);
+            File.WriteAllText(releasePath, "{}");
+
+            var result = new PowerForgeReleaseService(new NullLogger()).Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Module = new PowerForgeModuleReleaseOptions
+                    {
+                        RepositoryRoot = root,
+                        ConfigPath = moduleConfigPath
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = releasePath,
+                    PlanOnly = true
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal("1.2.X", result.ModulePlan!.ModuleVersion);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void ModulePackageCheckpoint_RejectsPackageMissingFromValidatedStage()
     {
         var root = CreateSandbox();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePublicationOrdering.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePublicationOrdering.cs
@@ -1375,7 +1375,10 @@ public sealed partial class PowerForgeReleaseServiceTests
                     request.SkipInstall,
                     request.IncludeProjectPackages,
                     request.StagingPath,
-                    request.RequireReusableOutput));
+                    request.RequireReusableOutput,
+                    request.ModuleVersion,
+                    request.PreReleaseTag,
+                    request.ReleaseCheckpoint));
                 return new ModuleBuildHostExecutionResult { ExitCode = 0 };
             });
 
@@ -1408,5 +1411,8 @@ public sealed partial class PowerForgeReleaseServiceTests
         bool SkipInstall,
         bool IncludeProjectPackages,
         string? StagingPath,
-        bool RequireReusableOutput);
+        bool RequireReusableOutput,
+        string? ModuleVersion,
+        string? PreReleaseTag,
+        bool ReleaseCheckpoint);
 }

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.UnifiedGitHubRelease.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.UnifiedGitHubRelease.cs
@@ -163,6 +163,43 @@ public sealed partial class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void UnifiedGitHubRelease_ModuleVersionSourceUsesProducedPackagePrerelease()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var sourceManifestPath = Path.Combine(root, "Sample.psd1");
+            File.WriteAllText(
+                sourceManifestPath,
+                "@{ ModuleVersion = '1.2.X'; PrivateData = @{ PSData = @{ Prerelease = 'stale' } } }");
+            var packagePath = Path.Combine(root, "Sample.1.2.3-preview1.nupkg");
+            using (var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create))
+            {
+                var entry = archive.CreateEntry("Sample.nuspec");
+                using var writer = new StreamWriter(entry.Open());
+                writer.Write(
+                    "<package><metadata><id>Sample</id><version>1.2.3-preview1</version></metadata></package>");
+            }
+
+            var plan = new PowerForgeModuleReleasePlanSummary
+            {
+                ManifestPath = sourceManifestPath,
+                ModuleVersion = "1.2.X",
+                IncludesPackages = true
+            };
+
+            PowerForgeReleaseService.UpdateResolvedModuleVersion(plan, new[] { packagePath });
+
+            Assert.Equal("1.2.3", plan.ModuleVersion);
+            Assert.Equal("preview1", plan.PreReleaseTag);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void UnifiedGitHubRelease_AcceptsXInsidePrereleaseLabel()
     {
         var result = new PowerForgeReleaseResult

--- a/PowerForge/Models/ModuleBuildHostBuildRequest.cs
+++ b/PowerForge/Models/ModuleBuildHostBuildRequest.cs
@@ -91,6 +91,11 @@ public sealed class ModuleBuildHostBuildRequest
     internal bool RequireReusableOutput { get; set; }
 
     /// <summary>
+    /// Preserves configured local signing during the build pass that produces a deferred release checkpoint.
+    /// </summary>
+    internal bool ReleaseCheckpoint { get; set; }
+
+    /// <summary>
     /// Disables module signing when true.
     /// </summary>
     public bool NoSign { get; set; }

--- a/PowerForge/Models/ModulePipelinePlan.cs
+++ b/PowerForge/Models/ModulePipelinePlan.cs
@@ -7,6 +7,7 @@ namespace PowerForge;
 /// </summary>
 public sealed class ModulePipelinePlan
 {
+    internal bool ReleaseCheckpoint { get; set; }
     internal bool UseLocalVersioning { get; set; }
     internal string? SourceRevision { get; set; }
     internal bool SourceDirty { get; set; }

--- a/PowerForge/Models/ModulePipelineSpec.cs
+++ b/PowerForge/Models/ModulePipelineSpec.cs
@@ -22,6 +22,12 @@ public sealed class ModulePipelineSpec
     public bool UnifiedGitHubRelease { get; set; }
 
     /// <summary>
+    /// Indicates that this build produces the exact local artifacts for a deferred release publication.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    internal bool ReleaseCheckpoint { get; set; }
+
+    /// <summary>
     /// Optional schema version for external tooling.
     /// </summary>
     public int SchemaVersion { get; set; } = 1;

--- a/PowerForge/Services/ModuleBuildHostService.cs
+++ b/PowerForge/Services/ModuleBuildHostService.cs
@@ -405,6 +405,8 @@ public sealed class ModuleBuildHostService
         AddDirectStringArgument(arguments, "StagingPath", request.StagingPath);
         if (request.ReuseStaging)
             arguments.Add("$moduleBuildArguments['ReuseStaging'] = $true");
+        if (request.ReleaseCheckpoint)
+            arguments.Add("$moduleBuildArguments['PowerForgeReleaseCheckpoint'] = $true");
         AddDirectBooleanArgument(
             arguments,
             "NoDotnetBuild",

--- a/PowerForge/Services/PowerForgeReleaseService.ModulePublication.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.ModulePublication.cs
@@ -28,6 +28,7 @@ internal sealed partial class PowerForgeReleaseService
         bool? skipInstall = null,
         bool? includeProjectPackages = null,
         bool? reuseStaging = null,
+        bool? releaseCheckpoint = null,
         CancellationToken cancellationToken = default)
     {
         var originalRunMode = request.RunMode;
@@ -37,6 +38,7 @@ internal sealed partial class PowerForgeReleaseService
         var originalSkipInstall = request.SkipInstall;
         var originalIncludeProjectPackages = request.IncludeProjectPackages;
         var originalReuseStaging = request.ReuseStaging;
+        var originalReleaseCheckpoint = request.ReleaseCheckpoint;
         try
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -53,6 +55,8 @@ internal sealed partial class PowerForgeReleaseService
                 request.IncludeProjectPackages = includeProjectPackages.Value;
             if (reuseStaging.HasValue)
                 request.ReuseStaging = reuseStaging.Value;
+            if (releaseCheckpoint.HasValue)
+                request.ReleaseCheckpoint = releaseCheckpoint.Value;
 
             return _executeModuleBuild(request, cancellationToken);
         }
@@ -65,6 +69,7 @@ internal sealed partial class PowerForgeReleaseService
             request.SkipInstall = originalSkipInstall;
             request.IncludeProjectPackages = originalIncludeProjectPackages;
             request.ReuseStaging = originalReuseStaging;
+            request.ReleaseCheckpoint = originalReleaseCheckpoint;
         }
     }
 

--- a/PowerForge/Services/PowerForgeReleaseService.UnifiedGitHubVersion.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.UnifiedGitHubVersion.cs
@@ -12,20 +12,69 @@ internal sealed partial class PowerForgeReleaseService
         if (plan is null)
             return;
 
-        var manifestText = ReadBuiltModuleManifestText(plan, artifactPaths) ?? ReadSourceModuleManifestText(plan);
-        if (string.IsNullOrWhiteSpace(manifestText))
-            return;
+        var builtManifestText = ReadBuiltModuleManifestText(plan, artifactPaths);
+        var sourceManifestText = ReadSourceModuleManifestText(plan);
+        var manifestText = builtManifestText ?? sourceManifestText;
 
-        ModuleManifestTextParser.TryGetTopLevelQuotedStringValue(manifestText!, "ModuleVersion", out var moduleVersion);
-        if (NormalizeReleaseVersion(plan.ModuleVersion) is null && !string.IsNullOrWhiteSpace(moduleVersion))
-            plan.ModuleVersion = moduleVersion!.Trim();
+        string? packageVersion = null;
+        if (NormalizeReleaseVersion(plan.ModuleVersion) is null)
+        {
+            var manifestVersion = ResolveExactModuleManifestVersion(builtManifestText);
+            if (string.IsNullOrWhiteSpace(manifestVersion) && plan.IncludesPackages)
+                packageVersion = ResolveUniqueModulePackageVersion(artifactPaths);
+            if (string.IsNullOrWhiteSpace(manifestVersion) && string.IsNullOrWhiteSpace(packageVersion))
+                manifestVersion = ResolveExactModuleManifestVersion(sourceManifestText);
+
+            var resolvedVersion = manifestVersion ?? packageVersion;
+            if (!string.IsNullOrWhiteSpace(resolvedVersion))
+                plan.ModuleVersion = PackageVersionUtility.GetNumericVersion(resolvedVersion!);
+        }
 
         if (string.IsNullOrWhiteSpace(plan.PreReleaseTag))
         {
-            plan.PreReleaseTag = ModuleManifestValueReader
-                .ReadPsDataStringOrArrayFromText(manifestText!, "Prerelease")
-                .FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(packageVersion))
+            {
+                plan.PreReleaseTag = NullIfEmpty(PackageVersionUtility.GetPrereleaseVersion(packageVersion!));
+            }
+            else
+            {
+                plan.PreReleaseTag = ModuleManifestValueReader
+                    .ReadPsDataStringOrArrayFromText(manifestText ?? string.Empty, "Prerelease")
+                    .FirstOrDefault();
+            }
         }
+    }
+
+    private static string? ResolveExactModuleManifestVersion(string? manifestText)
+    {
+        if (string.IsNullOrWhiteSpace(manifestText) ||
+            !ModuleManifestTextParser.TryGetTopLevelQuotedStringValue(
+                manifestText!,
+                "ModuleVersion",
+                out var moduleVersion) ||
+            NormalizeReleaseVersion(moduleVersion) is null)
+        {
+            return null;
+        }
+
+        return moduleVersion!.Trim();
+    }
+
+    private static string? ResolveUniqueModulePackageVersion(IEnumerable<string>? artifactPaths)
+    {
+        var versions = EnumerateModuleArtifactFiles(artifactPaths, plan: null)
+            .Where(IsNuGetPackagePath)
+            .Select(path => TryReadNuGetPackageIdentity(path, out _, out var packageVersion)
+                ? packageVersion
+                : null)
+            .Select(static version => PackageVersionUtility.TryNormalizeExact(version, out var normalized)
+                ? normalized
+                : string.Empty)
+            .Where(static version => !string.IsNullOrWhiteSpace(version))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return versions.Length == 1 ? versions[0] : null;
     }
 
     internal static string? ResolveUnifiedReleaseVersion(

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -563,6 +563,7 @@ internal sealed partial class PowerForgeReleaseService
                         module.Request,
                         ConfigurationGateMode.Build,
                         includeModulePublishing: false,
+                        releaseCheckpoint: true,
                         cancellationToken: request.CancellationToken)
                     : _executeModuleBuild(module.Request, request.CancellationToken);
                 result.Module = moduleResult;
@@ -580,7 +581,19 @@ internal sealed partial class PowerForgeReleaseService
                 if (result.ModulePlan is not null && moduleResult.ArtefactOutputs.Length > 0)
                     result.ModulePlan.ArtefactOutputs = moduleResult.ArtefactOutputs;
 
-                UpdateResolvedModuleVersion(result.ModulePlan, result.ModuleAssets);
+                var resolvedVersionEvidence = result.ModuleAssets;
+                if (captureModuleArtifactProvenance)
+                {
+                    result.ModuleProducedAssets = ResolveProducedModuleArtifacts(
+                        result.ModuleAssets,
+                        moduleArtifactBaseline,
+                        result.ModulePlan,
+                        ResolvePersistentModuleScriptArchiveRoot(result.ModulePlan, configDirectory));
+                    if (result.ModuleProducedAssets.Length > 0)
+                        resolvedVersionEvidence = result.ModuleProducedAssets;
+                }
+
+                UpdateResolvedModuleVersion(result.ModulePlan, resolvedVersionEvidence);
                 if (result.ModulePlan is not null)
                 {
                     if (moduleResult.ArtefactOutputs.Length == 0)
@@ -597,6 +610,12 @@ internal sealed partial class PowerForgeReleaseService
                         result.ModulePlan.ModuleVersion,
                         result.ModulePlan.PreReleaseTag);
                 }
+
+                if (deferredModulePublishRequest is not null && result.ModulePlan is not null)
+                {
+                    deferredModulePublishRequest.ModuleVersion = result.ModulePlan.ModuleVersion;
+                    deferredModulePublishRequest.PreReleaseTag = result.ModulePlan.PreReleaseTag;
+                }
                 result.ModuleAssets = ExpandModuleArtifactPaths(
                     result.ModuleAssets,
                     result.ModulePlan?.ModuleName,
@@ -604,14 +623,6 @@ internal sealed partial class PowerForgeReleaseService
                     result.ModulePlan?.PreReleaseTag);
                 if (result.ModulePlan is not null)
                     result.ModulePlan.ArtifactPaths = result.ModuleAssets;
-                if (captureModuleArtifactProvenance)
-                {
-                    result.ModuleProducedAssets = ResolveProducedModuleArtifacts(
-                        result.ModuleAssets,
-                        moduleArtifactBaseline,
-                        result.ModulePlan,
-                        ResolvePersistentModuleScriptArchiveRoot(result.ModulePlan, configDirectory));
-                }
 
                 if (result.ModulePlan?.IncludesProjectPackages == true &&
                     module.Request.ConfigPath is not null)
@@ -1608,7 +1619,7 @@ internal sealed partial class PowerForgeReleaseService
             NoDotnetBuild = noDotnetBuildOverride ?? false,
             NoDotnetBuildWasSpecified = noDotnetBuildOverride.HasValue,
             ModuleVersion = string.IsNullOrWhiteSpace(request.ResolvedReleaseVersion)
-                ? request.ModuleVersion ?? options.ModuleVersion
+                ? request.ModuleVersion ?? options.ModuleVersion ?? moduleConfig?.Spec.Build.Version
                 : PackageVersionUtility.GetNumericVersion(request.ResolvedReleaseVersion!),
             PreReleaseTag = string.IsNullOrWhiteSpace(request.ResolvedReleaseVersion)
                 ? request.ModulePreReleaseTag ?? options.PreReleaseTag


### PR DESCRIPTION
## Summary

- Resolve wildcard module versions from the unique NuGet package produced by the current release run.
- Carry the resolved numeric version and prerelease label into after-staging validation and deferred module publication.
- Preserve configured package signing only for the internal release-checkpoint build; ordinary `Build` gates still suppress publication signing.
- Fall back to the module configuration's build version when the release profile does not repeat it.

## Why

Unified releases can build and validate artifacts before publishing the module. That deferred path previously retained the wildcard version in later phases and cleared the package certificate during the exact build that created the release artifacts. The result was inconsistent artifact identity and unsigned project packages even though signing was configured.

This change keeps version and signing decisions attached to the exact release checkpoint while leaving normal non-release builds unchanged. It provides the shared PowerForge behavior required by public downstream module releases such as [EventViewerX](https://github.com/EvotecIT/EventViewerX).

## Validation

- Focused release-version, deferred-publication, host-propagation, and signing contracts pass (8 executions).
- Adjacent script/archive provenance contracts from current `main` pass (11 executions).
- `PSPublishModule`, `PowerForge`, and `PowerForge.PowerShell` build with zero warnings across `net472`, `net8.0`, and `net10.0`.
- A prior end-to-end downstream build produced five signed NuGet packages and resolved `4.0.X` to `4.0.0`.

## Release boundary

After merge, PSPublishModule/PowerForge must be published as a new three-part package release before downstream consumers can rely on this behavior. This PR does not publish that release.
