### PR TITLE
Fix release Build checkpoints for signed package artifacts

### DIFF
--- a/PSPublishModule/Cmdlets/InvokeModuleBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeModuleBuildCommand.cs
@@ -338,6 +338,8 @@ public sealed partial class InvokeModuleBuildCommand : PSCmdlet
     public SwitchParameter ReuseStaging { get; set; }
 
     /// <summary>Marks an internal build pass as the exact local checkpoint for deferred publication.</summary>
+    [Parameter(ParameterSetName = ParameterSetModern, DontShow = true)]
+    [Parameter(ParameterSetName = ParameterSetConfiguration, DontShow = true)]
     [Parameter(ParameterSetName = ParameterSetConfig, DontShow = true)]
     public SwitchParameter PowerForgeReleaseCheckpoint { get; set; }
 

--- a/PowerForge.Tests/ModuleBuildHostServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildHostServiceTests.cs
@@ -343,7 +343,8 @@ public sealed class ModuleBuildHostServiceTests
             Framework = "net10.0",
             RunMode = ConfigurationGateMode.Publish,
             PowerForgeReleaseStage = true,
-            UnifiedGitHubRelease = true
+            UnifiedGitHubRelease = true,
+            ReleaseCheckpoint = true
         });
 
         Assert.NotNull(captured);
@@ -357,7 +358,68 @@ public sealed class ModuleBuildHostServiceTests
         Assert.Contains("$buildScriptArguments['PowerForgeReleaseStage'] = $true", captured.CommandText!, StringComparison.Ordinal);
         Assert.Contains("$buildScriptCommand.Parameters.ContainsKey('PowerForgeUnifiedGitHubRelease')", captured.CommandText!, StringComparison.Ordinal);
         Assert.Contains("$buildScriptArguments['PowerForgeUnifiedGitHubRelease'] = $true", captured.CommandText!, StringComparison.Ordinal);
+        Assert.Contains("$PSDefaultParameterValues['Invoke-ModuleBuild:PowerForgeReleaseCheckpoint'] = $true", captured.CommandText!, StringComparison.Ordinal);
         Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task ExecuteBuildAsync_ReleaseCheckpointFlowsThroughLegacyScriptWithoutConsumerParameter()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "pf-module-host-release-checkpoint-" + Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "CheckpointHost";
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, moduleName));
+            var buildRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Build"));
+            var modulePath = Path.Combine(moduleRoot.FullName, moduleName + ".psd1");
+            var scriptPath = Path.Combine(buildRoot.FullName, "Build-Module.ps1");
+            var markerPath = Path.Combine(root.FullName, "release-checkpoint.txt");
+            File.WriteAllText(Path.Combine(moduleRoot.FullName, moduleName + ".psm1"), string.Empty);
+            File.WriteAllText(
+                modulePath,
+                $"@{{ RootModule = '{moduleName}.psm1'; ModuleVersion = '1.0.0' }}");
+            File.WriteAllText(
+                scriptPath,
+                $$"""
+                $result = Invoke-ModuleBuild -ModuleName '{{moduleName}}' -Path '{{root.FullName.Replace("'", "''")}}' -RunMode Manifest -PassThru -Settings { }
+                $flags = [Reflection.BindingFlags]'Instance,NonPublic'
+                $property = $result.Plan.GetType().GetProperty('ReleaseCheckpoint', $flags)
+                if ($null -eq $property -or -not [bool] $property.GetValue($result.Plan)) {
+                    throw 'The release checkpoint did not reach the legacy script module build.'
+                }
+                [IO.File]::WriteAllText('{{markerPath.Replace("'", "''")}}', 'True')
+                """);
+
+            var repoRoot = RepoRootLocator.Find();
+            var pspublishModulePath = Path.Combine(
+                repoRoot,
+                "PSPublishModule",
+                "bin",
+                "Release",
+                "net8.0",
+                "PSPublishModule.dll");
+            Assert.True(File.Exists(pspublishModulePath), $"Built net8.0 module was not found: {pspublishModulePath}");
+
+            var result = await new ModuleBuildHostService().ExecuteBuildAsync(new ModuleBuildHostBuildRequest
+            {
+                RepositoryRoot = root.FullName,
+                ScriptPath = scriptPath,
+                ModulePath = pspublishModulePath,
+                Framework = "net8.0",
+                RunMode = ConfigurationGateMode.Build,
+                ReleaseCheckpoint = true,
+                Timeout = TimeSpan.FromMinutes(1)
+            });
+
+            Assert.True(result.Succeeded, result.StandardError);
+            Assert.Equal("True", File.ReadAllText(markerPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
     }
 
     [Fact]

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -232,6 +232,24 @@ public sealed partial class ModuleBuildPreparationServiceTests
     }
 
     [Fact]
+    public void InvokeModuleBuild_ReleaseCheckpoint_AllowsEveryBuildParameterSet()
+    {
+        var releaseCheckpoint = typeof(InvokeModuleBuildCommand).GetProperty(
+            nameof(InvokeModuleBuildCommand.PowerForgeReleaseCheckpoint));
+        Assert.NotNull(releaseCheckpoint);
+
+        var parameterSets = releaseCheckpoint!
+            .GetCustomAttributes(typeof(ParameterAttribute), inherit: false)
+            .Cast<ParameterAttribute>()
+            .Select(static attribute => attribute.ParameterSetName)
+            .ToArray();
+
+        Assert.Contains("Modern", parameterSets);
+        Assert.Contains("Configuration", parameterSets);
+        Assert.Contains("Config", parameterSets);
+    }
+
+    [Fact]
     public void Prepare_from_modern_request_appends_run_mode_gate_segment()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-runmode-" + Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePackages.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePackages.cs
@@ -202,7 +202,6 @@ public sealed partial class PowerForgeReleaseServiceTests
                 new PowerForgeReleaseRequest
                 {
                     ConfigPath = releasePath,
-                    ModuleOnly = true,
                     ModuleRunMode = ConfigurationGateMode.Build
                 });
 
@@ -211,6 +210,9 @@ public sealed partial class PowerForgeReleaseServiceTests
             var package = Assert.Single(result.ReleaseAssetEntries);
             Assert.Equal(PowerForgeReleaseAssetCategory.Package, package.Category);
             Assert.True(package.IsFinalPackageOutput);
+            var moduleCall = Assert.Single(moduleCalls);
+            Assert.Equal(ConfigurationGateMode.Build, moduleCall.RunMode);
+            Assert.True(moduleCall.ReleaseCheckpoint);
         }
         finally
         {

--- a/PowerForge/Services/ModuleBuildHostService.cs
+++ b/PowerForge/Services/ModuleBuildHostService.cs
@@ -474,6 +474,11 @@ public sealed class ModuleBuildHostService
             "$buildScriptArguments = @{}"
         };
 
+        if (request.ReleaseCheckpoint)
+        {
+            arguments.Add("$PSDefaultParameterValues['Invoke-ModuleBuild:PowerForgeReleaseCheckpoint'] = $true");
+        }
+
         if (request.RequireReusableOutput)
         {
             arguments.Add("$requiredCheckpointParameters = @('NoDotnetBuild', 'StagingPath', 'ReuseStaging', 'IncludeProjectPackages', 'IncludeModulePublishing', 'SkipInstall')");

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -558,11 +558,16 @@ internal sealed partial class PowerForgeReleaseService
 
             if (!request.PlanOnly && !request.ValidateOnly)
             {
-                var moduleResult = deferModulePublishing
+                var releaseCheckpointBuild =
+                    deferModulePublishing ||
+                    (module.Request.RunMode == ConfigurationGateMode.Build && module.Plan.IncludesProjectPackages);
+                var moduleResult = releaseCheckpointBuild
                     ? ExecuteModuleRequest(
                         module.Request,
                         ConfigurationGateMode.Build,
-                        includeModulePublishing: false,
+                        includeModulePublishing: deferModulePublishing
+                            ? false
+                            : module.Request.IncludeModulePublishing,
                         releaseCheckpoint: true,
                         cancellationToken: request.CancellationToken)
                     : _executeModuleBuild(module.Request, request.CancellationToken);


### PR DESCRIPTION
## Summary

- Preserve configured NuGet package signing when a module release runs the Build gate with project packages.
- Carry the internal release-checkpoint signal through both JSON-backed configs and legacy script wrappers without requiring consumer parameters.
- Keep ModuleOnly requests outside the project-package checkpoint path.
- Add direct service coverage plus a real child PowerShell host regression test.

## Why

The unified release flow in [EventViewerX](https://github.com/EvotecIT/EventViewerX) exposed an owner-level gap: its module files and binaries were Authenticode-signed, but the five NuGet packages produced by a release Build were unsigned. PowerForge suppressed package credentials for ordinary Build gates and did not recognize that this Build was the exact local release checkpoint.

PSPublishModule owns this behavior. After this PR is merged and released, EventViewerX can declare the new minimum version and complete its downstream release-wrapper PR without a consumer-side signing workaround.

## Validation

- 63 focused module-host and preparation tests pass.
- Positive project-package and negative ModuleOnly release-service tests pass together.
- A real legacy ScriptPath child host confirms the hidden checkpoint reaches Invoke-ModuleBuild without a wrapper parameter.
- The EventViewerX release Build produces five author-signed packages that pass dotnet NuGet verification.
- The broader release-service run passes 713 of 714 tests; the single Apple metadata fixture failure reproduces unchanged on origin/main and is unrelated to this diff.