### PR TITLE
Fix duplicate runtime requirements in script artefacts

### DIFF
--- a/PowerForge.Tests/ArtefactBuilderScriptPreambleTests.cs
+++ b/PowerForge.Tests/ArtefactBuilderScriptPreambleTests.cs
@@ -1,11 +1,201 @@
 using System.IO.Compression;
 using System.Management.Automation.Language;
+using System.Text.RegularExpressions;
 using PowerForge;
 
 namespace PowerForge.Tests;
 
 public sealed class ArtefactBuilderScriptPreambleTests
 {
+    [Theory]
+    [InlineData(ArtefactType.Script)]
+    [InlineData(ArtefactType.ScriptPacked)]
+    public void Build_ConsolidatesRuntimeRequirementsFromManifestAndNestedModuleContent(ArtefactType artefactType)
+    {
+        var root = CreateRoot();
+        string? extractedRoot = null;
+        try
+        {
+            const string moduleName = "RuntimeRequirementModule";
+            string stagingRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "staging")).FullName;
+            File.WriteAllText(
+                Path.Combine(stagingRoot, moduleName + ".psd1"),
+                $"@{{ RootModule = '{moduleName}.psm1'; ModuleVersion = '1.0.0'; PowerShellVersion = '5.1'; CompatiblePSEditions = 'Core' }}");
+            File.WriteAllText(
+                Path.Combine(stagingRoot, moduleName + ".psm1"),
+                "function Get-RuntimeRequirement {\n" +
+                "    #requires -Version 5\n" +
+                "    #requires -PSEdition Core\n" +
+                "    $example = @'\n" +
+                "#requires -Version 99.0\n" +
+                "'@ | ForEach-Object { $_ }\n" +
+                "    $example\n" +
+                "}");
+
+            ArtefactBuildResult result = Build(
+                Path.Combine(root.FullName, "output"),
+                root.FullName,
+                stagingRoot,
+                moduleName,
+                artefactType,
+                string.Empty);
+
+            string inspectionRoot = result.OutputPath;
+            if (artefactType == ArtefactType.ScriptPacked)
+            {
+                extractedRoot = Path.Combine(root.FullName, "extracted-runtime-requirements");
+                ZipFile.ExtractToDirectory(result.OutputPath, extractedRoot);
+                inspectionRoot = extractedRoot;
+            }
+
+            string content = File.ReadAllText(Path.Combine(inspectionRoot, moduleName + ".ps1"));
+            Assert.Matches(@"\A#requires -Version 5\.1\r?\n#requires -PSEdition Core", content);
+            Assert.Single(Regex.Matches(content, @"(?im)^#requires -PSEdition Core\s*$", RegexOptions.CultureInvariant).Cast<Match>());
+            Assert.Contains("#requires -Version 99.0", content, StringComparison.Ordinal);
+            Parser.ParseInput(content, out _, out ParseError[] parseErrors);
+            Assert.Empty(parseErrors);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Theory]
+    [InlineData(ArtefactType.Script)]
+    [InlineData(ArtefactType.ScriptPacked)]
+    public void Build_DoesNotConsolidateRequirementsInsideMultilineStringsAfterHereStringTerminators(ArtefactType artefactType)
+    {
+        var root = CreateRoot();
+        string? extractedRoot = null;
+        try
+        {
+            const string moduleName = "HereStringSuffixModule";
+            string stagingRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "staging")).FullName;
+            File.WriteAllText(
+                Path.Combine(stagingRoot, moduleName + ".psd1"),
+                $"@{{ RootModule = '{moduleName}.psm1'; ModuleVersion = '1.0.0'; PowerShellVersion = '5.1'; CompatiblePSEditions = 'Core' }}");
+            File.WriteAllText(
+                Path.Combine(stagingRoot, moduleName + ".psm1"),
+                "$doubleQuoted = @'\n" +
+                "literal\n" +
+                "'@ + \"\n" +
+                "#requires -Version 98.0\n" +
+                "\"\n" +
+                "$singleQuoted = @\"\n" +
+                "literal\n" +
+                "\"@ + '\n" +
+                "#requires -PSEdition Desktop\n" +
+                "'\n" +
+                "function Get-HereStringSuffix { $doubleQuoted + $singleQuoted }");
+
+            ArtefactBuildResult result = Build(
+                Path.Combine(root.FullName, "output"),
+                root.FullName,
+                stagingRoot,
+                moduleName,
+                artefactType,
+                string.Empty);
+
+            string inspectionRoot = result.OutputPath;
+            if (artefactType == ArtefactType.ScriptPacked)
+            {
+                extractedRoot = Path.Combine(root.FullName, "extracted-here-string-suffix");
+                ZipFile.ExtractToDirectory(result.OutputPath, extractedRoot);
+                inspectionRoot = extractedRoot;
+            }
+
+            string content = File.ReadAllText(Path.Combine(inspectionRoot, moduleName + ".ps1"));
+            Assert.StartsWith("#requires -Version 5.1", content, StringComparison.Ordinal);
+            Assert.Contains("#requires -Version 98.0", content, StringComparison.Ordinal);
+            Assert.Contains("#requires -PSEdition Desktop", content, StringComparison.Ordinal);
+            Parser.ParseInput(content, out _, out ParseError[] parseErrors);
+            Assert.Empty(parseErrors);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Theory]
+    [InlineData(ArtefactType.Script)]
+    [InlineData(ArtefactType.ScriptPacked)]
+    public void Build_PreservesStricterNestedVersionRequirement(ArtefactType artefactType)
+    {
+        var root = CreateRoot();
+        string? extractedRoot = null;
+        try
+        {
+            const string moduleName = "StricterRuntimeRequirementModule";
+            string stagingRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "staging")).FullName;
+            File.WriteAllText(
+                Path.Combine(stagingRoot, moduleName + ".psd1"),
+                $"@{{ RootModule = '{moduleName}.psm1'; ModuleVersion = '1.0.0'; PowerShellVersion = '5.1' }}");
+            File.WriteAllText(
+                Path.Combine(stagingRoot, moduleName + ".psm1"),
+                "function Get-StricterRuntimeRequirement {\n    #requires -Version 7.0\n    'ok'\n}");
+
+            ArtefactBuildResult result = Build(
+                Path.Combine(root.FullName, "output"),
+                root.FullName,
+                stagingRoot,
+                moduleName,
+                artefactType,
+                string.Empty);
+
+            string inspectionRoot = result.OutputPath;
+            if (artefactType == ArtefactType.ScriptPacked)
+            {
+                extractedRoot = Path.Combine(root.FullName, "extracted-stricter-requirement");
+                ZipFile.ExtractToDirectory(result.OutputPath, extractedRoot);
+                inspectionRoot = extractedRoot;
+            }
+
+            string content = File.ReadAllText(Path.Combine(inspectionRoot, moduleName + ".ps1"));
+            Assert.StartsWith("#requires -Version 7.0", content, StringComparison.Ordinal);
+            Parser.ParseInput(content, out _, out ParseError[] parseErrors);
+            Assert.Empty(parseErrors);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Theory]
+    [InlineData(ArtefactType.Script)]
+    [InlineData(ArtefactType.ScriptPacked)]
+    public void Build_RejectsConflictingEditionRequirements(ArtefactType artefactType)
+    {
+        var root = CreateRoot();
+        try
+        {
+            const string moduleName = "ConflictingEditionModule";
+            string stagingRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "staging")).FullName;
+            File.WriteAllText(
+                Path.Combine(stagingRoot, moduleName + ".psd1"),
+                $"@{{ RootModule = '{moduleName}.psm1'; ModuleVersion = '1.0.0'; CompatiblePSEditions = 'Desktop' }}");
+            File.WriteAllText(
+                Path.Combine(stagingRoot, moduleName + ".psm1"),
+                "function Get-ConflictingEdition {\n    #requires -PSEdition Core\n    'unreachable'\n}");
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => Build(
+                Path.Combine(root.FullName, "output"),
+                root.FullName,
+                stagingRoot,
+                moduleName,
+                artefactType,
+                string.Empty));
+
+            Assert.Contains("both Core and Desktop PSEditions are required", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
     [Theory]
     [InlineData(ArtefactType.Script)]
     [InlineData(ArtefactType.ScriptPacked)]

--- a/PowerForge.Tests/ModuleMergeComposerTests.cs
+++ b/PowerForge.Tests/ModuleMergeComposerTests.cs
@@ -488,7 +488,17 @@ public sealed class ModuleMergeComposerTests
                 Path.Combine(publicRoot.FullName, "Get-Demo.ps1"),
                 "$text = @'" + Environment.NewLine +
                 "#requires -Assembly ../DoNotTouch.dll" + Environment.NewLine +
-                "'@" + Environment.NewLine +
+                "'@ | ForEach-Object { $_ }" + Environment.NewLine +
+                "$doubleQuoted = @'" + Environment.NewLine +
+                "literal" + Environment.NewLine +
+                "'@ + \"" + Environment.NewLine +
+                "#requires -Assembly ../AlsoDoNotTouch.dll" + Environment.NewLine +
+                "\"" + Environment.NewLine +
+                "$singleQuoted = @\"" + Environment.NewLine +
+                "literal" + Environment.NewLine +
+                "\"@ + '" + Environment.NewLine +
+                "#requires -Assembly ../StillDoNotTouch.dll" + Environment.NewLine +
+                "'" + Environment.NewLine +
                 "$script:BeforeRequirement = $true" + Environment.NewLine +
                 "#requires -Assembly System.Xml" + Environment.NewLine +
                 "#requires -Assembly ../Lib/RequiredTypes.dll" + Environment.NewLine +
@@ -506,6 +516,10 @@ public sealed class ModuleMergeComposerTests
             Assert.DoesNotContain("#requires -Assembly ./Public/System.Xml", sources.MergedScriptContent, StringComparison.Ordinal);
             Assert.Contains("#requires -Assembly ../DoNotTouch.dll", sources.MergedScriptContent, StringComparison.Ordinal);
             Assert.DoesNotContain("#requires -Assembly ./DoNotTouch.dll", sources.MergedScriptContent, StringComparison.Ordinal);
+            Assert.Contains("#requires -Assembly ../AlsoDoNotTouch.dll", sources.MergedScriptContent, StringComparison.Ordinal);
+            Assert.DoesNotContain("#requires -Assembly ./AlsoDoNotTouch.dll", sources.MergedScriptContent, StringComparison.Ordinal);
+            Assert.Contains("#requires -Assembly ../StillDoNotTouch.dll", sources.MergedScriptContent, StringComparison.Ordinal);
+            Assert.DoesNotContain("#requires -Assembly ./StillDoNotTouch.dll", sources.MergedScriptContent, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge/Services/ArtefactBuilder.Script.RuntimeRequirements.cs
+++ b/PowerForge/Services/ArtefactBuilder.Script.RuntimeRequirements.cs
@@ -1,0 +1,103 @@
+using System.Text.RegularExpressions;
+
+namespace PowerForge;
+
+public sealed partial class ArtefactBuilder
+{
+    private static readonly Regex SimpleRuntimeRequirement = new(
+        @"^\s*#requires\s+-(?<kind>Version|PSEdition)\s+(?<value>[^\s#]+)\s*(?:#.*)?$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private static string ConsolidateScriptRuntimeRequirements(
+        string manifestRuntimePreamble,
+        ref string preScriptContent,
+        ref string moduleContent,
+        ref string postScriptContent,
+        string newline)
+    {
+        var requirements = new ScriptRuntimeRequirements();
+        _ = ExtractSimpleRuntimeRequirements(manifestRuntimePreamble, requirements, newline);
+        preScriptContent = ExtractSimpleRuntimeRequirements(preScriptContent, requirements, newline);
+        moduleContent = ExtractSimpleRuntimeRequirements(moduleContent, requirements, newline);
+        postScriptContent = ExtractSimpleRuntimeRequirements(postScriptContent, requirements, newline);
+        return requirements.CreatePreamble(newline);
+    }
+
+    private static string ExtractSimpleRuntimeRequirements(
+        string content,
+        ScriptRuntimeRequirements requirements,
+        string newline)
+    {
+        if (string.IsNullOrEmpty(content))
+            return string.Empty;
+
+        var lines = content.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+        var state = ScriptLexicalState.Normal;
+        var blockCommentDepth = 0;
+        for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+        {
+            string line = lines[lineIndex] ?? string.Empty;
+            if (state == ScriptLexicalState.Normal && blockCommentDepth == 0)
+            {
+                Match match = SimpleRuntimeRequirement.Match(line);
+                if (match.Success && requirements.TryAdd(match.Groups["kind"].Value, match.Groups["value"].Value))
+                    lines[lineIndex] = string.Empty;
+            }
+
+            UpdateScriptLexicalState(line, ref state, ref blockCommentDepth);
+        }
+
+        return string.Join(newline, lines).Trim('\r', '\n');
+    }
+
+    private sealed class ScriptRuntimeRequirements
+    {
+        private Version? _minimumVersion;
+        private readonly HashSet<string> _editions = new(StringComparer.OrdinalIgnoreCase);
+
+        internal bool TryAdd(string kind, string value)
+        {
+            if (string.Equals(kind, "Version", StringComparison.OrdinalIgnoreCase))
+            {
+                string candidate = value.Trim('"', '\'');
+                if (candidate.IndexOf('.') < 0)
+                    candidate += ".0";
+                if (!Version.TryParse(candidate, out Version? parsed))
+                    return false;
+
+                if (_minimumVersion is null || parsed > _minimumVersion)
+                    _minimumVersion = parsed;
+                return true;
+            }
+
+            if (!string.Equals(kind, "PSEdition", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            string edition = value.Trim('"', '\'');
+            if (!string.Equals(edition, "Core", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(edition, "Desktop", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            _editions.Add(edition);
+            return true;
+        }
+
+        internal string CreatePreamble(string newline)
+        {
+            if (_editions.Count > 1)
+            {
+                throw new InvalidOperationException(
+                    "Script artefact runtime requirements conflict: both Core and Desktop PSEditions are required.");
+            }
+
+            var lines = new List<string>(2);
+            if (_minimumVersion is not null)
+                lines.Add("#requires -Version " + _minimumVersion);
+            if (_editions.Count == 1)
+                lines.Add("#requires -PSEdition " + (_editions.Contains("Core") ? "Core" : "Desktop"));
+            return string.Join(newline, lines);
+        }
+    }
+}

--- a/PowerForge/Services/ArtefactBuilder.Script.cs
+++ b/PowerForge/Services/ArtefactBuilder.Script.cs
@@ -412,12 +412,21 @@ public sealed partial class ArtefactBuilder
 
         var moduleContent = string.Join(newline, lines).TrimEnd('\r', '\n');
         var moduleShebang = ExtractLeadingShebang(moduleContent, newline, out var moduleWithoutShebang);
-        var modulePreamble = ModuleMergeComposer.ExtractMergedScriptPreamble(moduleWithoutShebang, out var body);
         var normalizedPreScript = string.IsNullOrWhiteSpace(preScriptMerge)
             ? string.Empty
             : NormalizeNewlines(preScriptMerge!.Trim(), newline);
         var preScriptShebang = ExtractLeadingShebang(normalizedPreScript, newline, out var preScriptWithoutShebang);
         var shebang = string.IsNullOrWhiteSpace(preScriptShebang) ? moduleShebang : preScriptShebang;
+        var normalizedPostScript = string.IsNullOrWhiteSpace(postScriptMerge)
+            ? string.Empty
+            : NormalizeNewlines(postScriptMerge!.Trim(), newline);
+        var runtimePreamble = ConsolidateScriptRuntimeRequirements(
+            manifestRuntimePreamble,
+            ref preScriptWithoutShebang,
+            ref moduleWithoutShebang,
+            ref normalizedPostScript,
+            newline);
+        var modulePreamble = ModuleMergeComposer.ExtractMergedScriptPreamble(moduleWithoutShebang, out var body);
         var preScriptPreamble = ModuleMergeComposer.ExtractMergedScriptPreamble(
             preScriptWithoutShebang,
             out var preScriptBody);
@@ -426,8 +435,8 @@ public sealed partial class ArtefactBuilder
         if (!string.IsNullOrWhiteSpace(shebang))
             sections.Add(shebang);
 
-        if (!string.IsNullOrWhiteSpace(manifestRuntimePreamble))
-            sections.Add(NormalizeNewlines(manifestRuntimePreamble.Trim(), newline));
+        if (!string.IsNullOrWhiteSpace(runtimePreamble))
+            sections.Add(runtimePreamble);
 
         if (!string.IsNullOrWhiteSpace(preScriptPreamble))
             sections.Add(NormalizeNewlines(preScriptPreamble.Trim(), newline));
@@ -441,8 +450,8 @@ public sealed partial class ArtefactBuilder
         if (!string.IsNullOrEmpty(body))
             sections.Add(NormalizeNewlines(body.TrimEnd('\r', '\n'), newline));
 
-        if (!string.IsNullOrWhiteSpace(postScriptMerge))
-            sections.Add(NormalizeNewlines(postScriptMerge!.Trim(), newline));
+        if (!string.IsNullOrWhiteSpace(normalizedPostScript))
+            sections.Add(normalizedPostScript);
 
         var rewritten = string.Join(newline, sections) + newline;
         bool startsWithShebang = rewritten.StartsWith("#!", StringComparison.Ordinal);
@@ -521,20 +530,19 @@ public sealed partial class ArtefactBuilder
         ref ScriptLexicalState state,
         ref int blockCommentDepth)
     {
+        var scanStart = 0;
         if (state is ScriptLexicalState.SingleQuotedHereString or ScriptLexicalState.DoubleQuotedHereString)
         {
             var terminator = state == ScriptLexicalState.SingleQuotedHereString ? "'@" : "\"@";
             var trimmed = line.TrimStart();
-            if (trimmed.StartsWith(terminator, StringComparison.Ordinal))
-            {
-                var suffix = trimmed.Substring(terminator.Length);
-                if (string.IsNullOrWhiteSpace(suffix) || suffix.TrimStart().StartsWith("#", StringComparison.Ordinal))
-                    state = ScriptLexicalState.Normal;
-            }
-            return;
+            if (!trimmed.StartsWith(terminator, StringComparison.Ordinal))
+                return;
+
+            state = ScriptLexicalState.Normal;
+            scanStart = line.Length - trimmed.Length + terminator.Length;
         }
 
-        for (var characterIndex = 0; characterIndex < line.Length; characterIndex++)
+        for (var characterIndex = scanStart; characterIndex < line.Length; characterIndex++)
         {
             var current = line[characterIndex];
             var next = characterIndex + 1 < line.Length ? line[characterIndex + 1] : '\0';

--- a/PowerForge/Services/ModuleMergeComposer.Directives.cs
+++ b/PowerForge/Services/ModuleMergeComposer.Directives.cs
@@ -22,6 +22,7 @@ internal static partial class ModuleMergeComposer
         {
             var line = lines[lineIndex] ?? string.Empty;
             var hasCode = state is PowerShellLexicalState.SingleQuotedString or PowerShellLexicalState.DoubleQuotedString;
+            var scanStart = 0;
 
             if (state is PowerShellLexicalState.SingleQuotedHereString or PowerShellLexicalState.DoubleQuotedHereString)
             {
@@ -30,15 +31,12 @@ internal static partial class ModuleMergeComposer
                 if (!trimmed.StartsWith(terminator, StringComparison.Ordinal))
                     continue;
 
-                var suffix = trimmed.Substring(terminator.Length);
-                if (suffix.Length > 0 && !string.IsNullOrWhiteSpace(suffix) && !suffix.TrimStart().StartsWith("#", StringComparison.Ordinal))
-                    continue;
-
                 state = PowerShellLexicalState.Normal;
-                continue;
+                hasCode = true;
+                scanStart = line.Length - trimmed.Length + terminator.Length;
             }
 
-            for (var characterIndex = 0; characterIndex < line.Length; characterIndex++)
+            for (var characterIndex = scanStart; characterIndex < line.Length; characterIndex++)
             {
                 var current = line[characterIndex];
                 var next = characterIndex + 1 < line.Length ? line[characterIndex + 1] : '\0';


### PR DESCRIPTION
## Summary

- consolidate manifest, pre-script, merged-module, and post-script `#requires -Version` / `#requires -PSEdition` directives into one valid runtime preamble
- preserve the strictest PowerShell version and reject conflicting Core/Desktop requirements
- keep requirement-like text inside comments, here-strings, and multiline quoted strings unchanged
- align late `#requires -Assembly` scanning with legal here-string terminator suffixes

## Why

PSPublishModule 3.0.138 can emit Script and ScriptPacked entry points with both the manifest-derived PowerShell requirement and a requirement already present in merged module source. PowerShell rejects that generated script with `ParameterAlreadyBound` before execution.

This blocks current standalone-script builds in [Locksmith](https://github.com/jakehildreth/Locksmith) and the shared build migration for [Locksmith2](https://github.com/jakehildreth/Locksmith2). A patch release is required before those consumers can pin the corrected package.

## Validation

- 278 focused Script/ScriptPacked and merge-composer tests pass
- PowerForge builds cleanly for `net8.0` and `net472`
- a locally built 3.0.139 candidate builds both downstream projects
- generated Locksmith Script and ScriptPacked payloads match byte-for-byte and parse in PowerShell 7 and Windows PowerShell 5.1
- packaged Locksmith2 imports in PowerShell 7 and Windows PowerShell 5.1

## Release order

1. Merge and publish PSPublishModule 3.0.139.
2. Update the downstream build wrappers to require 3.0.139.