### PR TITLE
Fix compiler gate timeout budget

### DIFF
--- a/.github/workflows/BuildModule.yml
+++ b/.github/workflows/BuildModule.yml
@@ -357,7 +357,7 @@ jobs:
 
       - name: Run bounded PowerShell compiler gate
         shell: pwsh
-        timeout-minutes: 30
+        timeout-minutes: 40
         run: |
           $ErrorActionPreference = 'Stop'
           . ./Benchmarks/PowerShellCompilation/Corpus/Corpus.Runner.Common.ps1


### PR DESCRIPTION
## Summary

Extends the bounded PowerShell compiler-gate step from 30 to 40 minutes.

The default-branch build at `8003ba7` passed all 278 compiler tests, then the final strict-number-theory stage exceeded the 30-minute step limit. The enclosing `ProductBuildSmoke` job remains bounded at 90 minutes.

## Outcome

Hosted Windows runs retain a finite gate deadline while allowing the verified workload to finish under normal runner variation.
