### PR TITLE
Honor the website repository SDK before installing workloads

### DIFF
--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -267,6 +267,7 @@ jobs:
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
+          global-json-file: ${{ hashFiles('global.json') != '' && 'global.json' || '' }}
 
       - name: Install requested .NET workloads
         if: ${{ inputs.dotnet_workloads != '' }}


### PR DESCRIPTION
The shared website runner installs the configured SDK channel but can miss the SDK selected by the caller's root global.json. Workload installation then fails before the website build when the installed feature band does not satisfy the repository's roll-forward policy.

Pass an existing root global.json to the pinned setup-dotnet action alongside the configured SDK channel. The action installs both selections and retains the existing behavior for repositories without global.json. This fixes the setup boundary exposed by the [OfficeIMO deployment](https://github.com/EvotecIT/OfficeIMO/actions/runs/34715112069), which requested 10.0.112 with latestPatch while the runner had 10.0.111 and newer feature bands.

Validation: inspected the pinned setup-dotnet implementation to verify combined input handling and missing-file behavior; checked the literal workflow diff. The downstream workflow pin must be updated after this shared change merges; its native WebAssembly publish provides runtime validation.
