### PR TITLE
Fix immutable coordinated release publishing

### DIFF
--- a/PSPublishModule/packages.lock.json
+++ b/PSPublishModule/packages.lock.json
@@ -319,7 +319,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.5.ReferenceAssemblies": "[1.1.0, )",
-          "PowerForge": "[3.0.138, )",
+          "PowerForge": "[3.0.139, )",
           "System.Security.Cryptography.Xml": "[10.0.11, )",
           "System.Text.Json": "[10.0.11, )"
         }
@@ -1128,7 +1128,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.6.5, )",
-          "PowerForge": "[3.0.138, )",
+          "PowerForge": "[3.0.139, )",
           "System.Security.Cryptography.Xml": "[10.0.11, )"
         }
       }
@@ -1896,7 +1896,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.4.20, )",
-          "PowerForge": "[3.0.138, )",
+          "PowerForge": "[3.0.139, )",
           "System.Security.Cryptography.Xml": "[10.0.11, )"
         }
       }

--- a/PowerForge.Cli/packages.lock.json
+++ b/PowerForge.Cli/packages.lock.json
@@ -756,7 +756,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.6.5, )",
-          "PowerForge": "[3.0.138, )",
+          "PowerForge": "[3.0.139, )",
           "System.Security.Cryptography.Xml": "[10.0.11, )"
         }
       }
@@ -1476,7 +1476,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.4.20, )",
-          "PowerForge": "[3.0.138, )",
+          "PowerForge": "[3.0.139, )",
           "System.Security.Cryptography.Xml": "[10.0.11, )"
         }
       }

--- a/PowerForge.Net472SmokeTests/packages.lock.json
+++ b/PowerForge.Net472SmokeTests/packages.lock.json
@@ -301,7 +301,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.5.ReferenceAssemblies": "[1.1.0, )",
-          "PowerForge": "[3.0.138, )",
+          "PowerForge": "[3.0.139, )",
           "System.Security.Cryptography.Xml": "[10.0.11, )",
           "System.Text.Json": "[10.0.11, )"
         }

--- a/PowerForge.PowerShell.Provider.Directory.Runtime/packages.lock.json
+++ b/PowerForge.PowerShell.Provider.Directory.Runtime/packages.lock.json
@@ -96,7 +96,7 @@
       "powerforge.powershell.providersdk": {
         "type": "Project",
         "dependencies": {
-          "PowerForge": "[3.0.138, )"
+          "PowerForge": "[3.0.139, )"
         }
       }
     }

--- a/PowerForge.PowerShell.Provider.Management.Runtime/packages.lock.json
+++ b/PowerForge.PowerShell.Provider.Management.Runtime/packages.lock.json
@@ -110,7 +110,7 @@
       "powerforge.powershell.providersdk": {
         "type": "Project",
         "dependencies": {
-          "PowerForge": "[3.0.138, )"
+          "PowerForge": "[3.0.139, )"
         }
       }
     }

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.PublicModuleRelease.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.PublicModuleRelease.cs
@@ -415,7 +415,7 @@ public sealed partial class AppleReleaseWorkflowTests
         var command = $". '{escapedHelper}'; " +
                       $"$config = Get-Content -Raw -LiteralPath '{escapedConfig}' | ConvertFrom-Json; " +
                       $"$ids = @(Get-PowerForgeReleasePackageIds -ReleaseConfig $config -RepositoryRoot '{escapedRoot}'); " +
-                      "$expected = @('PowerForge','PowerForge.PowerShell','PowerForge.Build','PowerForge.Blazor','PowerForge.Web','PowerForge.Web.Build'); " +
+                      "$expected = @('PowerForge','PowerForge.PowerShell','PowerForge.PowerShell.ProviderSdk','PowerForge.PowerShell.Provider.Directory','PowerForge.PowerShell.Provider.Directory.Runtime','PowerForge.PowerShell.Provider.Management','PowerForge.PowerShell.Provider.Management.Runtime','PowerForge.Build','PowerForge.Blazor','PowerForge.Web','PowerForge.Web.Build'); " +
                       "if (Compare-Object $expected $ids) { throw \"Resolved package IDs differ: $($ids -join ', ')\" }";
 
         Run("pwsh", root, "-NoProfile", "-Command", command).EnsureSuccess();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePackages.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePackages.cs
@@ -642,6 +642,85 @@ public sealed partial class PowerForgeReleaseServiceTests
         }
     }
 
+    [Theory]
+    [InlineData("3.0.76", true)]
+    [InlineData("3.0.75", false)]
+    public void Execute_CoordinatedVersions_ValidatesImmutablePackageVersionWithoutApplyingFloor(
+        string packageVersion,
+        bool expectedSuccess)
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var moduleConfig = Path.Combine(root, "powerforge.json");
+            var manifestPath = Path.Combine(root, "Module", "PSPublishModule.psd1");
+            Directory.CreateDirectory(Path.GetDirectoryName(manifestPath)!);
+            File.WriteAllText(moduleConfig, """{ "SchemaVersion": 1, "Build": { "Name": "PSPublishModule", "SourcePath": "Module", "Version": "3.0.76" }, "Segments": [] }""");
+            File.WriteAllText(manifestPath, "@{ ModuleVersion = '3.0.76' }");
+
+            ProjectBuildHostRequest? capturedRequest = null;
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (packageRequest, _, configPath) =>
+                {
+                    capturedRequest = packageRequest;
+                    var execution = new ProjectBuildHostExecutionResult
+                    {
+                        ConfigPath = configPath,
+                        Success = true
+                    };
+                    execution.Result.Release = new DotNetRepositoryReleaseResult { ResolvedVersion = packageVersion };
+                    execution.Result.Release.ResolvedVersionsByProject["PowerForge"] = packageVersion;
+                    return execution;
+                },
+                planTools: (_, _, _) => throw new InvalidOperationException("Tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."));
+
+            var releaseSpec = new PowerForgeReleaseSpec
+            {
+                Module = new PowerForgeModuleReleaseOptions
+                {
+                    RepositoryRoot = ".",
+                    ConfigPath = "powerforge.json",
+                    ManifestPath = "Module/PSPublishModule.psd1",
+                    ModuleVersion = "3.0.76",
+                    SynchronizeVersionWithPackages = true,
+                    VersionPrimaryProject = "PowerForge"
+                },
+                Packages = new ProjectBuildConfiguration
+                {
+                    RootPath = ".",
+                    UpdateVersions = false
+                }
+            };
+            var releaseRequest = new PowerForgeReleaseRequest
+            {
+                ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                PlanOnly = true
+            };
+
+            if (expectedSuccess)
+            {
+                var result = service.Execute(releaseSpec, releaseRequest);
+                Assert.True(result.Success, result.ErrorMessage);
+                Assert.Equal("3.0.76", result.ModulePlan!.ModuleVersion);
+            }
+            else
+            {
+                var exception = Assert.Throws<InvalidOperationException>(() => service.Execute(releaseSpec, releaseRequest));
+                Assert.Contains("lower than the coordinated module version floor", exception.Message, StringComparison.OrdinalIgnoreCase);
+            }
+            Assert.NotNull(capturedRequest);
+            Assert.Null(capturedRequest!.ReleaseVersionFloor);
+            Assert.Null(capturedRequest.ReleaseVersionFloorProject);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
     private sealed class RecordingReleaseProgress : IPowerForgeReleaseProgressReporter
     {
         public List<string> Events { get; } = new();

--- a/PowerForge.Tests/packages.lock.json
+++ b/PowerForge.Tests/packages.lock.json
@@ -1149,7 +1149,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.6.5, )",
-          "PowerForge": "[3.0.138, )",
+          "PowerForge": "[3.0.139, )",
           "System.Security.Cryptography.Xml": "[10.0.11, )"
         }
       },
@@ -1162,8 +1162,8 @@
       "powerforge.powershell.provider.directory.runtime": {
         "type": "Project",
         "dependencies": {
-          "PowerForge.PowerShell.Provider.Directory": "[3.0.138, )",
-          "PowerForge.PowerShell.ProviderSdk": "[3.0.138, )"
+          "PowerForge.PowerShell.Provider.Directory": "[3.0.139, )",
+          "PowerForge.PowerShell.ProviderSdk": "[3.0.139, )"
         }
       },
       "powerforge.powershell.provider.management": {
@@ -1175,14 +1175,14 @@
       "powerforge.powershell.provider.management.runtime": {
         "type": "Project",
         "dependencies": {
-          "PowerForge.PowerShell.Provider.Management": "[3.0.138, )",
-          "PowerForge.PowerShell.ProviderSdk": "[3.0.138, )"
+          "PowerForge.PowerShell.Provider.Management": "[3.0.139, )",
+          "PowerForge.PowerShell.ProviderSdk": "[3.0.139, )"
         }
       },
       "powerforge.powershell.providersdk": {
         "type": "Project",
         "dependencies": {
-          "PowerForge": "[3.0.138, )"
+          "PowerForge": "[3.0.139, )"
         }
       },
       "powerforge.web": {
@@ -1192,7 +1192,7 @@
           "HtmlTinkerX": "[3.0.1, )",
           "Magick.NET-Q8-AnyCPU": "[14.16.0, )",
           "OfficeIMO.Markdown": "[3.3.0, )",
-          "PowerForge": "[3.0.138, )",
+          "PowerForge": "[3.0.139, )",
           "Scriban": "[7.2.7, )",
           "YamlDotNet": "[18.1.0, )"
         }
@@ -1202,7 +1202,7 @@
         "dependencies": {
           "DBAClientX.SQLite": "[1.0.8, )",
           "NuGet.Versioning": "[7.9.0, )",
-          "PowerForge.Web": "[3.0.138, )"
+          "PowerForge.Web": "[3.0.139, )"
         }
       },
       "powerforgestudio.domain": {
@@ -1214,8 +1214,8 @@
           "HtmlForgeX": "[0.56.0, )",
           "HtmlForgeX.Markdown": "[0.56.0, )",
           "OfficeIMO.Markdown": "[3.3.0, )",
-          "PowerForge": "[3.0.138, )",
-          "PowerForge.PowerShell": "[3.0.138, )",
+          "PowerForge": "[3.0.139, )",
+          "PowerForge.PowerShell": "[3.0.139, )",
           "Spectre.Console": "[0.57.2, )",
           "Spectre.Console.Json": "[0.57.2, )",
           "System.IO.Packaging": "[10.0.11, )",

--- a/PowerForge.Web.Cli/packages.lock.json
+++ b/PowerForge.Web.Cli/packages.lock.json
@@ -368,7 +368,7 @@
           "HtmlTinkerX": "[3.0.1, )",
           "Magick.NET-Q8-AnyCPU": "[14.16.0, )",
           "OfficeIMO.Markdown": "[3.3.0, )",
-          "PowerForge": "[3.0.138, )",
+          "PowerForge": "[3.0.139, )",
           "Scriban": "[7.2.7, )",
           "YamlDotNet": "[18.1.0, )"
         }

--- a/PowerForge/Services/PowerForgeReleaseService.VersionCoordination.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.VersionCoordination.cs
@@ -109,6 +109,7 @@ internal sealed partial class PowerForgeReleaseService
         bool suppressPublishing = false)
     {
         ApplyPackageRequestOverrides(packages, request, configurationOverride);
+        var canApplyReleaseVersionFloor = packages.UpdateVersions != false;
         var packageRequest = new ProjectBuildHostRequest
         {
             ConfigPath = configPath,
@@ -116,8 +117,8 @@ internal sealed partial class PowerForgeReleaseService
             PlanOnly = forcePlanOnly || request.PlanOnly || request.ValidateOnly ? true : null,
             PublishNuget = suppressPublishing ? false : request.PublishNuget,
             PublishGitHub = suppressPublishing || publishUnifiedGitHub ? false : request.PublishProjectGitHub,
-            ReleaseVersionFloor = releaseVersionFloor,
-            ReleaseVersionFloorProject = releaseVersionFloorProject,
+            ReleaseVersionFloor = canApplyReleaseVersionFloor ? releaseVersionFloor : null,
+            ReleaseVersionFloorProject = canApplyReleaseVersionFloor ? releaseVersionFloorProject : null,
             BuildSpecPrepared = preparedSpec => request.PackageBuildSpec = preparedSpec,
             RemotePublishAttempted = () => ValidatePostBuildSourceState(request),
             CancellationToken = request.CancellationToken

--- a/PowerForgeStudio.Cli/packages.lock.json
+++ b/PowerForgeStudio.Cli/packages.lock.json
@@ -156,7 +156,7 @@
           "DBAClientX.Core": "[1.0.8, )",
           "DBAClientX.SQLite": "[1.0.8, )",
           "Microsoft.Data.Sqlite": "[10.0.11, )",
-          "PowerForge": "[3.0.138, )",
+          "PowerForge": "[3.0.139, )",
           "PowerForgeStudio.Domain": "[1.0.0, )"
         }
       }

--- a/PowerForgeStudio.Tests/packages.lock.json
+++ b/PowerForgeStudio.Tests/packages.lock.json
@@ -247,7 +247,7 @@
           "DBAClientX.Core": "[1.0.8, )",
           "DBAClientX.SQLite": "[1.0.8, )",
           "Microsoft.Data.Sqlite": "[10.0.11, )",
-          "PowerForge": "[3.0.138, )",
+          "PowerForge": "[3.0.139, )",
           "PowerForgeStudio.Domain": "[1.0.0, )"
         }
       }

--- a/PowerForgeStudio.Wpf/packages.lock.json
+++ b/PowerForgeStudio.Wpf/packages.lock.json
@@ -206,7 +206,7 @@
           "DBAClientX.Core": "[1.0.8, )",
           "DBAClientX.SQLite": "[1.0.8, )",
           "Microsoft.Data.Sqlite": "[10.0.11, )",
-          "PowerForge": "[3.0.138, )",
+          "PowerForge": "[3.0.139, )",
           "PowerForgeStudio.Domain": "[1.0.0, )"
         }
       }


### PR DESCRIPTION
## Summary

- keep publish-time package inputs immutable while coordinating the module and package version
- validate the resolved committed package version against the module floor in the release coordinator
- cover all configured package IDs during verified registry recovery
- refresh project-reference lock files for the committed 3.0.139 version

## Why it matters

The guarded public publisher intentionally disables version mutation after the release version is committed. Coordinated planning previously forwarded a version-floor mutation request anyway, so publication stopped before building or uploading any artifact. This keeps the immutable publish contract and removes that contradictory request.

## Validation

- solution restore succeeds in locked mode
- coordinated/public-release contract tests pass (27/27)
- .NET Framework 4.7.2 smoke tests pass (6/6)
- independent local release-path review and targeted confirmation found no remaining issues