### PR TITLE
Fix NETStandard SDK package provenance

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerSdkRuntimePackProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerSdkRuntimePackProvenanceTests.cs
@@ -168,6 +168,7 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
 
     [Theory]
     [InlineData("Microsoft.NET.ILLink.Tasks", true)]
+    [InlineData("NETStandard.Library.Ref", true)]
     [InlineData("Package.Snapshot", false)]
     [Trait("Category", "DotNetPublishPrGate")]
     public void SdkEvidence_AutoReferencedBypassRequiresSdkOwnedPackageIdentity(
@@ -179,6 +180,67 @@ public sealed partial class DotNetPublishPipelineRunnerManifestProvenanceTests
             BindingFlags.Static | BindingFlags.NonPublic)!;
 
         Assert.Equal(expected, Assert.IsType<bool>(method.Invoke(null, [packageId])));
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void SdkEvidence_TrustedAcquisitionRejectsPreseededShadowPackageRoot()
+    {
+        string root = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            string packageRoot = Directory.CreateDirectory(
+                Path.Combine(root, "packages", "netstandard.library.ref", "2.1.0")).Parent!.Parent!.FullName;
+            File.WriteAllText(
+                Path.Combine(packageRoot, "netstandard.library.ref", "2.1.0", "netstandard.library.ref.2.1.0.nupkg"),
+                "shadow package");
+            MethodInfo method = typeof(DotNetPublishPipelineRunner).GetMethod(
+                "TryPrimeSdkEvidencePackages",
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+
+            object? result = method.Invoke(
+                null,
+                [
+                    root,
+                    packageRoot,
+                    "https://api.nuget.org/v3/index.json",
+                    Path.Combine(root, "NuGet.Config"),
+                    new[] { "NETStandard.Library.Ref|2.1.0" },
+                    "sdk-packages",
+                    root,
+                    null,
+                    true
+                ]);
+
+            Assert.False(Assert.IsType<bool>(result));
+        }
+        finally
+        {
+            DeleteTestRepository(root);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "DotNetPublishPrGate")]
+    public void SdkEvidence_RejectsCommittedShadowPackageHash()
+    {
+        MethodInfo method = typeof(DotNetPublishPipelineRunner).GetMethod(
+            "HaveNoConflictingSdkPackageHashes",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        var committed = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["NETStandard.Library.Ref|2.1.0"] = "private-shadow-hash"
+        };
+        var trusted = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["NETStandard.Library.Ref|2.1.0"] = "nuget-org-hash"
+        };
+        object?[] arguments = [committed, trusted, null];
+
+        object? result = method.Invoke(null, arguments);
+
+        Assert.False(Assert.IsType<bool>(result));
+        Assert.Equal("NETStandard.Library.Ref|2.1.0", Assert.IsType<string>(arguments[2]));
     }
 
     [Fact]

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PackageInputProvenance.cs
@@ -635,6 +635,7 @@ public sealed partial class DotNetPublishPipelineRunner
                     sdkManagedPackageKeys,
                     effectiveGlobalProperties,
                     environmentVariables,
+                    committedPackageHashes,
                     archivePathsByPackageKey,
                     archives,
                     out sdkEvidenceFailureReason)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SdkPackageProvenance.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SdkPackageProvenance.cs
@@ -33,7 +33,8 @@ public sealed partial class DotNetPublishPipelineRunner
     private static readonly HashSet<string> TrustedSdkAutoReferencedPackageIds = new(
         new[]
         {
-            "Microsoft.NET.ILLink.Tasks"
+            "Microsoft.NET.ILLink.Tasks",
+            "NETStandard.Library.Ref"
         },
         StringComparer.OrdinalIgnoreCase);
 
@@ -45,6 +46,7 @@ public sealed partial class DotNetPublishPipelineRunner
         HashSet<string> sdkManagedPackageKeys,
         IReadOnlyDictionary<string, string>? effectiveGlobalProperties,
         IReadOnlyDictionary<string, string?>? environmentVariables,
+        IReadOnlyDictionary<string, string> committedPackageHashes,
         IReadOnlyDictionary<string, string> committedArchivePaths,
         VerifiedPackageArchiveCache archives,
         out string? failureReason)
@@ -55,6 +57,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 properties,
                 effectiveGlobalProperties,
                 environmentVariables,
+                committedPackageHashes,
                 committedArchivePaths,
                 archives,
                 out JsonDocument? document,
@@ -106,6 +109,7 @@ public sealed partial class DotNetPublishPipelineRunner
         JsonElement properties,
         IReadOnlyDictionary<string, string>? effectiveGlobalProperties,
         IReadOnlyDictionary<string, string?>? environmentVariables,
+        IReadOnlyDictionary<string, string> committedPackageHashes,
         IReadOnlyDictionary<string, string> committedArchivePaths,
         VerifiedPackageArchiveCache archives,
         out JsonDocument? document,
@@ -187,19 +191,6 @@ public sealed partial class DotNetPublishPipelineRunner
                 failureReason = "SDK package keys could not be read from the restore graph";
                 return false;
             }
-            if (!TryPrimeSdkEvidencePackages(
-                    temporaryRoot,
-                    isolatedPackageRoot,
-                    verifiedPackageSource,
-                    configPath,
-                    committedArchivePaths.Keys,
-                    "verified-lock",
-                    Path.GetDirectoryName(projectPath)!,
-                    environmentVariables))
-            {
-                failureReason = "locked packages could not be primed into the isolated package root";
-                return false;
-            }
             if (!TryWriteSdkEvidenceNuGetConfig(
                     configPath,
                     verifiedPackageSource,
@@ -216,7 +207,8 @@ public sealed partial class DotNetPublishPipelineRunner
                     sdkPackageKeys,
                     "sdk-packages",
                     Path.GetDirectoryName(projectPath)!,
-                    environmentVariables))
+                    environmentVariables,
+                    requireEmptyPackageRoot: true))
             {
                 failureReason = "SDK-owned packages could not be primed from the trusted source";
                 return false;
@@ -231,6 +223,28 @@ public sealed partial class DotNetPublishPipelineRunner
                     archives))
             {
                 failureReason = "SDK package hashes or archive snapshots could not be verified";
+                return false;
+            }
+            if (!HaveNoConflictingSdkPackageHashes(
+                    committedPackageHashes,
+                    trustedSdkPackageHashes,
+                    out string? conflictingPackageKey))
+            {
+                failureReason = $"SDK-owned package '{conflictingPackageKey}' conflicts with the committed package hash";
+                return false;
+            }
+            if (!TryPrimeSdkEvidencePackages(
+                    temporaryRoot,
+                    isolatedPackageRoot,
+                    verifiedPackageSource,
+                    configPath,
+                    committedArchivePaths.Keys,
+                    "verified-lock",
+                    Path.GetDirectoryName(projectPath)!,
+                    environmentVariables,
+                    requireEmptyPackageRoot: false))
+            {
+                failureReason = "locked packages could not be primed into the isolated package root";
                 return false;
             }
             if (!TryWriteSdkEvidenceNuGetConfig(
@@ -514,10 +528,17 @@ public sealed partial class DotNetPublishPipelineRunner
         IEnumerable<string> packageKeys,
         string projectName,
         string workingDirectory,
-        IReadOnlyDictionary<string, string?>? environmentVariables)
+        IReadOnlyDictionary<string, string?>? environmentVariables,
+        bool requireEmptyPackageRoot)
     {
         try
         {
+            if (requireEmptyPackageRoot &&
+                Directory.EnumerateFileSystemEntries(isolatedPackageRoot).Any())
+            {
+                return false;
+            }
+
             var packages = packageKeys
                 .Select(key =>
                 {
@@ -681,6 +702,24 @@ public sealed partial class DotNetPublishPipelineRunner
         return expected.Count == actual.Count &&
                expected.All(package => actual.TryGetValue(package.Key, out string? hash) &&
                                        string.Equals(package.Value, hash, StringComparison.Ordinal));
+    }
+
+    private static bool HaveNoConflictingSdkPackageHashes(
+        IReadOnlyDictionary<string, string> committedPackageHashes,
+        IReadOnlyDictionary<string, string> trustedSdkPackageHashes,
+        out string? conflictingPackageKey)
+    {
+        conflictingPackageKey = null;
+        foreach (KeyValuePair<string, string> package in trustedSdkPackageHashes)
+        {
+            if (committedPackageHashes.TryGetValue(package.Key, out string? committedHash) &&
+                !string.Equals(committedHash, package.Value, StringComparison.Ordinal))
+            {
+                conflictingPackageKey = package.Key;
+                return false;
+            }
+        }
+        return true;
     }
 
     private static void TryDeleteSdkEvidenceRoot(string? path)


### PR DESCRIPTION
## Summary

- recognize `NETStandard.Library.Ref` when the .NET SDK marks it as an auto-referenced package
- acquire SDK-owned packages from NuGet.org into a clean package root before adding committed dependencies
- reject committed packages whose verified hash conflicts with the independently acquired SDK package
- cover pre-seeded shadow packages and conflicting package hashes with regression tests

## Why

The [EventViewerX](https://github.com/EvotecIT/EventViewerX) standalone CLI release includes a `netstandard2.1` dependency graph. PowerForge correctly failed its controlled provenance check because the SDK-managed `NETStandard.Library.Ref` package was not admitted to the verified offline source.

This keeps the fix in PowerForge, while preserving the downstream release wrapper as a thin consumer. EventViewerX should consume the next three-part PSPublishModule release after this PR is merged and published.

## Validation

- focused SDK/runtime-pack provenance set: 9 passed
- Release solution build: succeeded with no warnings or errors
- exact-head EventViewerX CLI build: 12 archives across six runtimes and two styles; all 19 staged checksums verified
- independent read-only review and targeted remediation confirmation: no remaining P0-P2 finding