### PR TITLE
Fix signing for dotnet tool package dependencies

### DIFF
--- a/Build/release.json
+++ b/Build/release.json
@@ -54,6 +54,7 @@
     "CertificateThumbprint": "92E95FB58EFFA6A4A75E77A33CDD6BFE6DD30F1A",
     "CertificateStore": "CurrentUser",
     "TimeStampServer": "http://timestamp.digicert.com",
+    "SignDependencyAssemblies": true,
     "PublishSource": "https://api.nuget.org/v3/index.json",
     "PublishApiKeyFilePath": "C:\\Support\\Important\\NugetOrgEvotec.txt",
     "SkipDuplicate": true,

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.PublicModuleRelease.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.PublicModuleRelease.cs
@@ -89,6 +89,7 @@ public sealed partial class AppleReleaseWorkflowTests
         Assert.Contains("ExpectedTagCommitSha = gitHub.Commitish", Read(root, "PowerForge", "Services", "PowerForgeReleaseService.cs"), StringComparison.Ordinal);
         Assert.Contains("Status         = 'Failed'", script, StringComparison.Ordinal);
         Assert.Contains("\"PlanOutputPath\": \"../Artefacts/ProjectBuild/project.build.plan.json\"", releaseConfig, StringComparison.Ordinal);
+        Assert.Contains("\"SignDependencyAssemblies\": true", releaseConfig, StringComparison.Ordinal);
         Assert.Contains("\"Commitish\"", releaseSchema, StringComparison.Ordinal);
     }
 

--- a/PowerForge.Tests/DotNetRepositoryReleaseFreshBuildTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseFreshBuildTests.cs
@@ -742,27 +742,29 @@ public sealed class DotNetRepositoryReleaseFreshBuildTests
             File.WriteAllText(projectPath, """
                 <Project Sdk="Microsoft.NET.Sdk">
                   <PropertyGroup>
+                    <OutputType>Exe</OutputType>
                     <TargetFramework>net8.0</TargetFramework>
                     <PackageId>Sample.Output</PackageId>
                     <VersionPrefix>1.0.0</VersionPrefix>
-                    <IsPackable>true</IsPackable>
+                    <PackAsTool>true</PackAsTool>
+                    <ToolCommandName>sample-output</ToolCommandName>
                   </PropertyGroup>
                 </Project>
                 """);
-            File.WriteAllText(sourcePath, "namespace Sample.Output; public sealed class LegacyContract { }");
+            File.WriteAllText(sourcePath, "namespace Sample.Output; public static class Program { public static void Main() { } public sealed class LegacyContract { } }");
             RunDotNet(projectDirectory.FullName, "build", projectPath, "--configuration", "Release", "--nologo");
 
             var targetDirectory = Path.Combine(projectDirectory.FullName, "bin", "Release", "net8.0");
             var assemblyPath = Path.Combine(targetDirectory, "Sample.Output.dll");
             var legacyAssembly = File.ReadAllBytes(assemblyPath);
-            File.WriteAllText(sourcePath, "namespace Sample.Output; public sealed class CurrentContract { }");
+            File.WriteAllText(sourcePath, "namespace Sample.Output; public static class Program { public static void Main() { } public sealed class CurrentContract { } }");
             RunDotNet(projectDirectory.FullName, "build", projectPath, "--configuration", "Release", "--no-incremental", "--nologo");
 
             var publishDirectory = Directory.CreateDirectory(Path.Combine(targetDirectory, "publish"));
             File.WriteAllBytes(Path.Combine(publishDirectory.FullName, "Sample.Output.dll"), legacyAssembly);
             var packagePath = Path.Combine(root.FullName, "Sample.Output.1.0.0.nupkg");
             using (var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create))
-                WriteArchiveEntry(archive, "lib/net8.0/Sample.Output.dll", legacyAssembly);
+                WriteArchiveEntry(archive, "tools/net8.0/any/Sample.Output.dll", legacyAssembly);
 
             var success = DotNetRepositoryReleaseService.TryValidateProjectPackagePayloads(
                 new DotNetRepositoryProjectResult

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -661,7 +661,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
                 .Single(target => string.Equals(target.Attribute("Name")?.Value, "PackSelected", StringComparison.Ordinal))
                 .Attribute("DependsOnTargets")?.Value);
             Assert.Equal(
-                $"Configuration=Release;PackageOutputPath={outputPath.Replace("%", "%25").Replace(";", "%3B").Replace("=", "%3D").Replace("$", "%24").Replace("@", "%40")};NoBuild=true;BuildProjectReferences=false",
+                $"Configuration=Release;PackageOutputPath={outputPath.Replace("%", "%25").Replace(";", "%3B").Replace("=", "%3D").Replace("$", "%24").Replace("@", "%40")};_IsPacking=true;NoBuild=true;BuildProjectReferences=false",
                 msbuildTasks[2].Attribute("Properties")?.Value);
         }
         finally
@@ -901,28 +901,74 @@ public sealed class DotNetRepositoryReleaseServiceTests
     }
 
     [Theory]
-    [InlineData(DotNetRepositoryPackStrategy.PerProject)]
-    [InlineData(DotNetRepositoryPackStrategy.MSBuild)]
-    public void Execute_WithAssemblySigning_PreservesSignedPackToolAssembly(DotNetRepositoryPackStrategy packStrategy)
+    [InlineData(DotNetRepositoryPackStrategy.PerProject, false, false)]
+    [InlineData(DotNetRepositoryPackStrategy.MSBuild, false, false)]
+    [InlineData(DotNetRepositoryPackStrategy.PerProject, true, false)]
+    [InlineData(DotNetRepositoryPackStrategy.MSBuild, true, false)]
+    [InlineData(DotNetRepositoryPackStrategy.PerProject, true, true)]
+    [InlineData(DotNetRepositoryPackStrategy.MSBuild, true, true)]
+    public void Execute_WithAssemblySigning_PreservesSignedPackToolAssembly(
+        DotNetRepositoryPackStrategy packStrategy,
+        bool signDependencyAssemblies,
+        bool usePackConditionedPublishDirectory)
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
         {
-            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Tool"));
-            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.Tool.csproj");
-            File.WriteAllText(projectPath, """
+            var dependencyDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Dependency"));
+            var dependencyProjectPath = Path.Combine(dependencyDirectory.FullName, "Sample.Dependency.csproj");
+            File.WriteAllText(dependencyProjectPath, """
                 <Project Sdk="Microsoft.NET.Sdk">
                   <PropertyGroup>
-                    <OutputType>Exe</OutputType>
                     <TargetFramework>net8.0</TargetFramework>
-                    <PackageId>Sample.Tool</PackageId>
-                    <VersionPrefix>1.0.0</VersionPrefix>
-                    <PackAsTool>true</PackAsTool>
-                    <ToolCommandName>sample-tool</ToolCommandName>
+                    <IsPackable>false</IsPackable>
                   </PropertyGroup>
                 </Project>
                 """);
-            File.WriteAllText(Path.Combine(projectDirectory.FullName, "Program.cs"), "System.Console.WriteLine(\"sample\");");
+            File.WriteAllText(Path.Combine(dependencyDirectory.FullName, "Dependency.cs"), "namespace Sample.Dependency; public static class Dependency { public static string Value => \"sample\"; }");
+
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Tool"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.Tool.csproj");
+            var projectLines = new List<string>
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <OutputType>Exe</OutputType>",
+                "    <TargetFramework>net8.0</TargetFramework>",
+                "    <PackageId>Sample.Tool</PackageId>",
+                "    <VersionPrefix>1.0.0</VersionPrefix>",
+                "    <PackAsTool>true</PackAsTool>",
+                "    <ToolCommandName>sample-tool</ToolCommandName>"
+            };
+            if (usePackConditionedPublishDirectory)
+                projectLines.Add("    <PublishDir Condition=\"'$(_IsPacking)' == 'true' And '$(NoBuild)' == 'true' And '$(BuildProjectReferences)' == 'false'\">obj\\$(Configuration)\\$(TargetFramework)\\conditioned-publish\\</PublishDir>");
+            if (signDependencyAssemblies)
+            {
+                var obsoletePublishDirectory = usePackConditionedPublishDirectory
+                    ? "obj\\$(Configuration)\\$(TargetFramework)\\conditioned-publish\\"
+                    : "$(OutputPath)publish\\";
+                projectLines.Add($"    <ObsoletePublishDir>{obsoletePublishDirectory}</ObsoletePublishDir>");
+            }
+            projectLines.AddRange(new[]
+            {
+                "  </PropertyGroup>",
+                "  <ItemGroup>",
+                "    <ProjectReference Include=\"..\\Sample.Dependency\\Sample.Dependency.csproj\" />",
+                "  </ItemGroup>"
+            });
+            if (signDependencyAssemblies)
+            {
+                projectLines.AddRange(new[]
+                {
+                    "  <Target Name=\"SeedObsoletePublishDependency\" AfterTargets=\"Build\">",
+                    "    <MakeDir Directories=\"$(ObsoletePublishDir)\" />",
+                    "    <WriteLinesToFile File=\"$(ObsoletePublishDir)Obsolete.Dependency.dll\" Lines=\"obsolete\" Overwrite=\"true\" />",
+                    "  </Target>"
+                });
+            }
+            projectLines.Add("</Project>");
+            File.WriteAllText(projectPath, string.Join(Environment.NewLine, projectLines));
+            File.WriteAllText(Path.Combine(projectDirectory.FullName, "Program.cs"), "System.Console.WriteLine(Sample.Dependency.Dependency.Value);");
 
             var marker = new byte[] { 0x49, 0x58, 0x53, 0x49, 0x47 };
             string[] signedPaths = Array.Empty<string>();
@@ -939,12 +985,15 @@ public sealed class DotNetRepositoryReleaseServiceTests
                     CreateReleaseZip = false,
                     CertificateThumbprint = "ABC123",
                     SignAssemblies = true,
+                    SignDependencyAssemblies = signDependencyAssemblies,
                     SignPackages = false
                 },
                 request =>
                 {
                     signedPaths = Assert.IsType<string[]>(request.FilePaths);
-                    foreach (var path in signedPaths.Where(path => path.EndsWith("Sample.Tool.dll", StringComparison.OrdinalIgnoreCase)))
+                    foreach (var path in signedPaths.Where(path =>
+                                 path.EndsWith("Sample.Tool.dll", StringComparison.OrdinalIgnoreCase) ||
+                                 path.EndsWith("Sample.Dependency.dll", StringComparison.OrdinalIgnoreCase)))
                     {
                         using var stream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.None);
                         stream.Write(marker, 0, marker.Length);
@@ -954,14 +1003,83 @@ public sealed class DotNetRepositoryReleaseServiceTests
 
             Assert.True(result.Success, result.ErrorMessage);
             Assert.Contains(signedPaths, path => path.EndsWith(Path.Combine("obj", "Release", "net8.0", "Sample.Tool.dll"), StringComparison.OrdinalIgnoreCase));
+            if (signDependencyAssemblies)
+            {
+                var expectedPublishDirectory = usePackConditionedPublishDirectory ? "conditioned-publish" : "publish";
+                Assert.Contains(signedPaths, path => path.EndsWith(Path.Combine(expectedPublishDirectory, "Sample.Dependency.dll"), StringComparison.OrdinalIgnoreCase));
+            }
+            else
+                Assert.DoesNotContain(signedPaths, path => path.EndsWith("Sample.Dependency.dll", StringComparison.OrdinalIgnoreCase));
 
             var package = Assert.Single(Assert.Single(result.Projects, project => project.IsPackable).Packages);
             using var archive = ZipFile.OpenRead(package);
-            var entry = Assert.Single(archive.Entries, item => string.Equals(item.FullName, "tools/net8.0/any/Sample.Tool.dll", StringComparison.OrdinalIgnoreCase));
-            using var entryStream = entry.Open();
-            using var packagedAssembly = new MemoryStream();
-            entryStream.CopyTo(packagedAssembly);
-            Assert.Equal(marker, packagedAssembly.ToArray().TakeLast(marker.Length).ToArray());
+            Assert.DoesNotContain(archive.Entries, item => item.FullName.EndsWith("Obsolete.Dependency.dll", StringComparison.OrdinalIgnoreCase));
+            var signedEntryNames = signDependencyAssemblies
+                ? new[] { "Sample.Tool.dll", "Sample.Dependency.dll" }
+                : new[] { "Sample.Tool.dll" };
+            foreach (var entryName in signedEntryNames)
+            {
+                var entry = Assert.Single(archive.Entries, item => string.Equals(item.FullName, $"tools/net8.0/any/{entryName}", StringComparison.OrdinalIgnoreCase));
+                using var entryStream = entry.Open();
+                using var packagedAssembly = new MemoryStream();
+                entryStream.CopyTo(packagedAssembly);
+                Assert.Equal(marker, packagedAssembly.ToArray().TakeLast(marker.Length).ToArray());
+            }
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Theory]
+    [InlineData(DotNetRepositoryPackStrategy.PerProject)]
+    [InlineData(DotNetRepositoryPackStrategy.MSBuild)]
+    public void Execute_WithDependencyAssemblySigning_RejectsRidSpecificPackTool(
+        DotNetRepositoryPackStrategy packStrategy)
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Tool"));
+            File.WriteAllText(Path.Combine(projectDirectory.FullName, "Sample.Tool.csproj"), """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <PackageId>Sample.Tool</PackageId>
+                    <VersionPrefix>1.0.0</VersionPrefix>
+                    <PackAsTool>true</PackAsTool>
+                    <ToolCommandName>sample-tool</ToolCommandName>
+                    <ToolPackageRuntimeIdentifiers>win-x64</ToolPackageRuntimeIdentifiers>
+                  </PropertyGroup>
+                </Project>
+                """);
+            File.WriteAllText(Path.Combine(projectDirectory.FullName, "Program.cs"), "System.Console.WriteLine(\"sample\");");
+
+            var signingCalls = 0;
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(
+                new DotNetRepositoryReleaseSpec
+                {
+                    RootPath = root.FullName,
+                    Configuration = "Release",
+                    OutputPath = Path.Combine(root.FullName, "packages"),
+                    Pack = true,
+                    PackStrategy = packStrategy,
+                    Publish = false,
+                    UpdateVersions = false,
+                    CreateReleaseZip = false,
+                    CertificateThumbprint = "ABC123",
+                    SignAssemblies = true,
+                    SignDependencyAssemblies = true,
+                    SignPackages = false
+                },
+                _ => signingCalls++,
+                _ => { });
+
+            Assert.False(result.Success);
+            Assert.Contains("does not support RID-specific PackAsTool output", result.ErrorMessage, StringComparison.Ordinal);
+            Assert.Equal(0, signingCalls);
         }
         finally
         {

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -941,11 +941,11 @@ public sealed class DotNetRepositoryReleaseServiceTests
                 "    <ToolCommandName>sample-tool</ToolCommandName>"
             };
             if (usePackConditionedPublishDirectory)
-                projectLines.Add("    <PublishDir Condition=\"'$(_IsPacking)' == 'true' And '$(NoBuild)' == 'true' And '$(BuildProjectReferences)' == 'false'\">obj\\$(Configuration)\\$(TargetFramework)\\conditioned-publish\\</PublishDir>");
+                projectLines.Add("    <PublishDir Condition=\"'$(_IsPacking)' == 'true' And '$(NoBuild)' == 'true' And '$(BuildProjectReferences)' == 'false' And '$(PackageOutputPath)' != ''\">$(PackageOutputPath)\\conditioned-publish\\</PublishDir>");
             if (signDependencyAssemblies)
             {
                 var obsoletePublishDirectory = usePackConditionedPublishDirectory
-                    ? "obj\\$(Configuration)\\$(TargetFramework)\\conditioned-publish\\"
+                    ? "$(PackageOutputPath)\\conditioned-publish\\"
                     : "$(OutputPath)publish\\";
                 projectLines.Add($"    <ObsoletePublishDir>{obsoletePublishDirectory}</ObsoletePublishDir>");
             }
@@ -1080,6 +1080,40 @@ public sealed class DotNetRepositoryReleaseServiceTests
             Assert.False(result.Success);
             Assert.Contains("does not support RID-specific PackAsTool output", result.ErrorMessage, StringComparison.Ordinal);
             Assert.Equal(0, signingCalls);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void PackToolPathOverlapDetection_UsesActualFileSystemCaseSemantics()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var lowerCasePath = Directory.CreateDirectory(Path.Combine(root.FullName, "staging-a")).FullName;
+            var alternateCasePath = Path.Combine(root.FullName, "STAGING-A");
+            var isCaseInsensitive = Directory.Exists(alternateCasePath);
+
+            var success = DotNetRepositoryReleaseService.TryPackToolPathsOverlap(
+                lowerCasePath,
+                alternateCasePath,
+                out var overlap,
+                out var error);
+
+            Assert.True(success, error);
+            Assert.Equal(isCaseInsensitive, overlap);
+
+            success = DotNetRepositoryReleaseService.TryPackToolPathsOverlap(
+                lowerCasePath,
+                Path.Combine(lowerCasePath, "nested"),
+                out overlap,
+                out error);
+
+            Assert.True(success, error);
+            Assert.True(overlap);
         }
         finally
         {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.BatchPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.BatchPacking.cs
@@ -136,6 +136,18 @@ public sealed partial class DotNetRepositoryReleaseService
                     return result;
                 }
 
+                if (spec.SignDependencyAssemblies)
+                {
+                    if (!TryPreparePackToolPublishOutputs(projects, spec, logger, out var preparationDuration, out var preparationError))
+                    {
+                        result.Duration += preparationDuration;
+                        result.ErrorMessage = preparationError;
+                        return result;
+                    }
+
+                    result.Duration += preparationDuration;
+                }
+
                 var signing = SignBatchBuildOutputs(projects, spec, logger, signAssemblies!);
                 result.Duration += signing.Duration;
                 if (!signing.Success)
@@ -222,6 +234,7 @@ public sealed partial class DotNetRepositoryReleaseService
         {
             buildProperties,
             $"PackageOutputPath={EscapeMsBuildPropertyValue(outputPath)}",
+            "_IsPacking=true",
             "NoBuild=true",
             "BuildProjectReferences=false"
         };

--- a/PowerForge/Services/DotNetRepositoryReleaseService.BatchPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.BatchPacking.cs
@@ -138,7 +138,7 @@ public sealed partial class DotNetRepositoryReleaseService
 
                 if (spec.SignDependencyAssemblies)
                 {
-                    if (!TryPreparePackToolPublishOutputs(projects, spec, logger, out var preparationDuration, out var preparationError))
+                    if (!TryPreparePackToolPublishOutputs(projects, spec, outputPath, logger, out var preparationDuration, out var preparationError))
                     {
                         result.Duration += preparationDuration;
                         result.ErrorMessage = preparationError;
@@ -148,7 +148,7 @@ public sealed partial class DotNetRepositoryReleaseService
                     result.Duration += preparationDuration;
                 }
 
-                var signing = SignBatchBuildOutputs(projects, spec, logger, signAssemblies!);
+                var signing = SignBatchBuildOutputs(projects, spec, outputPath, logger, signAssemblies!);
                 result.Duration += signing.Duration;
                 if (!signing.Success)
                 {
@@ -291,6 +291,7 @@ public sealed partial class DotNetRepositoryReleaseService
     private static DotNetPackResult SignBatchBuildOutputs(
         IReadOnlyList<DotNetRepositoryProjectResult> projects,
         DotNetRepositoryReleaseSpec spec,
+        string packageOutputPath,
         ILogger logger,
         Action<DotNetReleaseBuildAssemblySigningRequest> signAssemblies)
     {
@@ -311,7 +312,15 @@ public sealed partial class DotNetRepositoryReleaseService
                 var signingPlan = BuildAssemblySigningPlan(
                     outputDirectories,
                     includePatterns,
-                    ResolvePackToolIntermediateAssemblyPaths(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns));
+                    ResolvePackToolIntermediateAssemblyPaths(
+                        project.CsprojPath,
+                        csprojDir,
+                        configuration,
+                        project.ProjectName,
+                        logger,
+                        includePatterns,
+                        spec.SignDependencyAssemblies,
+                        packageOutputPath));
                 if (signingPlan.Files.Length == 0 && !spec.SignDependencyAssemblies)
                 {
                     var evaluatedIncludePatterns = ResolveAssemblySigningIncludePatterns(project, spec, csprojDir, configuration, logger);
@@ -322,7 +331,15 @@ public sealed partial class DotNetRepositoryReleaseService
                         signingPlan = BuildAssemblySigningPlan(
                             outputDirectories,
                             includePatterns,
-                            ResolvePackToolIntermediateAssemblyPaths(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns));
+                            ResolvePackToolIntermediateAssemblyPaths(
+                                project.CsprojPath,
+                                csprojDir,
+                                configuration,
+                                project.ProjectName,
+                                logger,
+                                includePatterns,
+                                includePreparedPublishOutput: false,
+                                packageOutputPath));
                     }
                 }
                 logger.Info($"{project.ProjectName}: assembly signing include pattern(s): {string.Join(", ", includePatterns)}.");

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PackToolSigning.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PackToolSigning.cs
@@ -11,6 +11,7 @@ public sealed partial class DotNetRepositoryReleaseService
     private static bool TryPreparePackToolPublishOutputs(
         IReadOnlyList<DotNetRepositoryProjectResult> projects,
         DotNetRepositoryReleaseSpec spec,
+        string? packageOutputPath,
         ILogger logger,
         out TimeSpan duration,
         out string error)
@@ -18,7 +19,7 @@ public sealed partial class DotNetRepositoryReleaseService
         duration = TimeSpan.Zero;
         error = string.Empty;
         var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
-        var packProperties = CreatePackToolStagingGlobalProperties();
+        var packProperties = CreatePackToolStagingGlobalProperties(packageOutputPath);
         var plans = new List<PackToolPublishPlan>();
 
         foreach (var project in projects)
@@ -152,13 +153,18 @@ public sealed partial class DotNetRepositoryReleaseService
         return true;
     }
 
-    private static IReadOnlyDictionary<string, string> CreatePackToolStagingGlobalProperties()
-        => new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    private static IReadOnlyDictionary<string, string> CreatePackToolStagingGlobalProperties(string? packageOutputPath = null)
+    {
+        var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             ["_IsPacking"] = "true",
             ["NoBuild"] = "true",
             ["BuildProjectReferences"] = "false"
         };
+        if (!string.IsNullOrWhiteSpace(packageOutputPath))
+            properties["PackageOutputPath"] = Path.GetFullPath(packageOutputPath!);
+        return properties;
+    }
 
     private static bool TryReadPackToolProperty(
         DotNetRepositoryProjectResult project,
@@ -250,7 +256,7 @@ public sealed partial class DotNetRepositoryReleaseService
         out string error)
     {
         var allowedRoots = new List<string>();
-        foreach (var propertyName in new[] { "OutputPath", "IntermediateOutputPath", "ArtifactsPath" })
+        foreach (var propertyName in new[] { "OutputPath", "IntermediateOutputPath", "ArtifactsPath", "PackageOutputPath" })
         {
             if (!TryReadPackToolProperty(
                     project,
@@ -271,19 +277,30 @@ public sealed partial class DotNetRepositoryReleaseService
                 allowedRoots.Add(ResolveProjectPath(workingDirectory, value!));
         }
 
-        var containingRoot = allowedRoots
-            .Where(root => IsPathStrictlyWithin(publishDirectory, root))
-            .OrderByDescending(static root => root.Length)
-            .FirstOrDefault();
-        if (string.IsNullOrWhiteSpace(containingRoot))
-        {
-            error = $"The pack-tool publish output for {project.ProjectName} must be contained by its evaluated output, intermediate, or artifacts directory before PowerForge can clean it: {publishDirectory}";
-            return false;
-        }
-
         if (!TryValidateNoReparsePoints(publishDirectory, out error))
         {
             error = $"The pack-tool publish output for {project.ProjectName} cannot be cleaned safely. {error}";
+            return false;
+        }
+
+        string? containingRoot = null;
+        foreach (var allowedRoot in allowedRoots.OrderByDescending(static root => root.Length))
+        {
+            if (!TryResolveFileSystemPathComparison(allowedRoot, out var comparison, out error))
+            {
+                error = $"The pack-tool publish output for {project.ProjectName} cannot be cleaned safely. {error}";
+                return false;
+            }
+
+            if (IsPathStrictlyWithin(publishDirectory, allowedRoot, comparison))
+            {
+                containingRoot = allowedRoot;
+                break;
+            }
+        }
+        if (string.IsNullOrWhiteSpace(containingRoot))
+        {
+            error = $"The pack-tool publish output for {project.ProjectName} must be contained by its evaluated output, intermediate, artifacts, or package output directory before PowerForge can clean it: {publishDirectory}";
             return false;
         }
 
@@ -301,8 +318,16 @@ public sealed partial class DotNetRepositoryReleaseService
             {
                 var left = plans[index];
                 var right = plans[siblingIndex];
-                if (!IsPathAtOrWithinPlatform(left.PublishDirectory, right.PublishDirectory) &&
-                    !IsPathAtOrWithinPlatform(right.PublishDirectory, left.PublishDirectory))
+                if (!TryPackToolPathsOverlap(
+                        left.PublishDirectory,
+                        right.PublishDirectory,
+                        out var overlap,
+                        out error))
+                {
+                    return false;
+                }
+
+                if (!overlap)
                 {
                     continue;
                 }
@@ -354,24 +379,103 @@ public sealed partial class DotNetRepositoryReleaseService
         }
     }
 
-    private static bool IsPathStrictlyWithin(string path, string root)
+    private static bool IsPathStrictlyWithin(string path, string root, StringComparison comparison)
     {
         var normalizedPath = Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         var normalizedRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        return !string.Equals(normalizedPath, normalizedRoot, PackToolPathComparison) &&
-               normalizedPath.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, PackToolPathComparison);
+        return !string.Equals(normalizedPath, normalizedRoot, comparison) &&
+               normalizedPath.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, comparison);
     }
 
-    private static bool IsPathAtOrWithinPlatform(string path, string root)
+    private static bool IsPathAtOrWithin(string path, string root, StringComparison comparison)
     {
         var normalizedPath = Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         var normalizedRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        return string.Equals(normalizedPath, normalizedRoot, PackToolPathComparison) ||
-               normalizedPath.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, PackToolPathComparison);
+        return string.Equals(normalizedPath, normalizedRoot, comparison) ||
+               normalizedPath.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, comparison);
     }
 
-    private static StringComparison PackToolPathComparison
-        => Path.DirectorySeparatorChar == '\\' ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+    /// <summary>Determines whether two staging paths overlap using the case semantics of their actual filesystems.</summary>
+    internal static bool TryPackToolPathsOverlap(string left, string right, out bool overlap, out string error)
+    {
+        overlap = false;
+        if (!TryResolveFileSystemPathComparison(left, out var leftComparison, out error) ||
+            !TryResolveFileSystemPathComparison(right, out var rightComparison, out error))
+        {
+            return false;
+        }
+
+        overlap = IsPathAtOrWithin(left, right, leftComparison) ||
+                  IsPathAtOrWithin(right, left, leftComparison) ||
+                  IsPathAtOrWithin(left, right, rightComparison) ||
+                  IsPathAtOrWithin(right, left, rightComparison);
+        error = string.Empty;
+        return true;
+    }
+
+    private static bool TryResolveFileSystemPathComparison(
+        string path,
+        out StringComparison comparison,
+        out string error)
+    {
+        comparison = StringComparison.Ordinal;
+        string? probePath = null;
+        try
+        {
+            var probeDirectory = Path.GetFullPath(path);
+            while (!Directory.Exists(probeDirectory))
+            {
+                var parent = Directory.GetParent(probeDirectory);
+                if (parent is null)
+                {
+                    error = $"Unable to find an existing directory for filesystem case-sensitivity validation: {path}";
+                    return false;
+                }
+
+                probeDirectory = parent.FullName;
+            }
+
+            var probeName = $".powerforge-case-probe-{Guid.NewGuid():N}-a";
+            probePath = Path.Combine(probeDirectory, probeName);
+            var alternatePath = Path.Combine(
+                probeDirectory,
+                probeName.Substring(0, probeName.Length - 1) + "A");
+            using (File.Open(probePath, FileMode.CreateNew, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete))
+            {
+                comparison = File.Exists(alternatePath)
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal;
+            }
+        }
+        catch (Exception ex)
+        {
+            error = $"Unable to determine filesystem case sensitivity for {path}. {ex.Message}";
+            return false;
+        }
+        finally
+        {
+            if (!string.IsNullOrWhiteSpace(probePath))
+            {
+                try
+                {
+                    File.Delete(probePath);
+                }
+                catch
+                {
+                    // The staging cleanup remains fail-closed through the existence check below.
+                }
+            }
+        }
+
+        if (File.Exists(probePath))
+        {
+            error = $"Unable to remove the filesystem case-sensitivity probe for {path}: {probePath}";
+            return false;
+        }
+
+        error = string.Empty;
+        return true;
+    }
 
     private static string ResolveProjectPath(string workingDirectory, string value)
     {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PackToolSigning.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PackToolSigning.cs
@@ -1,0 +1,464 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace PowerForge;
+
+public sealed partial class DotNetRepositoryReleaseService
+{
+    private static bool TryPreparePackToolPublishOutputs(
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        DotNetRepositoryReleaseSpec spec,
+        ILogger logger,
+        out TimeSpan duration,
+        out string error)
+    {
+        duration = TimeSpan.Zero;
+        error = string.Empty;
+        var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
+        var packProperties = CreatePackToolStagingGlobalProperties();
+        var plans = new List<PackToolPublishPlan>();
+
+        foreach (var project in projects)
+        {
+            var workingDirectory = Path.GetDirectoryName(project.CsprojPath) ?? string.Empty;
+            foreach (var targetFramework in ResolveConfiguredTargetFrameworks(
+                         project.CsprojPath,
+                         workingDirectory,
+                         configuration,
+                         project.ProjectName,
+                         logger))
+            {
+                if (!TryReadPackToolProperty(
+                        project,
+                        workingDirectory,
+                        configuration,
+                        targetFramework,
+                        packProperties,
+                        "PackAsTool",
+                        logger,
+                        ref duration,
+                        out var packAsToolValue,
+                        out error))
+                {
+                    return false;
+                }
+
+                if (!bool.TryParse(packAsToolValue?.Trim(), out var packAsTool) || !packAsTool)
+                    continue;
+
+                if (!TryRejectRidSpecificPackTool(
+                        project,
+                        workingDirectory,
+                        configuration,
+                        targetFramework,
+                        packProperties,
+                        logger,
+                        ref duration,
+                        out error))
+                {
+                    return false;
+                }
+
+                if (!TryReadPackToolProperty(
+                        project,
+                        workingDirectory,
+                        configuration,
+                        targetFramework,
+                        packProperties,
+                        "PublishDir",
+                        logger,
+                        ref duration,
+                        out var publishDirectory,
+                        out error))
+                {
+                    return false;
+                }
+
+                if (string.IsNullOrWhiteSpace(publishDirectory))
+                {
+                    error = $"Unable to resolve the pack-tool publish output for {project.ProjectName}.";
+                    return false;
+                }
+
+                var resolvedPublishDirectory = ResolveProjectPath(workingDirectory, publishDirectory!);
+                if (!TryValidatePackToolPublishDirectory(
+                        project,
+                        workingDirectory,
+                        configuration,
+                        targetFramework,
+                        packProperties,
+                        resolvedPublishDirectory,
+                        logger,
+                        ref duration,
+                        out error))
+                {
+                    return false;
+                }
+
+                plans.Add(new PackToolPublishPlan(
+                    project,
+                    workingDirectory,
+                    targetFramework,
+                    resolvedPublishDirectory));
+            }
+        }
+
+        if (!TryValidateDistinctPackToolPublishDirectories(plans, out error))
+            return false;
+
+        foreach (var plan in plans)
+        {
+            try
+            {
+                if (Directory.Exists(plan.PublishDirectory))
+                    Directory.Delete(plan.PublishDirectory, recursive: true);
+            }
+            catch (Exception ex)
+            {
+                error = $"Unable to clean the pack-tool publish output for {plan.Project.ProjectName} at {plan.PublishDirectory}. {ex.Message}";
+                return false;
+            }
+
+            var exitCode = RunDotnetPublishForPackTool(
+                plan.Project.CsprojPath,
+                plan.WorkingDirectory,
+                configuration,
+                plan.TargetFramework,
+                packProperties,
+                plan.Project.ProjectName,
+                logger,
+                out var stdErr,
+                out var stdOut,
+                out var publishDuration);
+            duration += publishDuration;
+            if (exitCode != 0)
+            {
+                error = $"dotnet publish staging failed for {plan.Project.ProjectName} (exit {exitCode}). {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
+                return false;
+            }
+
+            if (!Directory.Exists(plan.PublishDirectory))
+            {
+                error = $"The pack-tool publish output for {plan.Project.ProjectName} was not created at {plan.PublishDirectory}.";
+                return false;
+            }
+
+            logger.Success($"{plan.Project.ProjectName}: prepared clean pack-tool publish output for assembly signing in {FormatDuration(publishDuration)}.");
+        }
+
+        return true;
+    }
+
+    private static IReadOnlyDictionary<string, string> CreatePackToolStagingGlobalProperties()
+        => new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["_IsPacking"] = "true",
+            ["NoBuild"] = "true",
+            ["BuildProjectReferences"] = "false"
+        };
+
+    private static bool TryReadPackToolProperty(
+        DotNetRepositoryProjectResult project,
+        string workingDirectory,
+        string configuration,
+        string? targetFramework,
+        IReadOnlyDictionary<string, string> globalProperties,
+        string propertyName,
+        ILogger logger,
+        ref TimeSpan duration,
+        out string? value,
+        out string error)
+    {
+        var exitCode = RunDotnetMsBuildGetProperty(
+            project.CsprojPath,
+            workingDirectory,
+            configuration,
+            targetFramework,
+            null,
+            globalProperties,
+            propertyName,
+            project.ProjectName,
+            logger,
+            out value,
+            out var stdErr,
+            out var stdOut,
+            out var propertyDuration);
+        duration += propertyDuration;
+        if (exitCode == 0)
+        {
+            error = string.Empty;
+            return true;
+        }
+
+        error = $"Unable to evaluate {propertyName} for {project.ProjectName}. {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
+        return false;
+    }
+
+    private static bool TryRejectRidSpecificPackTool(
+        DotNetRepositoryProjectResult project,
+        string workingDirectory,
+        string configuration,
+        string? targetFramework,
+        IReadOnlyDictionary<string, string> globalProperties,
+        ILogger logger,
+        ref TimeSpan duration,
+        out string error)
+    {
+        foreach (var propertyName in new[] { "RuntimeIdentifier", "CreateRidSpecificToolPackages" })
+        {
+            if (!TryReadPackToolProperty(
+                    project,
+                    workingDirectory,
+                    configuration,
+                    targetFramework,
+                    globalProperties,
+                    propertyName,
+                    logger,
+                    ref duration,
+                    out var value,
+                    out error))
+            {
+                return false;
+            }
+
+            var hasRidSpecificValue = string.Equals(propertyName, "RuntimeIdentifier", StringComparison.Ordinal)
+                ? !string.IsNullOrWhiteSpace(value)
+                : bool.TryParse(value?.Trim(), out var enabled) && enabled;
+            if (!hasRidSpecificValue)
+                continue;
+
+            error = $"Dependency assembly signing does not support RID-specific PackAsTool output for {project.ProjectName}; remove the RID-specific tool configuration or disable SignDependencyAssemblies.";
+            return false;
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    private static bool TryValidatePackToolPublishDirectory(
+        DotNetRepositoryProjectResult project,
+        string workingDirectory,
+        string configuration,
+        string? targetFramework,
+        IReadOnlyDictionary<string, string> globalProperties,
+        string publishDirectory,
+        ILogger logger,
+        ref TimeSpan duration,
+        out string error)
+    {
+        var allowedRoots = new List<string>();
+        foreach (var propertyName in new[] { "OutputPath", "IntermediateOutputPath", "ArtifactsPath" })
+        {
+            if (!TryReadPackToolProperty(
+                    project,
+                    workingDirectory,
+                    configuration,
+                    targetFramework,
+                    globalProperties,
+                    propertyName,
+                    logger,
+                    ref duration,
+                    out var value,
+                    out error))
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(value))
+                allowedRoots.Add(ResolveProjectPath(workingDirectory, value!));
+        }
+
+        var containingRoot = allowedRoots
+            .Where(root => IsPathStrictlyWithin(publishDirectory, root))
+            .OrderByDescending(static root => root.Length)
+            .FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(containingRoot))
+        {
+            error = $"The pack-tool publish output for {project.ProjectName} must be contained by its evaluated output, intermediate, or artifacts directory before PowerForge can clean it: {publishDirectory}";
+            return false;
+        }
+
+        if (!TryValidateNoReparsePoints(publishDirectory, out error))
+        {
+            error = $"The pack-tool publish output for {project.ProjectName} cannot be cleaned safely. {error}";
+            return false;
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    private static bool TryValidateDistinctPackToolPublishDirectories(
+        IReadOnlyList<PackToolPublishPlan> plans,
+        out string error)
+    {
+        for (var index = 0; index < plans.Count; index++)
+        {
+            for (var siblingIndex = index + 1; siblingIndex < plans.Count; siblingIndex++)
+            {
+                var left = plans[index];
+                var right = plans[siblingIndex];
+                if (!IsPathAtOrWithinPlatform(left.PublishDirectory, right.PublishDirectory) &&
+                    !IsPathAtOrWithinPlatform(right.PublishDirectory, left.PublishDirectory))
+                {
+                    continue;
+                }
+
+                error = $"Pack-tool publish outputs must not overlap: {left.Project.ProjectName} ({left.PublishDirectory}) and {right.Project.ProjectName} ({right.PublishDirectory}).";
+                return false;
+            }
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    private static bool TryValidateNoReparsePoints(string publishDirectory, out string error)
+    {
+        try
+        {
+            var fullPath = Path.GetFullPath(publishDirectory);
+            var current = Path.GetPathRoot(fullPath) ?? string.Empty;
+            if (!string.IsNullOrWhiteSpace(current) &&
+                (File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
+            {
+                error = $"The path traverses a linked filesystem root: {current}";
+                return false;
+            }
+
+            var relativePath = fullPath.Substring(current.Length);
+            foreach (var segment in relativePath.Split(
+                         new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+                         StringSplitOptions.RemoveEmptyEntries))
+            {
+                current = Path.Combine(current, segment);
+                if (!Directory.Exists(current) && !File.Exists(current))
+                    continue;
+                if ((File.GetAttributes(current) & FileAttributes.ReparsePoint) == 0)
+                    continue;
+
+                error = $"The path traverses a linked file or directory: {current}";
+                return false;
+            }
+
+            error = string.Empty;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = $"The path could not be inspected: {ex.Message}";
+            return false;
+        }
+    }
+
+    private static bool IsPathStrictlyWithin(string path, string root)
+    {
+        var normalizedPath = Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var normalizedRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return !string.Equals(normalizedPath, normalizedRoot, PackToolPathComparison) &&
+               normalizedPath.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, PackToolPathComparison);
+    }
+
+    private static bool IsPathAtOrWithinPlatform(string path, string root)
+    {
+        var normalizedPath = Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var normalizedRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return string.Equals(normalizedPath, normalizedRoot, PackToolPathComparison) ||
+               normalizedPath.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, PackToolPathComparison);
+    }
+
+    private static StringComparison PackToolPathComparison
+        => Path.DirectorySeparatorChar == '\\' ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    private static string ResolveProjectPath(string workingDirectory, string value)
+    {
+        var normalized = value.Trim().Trim('"');
+        return Path.IsPathRooted(normalized)
+            ? Path.GetFullPath(normalized)
+            : Path.GetFullPath(Path.Combine(workingDirectory, normalized));
+    }
+
+    private static int RunDotnetPublishForPackTool(
+        string csproj,
+        string workingDirectory,
+        string configuration,
+        string? targetFramework,
+        IReadOnlyDictionary<string, string> globalProperties,
+        string projectName,
+        ILogger logger,
+        out string stdErr,
+        out string stdOut,
+        out TimeSpan duration)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory
+        };
+        ProcessStartInfoEncoding.TryApplyUtf8(psi);
+
+        var args = new List<string>
+        {
+            "publish",
+            csproj,
+            "--configuration",
+            configuration,
+            "--no-build",
+            "--no-restore"
+        };
+        if (!string.IsNullOrWhiteSpace(targetFramework))
+        {
+            args.Add("--framework");
+            args.Add(targetFramework!.Trim());
+        }
+        foreach (var property in globalProperties)
+            args.Add($"-p:{property.Key}={EscapeMsBuildPropertyValue(property.Value)}");
+
+#if NET472
+        psi.Arguments = BuildWindowsArgumentString(args);
+#else
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+#endif
+
+        var exitCode = RunProcessWithHeartbeat(
+            psi,
+            logger,
+            elapsed => $"{projectName}: dotnet publish staging still running ({FormatDuration(elapsed)} elapsed).",
+            out stdErr,
+            out stdOut,
+            out duration);
+        LogProcessOutput(logger, projectName, "dotnet publish staging", stdOut, stdErr);
+        return exitCode;
+    }
+
+    private sealed class PackToolPublishPlan
+    {
+        internal PackToolPublishPlan(
+            DotNetRepositoryProjectResult project,
+            string workingDirectory,
+            string? targetFramework,
+            string publishDirectory)
+        {
+            Project = project;
+            WorkingDirectory = workingDirectory;
+            TargetFramework = targetFramework;
+            PublishDirectory = publishDirectory;
+        }
+
+        internal DotNetRepositoryProjectResult Project { get; }
+
+        internal string WorkingDirectory { get; }
+
+        internal string? TargetFramework { get; }
+
+        internal string PublishDirectory { get; }
+    }
+}

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -209,7 +209,7 @@ public sealed partial class DotNetRepositoryReleaseService
             {
                 if (spec.SignDependencyAssemblies)
                 {
-                    if (!TryPreparePackToolPublishOutputs(new[] { project }, spec, logger, out var preparationDuration, out var preparationError))
+                    if (!TryPreparePackToolPublishOutputs(new[] { project }, spec, outputPath, logger, out var preparationDuration, out var preparationError))
                     {
                         result.Duration += preparationDuration;
                         result.ErrorMessage = preparationError;
@@ -225,7 +225,15 @@ public sealed partial class DotNetRepositoryReleaseService
                 var signingPlan = BuildAssemblySigningPlan(
                     outputDirectories,
                     includePatterns,
-                    ResolvePackToolIntermediateAssemblyPaths(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns));
+                    ResolvePackToolIntermediateAssemblyPaths(
+                        project.CsprojPath,
+                        csprojDir,
+                        configuration,
+                        project.ProjectName,
+                        logger,
+                        includePatterns,
+                        spec.SignDependencyAssemblies,
+                        outputPath));
                 if (signingPlan.Files.Length == 0 && !spec.SignDependencyAssemblies)
                 {
                     var evaluatedIncludePatterns = ResolveAssemblySigningIncludePatterns(project, spec, csprojDir, configuration, logger);
@@ -236,7 +244,15 @@ public sealed partial class DotNetRepositoryReleaseService
                         signingPlan = BuildAssemblySigningPlan(
                             outputDirectories,
                             includePatterns,
-                            ResolvePackToolIntermediateAssemblyPaths(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns));
+                            ResolvePackToolIntermediateAssemblyPaths(
+                                project.CsprojPath,
+                                csprojDir,
+                                configuration,
+                                project.ProjectName,
+                                logger,
+                                includePatterns,
+                                includePreparedPublishOutput: false,
+                                outputPath));
                     }
                 }
                 resolveOutputWatch.Stop();
@@ -546,10 +562,12 @@ private static string? ResolvePackagePath(DotNetRepositoryReleaseSpec spec, DotN
         string configuration,
         string projectName,
         ILogger logger,
-        IReadOnlyList<string> includePatterns)
+        IReadOnlyList<string> includePatterns,
+        bool includePreparedPublishOutput = false,
+        string? packageOutputPath = null)
     {
         var files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var packProperties = CreatePackToolStagingGlobalProperties();
+        var packProperties = CreatePackToolStagingGlobalProperties(packageOutputPath);
         foreach (var targetFramework in ResolveConfiguredTargetFrameworks(csproj, workingDirectory, configuration, projectName, logger))
         {
             var packAsToolExitCode = RunDotnetMsBuildGetProperty(
@@ -594,6 +612,9 @@ private static string? ResolvePackagePath(DotNetRepositoryReleaseSpec spec, DotN
                 ? Path.GetFullPath(normalizedIntermediateOutputPath)
                 : Path.GetFullPath(Path.Combine(workingDirectory, normalizedIntermediateOutputPath));
             AddMatchingAssemblyPaths(files, resolvedDirectory, includePatterns, SearchOption.TopDirectoryOnly);
+
+            if (!includePreparedPublishOutput)
+                continue;
 
             var publishExitCode = RunDotnetMsBuildGetProperty(
                 csproj,

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -207,6 +207,18 @@ public sealed partial class DotNetRepositoryReleaseService
         {
             try
             {
+                if (spec.SignDependencyAssemblies)
+                {
+                    if (!TryPreparePackToolPublishOutputs(new[] { project }, spec, logger, out var preparationDuration, out var preparationError))
+                    {
+                        result.Duration += preparationDuration;
+                        result.ErrorMessage = preparationError;
+                        return result;
+                    }
+
+                    result.Duration += preparationDuration;
+                }
+
                 var includePatterns = ResolveAssemblySigningIncludePatterns(project, spec, csprojDir, configuration, logger);
                 var resolveOutputWatch = Stopwatch.StartNew();
                 var outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns);
@@ -350,7 +362,11 @@ private static string? ResolvePackagePath(DotNetRepositoryReleaseSpec spec, DotN
 #if NET472
         var args = new List<string> { "pack", csproj, "--configuration", configuration };
         if (noBuild)
+        {
             args.Add("--no-build");
+            args.Add("-p:_IsPacking=true");
+            args.Add("-p:BuildProjectReferences=false");
+        }
         if (!string.IsNullOrWhiteSpace(outputPath))
         {
             args.Add("-o");
@@ -368,7 +384,11 @@ private static string? ResolvePackagePath(DotNetRepositoryReleaseSpec spec, DotN
         psi.ArgumentList.Add("--configuration");
         psi.ArgumentList.Add(configuration);
         if (noBuild)
+        {
             psi.ArgumentList.Add("--no-build");
+            psi.ArgumentList.Add("-p:_IsPacking=true");
+            psi.ArgumentList.Add("-p:BuildProjectReferences=false");
+        }
         if (!string.IsNullOrWhiteSpace(outputPath))
         {
             psi.ArgumentList.Add("-o");
@@ -529,6 +549,7 @@ private static string? ResolvePackagePath(DotNetRepositoryReleaseSpec spec, DotN
         IReadOnlyList<string> includePatterns)
     {
         var files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var packProperties = CreatePackToolStagingGlobalProperties();
         foreach (var targetFramework in ResolveConfiguredTargetFrameworks(csproj, workingDirectory, configuration, projectName, logger))
         {
             var packAsToolExitCode = RunDotnetMsBuildGetProperty(
@@ -536,6 +557,8 @@ private static string? ResolvePackagePath(DotNetRepositoryReleaseSpec spec, DotN
                 workingDirectory,
                 configuration,
                 targetFramework,
+                null,
+                packProperties,
                 "PackAsTool",
                 projectName,
                 logger,
@@ -551,6 +574,8 @@ private static string? ResolvePackagePath(DotNetRepositoryReleaseSpec spec, DotN
                 workingDirectory,
                 configuration,
                 targetFramework,
+                null,
+                packProperties,
                 "IntermediateOutputPath",
                 projectName,
                 logger,
@@ -568,17 +593,52 @@ private static string? ResolvePackagePath(DotNetRepositoryReleaseSpec spec, DotN
             var resolvedDirectory = Path.IsPathRooted(normalizedIntermediateOutputPath)
                 ? Path.GetFullPath(normalizedIntermediateOutputPath)
                 : Path.GetFullPath(Path.Combine(workingDirectory, normalizedIntermediateOutputPath));
-            if (!Directory.Exists(resolvedDirectory))
-                continue;
+            AddMatchingAssemblyPaths(files, resolvedDirectory, includePatterns, SearchOption.TopDirectoryOnly);
 
-            foreach (var includePattern in includePatterns.Where(static pattern => !string.IsNullOrWhiteSpace(pattern)))
+            var publishExitCode = RunDotnetMsBuildGetProperty(
+                csproj,
+                workingDirectory,
+                configuration,
+                targetFramework,
+                null,
+                packProperties,
+                "PublishDir",
+                projectName,
+                logger,
+                out var publishDirectory,
+                out stdErr,
+                out stdOut,
+                out duration);
+            if (publishExitCode != 0 || string.IsNullOrWhiteSpace(publishDirectory))
             {
-                foreach (var path in Directory.EnumerateFiles(resolvedDirectory, includePattern, SearchOption.TopDirectoryOnly))
-                    files.Add(Path.GetFullPath(path));
+                logger.Verbose($"{projectName}: unable to resolve the pack-tool publish output in {FormatDuration(duration)}. {SummarizeProcessFailureOutput(stdErr, stdOut)}");
+                continue;
             }
+
+            var normalizedPublishDirectory = publishDirectory!.Trim().Trim('"');
+            var resolvedPublishDirectory = Path.IsPathRooted(normalizedPublishDirectory)
+                ? Path.GetFullPath(normalizedPublishDirectory)
+                : Path.GetFullPath(Path.Combine(workingDirectory, normalizedPublishDirectory));
+            AddMatchingAssemblyPaths(files, resolvedPublishDirectory, includePatterns, SearchOption.AllDirectories);
         }
 
         return files.ToArray();
+    }
+
+    private static void AddMatchingAssemblyPaths(
+        HashSet<string> files,
+        string directory,
+        IReadOnlyList<string> includePatterns,
+        SearchOption searchOption)
+    {
+        if (!Directory.Exists(directory))
+            return;
+
+        foreach (var includePattern in includePatterns.Where(static pattern => !string.IsNullOrWhiteSpace(pattern)))
+        {
+            foreach (var path in Directory.EnumerateFiles(directory, includePattern, searchOption))
+                files.Add(Path.GetFullPath(path));
+        }
     }
 
     private static string[] ResolveConventionalBuildOutputDirectories(


### PR DESCRIPTION
## Summary

- stage clean PackAsTool publish outputs before dependency assembly signing and include only those prepared outputs in the signing plan
- evaluate staging and both packing strategies with the same SDK pack-time properties, including the effective package output path
- keep post-pack provenance limited to fresh build outputs instead of trusting unprepared publish directories
- reject unsupported RID-specific tool packages, unsafe cleanup paths, and overlapping staging directories using the actual filesystem's case semantics
- enable dependency assembly signing for the repository release configuration

## Why

PSPublishModule is the shared packaging owner for [EventViewerX](https://github.com/EvotecIT/EventViewerX). A tool package could have a valid outer NuGet signature while carrying unsigned dependency DLLs. This fixes that packaging contract in the shared owner instead of adding a downstream workaround and closes #909.

Release order: merge and publish a corrected PowerForge/PSPublishModule package first, then rebuild and repin EventViewerX.

## Validation

- 12 focused regression cases passed across per-project and MSBuild strategies, dependency signing modes, package-output-conditioned staging, stale provenance rejection, RID rejection, traversal properties, and filesystem casing behavior
- PowerForge builds for net472, net8.0, and net10.0 with zero warnings
- non-publishing package run produced all 11 expected version 3.0.139 packages
- all 11 NuGet signatures verified; all 820 packaged DLL copies had valid Authenticode signatures; all 29 first-party DLL copies used the Evotec Services signer and a timestamp